### PR TITLE
UTY-347 Add helper for creating an attribute from worker id

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Utility/WorkerRequirements.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Utility/WorkerRequirements.cs
@@ -1,0 +1,18 @@
+namespace Improbable.Gdk.Core
+{
+    /// <summary>
+    /// Helpers for defining read and write access for components
+    /// </summary>
+    public class WorkerRequirements
+    {
+        /// <summary>
+        /// Creates a worker attribute string matching a worker Id
+        /// </summary>
+        /// <param name="workerId">A worker identifier string</param>
+        /// <returns>A worker attribute string matching the given <paramref name="workerId"/></returns>
+        public static string IdEquals(string workerId)
+        {
+            return $"workerId:{workerId}";
+        }
+    }
+}


### PR DESCRIPTION
#### Description
A helper to protect us from breaking changes to the attribute string format.

#### Tests
None

#### Documentation
In comments.