### PR TITLE
Added Android dependencies and building to ci script

### DIFF
--- a/ci/build-test.sh
+++ b/ci/build-test.sh
@@ -7,7 +7,10 @@ cd "$(dirname "$0")/../"
 # Get shared CI and prepare unity
 ci/bootstrap.sh
 .shared-ci/scripts/prepare-unity.sh
-.shared-ci/scripts/prepare-unity-mobile.sh "$(pwd)/logs/PrepareUnityMobile.log"
+
+if isWindows; then
+    .shared-ci/scripts/prepare-unity-mobile.sh "$(pwd)/logs/PrepareUnityMobile.log"
+fi
 
 source ".shared-ci/scripts/pinned-tools.sh"
 

--- a/ci/build-test.sh
+++ b/ci/build-test.sh
@@ -17,17 +17,11 @@ source ".shared-ci/scripts/pinned-tools.sh"
 ci/test.sh
 .shared-ci/scripts/build.sh "workers/unity" UnityClient local "$(pwd)/logs/UnityClientBuild.log"
 .shared-ci/scripts/build.sh "workers/unity" UnityGameLogic cloud "$(pwd)/logs/UnityGameLogicBuild.log"
-<<<<<<< HEAD
-=======
 
 if isWindows; then
     .shared-ci/scripts/build.sh "workers/unity" AndroidClient local "$(pwd)/logs/AndroidClientBuild.log"
 fi
->>>>>>> Add a check if it's running on Windows
 
 if isMacOS; then
   .shared-ci/scripts/build.sh "workers/unity" iOSClient local "$(pwd)/logs/iOSClientBuild.log"
 fi
-
-.shared-ci/scripts/build.sh "workers/unity" AndroidClient local "$(pwd)/logs/AndroidClientBuild.log"
-

--- a/ci/build-test.sh
+++ b/ci/build-test.sh
@@ -14,6 +14,13 @@ source ".shared-ci/scripts/pinned-tools.sh"
 ci/test.sh
 .shared-ci/scripts/build.sh "workers/unity" UnityClient local "$(pwd)/logs/UnityClientBuild.log"
 .shared-ci/scripts/build.sh "workers/unity" UnityGameLogic cloud "$(pwd)/logs/UnityGameLogicBuild.log"
+<<<<<<< HEAD
+=======
+
+if isWindows; then
+    .shared-ci/scripts/build.sh "workers/unity" AndroidClient local "$(pwd)/logs/AndroidClientBuild.log"
+fi
+>>>>>>> Add a check if it's running on Windows
 
 if isMacOS; then
   .shared-ci/scripts/build.sh "workers/unity" iOSClient local "$(pwd)/logs/iOSClientBuild.log"

--- a/ci/build-test.sh
+++ b/ci/build-test.sh
@@ -7,6 +7,7 @@ cd "$(dirname "$0")/../"
 # Get shared CI and prepare unity
 ci/bootstrap.sh
 .shared-ci/scripts/prepare-unity.sh
+.shared-ci/scripts/prepare-unity-mobile.sh "$(pwd)/logs/PrepareUnityMobile.log"
 
 source ".shared-ci/scripts/pinned-tools.sh"
 
@@ -17,3 +18,6 @@ ci/test.sh
 if isMacOS; then
   .shared-ci/scripts/build.sh "workers/unity" iOSClient local "$(pwd)/logs/iOSClientBuild.log"
 fi
+
+.shared-ci/scripts/build.sh "workers/unity" AndroidClient local "$(pwd)/logs/AndroidClientBuild.log"
+

--- a/ci/build-test.sh
+++ b/ci/build-test.sh
@@ -7,20 +7,14 @@ cd "$(dirname "$0")/../"
 # Get shared CI and prepare unity
 ci/bootstrap.sh
 .shared-ci/scripts/prepare-unity.sh
-
-if isWindows; then
-    .shared-ci/scripts/prepare-unity-mobile.sh "$(pwd)/logs/PrepareUnityMobile.log"
-fi
+.shared-ci/scripts/prepare-unity-mobile.sh "$(pwd)/logs/PrepareUnityMobile.log"
 
 source ".shared-ci/scripts/pinned-tools.sh"
 
 ci/test.sh
 .shared-ci/scripts/build.sh "workers/unity" UnityClient local "$(pwd)/logs/UnityClientBuild.log"
 .shared-ci/scripts/build.sh "workers/unity" UnityGameLogic cloud "$(pwd)/logs/UnityGameLogicBuild.log"
-
-if isWindows; then
-    .shared-ci/scripts/build.sh "workers/unity" AndroidClient local "$(pwd)/logs/AndroidClientBuild.log"
-fi
+.shared-ci/scripts/build.sh "workers/unity" AndroidClient local "$(pwd)/logs/AndroidClientBuild.log"
 
 if isMacOS; then
   .shared-ci/scripts/build.sh "workers/unity" iOSClient local "$(pwd)/logs/iOSClientBuild.log"


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Adding build steps for `AndroidClient`, as well as a reference to the preparation script from `shared-ci`.

#### Tests
How to test the preparation script from `shared-ci` repo:
- Checkout this branch
- Run `ci/bootstrap.sh`
- Go in `.shared-ci` and checkout the `feature/add-android-dependencies-unity` branch
- Comment out the call to bootstrap in `<ROOT_DIR>/ci/build-test.sh` (this would reset back to master)
- Run `ci/build-test.sh`
- ???
- Profit

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.