### PR TITLE
Replace usages of LogEvent default constructor

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/MonoBehaviourActivationManager.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/MonoBehaviourActivationManager.cs
@@ -271,7 +271,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
             catch (Exception e)
             {
                 // Log the exception but do not rethrow it.
-                logger.HandleLog(LogType.Exception, new LogEvent("Caught exception").WithException(e));
+                logger.HandleLog(LogType.Exception, new LogEvent("Caught exception in MonoBehaviour").WithException(e));
             }
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/MonoBehaviourActivationManager.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/MonoBehaviourActivationManager.cs
@@ -271,7 +271,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
             catch (Exception e)
             {
                 // Log the exception but do not rethrow it.
-                logger.HandleLog(LogType.Exception, new LogEvent().WithException(e));
+                logger.HandleLog(LogType.Exception, new LogEvent("Caught exception").WithException(e));
             }
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/MonoBehaviourActivationManager.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/MonoBehaviourActivationManager.cs
@@ -271,7 +271,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
             catch (Exception e)
             {
                 // Log the exception but do not rethrow it.
-                logger.HandleLog(LogType.Exception, new LogEvent("Caught exception in MonoBehaviour").WithException(e));
+                logger.HandleLog(LogType.Exception, new LogEvent("Caught exception in a MonoBehaviour").WithException(e));
             }
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/GameObjectDelegates.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/GameObjectDelegates.cs
@@ -35,7 +35,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
                 catch (Exception e)
                 {
                     // Log the exception but do not rethrow it, as other delegates should still get called
-                    logDispatcher.HandleLog(LogType.Exception, new LogEvent().WithException(e));
+                    logDispatcher.HandleLog(LogType.Exception, new LogEvent("Caught exception").WithException(e));
                 }
             }
         }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/GameObjectDelegates.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/GameObjectDelegates.cs
@@ -35,7 +35,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
                 catch (Exception e)
                 {
                     // Log the exception but do not rethrow it, as other delegates should still get called
-                    logDispatcher.HandleLog(LogType.Exception, new LogEvent("Caught exception in a dispatcher callback").WithException(e));
+                    logDispatcher.HandleLog(LogType.Exception, new LogEvent("Caught exception in a MonoBehaviour").WithException(e));
                 }
             }
         }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/GameObjectDelegates.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/GameObjectDelegates.cs
@@ -35,7 +35,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
                 catch (Exception e)
                 {
                     // Log the exception but do not rethrow it, as other delegates should still get called
-                    logDispatcher.HandleLog(LogType.Exception, new LogEvent("Caught exception").WithException(e));
+                    logDispatcher.HandleLog(LogType.Exception, new LogEvent("Caught exception in a dispatcher callback").WithException(e));
                 }
             }
         }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/ReaderWriterBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/ReaderWriterBase.cs
@@ -170,7 +170,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
                 {
                     // Log the exception but do not rethrow it, as other delegates should still get called
                     logDispatcher.HandleLog(LogType.Exception,
-                        new LogEvent("Caught exception while processing authority changes").WithException(e));
+                        new LogEvent("Caught exception in a MonoBehaviour authority change callback").WithException(e));
                 }
             }
         }
@@ -215,7 +215,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
                 {
                     // Log the exception but do not rethrow it, as other delegates should still get called
                     logDispatcher.HandleLog(LogType.Exception,
-                        new LogEvent("Caught exception while processing component updates").WithException(e));
+                        new LogEvent("Caught exception in a MonoBehaviour component update callback").WithException(e));
                 }
             }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/ReaderWriterBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/ReaderWriterBase.cs
@@ -169,7 +169,8 @@ namespace Improbable.Gdk.GameObjectRepresentation
                 catch (Exception e)
                 {
                     // Log the exception but do not rethrow it, as other delegates should still get called
-                    logDispatcher.HandleLog(LogType.Exception, new LogEvent().WithException(e));
+                    logDispatcher.HandleLog(LogType.Exception,
+                        new LogEvent("Caught exception while processing authority changes").WithException(e));
                 }
             }
         }
@@ -213,7 +214,8 @@ namespace Improbable.Gdk.GameObjectRepresentation
                 catch (Exception e)
                 {
                     // Log the exception but do not rethrow it, as other delegates should still get called
-                    logDispatcher.HandleLog(LogType.Exception, new LogEvent().WithException(e));
+                    logDispatcher.HandleLog(LogType.Exception,
+                        new LogEvent("Caught exception while processing component updates").WithException(e));
                 }
             }
 


### PR DESCRIPTION
#### Description
The default constructor doesn't initialise the Data field because this is a struct. This may cause NPEs. Calling the non-default constructor is a temporary solution.