### PR TITLE
UTY-1363: Use SchemaObject.IndexObject instead of GetObject to remove duplicate events

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -216,9 +216,9 @@ namespace <#= qualifiedNamespace #>
                         }
 
                         // Deserialize events onto component
-                        for (var i = 0; i < eventCount; i++)
+                        for (uint i = 0; i < eventCount; i++)
                         {
-                            var e = <#= eventDetails.FqnPayloadType #>.Serialization.Deserialize(eventsObject.GetObject(<#= eventDetails.EventIndex #>));
+                            var e = <#= eventDetails.FqnPayloadType #>.Serialization.Deserialize(eventsObject.IndexObject(<#= eventDetails.EventIndex #>, i));
                             eventList.Add(e);
                         }
                     }


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Use `SchemaObject.IndexObject` to retrieve all events if multiple events are received as part of the same component update. `SchemaObject.GetObject` only gives you the last element in a repeated proto object (according to Sami and David) leading to us retrieving the last event multiple times.
#### Tests
Manual tests. I'm not aware of a way to test this nicely at a unit test level. Help appreciated.
#### Documentation
As far as I understand we don't do explicit release/bugfix notes atm.
#### Primary reviewers
@samiwh @mattyoung-improbable 