### PR TITLE
Adding Android and iOS Workers to configs

### DIFF
--- a/mobile_launch.json
+++ b/mobile_launch.json
@@ -1,0 +1,43 @@
+{
+  "template": "small_bridge_v2",
+  "world": {
+    "chunkEdgeLengthMeters": 50,
+    "snapshots": {
+      "snapshotWritePeriodSeconds": 0
+    },
+    "dimensions": {
+      "xMeters": 5000,
+      "zMeters": 5000
+    },
+    "legacy_flags": [
+      {
+        "name": "bridge_qos_max_timeout",
+        "value": "0"
+      }
+    ]
+  },
+  "workers": [
+    {
+      "worker_type": "UnityGameLogic",
+      "permissions": [
+        {
+          "all": {}
+        }
+      ],
+      "load_balancing": {
+        "auto_hex_grid": {
+          "num_workers": 1
+        }
+      }
+    },
+    {
+      "worker_type": "UnityClient",
+      "permissions": [{
+          "all": {}
+      }],
+      "load_balancing": {
+        "singleton_worker": {}
+      }
+    }
+  ]
+}

--- a/workers/unity/Assets/Playground/Config/BuildConfiguration.asset
+++ b/workers/unity/Assets/Playground/Config/BuildConfiguration.asset
@@ -30,4 +30,22 @@ MonoBehaviour:
     CloudBuildConfig:
       BuildPlatforms: 8
       BuildOptions: 16384
+  - WorkerType: AndroidClient
+    ScenesForWorker:
+    - {fileID: 102900000, guid: 82ccd0fd96a2ba24f88d0c7d01592f2e, type: 3}
+    LocalBuildConfig:
+      BuildPlatforms: 32
+      BuildOptions: 0
+    CloudBuildConfig:
+      BuildPlatforms: 0
+      BuildOptions: 16384
+  - WorkerType: IosClient
+    ScenesForWorker:
+    - {fileID: 102900000, guid: 424c4b2c090874512badc5e7ee757d5f, type: 3}
+    LocalBuildConfig:
+      BuildPlatforms: 64
+      BuildOptions: 1
+    CloudBuildConfig:
+      BuildPlatforms: 0
+      BuildOptions: 16384
   isInitialised: 1

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/Configuration/SpatialBuildPlatforms.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/Configuration/SpatialBuildPlatforms.cs
@@ -7,6 +7,8 @@ namespace Improbable.Gdk.BuildSystem.Configuration
         Windows32 = 1 << 1,
         Windows64 = 1 << 2,
         Linux = 1 << 3,
-        OSX = 1 << 4
+        OSX = 1 << 4,
+        Android = 1 << 5,
+        iOS = 1 << 6
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/Configuration/SpatialOSBuildConfiguration.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/Configuration/SpatialOSBuildConfiguration.cs
@@ -8,12 +8,12 @@ namespace Improbable.Gdk.BuildSystem.Configuration
 {
     [CreateAssetMenu(fileName = "SpatialOS Build Configuration", menuName = EditorConfig.BuildConfigurationMenu)]
     public class SpatialOSBuildConfiguration : SingletonScriptableObject<SpatialOSBuildConfiguration>
-    {        
-        [SerializeField] public List<WorkerBuildConfiguration> WorkerBuildConfigurations = 
+    {
+        [SerializeField] public List<WorkerBuildConfiguration> WorkerBuildConfigurations =
             new List<WorkerBuildConfiguration>();
-        
+
         [SerializeField] private bool isInitialised;
-        
+
         public BuildEnvironmentConfig GetEnvironmentConfigForWorker(string workerType, BuildEnvironment environment)
         {
             var config = WorkerBuildConfigurations.FirstOrDefault(x => x.WorkerType == workerType);
@@ -33,7 +33,7 @@ namespace Improbable.Gdk.BuildSystem.Configuration
                 .Select(AssetDatabase.GetAssetPath)
                 .ToArray();
         }
-        
+
         internal void UpdateEditorScenesForBuild()
         {
             EditorBuildSettings.scenes =
@@ -62,24 +62,46 @@ namespace Improbable.Gdk.BuildSystem.Configuration
         {
             WorkerBuildConfigurations = new List<WorkerBuildConfiguration>
             {
+                new WorkerBuildConfiguration
                 {
-                    new WorkerBuildConfiguration
+                    WorkerType = "UnityClient",
+                    LocalBuildConfig = new BuildEnvironmentConfig { BuildOptions = BuildOptions.Development },
+                },
+                new WorkerBuildConfiguration
+                {
+                    WorkerType = "UnityGameLogic",
+                    LocalBuildConfig =
+                        new BuildEnvironmentConfig { BuildOptions = BuildOptions.EnableHeadlessMode },
+                    CloudBuildConfig = new BuildEnvironmentConfig
                     {
-                        WorkerType = "UnityClient",
-                        LocalBuildConfig = new BuildEnvironmentConfig { BuildOptions = BuildOptions.Development },
+                        BuildPlatforms = SpatialBuildPlatforms.Linux,
+                        BuildOptions = BuildOptions.EnableHeadlessMode
                     }
                 },
+                new WorkerBuildConfiguration
                 {
-                    new WorkerBuildConfiguration
+                    WorkerType = "AndroidClient",
+                    LocalBuildConfig = new BuildEnvironmentConfig
                     {
-                        WorkerType = "UnityGameLogic",
-                        LocalBuildConfig =
-                            new BuildEnvironmentConfig { BuildOptions = BuildOptions.EnableHeadlessMode },
-                        CloudBuildConfig = new BuildEnvironmentConfig
-                        {
-                            BuildPlatforms = SpatialBuildPlatforms.Linux,
-                            BuildOptions = BuildOptions.EnableHeadlessMode
-                        }
+                        BuildPlatforms = SpatialBuildPlatforms.Android,
+                        BuildOptions = BuildOptions.Development
+                    },
+                    CloudBuildConfig = new BuildEnvironmentConfig
+                    {
+                        BuildPlatforms = SpatialBuildPlatforms.Android
+                    }
+                },
+                new WorkerBuildConfiguration
+                {
+                    WorkerType = "IosClient",
+                    LocalBuildConfig = new BuildEnvironmentConfig
+                    {
+                        BuildPlatforms = SpatialBuildPlatforms.iOS,
+                        BuildOptions = BuildOptions.Development
+                    },
+                    CloudBuildConfig = new BuildEnvironmentConfig
+                    {
+                        BuildPlatforms = SpatialBuildPlatforms.iOS
                     }
                 }
             };

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/Configuration/WorkerBuildData.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/Configuration/WorkerBuildData.cs
@@ -10,13 +10,13 @@ namespace Improbable.Gdk.BuildSystem.Configuration
         public readonly string WorkerType;
 
         public string PackageName => $"{WorkerType}@{BuildTargetName}";
-        
+
         public string BuildScratchDirectory =>
             Path.Combine(EditorPaths.BuildScratchDirectory, PackageName, ExecutableName);
-        
+
         private string BuildTargetName => BuildTargetNames[buildTarget];
         private string ExecutableName => PackageName + BuildPlatformExtensions[buildTarget];
-        
+
         private readonly BuildTarget buildTarget;
 
         private static readonly Dictionary<BuildTarget, string> BuildTargetNames =
@@ -25,7 +25,9 @@ namespace Improbable.Gdk.BuildSystem.Configuration
                 { BuildTarget.StandaloneWindows, "Windows" },
                 { BuildTarget.StandaloneWindows64, "Windows" },
                 { BuildTarget.StandaloneLinux64, "Linux" },
-                { BuildTarget.StandaloneOSX, "Mac" }
+                { BuildTarget.StandaloneOSX, "Mac" },
+                { BuildTarget.Android, "Android" },
+                { BuildTarget.iOS, "iOS" }
             };
 
         private static readonly Dictionary<BuildTarget, string> BuildPlatformExtensions =
@@ -34,7 +36,9 @@ namespace Improbable.Gdk.BuildSystem.Configuration
                 { BuildTarget.StandaloneWindows, ".exe" },
                 { BuildTarget.StandaloneWindows64, ".exe" },
                 { BuildTarget.StandaloneLinux64, "" },
-                { BuildTarget.StandaloneOSX, "" }
+                { BuildTarget.StandaloneOSX, "" },
+                { BuildTarget.Android, ".apk" },
+                { BuildTarget.iOS, "" }
             };
 
         public WorkerBuildData(string workerType, BuildTarget buildTarget)

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
@@ -49,7 +49,7 @@ namespace Improbable.Gdk.BuildSystem
 
                 var workerTypesArg =
                     CommandLineUtility.GetCommandLineValue(commandLine, BuildWorkerTypes,
-                        "UnityClient,UnityGameLogic");
+                        "UnityClient,UnityGameLogic,AndroidClient");
 
                 var wantedWorkerTypes = workerTypesArg.Split(',');
                 LocalLaunch.BuildConfig();
@@ -127,10 +127,20 @@ namespace Improbable.Gdk.BuildSystem
                 }
 
                 result.Add(BuildTarget.StandaloneWindows);
-            } 
+            }
             else if ((actualPlatforms & SpatialBuildPlatforms.Windows64) != 0)
             {
                 result.Add(BuildTarget.StandaloneWindows64);
+            }
+
+            if ((actualPlatforms & SpatialBuildPlatforms.Android) != 0)
+            {
+                result.Add(BuildTarget.Android);
+            }
+
+            if ((actualPlatforms & SpatialBuildPlatforms.iOS) != 0)
+            {
+                result.Add(BuildTarget.iOS);
             }
 
             return result.ToArray();
@@ -184,7 +194,7 @@ namespace Improbable.Gdk.BuildSystem
         {
             using (new ShowProgressBarScope($"Package {basePath}"))
             {
-                RedirectedProcess.Run(Common.SpatialBinary, "file", "zip", 
+                RedirectedProcess.Run(Common.SpatialBinary, "file", "zip",
                     $"--output=\"{Path.GetFullPath(zipAbsolutePath)}\"",
                     $"--basePath=\"{Path.GetFullPath(basePath)}\"", "\"**\"",
                     $"--compression={useCompression}");

--- a/workers/unity/spatialos.AndroidClient.worker.json
+++ b/workers/unity/spatialos.AndroidClient.worker.json
@@ -1,0 +1,69 @@
+{
+  "build": {
+    "tasks": [
+      {
+        "name": "Codegen",
+        "steps": [{"name": "** Load Unity to generate code **", "command": "echo", "arguments": ["No-op."]}]
+      },
+      {
+        "name": "build",
+        "steps": [{"name": "** Run ci/build-client.sh instead **", "command": "echo", "arguments": ["No-op."]}]
+      },
+      {
+        "name": "clean",
+        "steps": [{"name": "No-op", "command": "echo", "arguments": ["No-op."]}]
+      }
+    ]
+  },
+  "bridge": {
+    "worker_attribute_set": {
+      "attributes": [
+        "UnityClient"
+      ]
+    },
+    "entity_interest": {
+      "range_entity_interest": {
+        "radius": 500
+      }
+    },
+    "component_delivery": {
+      "default": "RELIABLE_ORDERED",
+      "checkoutAllInitially": true
+    }
+  },
+  "external": {
+    "default": {
+      "run_type": "EXECUTABLE",
+      "windows": {
+        "command": "echo",
+        "arguments": [
+          "+workerType",
+          "AndroidClient",
+          "+infraServicesUrl",
+          "http://127.0.0.1:21000",
+          "+projectName",
+          "${IMPROBABLE_PROJECT_NAME}",
+          "-logfile",
+          "../../logs/external-default-androidclient.log"
+        ]
+      },
+      "macos": {
+        "command": "echo",
+        "arguments": [
+          "./build/worker/UnityClient@Mac/UnityClient@Mac.app",
+          "--args",
+          "+assemblyName",
+          "local_assembly",
+          "+workerType",
+          "AndroidClient",
+          "+infraServicesUrl",
+          "http://127.0.0.1:21000",
+          "+projectName",
+          "${IMPROBABLE_PROJECT_NAME}",
+          "-logfile",
+          "../../logs/external-default-androidclient.log"
+        ]
+      }
+    }
+  }
+}

--- a/workers/unity/spatialos.IosClient.worker.json
+++ b/workers/unity/spatialos.IosClient.worker.json
@@ -1,0 +1,69 @@
+{
+  "build": {
+    "tasks": [
+      {
+        "name": "Codegen",
+        "steps": [{"name": "** Load Unity to generate code **", "command": "echo", "arguments": ["No-op."]}]
+      },
+      {
+        "name": "build",
+        "steps": [{"name": "** Run ci/build-client.sh instead **", "command": "echo", "arguments": ["No-op."]}]
+      },
+      {
+        "name": "clean",
+        "steps": [{"name": "No-op", "command": "echo", "arguments": ["No-op."]}]
+      }
+    ]
+  },
+  "bridge": {
+    "worker_attribute_set": {
+      "attributes": [
+        "UnityClient"
+      ]
+    },
+    "entity_interest": {
+      "range_entity_interest": {
+        "radius": 500
+      }
+    },
+    "component_delivery": {
+      "default": "RELIABLE_ORDERED",
+      "checkoutAllInitially": true
+    }
+  },
+  "external": {
+    "default": {
+      "run_type": "EXECUTABLE",
+      "windows": {
+        "command": "echo",
+        "arguments": [
+          "+workerType",
+          "IosClient",
+          "+infraServicesUrl",
+          "http://127.0.0.1:21000",
+          "+projectName",
+          "${IMPROBABLE_PROJECT_NAME}",
+          "-logfile",
+          "../../logs/external-default-iosclient.log"
+        ]
+      },
+      "macos": {
+        "command": "echo",
+        "arguments": [
+          "./build/worker/UnityClient@Mac/UnityClient@Mac.app",
+          "--args",
+          "+assemblyName",
+          "local_assembly",
+          "+workerType",
+          "IosClient",
+          "+infraServicesUrl",
+          "http://127.0.0.1:21000",
+          "+projectName",
+          "${IMPROBABLE_PROJECT_NAME}",
+          "-logfile",
+          "../../logs/external-default-iosclient.log"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
This PR adds configuration changes that introduce Android Client and iOS Client. It also adds mobile_launch.json config that launches GameLogic client on local deployment
#### Tests
Tested along with other PRs on iOS and Android devices and sims
#### Documentation
#### Primary reviewers
cc @DanailPenev 