### PR TITLE
Force Position to Replicate Last

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSSendSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSSendSystem.cs
@@ -17,6 +17,9 @@ namespace Improbable.Gdk.Core
     [UpdateInGroup(typeof(SpatialOSSendGroup.InternalSpatialOSSendGroup))]
     public class SpatialOSSendSystem : ComponentSystem
     {
+        // Can't access the generated component ID in Core code.
+        private const uint PositionComponentId = 54;
+
         private Connection connection;
 
         private readonly List<ComponentReplicator> componentReplicators =
@@ -89,6 +92,16 @@ namespace Improbable.Gdk.Core
 
                 AddComponentReplicator(componentReplicationHandler);
             }
+
+            // Force the position component to be replicated last to delay authority changes until this frame's updates
+            // are applied as expected. If the position update is applied earlier and triggers an authority change -
+            // the other updates may be dropped leading to inconsistent states.
+            var positionReplicatorIndex =
+                componentReplicators.FindIndex(replicator => replicator.ComponentId == PositionComponentId);
+            var positionReplicator = componentReplicators[positionReplicatorIndex];
+
+            componentReplicators.RemoveAt(positionReplicatorIndex);
+            componentReplicators.Add(positionReplicator);
         }
 
         private struct ComponentReplicator

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSSendSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSSendSystem.cs
@@ -93,9 +93,8 @@ namespace Improbable.Gdk.Core
                 AddComponentReplicator(componentReplicationHandler);
             }
 
-            // Force the position component to be replicated last to delay authority changes until this frame's updates
-            // are applied as expected. If the position update is applied earlier and triggers an authority change -
-            // the other updates may be dropped leading to inconsistent states.
+            // Force the position component to be replicated last. A position update can trigger an authority
+            // change, which could cause subsequent updates to be dropped.
             var positionReplicatorIndex =
                 componentReplicators.FindIndex(replicator => replicator.ComponentId == PositionComponentId);
             var positionReplicator = componentReplicators[positionReplicatorIndex];


### PR DESCRIPTION
#### Description
This PR forces the position component to be replicated last. Otherwise, the position change could trigger a load balancing operation that would cause valid update ops to be dropped.
#### Tests
Verified that position was hit last in the loop.
#### Documentation
N/A - Should this be documented? 
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.