### PR TITLE
Clarify optional step in the tutorial

### DIFF
--- a/docs/projects/fps/tutorial.md
+++ b/docs/projects/fps/tutorial.md
@@ -635,7 +635,7 @@ The newly authoritative worker will not know how long the cool-down had already 
 
 The `HandleCollisionWithPlayer` function in your `HealthPickupServerBehaviour.cs` script currently attempts to heal any colliding player. If the player is already on full health we might want to ignore them so that the health pack is not consumed and the health modifier command is never sent.
 
-At the beginning of the `HandleCollisionWithPlayer` function you could add an if-statement which reads the player's current health from `playerSpatialOsComponent` and returns early if their health is at maximum. In the code that handles incoming `ModifyHealthRequest` commands the player's health is clamped to the value of the `Health` component's `max_health` property, but it's preferable to avoid sending the request if we know it will be denied anyway.
+At the beginning of the `HandleCollisionWithPlayer` function you could add an if-statement which reads the player's current health from a Monobehaviour (that you will need to write) and returns early if their health is at the maximum. In the code that handles incoming `ModifyHealthRequest` commands the player's health is clamped to the value of the `Health` component's `max_health` property, but it's preferable to avoid sending the request if we know it will be denied anyway.
 
 # Testing health pickups locally
 


### PR DESCRIPTION
#### Description
The docs previously said to read the health from the `playerSpatialOsComponent` - which does not have any such method. Instead add a hint to add a monobehaviour on the player
#### Tests
Read the docs
#### Documentation
Si!
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.