### PR TITLE
Added Dynamic in for generic component functionality

### DIFF
--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingular.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingular.cs
@@ -2,14 +2,18 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
-using Unity.Entities;
 using Improbable.Gdk.Core;
+using Improbable.Worker.Core;
+using System;
 using System.Collections.Generic;
+using Unity.Entities;
 
 namespace Improbable.Gdk.Tests
 {
     public partial class ExhaustiveBlittableSingular
     {
+        public const uint ComponentId = 197720;
+
         public struct Component : IComponentData, ISpatialComponentData
         {
             public uint ComponentId => 197720;
@@ -651,6 +655,38 @@ namespace Improbable.Gdk.Tests
             public global::System.Collections.Generic.List<Update> Updates
             {
                 get => Improbable.Gdk.Tests.ExhaustiveBlittableSingular.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+            }
+        }
+
+        internal class ExhaustiveBlittableSingularDynamic : IDynamicInvokable
+        {
+            public uint ComponentId => ExhaustiveBlittableSingular.ComponentId;
+
+            private static Component DeserializeData(ComponentData data, World world)
+            {
+                var schemaDataOpt = data.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentData)}");
+                }
+
+                return Serialization.Deserialize(schemaDataOpt.Value.GetFields(), world);
+            }
+
+            private static Update DeserializeUpdate(ComponentUpdate update, World world)
+            {
+                var schemaDataOpt = update.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentUpdate)}");
+                }
+
+                return Serialization.DeserializeUpdate(schemaDataOpt.Value);
+            }
+
+            public void InvokeHandler(Dynamic.IHandler handler)
+            {
+                handler.Accept<Component, Update>(ExhaustiveBlittableSingular.ComponentId, DeserializeData, DeserializeUpdate);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKey.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKey.cs
@@ -2,14 +2,18 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
-using Unity.Entities;
 using Improbable.Gdk.Core;
+using Improbable.Worker.Core;
+using System;
 using System.Collections.Generic;
+using Unity.Entities;
 
 namespace Improbable.Gdk.Tests
 {
     public partial class ExhaustiveMapKey
     {
+        public const uint ComponentId = 197719;
+
         public struct Component : IComponentData, ISpatialComponentData
         {
             public uint ComponentId => 197719;
@@ -1736,6 +1740,38 @@ namespace Improbable.Gdk.Tests
             public global::System.Collections.Generic.List<Update> Updates
             {
                 get => Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+            }
+        }
+
+        internal class ExhaustiveMapKeyDynamic : IDynamicInvokable
+        {
+            public uint ComponentId => ExhaustiveMapKey.ComponentId;
+
+            private static Component DeserializeData(ComponentData data, World world)
+            {
+                var schemaDataOpt = data.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentData)}");
+                }
+
+                return Serialization.Deserialize(schemaDataOpt.Value.GetFields(), world);
+            }
+
+            private static Update DeserializeUpdate(ComponentUpdate update, World world)
+            {
+                var schemaDataOpt = update.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentUpdate)}");
+                }
+
+                return Serialization.DeserializeUpdate(schemaDataOpt.Value);
+            }
+
+            public void InvokeHandler(Dynamic.IHandler handler)
+            {
+                handler.Accept<Component, Update>(ExhaustiveMapKey.ComponentId, DeserializeData, DeserializeUpdate);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValue.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValue.cs
@@ -2,14 +2,18 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
-using Unity.Entities;
 using Improbable.Gdk.Core;
+using Improbable.Worker.Core;
+using System;
 using System.Collections.Generic;
+using Unity.Entities;
 
 namespace Improbable.Gdk.Tests
 {
     public partial class ExhaustiveMapValue
     {
+        public const uint ComponentId = 197718;
+
         public struct Component : IComponentData, ISpatialComponentData
         {
             public uint ComponentId => 197718;
@@ -1736,6 +1740,38 @@ namespace Improbable.Gdk.Tests
             public global::System.Collections.Generic.List<Update> Updates
             {
                 get => Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+            }
+        }
+
+        internal class ExhaustiveMapValueDynamic : IDynamicInvokable
+        {
+            public uint ComponentId => ExhaustiveMapValue.ComponentId;
+
+            private static Component DeserializeData(ComponentData data, World world)
+            {
+                var schemaDataOpt = data.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentData)}");
+                }
+
+                return Serialization.Deserialize(schemaDataOpt.Value.GetFields(), world);
+            }
+
+            private static Update DeserializeUpdate(ComponentUpdate update, World world)
+            {
+                var schemaDataOpt = update.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentUpdate)}");
+                }
+
+                return Serialization.DeserializeUpdate(schemaDataOpt.Value);
+            }
+
+            public void InvokeHandler(Dynamic.IHandler handler)
+            {
+                handler.Accept<Component, Update>(ExhaustiveMapValue.ComponentId, DeserializeData, DeserializeUpdate);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptional.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptional.cs
@@ -2,14 +2,18 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
-using Unity.Entities;
 using Improbable.Gdk.Core;
+using Improbable.Worker.Core;
+using System;
 using System.Collections.Generic;
+using Unity.Entities;
 
 namespace Improbable.Gdk.Tests
 {
     public partial class ExhaustiveOptional
     {
+        public const uint ComponentId = 197716;
+
         public struct Component : IComponentData, ISpatialComponentData
         {
             public uint ComponentId => 197716;
@@ -1481,6 +1485,38 @@ namespace Improbable.Gdk.Tests
             public global::System.Collections.Generic.List<Update> Updates
             {
                 get => Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+            }
+        }
+
+        internal class ExhaustiveOptionalDynamic : IDynamicInvokable
+        {
+            public uint ComponentId => ExhaustiveOptional.ComponentId;
+
+            private static Component DeserializeData(ComponentData data, World world)
+            {
+                var schemaDataOpt = data.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentData)}");
+                }
+
+                return Serialization.Deserialize(schemaDataOpt.Value.GetFields(), world);
+            }
+
+            private static Update DeserializeUpdate(ComponentUpdate update, World world)
+            {
+                var schemaDataOpt = update.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentUpdate)}");
+                }
+
+                return Serialization.DeserializeUpdate(schemaDataOpt.Value);
+            }
+
+            public void InvokeHandler(Dynamic.IHandler handler)
+            {
+                handler.Accept<Component, Update>(ExhaustiveOptional.ComponentId, DeserializeData, DeserializeUpdate);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeated.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeated.cs
@@ -2,14 +2,18 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
-using Unity.Entities;
 using Improbable.Gdk.Core;
+using Improbable.Worker.Core;
+using System;
 using System.Collections.Generic;
+using Unity.Entities;
 
 namespace Improbable.Gdk.Tests
 {
     public partial class ExhaustiveRepeated
     {
+        public const uint ComponentId = 197717;
+
         public struct Component : IComponentData, ISpatialComponentData
         {
             public uint ComponentId => 197717;
@@ -1549,6 +1553,38 @@ namespace Improbable.Gdk.Tests
             public global::System.Collections.Generic.List<Update> Updates
             {
                 get => Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+            }
+        }
+
+        internal class ExhaustiveRepeatedDynamic : IDynamicInvokable
+        {
+            public uint ComponentId => ExhaustiveRepeated.ComponentId;
+
+            private static Component DeserializeData(ComponentData data, World world)
+            {
+                var schemaDataOpt = data.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentData)}");
+                }
+
+                return Serialization.Deserialize(schemaDataOpt.Value.GetFields(), world);
+            }
+
+            private static Update DeserializeUpdate(ComponentUpdate update, World world)
+            {
+                var schemaDataOpt = update.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentUpdate)}");
+                }
+
+                return Serialization.DeserializeUpdate(schemaDataOpt.Value);
+            }
+
+            public void InvokeHandler(Dynamic.IHandler handler)
+            {
+                handler.Accept<Component, Update>(ExhaustiveRepeated.ComponentId, DeserializeData, DeserializeUpdate);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingular.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingular.cs
@@ -2,14 +2,18 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
-using Unity.Entities;
 using Improbable.Gdk.Core;
+using Improbable.Worker.Core;
+using System;
 using System.Collections.Generic;
+using Unity.Entities;
 
 namespace Improbable.Gdk.Tests
 {
     public partial class ExhaustiveSingular
     {
+        public const uint ComponentId = 197715;
+
         public struct Component : IComponentData, ISpatialComponentData
         {
             public uint ComponentId => 197715;
@@ -731,6 +735,38 @@ namespace Improbable.Gdk.Tests
             public global::System.Collections.Generic.List<Update> Updates
             {
                 get => Improbable.Gdk.Tests.ExhaustiveSingular.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+            }
+        }
+
+        internal class ExhaustiveSingularDynamic : IDynamicInvokable
+        {
+            public uint ComponentId => ExhaustiveSingular.ComponentId;
+
+            private static Component DeserializeData(ComponentData data, World world)
+            {
+                var schemaDataOpt = data.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentData)}");
+                }
+
+                return Serialization.Deserialize(schemaDataOpt.Value.GetFields(), world);
+            }
+
+            private static Update DeserializeUpdate(ComponentUpdate update, World world)
+            {
+                var schemaDataOpt = update.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentUpdate)}");
+                }
+
+                return Serialization.DeserializeUpdate(schemaDataOpt.Value);
+            }
+
+            public void InvokeHandler(Dynamic.IHandler handler)
+            {
+                handler.Accept<Component, Update>(ExhaustiveSingular.ComponentId, DeserializeData, DeserializeUpdate);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponent.cs
@@ -2,14 +2,18 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
-using Unity.Entities;
 using Improbable.Gdk.Core;
+using Improbable.Worker.Core;
+using System;
 using System.Collections.Generic;
+using Unity.Entities;
 
 namespace Improbable.Gdk.Tests
 {
     public partial class NestedComponent
     {
+        public const uint ComponentId = 20152;
+
         public struct Component : IComponentData, ISpatialComponentData
         {
             public uint ComponentId => 20152;
@@ -105,6 +109,38 @@ namespace Improbable.Gdk.Tests
             public global::System.Collections.Generic.List<Update> Updates
             {
                 get => Improbable.Gdk.Tests.NestedComponent.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+            }
+        }
+
+        internal class NestedComponentDynamic : IDynamicInvokable
+        {
+            public uint ComponentId => NestedComponent.ComponentId;
+
+            private static Component DeserializeData(ComponentData data, World world)
+            {
+                var schemaDataOpt = data.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentData)}");
+                }
+
+                return Serialization.Deserialize(schemaDataOpt.Value.GetFields(), world);
+            }
+
+            private static Update DeserializeUpdate(ComponentUpdate update, World world)
+            {
+                var schemaDataOpt = update.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentUpdate)}");
+                }
+
+                return Serialization.DeserializeUpdate(schemaDataOpt.Value);
+            }
+
+            public void InvokeHandler(Dynamic.IHandler handler)
+            {
+                handler.Accept<Component, Update>(NestedComponent.ComponentId, DeserializeData, DeserializeUpdate);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/Connection.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/Connection.cs
@@ -2,14 +2,18 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
-using Unity.Entities;
 using Improbable.Gdk.Core;
+using Improbable.Worker.Core;
+using System;
 using System.Collections.Generic;
+using Unity.Entities;
 
 namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
 {
     public partial class Connection
     {
+        public const uint ComponentId = 1105;
+
         public struct Component : IComponentData, ISpatialComponentData
         {
             public uint ComponentId => 1105;
@@ -66,6 +70,38 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
             public global::System.Collections.Generic.List<Update> Updates
             {
                 get => Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+            }
+        }
+
+        internal class ConnectionDynamic : IDynamicInvokable
+        {
+            public uint ComponentId => Connection.ComponentId;
+
+            private static Component DeserializeData(ComponentData data, World world)
+            {
+                var schemaDataOpt = data.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentData)}");
+                }
+
+                return Serialization.Deserialize(schemaDataOpt.Value.GetFields(), world);
+            }
+
+            private static Update DeserializeUpdate(ComponentUpdate update, World world)
+            {
+                var schemaDataOpt = update.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentUpdate)}");
+                }
+
+                return Serialization.DeserializeUpdate(schemaDataOpt.Value);
+            }
+
+            public void InvokeHandler(Dynamic.IHandler handler)
+            {
+                handler.Accept<Component, Update>(Connection.ComponentId, DeserializeData, DeserializeUpdate);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponent.cs
@@ -2,14 +2,18 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
-using Unity.Entities;
 using Improbable.Gdk.Core;
+using Improbable.Worker.Core;
+using System;
 using System.Collections.Generic;
+using Unity.Entities;
 
 namespace Improbable.Gdk.Tests.BlittableTypes
 {
     public partial class BlittableComponent
     {
+        public const uint ComponentId = 1001;
+
         public struct Component : IComponentData, ISpatialComponentData
         {
             public uint ComponentId => 1001;
@@ -261,6 +265,38 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             public global::System.Collections.Generic.List<Update> Updates
             {
                 get => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+            }
+        }
+
+        internal class BlittableComponentDynamic : IDynamicInvokable
+        {
+            public uint ComponentId => BlittableComponent.ComponentId;
+
+            private static Component DeserializeData(ComponentData data, World world)
+            {
+                var schemaDataOpt = data.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentData)}");
+                }
+
+                return Serialization.Deserialize(schemaDataOpt.Value.GetFields(), world);
+            }
+
+            private static Update DeserializeUpdate(ComponentUpdate update, World world)
+            {
+                var schemaDataOpt = update.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentUpdate)}");
+                }
+
+                return Serialization.DeserializeUpdate(schemaDataOpt.Value);
+            }
+
+            public void InvokeHandler(Dynamic.IHandler handler)
+            {
+                handler.Accept<Component, Update>(BlittableComponent.ComponentId, DeserializeData, DeserializeUpdate);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFields.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFields.cs
@@ -2,14 +2,18 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
-using Unity.Entities;
 using Improbable.Gdk.Core;
+using Improbable.Worker.Core;
+using System;
 using System.Collections.Generic;
+using Unity.Entities;
 
 namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 {
     public partial class ComponentWithNoFields
     {
+        public const uint ComponentId = 1003;
+
         public struct Component : IComponentData, ISpatialComponentData
         {
             public uint ComponentId => 1003;
@@ -66,6 +70,38 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             public global::System.Collections.Generic.List<Update> Updates
             {
                 get => Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+            }
+        }
+
+        internal class ComponentWithNoFieldsDynamic : IDynamicInvokable
+        {
+            public uint ComponentId => ComponentWithNoFields.ComponentId;
+
+            private static Component DeserializeData(ComponentData data, World world)
+            {
+                var schemaDataOpt = data.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentData)}");
+                }
+
+                return Serialization.Deserialize(schemaDataOpt.Value.GetFields(), world);
+            }
+
+            private static Update DeserializeUpdate(ComponentUpdate update, World world)
+            {
+                var schemaDataOpt = update.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentUpdate)}");
+                }
+
+                return Serialization.DeserializeUpdate(schemaDataOpt.Value);
+            }
+
+            public void InvokeHandler(Dynamic.IHandler handler)
+            {
+                handler.Accept<Component, Update>(ComponentWithNoFields.ComponentId, DeserializeData, DeserializeUpdate);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommands.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommands.cs
@@ -2,14 +2,18 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
-using Unity.Entities;
 using Improbable.Gdk.Core;
+using Improbable.Worker.Core;
+using System;
 using System.Collections.Generic;
+using Unity.Entities;
 
 namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 {
     public partial class ComponentWithNoFieldsWithCommands
     {
+        public const uint ComponentId = 1005;
+
         public struct Component : IComponentData, ISpatialComponentData
         {
             public uint ComponentId => 1005;
@@ -66,6 +70,38 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             public global::System.Collections.Generic.List<Update> Updates
             {
                 get => Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+            }
+        }
+
+        internal class ComponentWithNoFieldsWithCommandsDynamic : IDynamicInvokable
+        {
+            public uint ComponentId => ComponentWithNoFieldsWithCommands.ComponentId;
+
+            private static Component DeserializeData(ComponentData data, World world)
+            {
+                var schemaDataOpt = data.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentData)}");
+                }
+
+                return Serialization.Deserialize(schemaDataOpt.Value.GetFields(), world);
+            }
+
+            private static Update DeserializeUpdate(ComponentUpdate update, World world)
+            {
+                var schemaDataOpt = update.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentUpdate)}");
+                }
+
+                return Serialization.DeserializeUpdate(schemaDataOpt.Value);
+            }
+
+            public void InvokeHandler(Dynamic.IHandler handler)
+            {
+                handler.Accept<Component, Update>(ComponentWithNoFieldsWithCommands.ComponentId, DeserializeData, DeserializeUpdate);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEvents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEvents.cs
@@ -2,14 +2,18 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
-using Unity.Entities;
 using Improbable.Gdk.Core;
+using Improbable.Worker.Core;
+using System;
 using System.Collections.Generic;
+using Unity.Entities;
 
 namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 {
     public partial class ComponentWithNoFieldsWithEvents
     {
+        public const uint ComponentId = 1004;
+
         public struct Component : IComponentData, ISpatialComponentData
         {
             public uint ComponentId => 1004;
@@ -66,6 +70,38 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             public global::System.Collections.Generic.List<Update> Updates
             {
                 get => Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+            }
+        }
+
+        internal class ComponentWithNoFieldsWithEventsDynamic : IDynamicInvokable
+        {
+            public uint ComponentId => ComponentWithNoFieldsWithEvents.ComponentId;
+
+            private static Component DeserializeData(ComponentData data, World world)
+            {
+                var schemaDataOpt = data.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentData)}");
+                }
+
+                return Serialization.Deserialize(schemaDataOpt.Value.GetFields(), world);
+            }
+
+            private static Update DeserializeUpdate(ComponentUpdate update, World world)
+            {
+                var schemaDataOpt = update.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentUpdate)}");
+                }
+
+                return Serialization.DeserializeUpdate(schemaDataOpt.Value);
+            }
+
+            public void InvokeHandler(Dynamic.IHandler handler)
+            {
+                handler.Accept<Component, Update>(ComponentWithNoFieldsWithEvents.ComponentId, DeserializeData, DeserializeUpdate);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponent.cs
@@ -2,14 +2,18 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
-using Unity.Entities;
 using Improbable.Gdk.Core;
+using Improbable.Worker.Core;
+using System;
 using System.Collections.Generic;
+using Unity.Entities;
 
 namespace Improbable.Gdk.Tests.NonblittableTypes
 {
     public partial class NonBlittableComponent
     {
+        public const uint ComponentId = 1002;
+
         public struct Component : IComponentData, ISpatialComponentData
         {
             public uint ComponentId => 1002;
@@ -579,6 +583,38 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             public global::System.Collections.Generic.List<Update> Updates
             {
                 get => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+            }
+        }
+
+        internal class NonBlittableComponentDynamic : IDynamicInvokable
+        {
+            public uint ComponentId => NonBlittableComponent.ComponentId;
+
+            private static Component DeserializeData(ComponentData data, World world)
+            {
+                var schemaDataOpt = data.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentData)}");
+                }
+
+                return Serialization.Deserialize(schemaDataOpt.Value.GetFields(), world);
+            }
+
+            private static Update DeserializeUpdate(ComponentUpdate update, World world)
+            {
+                var schemaDataOpt = update.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentUpdate)}");
+                }
+
+                return Serialization.DeserializeUpdate(schemaDataOpt.Value);
+            }
+
+            public void InvokeHandler(Dynamic.IHandler handler)
+            {
+                handler.Accept<Component, Update>(NonBlittableComponent.ComponentId, DeserializeData, DeserializeUpdate);
             }
         }
     }

--- a/workers/unity/Packages/com.improbable.gdk.core/Dynamic.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Dynamic.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0c5a043d9c8342b4dafee05e9bc60bb7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/Dynamic/Dynamic.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Dynamic/Dynamic.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using Improbable.Worker.Core;
+using Unity.Entities;
+
+namespace Improbable.Gdk.Core
+{
+    public delegate T ComponentDeserializer<out T>(ComponentData data, World world) where T : ISpatialComponentData;
+
+    public delegate T UpdateDeserializer<out T>(ComponentUpdate update, World world) where T : ISpatialComponentUpdate;
+
+    public static class Dynamic
+    {
+        public interface IHandler
+        {
+            void Accept<TData, TUpdate>(uint componentId,
+                ComponentDeserializer<TData> deserializeComponentData,
+                UpdateDeserializer<TUpdate> deserializeComponentUpdate)
+                where TData : ISpatialComponentData
+                where TUpdate : ISpatialComponentUpdate;
+        }
+
+        private static readonly Dictionary<uint, IDynamicInvokable> idsToComponents =
+            new Dictionary<uint, IDynamicInvokable>();
+
+        private static readonly Dictionary<Type, uint> componentsToIds = new Dictionary<Type, uint>();
+
+        static Dynamic()
+        {
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                foreach (var type in assembly.GetTypes())
+                {
+                    if (typeof(IDynamicInvokable).IsAssignableFrom(type) && !type.IsAbstract)
+                    {
+                        var instance = (IDynamicInvokable) Activator.CreateInstance(type);
+                        idsToComponents.Add(instance.ComponentId, instance);
+                    }
+
+                    if (typeof(ISpatialComponentData).IsAssignableFrom(type) && !type.IsAbstract)
+                    {
+                        var instance = (ISpatialComponentData) Activator.CreateInstance(type);
+                        componentsToIds.Add(type, instance.ComponentId);
+                    }
+                }
+            }
+        }
+
+        public static void ForEachComponent(IHandler handler)
+        {
+            foreach (var component in idsToComponents.Values)
+            {
+                component.InvokeHandler(handler);
+            }
+        }
+
+        public static void ForComponent(uint componentId, IHandler handler)
+        {
+            if (!idsToComponents.TryGetValue(componentId, out var component))
+            {
+                throw new ArgumentException($"Unknown component ID {componentId}.");
+            }
+
+            component.InvokeHandler(handler);
+        }
+
+        public static uint GetComponentId<T>() where T : ISpatialComponentData
+        {
+            if (!componentsToIds.TryGetValue(typeof(T), out var id))
+            {
+                throw new ArgumentException($"Can not find ID for unregistered SpatialOS component {nameof(T)}.");
+            }
+
+            return id;
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Dynamic/Dynamic.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Dynamic/Dynamic.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f70702bcdd4a90a4faa4106a70f389f0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/Dynamic/IDynamicInvokable.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Dynamic/IDynamicInvokable.cs
@@ -1,0 +1,8 @@
+namespace Improbable.Gdk.Core
+{
+    public interface IDynamicInvokable
+    {
+        uint ComponentId { get; }
+        void InvokeHandler(Dynamic.IHandler handler);
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Dynamic/IDynamicInvokable.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Dynamic/IDynamicInvokable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f26b430b115a6c041845d76d3b234c7f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
@@ -19,8 +19,9 @@ namespace Improbable.Gdk.Core
     [UpdateInGroup(typeof(SpatialOSReceiveGroup.InternalSpatialOSReceiveGroup))]
     public class SpatialOSReceiveSystem : ComponentSystem
     {
+        public Dispatcher Dispatcher;
+
         private WorkerSystem worker;
-        private Dispatcher dispatcher;
 
         private readonly Dictionary<uint, ComponentDispatcherHandler> componentSpecificDispatchers =
             new Dictionary<uint, ComponentDispatcherHandler>();
@@ -44,7 +45,7 @@ namespace Improbable.Gdk.Core
             base.OnCreateManager();
 
             worker = World.GetExistingManager<WorkerSystem>();
-            dispatcher = new Dispatcher();
+            Dispatcher = new Dispatcher();
             SetupDispatcherHandlers();
 
             var requestTracker = World.GetOrCreateManager<CommandRequestTrackerSystem>();
@@ -76,7 +77,7 @@ namespace Improbable.Gdk.Core
             {
                 using (var opList = worker.Connection.GetOpList(0))
                 {
-                    dispatcher.Process(opList);
+                    Dispatcher.Process(opList);
                 }
             }
             while (inCriticalSection);
@@ -404,23 +405,23 @@ namespace Improbable.Gdk.Core
                     Activator.CreateInstance(componentDispatcherType, worker, World));
             }
 
-            dispatcher.OnAddEntity(OnAddEntity);
-            dispatcher.OnRemoveEntity(OnRemoveEntity);
-            dispatcher.OnDisconnect(OnDisconnect);
-            dispatcher.OnCriticalSection(op => { inCriticalSection = op.InCriticalSection; });
+            Dispatcher.OnAddEntity(OnAddEntity);
+            Dispatcher.OnRemoveEntity(OnRemoveEntity);
+            Dispatcher.OnDisconnect(OnDisconnect);
+            Dispatcher.OnCriticalSection(op => { inCriticalSection = op.InCriticalSection; });
 
-            dispatcher.OnAddComponent(OnAddComponent);
-            dispatcher.OnRemoveComponent(OnRemoveComponent);
-            dispatcher.OnComponentUpdate(OnComponentUpdate);
-            dispatcher.OnAuthorityChange(OnAuthorityChange);
+            Dispatcher.OnAddComponent(OnAddComponent);
+            Dispatcher.OnRemoveComponent(OnRemoveComponent);
+            Dispatcher.OnComponentUpdate(OnComponentUpdate);
+            Dispatcher.OnAuthorityChange(OnAuthorityChange);
 
-            dispatcher.OnCommandRequest(OnCommandRequest);
-            dispatcher.OnCommandResponse(OnCommandResponse);
+            Dispatcher.OnCommandRequest(OnCommandRequest);
+            Dispatcher.OnCommandResponse(OnCommandResponse);
 
-            dispatcher.OnCreateEntityResponse(OnCreateEntityResponse);
-            dispatcher.OnDeleteEntityResponse(OnDeleteEntityResponse);
-            dispatcher.OnReserveEntityIdsResponse(OnReserveEntityIdsResponse);
-            dispatcher.OnEntityQueryResponse(OnEntityQueryResponse);
+            Dispatcher.OnCreateEntityResponse(OnCreateEntityResponse);
+            Dispatcher.OnDeleteEntityResponse(OnDeleteEntityResponse);
+            Dispatcher.OnReserveEntityIdsResponse(OnReserveEntityIdsResponse);
+            Dispatcher.OnEntityQueryResponse(OnEntityQueryResponse);
 
             ClientError.ExceptionCallback = HandleException;
         }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
@@ -8,14 +8,18 @@
 #>
 <#= generatedHeader #>
 
-using Unity.Entities;
 using Improbable.Gdk.Core;
+using Improbable.Worker.Core;
+using System;
 using System.Collections.Generic;
+using Unity.Entities;
 
 namespace <#= qualifiedNamespace #>
 {
     public partial class <#= componentDetails.ComponentName  #>
     {
+        public const uint ComponentId = <#= componentDetails.ComponentId #>;
+
         public struct Component : IComponentData, ISpatialComponentData
         {
             public uint ComponentId => <#= componentDetails.ComponentId #>;
@@ -150,6 +154,38 @@ namespace <#= qualifiedNamespace #>
             public global::System.Collections.Generic.List<Update> Updates
             {
                 get => <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+            }
+        }
+
+        internal class <#= componentDetails.ComponentName  #>Dynamic : IDynamicInvokable
+        {
+            public uint ComponentId => <#= componentDetails.ComponentName  #>.ComponentId;
+
+            private static Component DeserializeData(ComponentData data, World world)
+            {
+                var schemaDataOpt = data.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentData)}");
+                }
+
+                return Serialization.Deserialize(schemaDataOpt.Value.GetFields(), world);
+            }
+
+            private static Update DeserializeUpdate(ComponentUpdate update, World world)
+            {
+                var schemaDataOpt = update.SchemaData;
+                if (!schemaDataOpt.HasValue)
+                {
+                    throw new ArgumentException($"Can not deserialize an empty {nameof(ComponentUpdate)}");
+                }
+
+                return Serialization.DeserializeUpdate(schemaDataOpt.Value);
+            }
+
+            public void InvokeHandler(Dynamic.IHandler handler)
+            {
+                handler.Accept<Component, Update>(<#= componentDetails.ComponentName  #>.ComponentId, DeserializeData, DeserializeUpdate);
             }
         }
     }


### PR DESCRIPTION
#### Description
Basically the same as the C# Worker SDK Dyanmic.ForEachComponent and Dynamic.ForComponent but with a slightly different interface.

Here's a silly example of printing all transform updates on a given entity
```
using System;
using System.Collections.Generic;
using Improbable.Gdk.Core;
using Improbable.Transform;
using Improbable.Worker;
using Improbable.Worker.Core;
using Unity.Entities;
using UnityEngine;

[WorkerType("UnityClient")]
public class ForEachComponentTest : MonoBehaviour
{
    private struct Handler : Dynamic.IHandler
    {
        public World World;
        public Dispatcher Dispatcher;
        public EntityId EntityId;

        public void Accept<TData, TUpdate>(uint componentId,
            ComponentDeserializer<TData> deserializeComponentAdded,
            UpdateDeserializer<TUpdate> deserializeComponentUpdate) where TData : ISpatialComponentData
            where TUpdate : ISpatialComponentUpdate
        {
            if (componentId != TransformInternal.ComponentId)
            {
                return;
            }

            var capturedHandler = this;
            Dispatcher.OnComponentUpdate(op =>
            {
                if (op.EntityId != capturedHandler.EntityId)
                {
                    return;
                }

                var transformUpdate = deserializeComponentUpdate(op.Update, capturedHandler.World);
                PrintTransformUpdate(transformUpdate);
            });
        }
    }

    private void OnEnable()
    {
        var spatialOSComponent = GetComponent<SpatialOSComponent>();
        Dynamic.ForEachComponent(new Handler
        {
            World = spatialOSComponent.World,
            Dispatcher = spatialOSComponent.World.GetExistingManager<SpatialOSReceiveSystem>().Dispatcher,
            EntityId = spatialOSComponent.SpatialEntityId
        });
    }

    private static void PrintTransformUpdate(object update)
    {
        if (!(update is TransformInternal.Update))
        {
            return;
        }

        var c = (TransformInternal.Update) update;
        if (c.Location.HasValue)
        {
            Debug.Log(c.Location.Value.X);
        }
    }
}

```