### PR TITLE
UTY-1337: Worker Flags

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Unity.Entities;
 
 namespace Improbable.Gdk.Core
@@ -35,5 +36,16 @@ namespace Improbable.Gdk.Core
         ///     The reported reason for disconnecting
         /// </summary>
         public string ReasonForDisconnect;
+    }
+
+    /// <summary>
+    ///     ECS Component added to the worker entity which contains the worker flags
+    /// </summary>
+    public struct WorkerFlags : ISharedComponentData
+    {
+        /// <summary>
+        ///     A dictionary from flag name to flag value
+        /// </summary>
+        public Dictionary<string, string> Flags;
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/EntityGameObjectLinker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/EntityGameObjectLinker.cs
@@ -92,10 +92,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
             viewCommandBuffer.AddComponent(entity, new GameObjectReference { GameObject = gameObject });
 
             var spatialOSComponent = gameObject.AddComponent<SpatialOSComponent>();
-            spatialOSComponent.World = world;
-            spatialOSComponent.Worker = worker;
-            spatialOSComponent.Entity = entity;
-            spatialOSComponent.SpatialEntityId = spatialEntityId;
+            spatialOSComponent.Init(world, spatialEntityId, entity);
         }
 
         /// <summary>

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/SpatialOSComponent.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/SpatialOSComponent.cs
@@ -33,6 +33,22 @@ namespace Improbable.Gdk.GameObjectRepresentation
         private EntityManager entityManager;
 
         /// <summary>
+        ///     Initialise the SpatialOSComponent with its context.
+        /// </summary>
+        /// <param name="world">The ECS world which the underlying ECS entity belongs to.</param>
+        /// <param name="spatialEntityId">The entity ID of the SpatialOS entity.</param>
+        /// <param name="entity">The ECS entity that represents the SpatialOS entity.</param>
+        public void Init(World world, EntityId spatialEntityId, Entity entity)
+        {
+            World = world;
+            SpatialEntityId = spatialEntityId;
+            Entity = entity;
+            Worker = world.GetExistingManager<WorkerSystem>();
+
+            entityManager = world.GetExistingManager<EntityManager>();
+        }
+
+        /// <summary>
         ///     Checks whether a SpatialOS entity is in this worker's view.
         /// </summary>
         /// <param name="entityId">The entity ID to check.</param>
@@ -59,7 +75,6 @@ namespace Improbable.Gdk.GameObjectRepresentation
                 return false;
             }
 
-            entityManager = entityManager ?? World.GetOrCreateManager<EntityManager>();
             if (!entityManager.HasComponent<GameObjectReference>(entity))
             {
                 return false;
@@ -94,7 +109,6 @@ namespace Improbable.Gdk.GameObjectRepresentation
                 return false;
             }
 
-            entityManager = entityManager ?? World.GetOrCreateManager<EntityManager>();
             if (!entityManager.HasComponent<GameObjectReference>(component.Entity))
             {
                 return false;

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/SpatialOSComponent.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/SpatialOSComponent.cs
@@ -1,3 +1,4 @@
+using System;
 using Improbable.Gdk.Core;
 using Improbable.Worker;
 using Unity.Entities;
@@ -30,7 +31,17 @@ namespace Improbable.Gdk.GameObjectRepresentation
         /// </summary>
         public WorkerSystem Worker;
 
+        /// <summary>
+        ///     An event that triggers when a worker flag changes.
+        /// </summary>
+        public event Action<string, string> OnWorkerFlagChange
+        {
+            add => flagSystem.OnWorkerFlagChange += value;
+            remove => flagSystem.OnWorkerFlagChange -= value;
+        }
+
         private EntityManager entityManager;
+        private WorkerFlagSystem flagSystem;
 
         /// <summary>
         ///     Initialise the SpatialOSComponent with its context.
@@ -46,6 +57,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
             Worker = world.GetExistingManager<WorkerSystem>();
 
             entityManager = world.GetExistingManager<EntityManager>();
+            flagSystem = world.GetExistingManager<WorkerFlagSystem>();
         }
 
         /// <summary>

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/SpatialOSComponent.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/SpatialOSComponent.cs
@@ -44,6 +44,20 @@ namespace Improbable.Gdk.GameObjectRepresentation
         private WorkerFlagSystem flagSystem;
 
         /// <summary>
+        ///     Attempts to retrieve the value of a worker flag.
+        /// </summary>
+        /// <remarks>
+        ///     Will return null if no worker flag of "<see cref="name"/>" is found.
+        /// </remarks>
+        /// <param name="name">The name of the worker flag</param>
+        /// <returns>The value of the worker flag, if it exists, null otherwise.</returns>
+        public string TryGetWorkerFlag(string name)
+        {
+            var flags = entityManager.GetSharedComponentData<WorkerFlags>(Worker.WorkerEntity);
+            return !flags.Flags.TryGetValue(name, out var value) ? null : value;
+        }
+
+        /// <summary>
         ///     Initialise the SpatialOSComponent with its context.
         /// </summary>
         /// <param name="world">The ECS world which the underlying ECS entity belongs to.</param>

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
@@ -19,13 +19,14 @@ namespace Improbable.Gdk.Core
     [UpdateInGroup(typeof(SpatialOSReceiveGroup.InternalSpatialOSReceiveGroup))]
     public class SpatialOSReceiveSystem : ComponentSystem
     {
+        public List<Action<Unity.Entities.Entity>> AddAllCommandComponents = new List<Action<Unity.Entities.Entity>>();
+
+        internal Dispatcher Dispatcher;
+
         private WorkerSystem worker;
-        private Dispatcher dispatcher;
 
         private readonly Dictionary<uint, ComponentDispatcherHandler> componentSpecificDispatchers =
             new Dictionary<uint, ComponentDispatcherHandler>();
-
-        public List<Action<Unity.Entities.Entity>> AddAllCommandComponents = new List<Action<Unity.Entities.Entity>>();
 
         private bool inCriticalSection;
 
@@ -44,7 +45,7 @@ namespace Improbable.Gdk.Core
             base.OnCreateManager();
 
             worker = World.GetExistingManager<WorkerSystem>();
-            dispatcher = new Dispatcher();
+            Dispatcher = new Dispatcher();
             SetupDispatcherHandlers();
 
             var requestTracker = World.GetOrCreateManager<CommandRequestTrackerSystem>();
@@ -76,7 +77,7 @@ namespace Improbable.Gdk.Core
             {
                 using (var opList = worker.Connection.GetOpList(0))
                 {
-                    dispatcher.Process(opList);
+                    Dispatcher.Process(opList);
                 }
             }
             while (inCriticalSection);
@@ -404,23 +405,23 @@ namespace Improbable.Gdk.Core
                     Activator.CreateInstance(componentDispatcherType, worker, World));
             }
 
-            dispatcher.OnAddEntity(OnAddEntity);
-            dispatcher.OnRemoveEntity(OnRemoveEntity);
-            dispatcher.OnDisconnect(OnDisconnect);
-            dispatcher.OnCriticalSection(op => { inCriticalSection = op.InCriticalSection; });
+            Dispatcher.OnAddEntity(OnAddEntity);
+            Dispatcher.OnRemoveEntity(OnRemoveEntity);
+            Dispatcher.OnDisconnect(OnDisconnect);
+            Dispatcher.OnCriticalSection(op => { inCriticalSection = op.InCriticalSection; });
 
-            dispatcher.OnAddComponent(OnAddComponent);
-            dispatcher.OnRemoveComponent(OnRemoveComponent);
-            dispatcher.OnComponentUpdate(OnComponentUpdate);
-            dispatcher.OnAuthorityChange(OnAuthorityChange);
+            Dispatcher.OnAddComponent(OnAddComponent);
+            Dispatcher.OnRemoveComponent(OnRemoveComponent);
+            Dispatcher.OnComponentUpdate(OnComponentUpdate);
+            Dispatcher.OnAuthorityChange(OnAuthorityChange);
 
-            dispatcher.OnCommandRequest(OnCommandRequest);
-            dispatcher.OnCommandResponse(OnCommandResponse);
+            Dispatcher.OnCommandRequest(OnCommandRequest);
+            Dispatcher.OnCommandResponse(OnCommandResponse);
 
-            dispatcher.OnCreateEntityResponse(OnCreateEntityResponse);
-            dispatcher.OnDeleteEntityResponse(OnDeleteEntityResponse);
-            dispatcher.OnReserveEntityIdsResponse(OnReserveEntityIdsResponse);
-            dispatcher.OnEntityQueryResponse(OnEntityQueryResponse);
+            Dispatcher.OnCreateEntityResponse(OnCreateEntityResponse);
+            Dispatcher.OnDeleteEntityResponse(OnDeleteEntityResponse);
+            Dispatcher.OnReserveEntityIdsResponse(OnReserveEntityIdsResponse);
+            Dispatcher.OnEntityQueryResponse(OnEntityQueryResponse);
 
             ClientError.ExceptionCallback = HandleException;
         }

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerFlagSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerFlagSystem.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using Improbable.Worker.Core;
+using Unity.Entities;
+using UnityEngine;
+using Entity = Unity.Entities.Entity;
+
+namespace Improbable.Gdk.Core
+{
+    /// <summary>
+    ///     Updates worker flags on the worker entity and provides a callback on worker flag changes.
+    /// </summary>
+    [DisableAutoCreation]
+    [UpdateInGroup(typeof(SpatialOSReceiveGroup.InternalSpatialOSReceiveGroup))]
+    [UpdateAfter(typeof(SpatialOSReceiveSystem))]
+    public class WorkerFlagSystem : ComponentSystem
+    {
+        /// <summary>
+        ///     An event which is triggered when a worker flag changes
+        /// </summary>
+        /// <remarks>
+        ///     Note that this is not fired when the Dispatcher callback is fired, but after the local view is updated
+        ///     completely.
+        /// </remarks>
+        public event Action<string, string> OnWorkerFlagChange;
+
+        // Okay to keep a copy of the struct as the reference to the dictionary inside will still be valid.
+        private WorkerFlags flags;
+
+        private readonly List<(string, string)> queuedFlagChanges = new List<(string, string)>();
+
+        protected override void OnCreateManager()
+        {
+            base.OnCreateManager();
+
+            var receiveSystem = World.GetOrCreateManager<SpatialOSReceiveSystem>();
+            receiveSystem.Dispatcher.OnFlagUpdate(OnFlagUpdate);
+
+            var workerEntity = World.GetExistingManager<WorkerSystem>().WorkerEntity;
+            flags = EntityManager.GetSharedComponentData<WorkerFlags>(workerEntity);
+        }
+
+        protected override void OnUpdate()
+        {
+            if (OnWorkerFlagChange == null)
+            {
+                return;
+            }
+
+            foreach (var (name, value) in queuedFlagChanges)
+            {
+                OnWorkerFlagChange.Invoke(name, value);
+            }
+
+            queuedFlagChanges.Clear();
+        }
+
+        private void OnFlagUpdate(FlagUpdateOp op)
+        {
+            flags.Flags[op.Name] = op.Value;
+            queuedFlagChanges.Add((op.Name, op.Value));
+        }
+    }
+
+}
+
+

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerFlagSystem.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerFlagSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eeb5ae1167152d94db94ba2ae642330c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs
@@ -53,8 +53,14 @@ namespace Improbable.Gdk.Core
         {
             base.OnCreateManager();
             var entityManager = World.GetOrCreateManager<EntityManager>();
-            WorkerEntity = entityManager.CreateEntity(typeof(OnConnected), typeof(WorkerEntityTag));
+            WorkerEntity = entityManager.CreateEntity(ComponentType.Create<OnConnected>(),
+                ComponentType.Create<WorkerEntityTag>(), ComponentType.Create<WorkerFlags>());
             Enabled = false;
+
+            entityManager.SetSharedComponentData(WorkerEntity, new WorkerFlags
+            {
+                Flags = new Dictionary<string, string>()
+            });
         }
 
         protected override void OnUpdate()

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/GameObjectRepresentation/SpatialOSComponentTests.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/GameObjectRepresentation/SpatialOSComponentTests.cs
@@ -140,10 +140,7 @@ namespace Improbable.Gdk.Core.EditmodeTests
         private static SpatialOSComponent LinkGameObjectToEntity(EntityId entityId, Entity entity, GameObject gameObject, World world)
         {
             var spatialOSComponent = gameObject.AddComponent<SpatialOSComponent>();
-            spatialOSComponent.Worker = world.GetExistingManager<WorkerSystem>();
-            spatialOSComponent.World = world;
-            spatialOSComponent.Entity = entity;
-            spatialOSComponent.SpatialEntityId = entityId;
+            spatialOSComponent.Init(world, entityId, entity);
             return spatialOSComponent;
         }
     }

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs
@@ -194,6 +194,7 @@ namespace Improbable.Gdk.Core
             World.CreateManager<WorkerSystem>(Connection, LogDispatcher, WorkerType, Origin);
             World.GetOrCreateManager<SpatialOSSendSystem>();
             World.GetOrCreateManager<SpatialOSReceiveSystem>();
+            World.GetOrCreateManager<WorkerFlagSystem>();
             World.GetOrCreateManager<CleanReactiveComponentsSystem>();
             World.GetOrCreateManager<WorldCommandsCleanSystem>();
             World.GetOrCreateManager<WorldCommandsSendSystem>();


### PR DESCRIPTION
#### Description
Added worker flags in both the ECS and Monobehaviour workflows.
* Added the worker flags in a `Dictionary` on a SharedComponent on the Worker Entity.
* Added a `WorkerFlagSystem` which registers on the Dispatcher and defers callbacks until it is updated.
* Small refactor on `SpatialOSComponent`
* Add event on `SpatialOSComponent` to register for WorkerFlag changes.
* Add a `TryGetWorkerFlag(string name)` method on `SpatialOSComponent`

#### Tests
Tested both workflows via a cloud deployment. See example usage below.
#### Documentation
Will need to be documented.
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@samiwh @zeroZshadow 

#### Example Usage

**ECS**
```
    [DisableAutoCreation]
    [UpdateInGroup(typeof(SpatialOSUpdateGroup))]
    internal class FlagTestSystem: ComponentSystem
    {
        private struct Flags
        {
            public readonly int Length;
            [ReadOnly] public SharedComponentDataArray<WorkerFlags> WorkerFlags;
        }

        [Inject] private Flags flags;

        private ILogDispatcher logDispatcher;
        private int tick;

        protected override void OnCreateManager()
        {
            base.OnCreateManager();

            logDispatcher = World.GetExistingManager<WorkerSystem>().LogDispatcher;
        }

        protected override void OnUpdate()
        {
            for (var i = 0; i < flags.Length; i++)
            {
                var f = flags.WorkerFlags[i];

                foreach (var flagPairs in f.Flags)
                {
                    logDispatcher.HandleLog(LogType.Warning, new LogEvent($"ECS Flag: {flagPairs.Key}, Value: {flagPairs.Value}"));
                }
            }
        }
    }
```

**Monobehaviours**
```
    public class FlagReader : MonoBehaviour
    {
        private void OnEnable()
        {
            GetComponent<SpatialOSComponent>().OnWorkerFlagChange += OnWorkerFlagChange;

            var value = GetComponent<SpatialOSComponent>().TryGetWorkerFlag("world_size");

            if (value != null)
            {
                GetComponent<SpatialOSComponent>().Worker.LogDispatcher.HandleLog(LogType.Warning, new LogEvent($"Flag: world_size, Value: {value}"));
            }
        }

        private void OnWorkerFlagChange(string name, string value)
        {
            GetComponent<SpatialOSComponent>().Worker.LogDispatcher.HandleLog(LogType.Warning, new LogEvent($"Flag: {name}, Value: {value}"));
        }
    }
```