### PR TITLE
Mobile local dev: Rename iOS libraries after downloading

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.tools/.DownloadCoreSdk/Program.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.DownloadCoreSdk/Program.cs
@@ -9,6 +9,8 @@ namespace Improbable
 {
     internal class Program
     {
+        private delegate void PostprocessPackage(string directoryPath);
+
         private static void Main(string[] args)
         {
             if (args.Length != 3)
@@ -29,8 +31,8 @@ namespace Improbable
                 new Package(tempPath, "worker_sdk", "c-dynamic-x86_64-msvc_mt-win32", $"{nativeDependenciesPath}/Windows/x86_64", new List<string> {"include", "worker.lib"}),
                 new Package(tempPath, "worker_sdk", "c-dynamic-x86_64-gcc_libstdcpp-linux", $"{nativeDependenciesPath}/Linux/x86_64", new List<string> {"include"}),
                 new Package(tempPath, "worker_sdk", "c-bundle-x86_64-clang_libcpp-macos", $"{nativeDependenciesPath}/OSX", new List<string> {"include"}),
-                new Package(tempPath, "worker_sdk", "c-static-fullylinked-arm-clang_libcpp-ios", $"{nativeDependenciesPath}/iOS/arm", new List<string> {"include", "libworker_static_fullylinked.a.pic", "worker_static_fullylinked.lib"}),
-                new Package(tempPath, "worker_sdk", "c-static-fullylinked-x86_64-clang_libcpp-ios", $"{nativeDependenciesPath}/iOS/x86_64", new List<string> {"include", "libworker_static_fullylinked.a.pic", "worker_static_fullylinked.lib"}),
+                new Package(tempPath, "worker_sdk", "c-static-fullylinked-arm-clang_libcpp-ios", $"{nativeDependenciesPath}/iOS/arm", new List<string> {"include", "libworker_static_fullylinked.a.pic", "worker_static_fullylinked.lib"}, postprocessCallback:PostProcess_iOS_Arm),
+                new Package(tempPath, "worker_sdk", "c-static-fullylinked-x86_64-clang_libcpp-ios", $"{nativeDependenciesPath}/iOS/x86_64", new List<string> {"include", "libworker_static_fullylinked.a.pic", "worker_static_fullylinked.lib"}, postprocessCallback:PostProcess_iOS_x86_64),
                 new Package(tempPath, "worker_sdk", "c-dynamic-arm64-clang_libcpp-android", $"{nativeDependenciesPath}/Android/arm64", new List<string> {"include"}),
                 new Package(tempPath, "worker_sdk", "c-dynamic-armeabi_v7a-clang_libcpp-android", $"{nativeDependenciesPath}/Android/armeabi-v7a", new List<string> {"include"}),
                 new Package(tempPath, "worker_sdk", "c-dynamic-x86-android-clang_libcpp-android", $"{nativeDependenciesPath}/Android/x86", new List<string> {"include"}),
@@ -79,6 +81,8 @@ namespace Improbable
                         Directory.Delete(cleanPath, true);
                     }
                 }
+
+                package.PostprocessCallback?.Invoke(package.TargetPath);
             }
         }
 
@@ -109,6 +113,20 @@ namespace Improbable
             }
         }
 
+        private static void PostProcess_iOS_Arm(string directoryPath)
+        {
+            var originalPath = Path.Combine(directoryPath, "libworker_static_fullylinked.a");
+            var destinationPath = Path.Combine(directoryPath, "libworker_static_fullylinked_arm.a");
+            File.Move(originalPath, destinationPath);
+        }
+
+        private static void PostProcess_iOS_x86_64(string directoryPath)
+        {
+            var originalPath = Path.Combine(directoryPath, "libworker_static_fullylinked.a");
+            var destinationPath = Path.Combine(directoryPath, "libworker_static_fullylinked_x86_64.a");
+            File.Move(originalPath, destinationPath);
+        }
+
         private static void WriteException(Exception e)
         {
             Console.ForegroundColor = ConsoleColor.Red;
@@ -118,7 +136,7 @@ namespace Improbable
 
         private class Package
         {
-            public Package(string tempPath, string type, string name, string targetPath, List<string> cleanPaths = null, OSPlatform? platform = null)
+            public Package(string tempPath, string type, string name, string targetPath, List<string> cleanPaths = null, OSPlatform? platform = null, PostprocessPackage postprocessCallback = null)
             {
                 Type = type;
                 Name = name;
@@ -126,6 +144,7 @@ namespace Improbable
                 CleanPaths = cleanPaths ?? new List<string>();
                 SourceFile = Path.Combine(tempPath, $"{Name}.zip");
                 InstallOnThisPlatform = !platform.HasValue || RuntimeInformation.IsOSPlatform(platform.Value);
+                PostprocessCallback = postprocessCallback;
             }
 
             public string Type { get; }
@@ -134,6 +153,7 @@ namespace Improbable
             public string TargetPath { get; }
             public List<string> CleanPaths { get; }
             public bool InstallOnThisPlatform { get; }
+            public PostprocessPackage PostprocessCallback { get; }
         }
     }
 }


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
This PR adds postprocessing logic for packages download and renaming iOS libraries after download.
This is done to avoid name clash - iOS libraries have same names and will cause error when compiling Xcode project
#### Tests
Checkout clean repo -> Open Unity Editor -> Ensure Xcode project don't have clashing libraries
#### Documentation
#### Primary reviewers
cc @DanailPenev 