### PR TITLE
Remove the burst package as a requirement from Core

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/package.json
+++ b/workers/unity/Packages/com.improbable.gdk.core/package.json
@@ -7,7 +7,6 @@
     "description": "SpatialOS GDK Core Module. Made by Improbable.",
     "dependencies": {
         "com.improbable.gdk.tools": "0.0.1",
-        "com.unity.burst": "0.2.4-preview.30",
         "com.unity.entities": "0.0.12-preview.13",
         "com.unity.incrementalcompiler": "0.0.42-preview.21"
     }


### PR DESCRIPTION
#### Description
We don't use Burst ourselves, only through entities, which has its own dependency already.

#### Tests
Build all workers for local and cloud