### PR TITLE
fixing link to worker.json

### DIFF
--- a/docs/content/set-up-new-project.md
+++ b/docs/content/set-up-new-project.md
@@ -8,7 +8,7 @@ The **spatialos.json** file for your project needs to have the same `sdk_version
 
 For a basic set up of two workers, one `UnityGameLogic` and one `UnityClient`, we recommend you to reuse these files (within `workers/unity`):
 - [spatialos.UnityGameLogic.worker.json](https://github.com/spatialos/gdk-for-unity/blob/master/workers/unity/spatialos.UnityGameLogic.worker.json)
-- [spatialos.UnityClient.worker.json](https://github.com/spatialos/gdk-for-unity/blob/master/workers/unity/spatialos.UnityGameLogic.worker.json)
+- [spatialos.UnityClient.worker.json](https://github.com/spatialos/gdk-for-unity/blob/master/workers/unity/spatialos.UnityClient.worker.json)
 
 ## Set up base assets and directories
 - Copy [this file](https://github.com/spatialos/gdk-for-unity/blob/master/workers/unity/Assets/Generated/Improbable.Gdk.Generated.asmdef) into `workers/unity/Assets/Generated/Improbable.Gdk.Generated.asmdef`.

--- a/docs/content/set-up-new-project.md
+++ b/docs/content/set-up-new-project.md
@@ -7,11 +7,13 @@ To use the SpatialOS GDK for Unity in a new project, you need to set up your pro
 The **spatialos.json** file for your project needs to have the same `sdk_version` and `dependencies` as the GDK's [spatialos.json](https://github.com/spatialos/gdk-for-unity/blob/master/spatialos.json).
 
 For a basic set up of two workers, one `UnityGameLogic` and one `UnityClient`, we recommend you to reuse these files (within `workers/unity`):
-- [spatialos.UnityGameLogic.worker.json](https://github.com/spatialos/gdk-for-unity/blob/master/workers/unity/spatialos.UnityGameLogic.worker.json)
-- [spatialos.UnityClient.worker.json](https://github.com/spatialos/gdk-for-unity/blob/master/workers/unity/spatialos.UnityClient.worker.json)
+
+  * [spatialos.UnityGameLogic.worker.json](https://github.com/spatialos/gdk-for-unity/blob/master/workers/unity/spatialos.UnityGameLogic.worker.json)
+  * [spatialos.UnityClient.worker.json](https://github.com/spatialos/gdk-for-unity/blob/master/workers/unity/spatialos.UnityClient.worker.json)
 
 ## Set up base assets and directories
-- Copy [this file](https://github.com/spatialos/gdk-for-unity/blob/master/workers/unity/Assets/Generated/Improbable.Gdk.Generated.asmdef) into `workers/unity/Assets/Generated/Improbable.Gdk.Generated.asmdef`.
+
+  * Copy [this file](https://github.com/spatialos/gdk-for-unity/blob/master/workers/unity/Assets/Generated/Improbable.Gdk.Generated.asmdef) into `workers/unity/Assets/Generated/Improbable.Gdk.Generated.asmdef`.
 
 ## Set up your project manifest
 Add the following dependencies to the `packages` manifest located inside `workers/unity/Packages/manifest.json`:


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Link to the `spatialos.Unityclient.worker.json` was pointing to the GameLogic one.

#### Tests
checked the preview mode

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.