### PR TITLE
changing Temp to TempJob

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/WorldCommandsCleanSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/WorldCommandsCleanSystem.cs
@@ -44,7 +44,7 @@ namespace Improbable.Gdk.Core
                 GetArchetypeChunkComponentType<WorldCommands.ReserveEntityIds.CommandResponses>();
             var entityQueryType = GetArchetypeChunkComponentType<WorldCommands.EntityQuery.CommandResponses>();
 
-            var chunkArray = worldCommandResponseGroup.CreateArchetypeChunkArray(Allocator.Temp);
+            var chunkArray = worldCommandResponseGroup.CreateArchetypeChunkArray(Allocator.TempJob);
 
             foreach (var chunk in chunkArray)
             {

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/WorldCommandsSendSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/WorldCommandsSendSystem.cs
@@ -64,7 +64,7 @@ namespace Improbable.Gdk.Core
             var reserveEntityIdsType = GetArchetypeChunkComponentType<WorldCommands.ReserveEntityIds.CommandSender>();
             var entityQueryType = GetArchetypeChunkComponentType<WorldCommands.EntityQuery.CommandSender>();
 
-            var chunkArray = group.CreateArchetypeChunkArray(Allocator.Temp);
+            var chunkArray = group.CreateArchetypeChunkArray(Allocator.TempJob);
 
             foreach (var chunk in chunkArray)
             {

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatRequestSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatRequestSystem.cs
@@ -37,7 +37,7 @@ namespace Improbable.Gdk.PlayerLifecycle
             var requestsType = GetArchetypeChunkComponentType<PlayerHeartbeatClient.CommandRequests.PlayerHeartbeat>(true);
             var responderType = GetArchetypeChunkComponentType<PlayerHeartbeatClient.CommandResponders.PlayerHeartbeat>();
 
-            var chunkArray = group.CreateArchetypeChunkArray(Allocator.Temp);
+            var chunkArray = group.CreateArchetypeChunkArray(Allocator.TempJob);
 
             foreach (var chunk in chunkArray)
             {

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatResponseSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatResponseSystem.cs
@@ -45,7 +45,7 @@ namespace Improbable.Gdk.PlayerLifecycle
                 GetArchetypeChunkComponentType<PlayerHeartbeatClient.CommandResponses.PlayerHeartbeat>(true);
             var spatialIdType = GetArchetypeChunkComponentType<SpatialEntityId>(true);
 
-            var chunkArray = group.CreateArchetypeChunkArray(Allocator.Temp);
+            var chunkArray = group.CreateArchetypeChunkArray(Allocator.TempJob);
 
             foreach (var chunk in chunkArray)
             {

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/PlayerHeartbeatInitializationSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/PlayerHeartbeatInitializationSystem.cs
@@ -36,7 +36,7 @@ namespace Improbable.Gdk.PlayerLifecycle
         protected override void OnUpdate()
         {
             var entityType = GetArchetypeChunkEntityType();
-            var chunkArray = initializerGroup.CreateArchetypeChunkArray(Allocator.Temp);
+            var chunkArray = initializerGroup.CreateArchetypeChunkArray(Allocator.TempJob);
 
             foreach (var chunk in chunkArray)
             {

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/SendPlayerHeartbeatRequestSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/SendPlayerHeartbeatRequestSystem.cs
@@ -53,7 +53,7 @@ namespace Improbable.Gdk.PlayerLifecycle
 
             timeOfNextHeartbeat = Time.time + PlayerLifecycleConfig.PlayerHeartbeatIntervalSeconds;
 
-            var chunkArray = group.CreateArchetypeChunkArray(Allocator.Temp);
+            var chunkArray = group.CreateArchetypeChunkArray(Allocator.TempJob);
 
             var senderType = GetArchetypeChunkComponentType<PlayerHeartbeatClient.CommandSenders.PlayerHeartbeat>();
             var spatialIdType = GetArchetypeChunkComponentType<SpatialEntityId>(true);

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -533,7 +533,7 @@ namespace <#= qualifiedNamespace #>
             {
                 <#= profilingStart #>
 
-                var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.Temp);
+                var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
                 var componentType = system.GetArchetypeChunkComponentType<<#= componentNamespace #>.Component>();
 <# foreach (var eventDetail in eventDetailsList) { #>
@@ -712,7 +712,7 @@ for (var j = 0; j < commandDetailsList.Count; j++) {
                 var <#= commandDetails.CamelCaseCommandName #>ResponseType = system.GetArchetypeChunkComponentType<CommandResponses.<#= commandDetails.CommandName #>>();
 <# } #>
 
-                var chunkArray = group.CreateArchetypeChunkArray(Allocator.Temp);
+                var chunkArray = group.CreateArchetypeChunkArray(Allocator.TempJob);
 
                 foreach (var chunk in chunkArray)
                 {


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Because later versions of Unity really don't like it when we use `Allocator.Temp` for chunks.

#### Tests
tested it in a later version. currently testing on 2018.2.8 

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.