### PR TITLE
Add error messages for platforms that miss support

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/Configuration/SpatialOSBuildConfiguration.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/Configuration/SpatialOSBuildConfiguration.cs
@@ -8,18 +8,18 @@ namespace Improbable.Gdk.BuildSystem.Configuration
 {
     [CreateAssetMenu(fileName = "SpatialOS Build Configuration", menuName = EditorConfig.BuildConfigurationMenu)]
     public class SpatialOSBuildConfiguration : SingletonScriptableObject<SpatialOSBuildConfiguration>
-    {        
-        [SerializeField] public List<WorkerBuildConfiguration> WorkerBuildConfigurations = 
+    {
+        [SerializeField] public List<WorkerBuildConfiguration> WorkerBuildConfigurations =
             new List<WorkerBuildConfiguration>();
-        
+
         [SerializeField] private bool isInitialised;
-        
+
         public BuildEnvironmentConfig GetEnvironmentConfigForWorker(string workerType, BuildEnvironment environment)
         {
             var config = WorkerBuildConfigurations.FirstOrDefault(x => x.WorkerType == workerType);
             if (config == null)
             {
-                Debug.LogWarning($"The worker type {workerType} does not have a build configuration.");
+                Debug.LogWarning($"The worker type {workerType} does not have a build configuration.", this);
                 return null;
             }
 
@@ -33,7 +33,7 @@ namespace Improbable.Gdk.BuildSystem.Configuration
                 .Select(AssetDatabase.GetAssetPath)
                 .ToArray();
         }
-        
+
         internal void UpdateEditorScenesForBuild()
         {
             EditorBuildSettings.scenes =

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/Configuration/SpatialOSBuildConfigurationEditor.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/Configuration/SpatialOSBuildConfigurationEditor.cs
@@ -338,12 +338,10 @@ namespace Improbable.Gdk.BuildSystem.Configuration
                         MessageType.Error);
                 }
 
-                foreach (var buildTarget in WorkerBuilder.GetUnityBuildTargets(newBuildPlatforms))
+                var buildTargetsMissingBuildSupport = BuildSupportChecker.GetBuildTargetsMissingBuildSupport(WorkerBuilder.GetUnityBuildTargets(newBuildPlatforms));
+                if (buildTargetsMissingBuildSupport.Length > 0)
                 {
-                    if (!BuildSupportChecker.CheckBuildSupport(buildTarget).CanBuild)
-                    {
-                        EditorGUILayout.HelpBox($"Missing build support for {buildTarget}", MessageType.Error);
-                    }
+                    EditorGUILayout.HelpBox($"Missing build support for {string.Join(", ", buildTargetsMissingBuildSupport)}", MessageType.Error);
                 }
 
                 if (EditorGUI.EndChangeCheck())

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/Configuration/SpatialOSBuildConfigurationEditor.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/Configuration/SpatialOSBuildConfigurationEditor.cs
@@ -325,11 +325,25 @@ namespace Improbable.Gdk.BuildSystem.Configuration
                 }
 
                 var currentAdjustedPlatforms = newBuildPlatforms;
+
+                if ((currentAdjustedPlatforms & SpatialBuildPlatforms.Current) != 0)
+                {
+                    currentAdjustedPlatforms |= WorkerBuilder.GetCurrentBuildPlatform();
+                }
+
                 if ((currentAdjustedPlatforms & SpatialBuildPlatforms.Windows32) != 0 &&
                     (currentAdjustedPlatforms & SpatialBuildPlatforms.Windows64) != 0)
                 {
                     EditorGUILayout.HelpBox(WorkerBuilder.IncompatibleWindowsPlatformsErrorMessage,
                         MessageType.Error);
+                }
+
+                foreach (var buildTarget in WorkerBuilder.GetUnityBuildTargets(newBuildPlatforms))
+                {
+                    if (!BuildSupportChecker.CheckBuildSupport(buildTarget).CanBuild)
+                    {
+                        EditorGUILayout.HelpBox($"Missing build support for {buildTarget}", MessageType.Error);
+                    }
                 }
 
                 if (EditorGUI.EndChangeCheck())

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/Configuration/WorkerBuildData.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/Configuration/WorkerBuildData.cs
@@ -10,13 +10,13 @@ namespace Improbable.Gdk.BuildSystem.Configuration
         public readonly string WorkerType;
 
         public string PackageName => $"{WorkerType}@{BuildTargetName}";
-        
+
         public string BuildScratchDirectory =>
             Path.Combine(EditorPaths.BuildScratchDirectory, PackageName, ExecutableName);
-        
+
         private string BuildTargetName => BuildTargetNames[buildTarget];
         private string ExecutableName => PackageName + BuildPlatformExtensions[buildTarget];
-        
+
         private readonly BuildTarget buildTarget;
 
         private static readonly Dictionary<BuildTarget, string> BuildTargetNames =
@@ -35,6 +35,15 @@ namespace Improbable.Gdk.BuildSystem.Configuration
                 { BuildTarget.StandaloneWindows64, ".exe" },
                 { BuildTarget.StandaloneLinux64, "" },
                 { BuildTarget.StandaloneOSX, "" }
+            };
+
+        public static readonly Dictionary<BuildTarget, string> BuildTargetSupportDirectoryNames =
+            new Dictionary<BuildTarget, string>
+            {
+                { BuildTarget.StandaloneWindows, "WindowsStandaloneSupport" },
+                { BuildTarget.StandaloneWindows64, "WindowsStandaloneSupport" },
+                { BuildTarget.StandaloneLinux64, "LinuxStandaloneSupport" },
+                { BuildTarget.StandaloneOSX, "MacStandaloneSupport" }
             };
 
         public WorkerBuildData(string workerType, BuildTarget buildTarget)

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/BuildSupportChecker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/BuildSupportChecker.cs
@@ -7,35 +7,6 @@ using UnityEngine;
 
 public static class BuildSupportChecker
 {
-    private const string LinuxStandaloneSupportDirectoryName = "LinuxStandaloneSupport";
-    private const string WindowsStandaloneSupportDirectoryName = "WindowsStandaloneSupport";
-    private const string MacStandaloneSupportDirectoryName = "MacStandaloneSupport";
-
-    private static readonly Dictionary<BuildTarget, string> BuildPlatformSupportModuleDirectoryNames;
-
-    static BuildSupportChecker()
-    {
-        BuildPlatformSupportModuleDirectoryNames = new Dictionary<BuildTarget, string>
-        {
-            [BuildTarget.StandaloneLinux] = LinuxStandaloneSupportDirectoryName,
-            [BuildTarget.StandaloneLinux64] = LinuxStandaloneSupportDirectoryName,
-            [BuildTarget.StandaloneLinuxUniversal] = LinuxStandaloneSupportDirectoryName
-        };
-
-        if (Application.platform != RuntimePlatform.OSXEditor)
-        {
-            BuildPlatformSupportModuleDirectoryNames[BuildTarget.StandaloneOSX] = MacStandaloneSupportDirectoryName;
-        }
-
-        if (Application.platform != RuntimePlatform.WindowsEditor)
-        {
-            BuildPlatformSupportModuleDirectoryNames[BuildTarget.StandaloneWindows] =
-                WindowsStandaloneSupportDirectoryName;
-            BuildPlatformSupportModuleDirectoryNames[BuildTarget.StandaloneWindows64] =
-                WindowsStandaloneSupportDirectoryName;
-        }
-    }
-
     public static BuildTarget[] GetBuildTargetsMissingBuildSupport(params BuildTarget[] buildTargets)
     {
         var editorDirectory = Directory.GetParent(EditorApplication.applicationPath);
@@ -57,13 +28,13 @@ public static class BuildSupportChecker
         return buildTargets
             .Where(target =>
             {
-                if (BuildPlatformSupportModuleDirectoryNames.TryGetValue(target, out var playbackEnginesDirectoryName))
+                if (WorkerBuildData.BuildTargetSupportDirectoryNames.TryGetValue(target, out var playbackEnginesDirectoryName))
                 {
                     return !Directory.Exists(Path.Combine(playbackEnginesDirectory, playbackEnginesDirectoryName));
                 }
 
-                // If it's not in the dictionary, then assume it's not missing support.
-                // e.g. if we're on a Windows Editor, it should have windows support.
+                Debug.LogWarning($"Unsupported build target: {target}");
+
                 return false;
             })
             .ToArray();

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/BuildSupportChecker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/BuildSupportChecker.cs
@@ -50,7 +50,7 @@ public static class BuildSupportChecker
         BuildTarget[] buildTargetsMissingBuildSupport)
     {
         return
-            $"The worker \"{workerType}\" cannot be built for a {environment} deployment -" +
+            $"The worker \"{workerType}\" cannot be built for a {environment} deployment:" +
             $" the Unity Editor is missing build support for {string.Join(", ", buildTargetsMissingBuildSupport)}.\n" +
             "Please add the missing build support options to your Unity Editor.";
     }

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/BuildSupportChecker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/BuildSupportChecker.cs
@@ -7,29 +7,32 @@ using UnityEngine;
 
 public static class BuildSupportChecker
 {
+    private const string LinuxStandaloneSupportDirectoryName = "LinuxStandaloneSupport";
+    private const string WindowsStandaloneSupportDirectoryName = "WindowsStandaloneSupport";
+    private const string MacStandaloneSupportDirectoryName = "MacStandaloneSupport";
+
     private static readonly Dictionary<BuildTarget, string> BuildPlatformSupportModuleDirectoryNames;
 
     static BuildSupportChecker()
     {
-        BuildPlatformSupportModuleDirectoryNames = new Dictionary<BuildTarget, string>();
-
-        const string linuxStandaloneSupport = "LinuxStandaloneSupport";
-        const string windowsStandaloneSupport = "WindowsStandaloneSupport";
-        const string macStandaloneSupport = "MacStandaloneSupport";
-
-        BuildPlatformSupportModuleDirectoryNames[BuildTarget.StandaloneLinux] = linuxStandaloneSupport;
-        BuildPlatformSupportModuleDirectoryNames[BuildTarget.StandaloneLinux64] = linuxStandaloneSupport;
-        BuildPlatformSupportModuleDirectoryNames[BuildTarget.StandaloneLinuxUniversal] = linuxStandaloneSupport;
+        BuildPlatformSupportModuleDirectoryNames = new Dictionary<BuildTarget, string>
+        {
+            [BuildTarget.StandaloneLinux] = LinuxStandaloneSupportDirectoryName,
+            [BuildTarget.StandaloneLinux64] = LinuxStandaloneSupportDirectoryName,
+            [BuildTarget.StandaloneLinuxUniversal] = LinuxStandaloneSupportDirectoryName
+        };
 
         if (Application.platform != RuntimePlatform.OSXEditor)
         {
-            BuildPlatformSupportModuleDirectoryNames[BuildTarget.StandaloneOSX] = macStandaloneSupport;
+            BuildPlatformSupportModuleDirectoryNames[BuildTarget.StandaloneOSX] = MacStandaloneSupportDirectoryName;
         }
 
         if (Application.platform != RuntimePlatform.WindowsEditor)
         {
-            BuildPlatformSupportModuleDirectoryNames[BuildTarget.StandaloneWindows] = windowsStandaloneSupport;
-            BuildPlatformSupportModuleDirectoryNames[BuildTarget.StandaloneWindows64] = windowsStandaloneSupport;
+            BuildPlatformSupportModuleDirectoryNames[BuildTarget.StandaloneWindows] =
+                WindowsStandaloneSupportDirectoryName;
+            BuildPlatformSupportModuleDirectoryNames[BuildTarget.StandaloneWindows64] =
+                WindowsStandaloneSupportDirectoryName;
         }
     }
 

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/BuildSupportChecker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/BuildSupportChecker.cs
@@ -49,16 +49,12 @@ public static class BuildSupportChecker
 
         var editorDirectory = Directory.GetParent(editorExePath);
 
+#if UNITY_EDITOR_OSX
+        var playbackEnginesDirectory = Path.Combine(editorDirectory.FullName, "PlaybackEngines");
+#else
         var installDirectory = editorDirectory.Parent;
-        if (installDirectory == null)
-        {
-            Debug.LogError("Build support check failed: could not find Unity Editor installation directory.");
-
-            // Since we're not certain, let's allow a build attempt.
-            return new BuildSupportCheckResult(true, new BuildTarget[0]);
-        }
-
         var playbackEnginesDirectory = Path.Combine(installDirectory.FullName, "Editor", "Data", "PlaybackEngines");
+#endif
 
         var buildTargetsWithoutSupport = buildTargets
             .Where(target =>

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/BuildSupportChecker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/BuildSupportChecker.cs
@@ -24,7 +24,7 @@ public static class BuildSupportChecker
 #endif
 
 #if !UNITY_EDITOR_WIN
-        var windowsStandaloneSupport = "WindowsStandaloneSupport";
+        const string windowsStandaloneSupport = "WindowsStandaloneSupport";
 
         BuildPlatformSupportModuleDirectoryNames[BuildTarget.StandaloneWindows] = windowsStandaloneSupport;
         BuildPlatformSupportModuleDirectoryNames[BuildTarget.StandaloneWindows64] = windowsStandaloneSupport;
@@ -45,7 +45,7 @@ public static class BuildSupportChecker
 
     public static BuildSupportCheckResult CheckBuildSupport(params BuildTarget[] buildTargets)
     {
-        string editorExePath = Environment.GetCommandLineArgs()[0];
+        string editorExePath = EditorApplication.applicationPath;
 
         var editorDirectory = Directory.GetParent(editorExePath);
 

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/BuildSupportChecker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/BuildSupportChecker.cs
@@ -7,6 +7,8 @@ using UnityEngine;
 
 public static class BuildSupportChecker
 {
+    private static readonly HashSet<BuildTarget> UnsupportedBuildTargetWarningDisplayed = new HashSet<BuildTarget>();
+
     public static BuildTarget[] GetBuildTargetsMissingBuildSupport(params BuildTarget[] buildTargets)
     {
         var editorDirectory = Directory.GetParent(EditorApplication.applicationPath);
@@ -33,7 +35,11 @@ public static class BuildSupportChecker
                     return !Directory.Exists(Path.Combine(playbackEnginesDirectory, playbackEnginesDirectoryName));
                 }
 
-                Debug.LogWarning($"Unsupported build target: {target}");
+                if (!UnsupportedBuildTargetWarningDisplayed.Contains(target))
+                {
+                    Debug.LogWarning($"Unsupported build target: {target}");
+                    UnsupportedBuildTargetWarningDisplayed.Add(target);
+                }
 
                 return false;
             })

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/BuildSupportChecker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/BuildSupportChecker.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+public static class BuildSupportChecker
+{
+    private static readonly Dictionary<BuildTarget, string> BuildPlatformSupportModuleDirectoryNames;
+
+    static BuildSupportChecker()
+    {
+        BuildPlatformSupportModuleDirectoryNames = new Dictionary<BuildTarget, string>();
+
+        const string linuxStandaloneSupport = "LinuxStandaloneSupport";
+
+        BuildPlatformSupportModuleDirectoryNames[BuildTarget.StandaloneLinux] = linuxStandaloneSupport;
+        BuildPlatformSupportModuleDirectoryNames[BuildTarget.StandaloneLinux64] = linuxStandaloneSupport;
+        BuildPlatformSupportModuleDirectoryNames[BuildTarget.StandaloneLinuxUniversal] = linuxStandaloneSupport;
+
+#if !UNITY_EDITOR_OSX
+        BuildPlatformSupportModuleDirectoryNames[BuildTarget.StandaloneOSX] = "MacStandaloneSupport";
+#endif
+
+#if !UNITY_EDITOR_WIN
+        var windowsStandaloneSupport = "WindowsStandaloneSupport";
+
+        BuildPlatformSupportModuleDirectoryNames[BuildTarget.StandaloneWindows] = windowsStandaloneSupport;
+        BuildPlatformSupportModuleDirectoryNames[BuildTarget.StandaloneWindows64] = windowsStandaloneSupport;
+#endif
+    }
+
+    public class BuildSupportCheckResult
+    {
+        public readonly bool CanBuild;
+        public readonly BuildTarget[] TargetsWithoutBuildSupport;
+
+        public BuildSupportCheckResult(bool canBuild, BuildTarget[] targetsWithoutBuildSupport)
+        {
+            CanBuild = canBuild;
+            TargetsWithoutBuildSupport = targetsWithoutBuildSupport;
+        }
+    }
+
+    public static BuildSupportCheckResult CheckBuildSupport(params BuildTarget[] buildTargets)
+    {
+        string editorExePath = Environment.GetCommandLineArgs()[0];
+
+        var editorDirectory = Directory.GetParent(editorExePath);
+
+        var installDirectory = editorDirectory.Parent;
+        if (installDirectory == null)
+        {
+            Debug.LogError("Build support check failed: could not find Unity Editor installation directory.");
+
+            // Since we're not certain, let's allow a build attempt.
+            return new BuildSupportCheckResult(true, new BuildTarget[0]);
+        }
+
+        var playbackEnginesDirectory = Path.Combine(installDirectory.FullName, "Editor", "Data", "PlaybackEngines");
+
+        var buildTargetsWithoutSupport = buildTargets
+            .Where(target =>
+            {
+                if (BuildPlatformSupportModuleDirectoryNames.TryGetValue(target, out var playbackEnginesDirectoryName))
+                {
+                    return !Directory.Exists(Path.Combine(playbackEnginesDirectory, playbackEnginesDirectoryName));
+                }
+
+                // If it's not in the dictionary, then assume it's not missing support.
+                // e.g. if we're on a Windows Editor, it should have windows support.
+                return false;
+            })
+            .ToArray();
+
+        return new BuildSupportCheckResult(buildTargetsWithoutSupport.Length == 0, buildTargetsWithoutSupport);
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/BuildSupportChecker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/BuildSupportChecker.cs
@@ -45,15 +45,12 @@ public static class BuildSupportChecker
 
     public static BuildSupportCheckResult CheckBuildSupport(params BuildTarget[] buildTargets)
     {
-        string editorExePath = EditorApplication.applicationPath;
-
-        var editorDirectory = Directory.GetParent(editorExePath);
+        var editorDirectory = Directory.GetParent(EditorApplication.applicationPath);
 
 #if UNITY_EDITOR_OSX
         var playbackEnginesDirectory = Path.Combine(editorDirectory.FullName, "PlaybackEngines");
 #else
-        var installDirectory = editorDirectory.Parent;
-        var playbackEnginesDirectory = Path.Combine(installDirectory.FullName, "Editor", "Data", "PlaybackEngines");
+        var playbackEnginesDirectory = Path.Combine(editorDirectory.FullName, "Data", "PlaybackEngines");
 #endif
 
         var buildTargetsWithoutSupport = buildTargets

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/BuildSupportChecker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/BuildSupportChecker.cs
@@ -31,7 +31,7 @@ public static class BuildSupportChecker
 #endif
     }
 
-    public class BuildSupportCheckResult
+    public struct BuildSupportCheckResult
     {
         public readonly bool CanBuild;
         public readonly BuildTarget[] TargetsWithoutBuildSupport;

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/BuildSupportChecker.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/BuildSupportChecker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 32bdb3daadef80f43ae18fd3e590ac8a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
@@ -53,7 +53,7 @@ namespace Improbable.Gdk.BuildSystem
                 var wantedWorkerTypes = workerTypesArg.Split(',');
                 foreach (var wantedWorkerType in wantedWorkerTypes)
                 {
-                    AssertWorkerCanBuildForEnvironment(wantedWorkerType, buildEnvironment);
+                    ValidateWorkerCanBuildForEnvironment(wantedWorkerType, buildEnvironment);
                 }
 
                 LocalLaunch.BuildConfig();
@@ -75,7 +75,7 @@ namespace Improbable.Gdk.BuildSystem
             }
         }
 
-        public static void AssertWorkerCanBuildForEnvironment(string workerType, BuildEnvironment targetEnvironment)
+        public static void ValidateWorkerCanBuildForEnvironment(string workerType, BuildEnvironment targetEnvironment)
         {
             var spatialOSBuildConfiguration = SpatialOSBuildConfiguration.GetInstance();
             var environmentConfig = spatialOSBuildConfiguration.GetEnvironmentConfigForWorker(workerType, targetEnvironment);

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
@@ -84,8 +84,7 @@ namespace Improbable.Gdk.BuildSystem
                 return;
             }
 
-            var buildPlatforms = environmentConfig.BuildPlatforms;
-            var buildTargets = GetUnityBuildTargets(buildPlatforms);
+            var buildTargets = GetUnityBuildTargets(environmentConfig.BuildPlatforms);
             var buildSupportResult = BuildSupportChecker.CheckBuildSupport(buildTargets);
 
             if (buildSupportResult.CanBuild)

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityWorkerMenuGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityWorkerMenuGenerator.tt
@@ -124,7 +124,7 @@ var workerType = workerTypeList[i];
                 "OK");
         }
 
-        [MenuItem(EditorConfig.ParentMenu + "/Check Build Support", false, EditorConfig.MenuOffset + <#= workerTypeList.Count + 1 #>)]
+        [MenuItem(EditorConfig.ParentMenu + "/Check build support", false, EditorConfig.MenuOffset + <#= workerTypeList.Count + 1 #>)]
         private static void CheckBuildSupport()
         {
             bool checksPassed = CheckWorkersCanBuildForEnvironment(BuildEnvironment.Local, AllWorkers);

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityWorkerMenuGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityWorkerMenuGenerator.tt
@@ -63,7 +63,7 @@ var workerType = workerTypeList[i];
             Debug.Log("Clean completed");
         }
 
-        private static bool VerifyWorkersCanBuildForEnvironment(BuildEnvironment environment, string[] workerTypes)
+        private static bool ValidateWorkersCanBuildForEnvironment(BuildEnvironment environment, string[] workerTypes)
         {
             var canInitiateBuild = true;
             var spatialOSBuildConfiguration = SpatialOSBuildConfiguration.GetInstance();
@@ -90,7 +90,7 @@ var workerType = workerTypeList[i];
             // Delaying build by a frame to ensure the editor has re-rendered the UI to avoid odd glitches.
             EditorApplication.delayCall += () =>
             {
-                if (!VerifyWorkersCanBuildForEnvironment(environment, workerTypes))
+                if (!ValidateWorkersCanBuildForEnvironment(environment, workerTypes))
                 {
                     DisplayBuildFailureDialog();
 
@@ -129,22 +129,22 @@ var workerType = workerTypeList[i];
         {
             Debug.Log("Checking for build platform support...");
 
-            var verificationsPassed = true;
+            var validationsPassed = true;
 
-            Debug.Log("Verifying local builds");
-            if (!VerifyWorkersCanBuildForEnvironment(BuildEnvironment.Local, AllWorkers))
+            Debug.Log("Validating local builds");
+            if (!ValidateWorkersCanBuildForEnvironment(BuildEnvironment.Local, AllWorkers))
             {
-                verificationsPassed = false;
+                validationsPassed = false;
             }
 
-            Debug.Log("Verifying cloud builds");
-            if (!VerifyWorkersCanBuildForEnvironment(BuildEnvironment.Cloud, AllWorkers))
+            Debug.Log("Validating cloud builds");
+            if (!ValidateWorkersCanBuildForEnvironment(BuildEnvironment.Cloud, AllWorkers))
             {
-                verificationsPassed = false;
+                validationsPassed = false;
             }
 
             EditorUtility.DisplayDialog("Build Support Validation",
-                verificationsPassed
+                validationsPassed
                     ? "Build support validation confirms your Unity Editor installation has all necessary components."
                     : "Build support validation failed. Please see the Unity Console Window for information.",
                 "OK");

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityWorkerMenuGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityWorkerMenuGenerator.tt
@@ -127,17 +127,13 @@ var workerType = workerTypeList[i];
         [MenuItem(EditorConfig.ParentMenu + "/Validate Build Support", false, EditorConfig.MenuOffset + <#= workerTypeList.Count + 1 #>)]
         private static void ValidateBuildSupport()
         {
-            Debug.Log("Checking for build platform support...");
-
             var validationsPassed = true;
 
-            Debug.Log("Validating local builds");
             if (!ValidateWorkersCanBuildForEnvironment(BuildEnvironment.Local, AllWorkers))
             {
                 validationsPassed = false;
             }
 
-            Debug.Log("Validating cloud builds");
             if (!ValidateWorkersCanBuildForEnvironment(BuildEnvironment.Cloud, AllWorkers))
             {
                 validationsPassed = false;

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityWorkerMenuGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityWorkerMenuGenerator.tt
@@ -63,25 +63,65 @@ var workerType = workerTypeList[i];
             Debug.Log("Clean completed");
         }
 
+        private static bool VerifyWorkersCanBuildForEnvironment(BuildEnvironment environment, string[] workerTypes)
+        {
+            var canInitiateBuild = true;
+            var spatialOSBuildConfiguration = SpatialOSBuildConfiguration.GetInstance();
+
+            foreach (var workerType in workerTypes)
+            {
+                try
+                {
+                    WorkerBuilder.AssertWorkerCanBuildForEnvironment(workerType, environment);
+                }
+                catch (System.Exception e)
+                {
+                    canInitiateBuild = false;
+
+                    Debug.LogException(e, spatialOSBuildConfiguration);
+                }
+            }
+
+            return canInitiateBuild;
+        }
+
         private static void MenuBuild(BuildEnvironment environment, params string[] workerTypes)
         {
             // Delaying build by a frame to ensure the editor has re-rendered the UI to avoid odd glitches.
             EditorApplication.delayCall += () =>
             {
-                foreach (var workerType in workerTypes)
+                if (!VerifyWorkersCanBuildForEnvironment(environment, workerTypes))
                 {
-                    WorkerBuilder.AssertWorkerCanBuildForEnvironment(workerType, environment);
+                    DisplayBuildFailureDialog();
+
+                    return;
                 }
 
-                LocalLaunch.BuildConfig();
-
-                foreach (var workerType in workerTypes)
+                try
                 {
-                    WorkerBuilder.BuildWorkerForEnvironment(workerType, environment);
-                }
+                    LocalLaunch.BuildConfig();
 
-                Debug.LogFormat("Completed build for {0} target", environment);
+                    foreach (var workerType in workerTypes)
+                    {
+                        WorkerBuilder.BuildWorkerForEnvironment(workerType, environment);
+                    }
+
+                    Debug.LogFormat("Completed build for {0} target", environment);
+                }
+                catch (System.Exception)
+                {
+                    DisplayBuildFailureDialog();
+
+                    throw;
+                }
             };
+        }
+
+        private static void DisplayBuildFailureDialog()
+        {
+            EditorUtility.DisplayDialog("Build Failed",
+                "Build failed. Please see the Unity Console Window for information.",
+                "OK");
         }
 
         [MenuItem(EditorConfig.ParentMenu + "/Validate Build Support", false, EditorConfig.MenuOffset + <#= workerTypeList.Count + 1 #>)]
@@ -89,35 +129,27 @@ var workerType = workerTypeList[i];
         {
             Debug.Log("Checking for build platform support...");
 
-            try
-            {
-                var buildConfiguration = SpatialOSBuildConfiguration.GetInstance();
+            var verificationsPassed = true;
 
-                foreach (var workerType in AllWorkers)
-                {
-                    try
-                    {
-                        WorkerBuilder.AssertWorkerCanBuildForEnvironment(workerType, BuildEnvironment.Local);
-                    }
-                    catch (System.Exception caughtException)
-                    {
-                        Debug.LogException(caughtException, buildConfiguration);
-                    }
-
-                    try
-                    {
-                        WorkerBuilder.AssertWorkerCanBuildForEnvironment(workerType, BuildEnvironment.Cloud);
-                    }
-                    catch (System.Exception caughtException)
-                    {
-                        Debug.LogException(caughtException, buildConfiguration);
-                    }
-                }
-            }
-            finally
+            Debug.Log("Verifying local builds");
+            if (!VerifyWorkersCanBuildForEnvironment(BuildEnvironment.Local, AllWorkers))
             {
-                Debug.Log("Diagnosis complete.");
+                verificationsPassed = false;
             }
+
+            Debug.Log("Verifying cloud builds");
+            if (!VerifyWorkersCanBuildForEnvironment(BuildEnvironment.Cloud, AllWorkers))
+            {
+                verificationsPassed = false;
+            }
+
+            EditorUtility.DisplayDialog("Build Support Validation",
+                verificationsPassed
+                    ? "Build support validation confirms your Unity Editor installation has all necessary components."
+                    : "Build support validation failed. Please see the Unity Console Window for information.",
+                "OK");
+
+            Debug.Log("Diagnosis complete.");
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityWorkerMenuGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityWorkerMenuGenerator.tt
@@ -13,21 +13,21 @@ using UnityEditor;
 using UnityEngine;
 
 namespace Improbable
-{ 
+{
     internal static class BuildWorkerMenu
     {
         private const string LocalMenu = "Build for local";
         private const string CloudMenu = "Build for cloud";
 
-        private static readonly string[] AllWorkers = 
+        private static readonly string[] AllWorkers =
         {
 <# foreach (var workerType in workerTypeList) { #>
             "<#= workerType #>",
 <# } #>
         };
 
-<# 
-for (var i = 0; i < workerTypeList.Count; i++) { 
+<#
+for (var i = 0; i < workerTypeList.Count; i++) {
 var workerType = workerTypeList[i];
 #>
         [MenuItem(EditorConfig.ParentMenu + "/" + LocalMenu + "/<#= workerType #>", false, EditorConfig.MenuOffset + <#=i #>)]
@@ -62,21 +62,62 @@ var workerType = workerTypeList[i];
             WorkerBuilder.Clean();
             Debug.Log("Clean completed");
         }
-        
-        private static void MenuBuild(BuildEnvironment environment, params string[] platforms)
+
+        private static void MenuBuild(BuildEnvironment environment, params string[] workerTypes)
         {
             // Delaying build by a frame to ensure the editor has re-rendered the UI to avoid odd glitches.
             EditorApplication.delayCall += () =>
             {
+                foreach (var workerType in workerTypes)
+                {
+                    WorkerBuilder.AssertWorkerCanBuildForEnvironment(workerType, environment);
+                }
+
                 LocalLaunch.BuildConfig();
 
-                foreach (var platform in platforms)
+                foreach (var workerType in workerTypes)
                 {
-                    WorkerBuilder.BuildWorkerForEnvironment(platform, environment);
+                    WorkerBuilder.BuildWorkerForEnvironment(workerType, environment);
                 }
 
                 Debug.LogFormat("Completed build for {0} target", environment);
             };
+        }
+
+        [MenuItem(EditorConfig.ParentMenu + "/Validate Build Support", false, EditorConfig.MenuOffset + <#= workerTypeList.Count + 1 #>)]
+        private static void ValidateBuildSupport()
+        {
+            Debug.Log("Checking for build platform support...");
+
+            try
+            {
+                var buildConfiguration = SpatialOSBuildConfiguration.GetInstance();
+
+                foreach (var workerType in AllWorkers)
+                {
+                    try
+                    {
+                        WorkerBuilder.AssertWorkerCanBuildForEnvironment(workerType, BuildEnvironment.Local);
+                    }
+                    catch (System.Exception caughtException)
+                    {
+                        Debug.LogException(caughtException, buildConfiguration);
+                    }
+
+                    try
+                    {
+                        WorkerBuilder.AssertWorkerCanBuildForEnvironment(workerType, BuildEnvironment.Cloud);
+                    }
+                    catch (System.Exception caughtException)
+                    {
+                        Debug.LogException(caughtException, buildConfiguration);
+                    }
+                }
+            }
+            finally
+            {
+                Debug.Log("Diagnosis complete.");
+            }
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityWorkerMenuGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityWorkerMenuGenerator.tt
@@ -63,22 +63,22 @@ var workerType = workerTypeList[i];
             Debug.Log("Clean completed");
         }
 
-        private static bool ValidateWorkersCanBuildForEnvironment(BuildEnvironment environment, string[] workerTypes)
+        private static bool CheckWorkersCanBuildForEnvironment(BuildEnvironment environment, string[] workerTypes)
         {
             var canInitiateBuild = true;
             var spatialOSBuildConfiguration = SpatialOSBuildConfiguration.GetInstance();
 
             foreach (var workerType in workerTypes)
             {
-                try
-                {
-                    WorkerBuilder.ValidateWorkerCanBuildForEnvironment(workerType, environment);
-                }
-                catch (System.Exception e)
+                var buildTargetsForWorker = WorkerBuilder.GetBuildTargetsForWorkerForEnvironment(workerType, environment);
+                var buildTargetsMissingBuildSupport = BuildSupportChecker.GetBuildTargetsMissingBuildSupport(buildTargetsForWorker);
+
+                if (buildTargetsMissingBuildSupport.Length > 0)
                 {
                     canInitiateBuild = false;
 
-                    Debug.LogException(e, spatialOSBuildConfiguration);
+                    Debug.LogError(BuildSupportChecker.ConstructMissingSupportMessage(workerType, environment, buildTargetsMissingBuildSupport),
+                        spatialOSBuildConfiguration);
                 }
             }
 
@@ -90,7 +90,7 @@ var workerType = workerTypeList[i];
             // Delaying build by a frame to ensure the editor has re-rendered the UI to avoid odd glitches.
             EditorApplication.delayCall += () =>
             {
-                if (!ValidateWorkersCanBuildForEnvironment(environment, workerTypes))
+                if (!CheckWorkersCanBuildForEnvironment(environment, workerTypes))
                 {
                     DisplayBuildFailureDialog();
 
@@ -124,28 +124,23 @@ var workerType = workerTypeList[i];
                 "OK");
         }
 
-        [MenuItem(EditorConfig.ParentMenu + "/Validate Build Support", false, EditorConfig.MenuOffset + <#= workerTypeList.Count + 1 #>)]
-        private static void ValidateBuildSupport()
+        [MenuItem(EditorConfig.ParentMenu + "/Check Build Support", false, EditorConfig.MenuOffset + <#= workerTypeList.Count + 1 #>)]
+        private static void CheckBuildSupport()
         {
-            var validationsPassed = true;
+            bool checksPassed = CheckWorkersCanBuildForEnvironment(BuildEnvironment.Local, AllWorkers);
 
-            if (!ValidateWorkersCanBuildForEnvironment(BuildEnvironment.Local, AllWorkers))
+            if (!CheckWorkersCanBuildForEnvironment(BuildEnvironment.Cloud, AllWorkers))
             {
-                validationsPassed = false;
+                checksPassed = false;
             }
 
-            if (!ValidateWorkersCanBuildForEnvironment(BuildEnvironment.Cloud, AllWorkers))
-            {
-                validationsPassed = false;
-            }
-
-            EditorUtility.DisplayDialog("Build Support Validation",
-                validationsPassed
-                    ? "Build support validation confirms your Unity Editor installation has all necessary components."
-                    : "Build support validation failed. Please see the Unity Console Window for information.",
+            EditorUtility.DisplayDialog("Build Support Check",
+                checksPassed
+                    ? "Build support check passed. Your Unity Editor installation has all necessary components."
+                    : "Build support check failed. Please see the Unity Console Window for information.",
                 "OK");
 
-            Debug.Log("Diagnosis complete.");
+            Debug.Log("Build support check completed.");
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityWorkerMenuGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityWorkerMenuGenerator.tt
@@ -72,7 +72,7 @@ var workerType = workerTypeList[i];
             {
                 try
                 {
-                    WorkerBuilder.AssertWorkerCanBuildForEnvironment(workerType, environment);
+                    WorkerBuilder.ValidateWorkerCanBuildForEnvironment(workerType, environment);
                 }
                 catch (System.Exception e)
                 {


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Success:
![image](https://user-images.githubusercontent.com/31209570/47014143-48d81400-d141-11e8-9f4f-dbc3015a6c96.png)

Failure:
![image](https://user-images.githubusercontent.com/31209570/47014182-686f3c80-d141-11e8-98bf-55ce4aadfe1e.png)


Completed:
- [x] test for windows (with missing modules) - shows errors
- [x] test for windows (with modules) - doesn't show errors
- [x] test for mac (with missing modules) - shows errors
- [x] test for mac (with modules) - doesn't show errors

#### Tests
Tested locally, if you don't have build support, it gives errors before building and on validation

#### Documentation
- Needs to be done