### PR TITLE
UTY-356: Support steam auth

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Config/ConnectionConfig.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Config/ConnectionConfig.cs
@@ -77,13 +77,26 @@ namespace Improbable.Gdk.Core
         /// <exception cref="ConnectionFailedException">
         ///     Thrown if configValue is null or empty.
         /// </exception>
-        protected void ValidateConfig(string configValue, string configName)
+        protected void ValidateString(string configValue, string configName)
         {
-            if (string.IsNullOrEmpty(configValue))
+            ValidateCondition(!string.IsNullOrEmpty(configValue),
+                $"Config validation failed with: No valid {configName} has been provided");
+        }
+
+        /// <summary>
+        ///     Checks that a condition is satisfied.
+        /// </summary>
+        /// <param name="condition">The condition to satisfy.</param>
+        /// <param name="errorMessage">Error message in the Exception if condition is not satisfied.</param>
+        /// <exception cref="ConnectionFailedException">
+        ///     Thrown if condition is not satisfied.
+        /// </exception>
+        protected void ValidateCondition(bool condition, string errorMessage)
+        {
+            if (!condition)
             {
                 throw new ConnectionFailedException(
-                    $"Config validation failed with: No valid {configName} has been provided",
-                    ConnectionErrorReason.InvalidConfig);
+                    errorMessage, ConnectionErrorReason.InvalidConfig);
             }
         }
     }

--- a/workers/unity/Packages/com.improbable.gdk.core/Config/ReceptionistConfig.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Config/ReceptionistConfig.cs
@@ -33,7 +33,7 @@ namespace Improbable.Gdk.Core
         /// </summary>
         public override void Validate()
         {
-            ValidateConfig(ReceptionistHost, RuntimeConfigNames.ReceptionistHost);
+            ValidateString(ReceptionistHost, RuntimeConfigNames.ReceptionistHost);
         }
 
         /// <summary>

--- a/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs
@@ -18,12 +18,14 @@ namespace Improbable.Gdk.Core
     /// </summary>
     public static class RuntimeConfigNames
     {
+        public const string DeploymentTag = "deploymentTag";
         public const string LinkProtocol = "linkProtocol";
         public const string LocatorHost = "locatorHost";
         public const string LoginToken = "loginToken";
         public const string ProjectName = "projectName";
         public const string ReceptionistHost = "receptionistHost";
         public const string ReceptionistPort = "receptionistPort";
+        public const string SteamTicket = "steamTicket";
         public const string WorkerId = "workerId";
         public const string WorkerType = "workerType";
     }

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Config/LocatorConfigTests.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Config/LocatorConfigTests.cs
@@ -43,8 +43,6 @@ namespace Improbable.Gdk.Core.EditmodeTests
         public void Validate_should_return_false_when_ProjectName_is_empty()
         {
             var config = GetDefaultWorkingConfig();
-            config.LocatorParameters.CredentialsType = LocatorCredentialsType.LoginToken;
-            config.LocatorParameters.LoginToken.Token = "some token who cares";
             config.LocatorParameters.ProjectName = "";
 
             var exception = Assert.Throws<ConnectionFailedException>(() => config.Validate());
@@ -52,15 +50,38 @@ namespace Improbable.Gdk.Core.EditmodeTests
         }
 
         [Test]
-        public void Validate_should_return_false_when_LoginToken_is_empty()
+        public void Validate_should_return_false_when_LoginToken_is_empty_for_login_token_flow()
         {
             var config = GetDefaultWorkingConfig();
             config.LocatorParameters.CredentialsType = LocatorCredentialsType.LoginToken;
             config.LocatorParameters.LoginToken.Token = "";
-            config.LocatorParameters.ProjectName = "some project who cares";
 
             var exception = Assert.Throws<ConnectionFailedException>(() => config.Validate());
             Assert.IsTrue(exception.Message.Contains("loginToken"));
+        }
+
+        [Test]
+        public void Validate_should_return_false_when_DeploymentTag_empty_for_steam_flow()
+        {
+            var config = GetDefaultWorkingConfig();
+            config.LocatorParameters.CredentialsType = LocatorCredentialsType.Steam;
+            config.LocatorParameters.Steam.DeploymentTag = "";
+            config.LocatorParameters.Steam.Ticket = "something";
+
+            var exception = Assert.Throws<ConnectionFailedException>(() => config.Validate());
+            Assert.IsTrue(exception.Message.Contains("deploymentTag"));
+        }
+
+        [Test]
+        public void Validate_should_return_false_when_steam_ticket_empty_for_steam_flow()
+        {
+            var config = GetDefaultWorkingConfig();
+            config.LocatorParameters.CredentialsType = LocatorCredentialsType.Steam;
+            config.LocatorParameters.Steam.DeploymentTag = "something";
+            config.LocatorParameters.Steam.Ticket = "";
+
+            var exception = Assert.Throws<ConnectionFailedException>(() => config.Validate());
+            Assert.IsTrue(exception.Message.Contains("steamTicket"));
         }
 
         [Test]
@@ -76,12 +97,25 @@ namespace Improbable.Gdk.Core.EditmodeTests
         [Test]
         public void SetLoginToken_should_update_LoginToken_and_CredentialsType_properties()
         {
-            var config = GetDefaultWorkingConfig();
+            var config = new LocatorConfig();
             const string loginToken = "mylogintoken";
             config.SetLoginToken(loginToken);
 
             Assert.AreEqual(loginToken, config.LocatorParameters.LoginToken.Token);
             Assert.AreEqual(LocatorCredentialsType.LoginToken, config.LocatorParameters.CredentialsType);
+        }
+
+        [Test]
+        public void SetSteamCredentials_should_update_LoginToken_and_CredentialsType_properties()
+        {
+            var config = new LocatorConfig();
+            const string deploymentTag = "mydeploymenttag";
+            const string steamTicket = "mysteamTicket";
+            config.SetSteamCredentials(deploymentTag, steamTicket);
+
+            Assert.AreEqual(deploymentTag, config.LocatorParameters.Steam.DeploymentTag);
+            Assert.AreEqual(steamTicket, config.LocatorParameters.Steam.Ticket);
+            Assert.AreEqual(LocatorCredentialsType.Steam, config.LocatorParameters.CredentialsType);
         }
 
         [Test]
@@ -110,21 +144,21 @@ namespace Improbable.Gdk.Core.EditmodeTests
         }
 
         [Test]
-        public void CreateConnectionConfigFromCommandLine_should_provide_defaults_for_missing_values()
+        public void CreateConnectionConfigFromCommandLine_should_provide_default_values()
         {
             var parsedArgs = new Dictionary<string, string>();
             var config = LocatorConfig.CreateConnectionConfigFromCommandLine(parsedArgs);
 
-            Assert.AreEqual(LocatorCredentialsType.LoginToken, config.LocatorParameters.CredentialsType);
-            Assert.AreEqual(string.Empty, config.LocatorParameters.LoginToken.Token);
             Assert.AreEqual(RuntimeConfigDefaults.LocatorHost, config.LocatorHost);
-            Assert.AreEqual(string.Empty, config.LocatorParameters.ProjectName);
             Assert.AreEqual(RuntimeConfigDefaults.LinkProtocol, config.LinkProtocol);
         }
 
         private static LocatorConfig GetDefaultWorkingConfig()
         {
-            return new LocatorConfig();
+            var locatorConfig = new LocatorConfig();
+            locatorConfig.SetProjectName("defaultProjectName");
+            locatorConfig.SetLoginToken("defaultLoginToken");
+            return locatorConfig;
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
@@ -158,7 +158,10 @@ namespace Improbable.Gdk.Core
 
             var commandLineArguments = Environment.GetCommandLineArgs();
             var commandLineArgs = CommandLineUtility.ParseCommandLineArgs(commandLineArguments);
-            return commandLineArgs.ContainsKey(RuntimeConfigNames.LoginToken);
+            var shouldUseLocator = commandLineArgs.ContainsKey(RuntimeConfigNames.LoginToken) ||
+                commandLineArgs.ContainsKey(RuntimeConfigNames.DeploymentTag) ||
+                commandLineArgs.ContainsKey(RuntimeConfigNames.SteamTicket);
+            return shouldUseLocator;
         }
 
         /// <summary>


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Surface worker sdk APIs for setting steam auth configs.
#### Tests
Updated unit tests. Will manually deploy to see if launcher flow is not broken. Will not test steam flow manually as that is a lot of work.
#### Documentation
None yet.
#### Primary reviewers
@samiwh @jamiebrynes7 