### PR TITLE
Soft handover - now 50% less soft

### DIFF
--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
@@ -413,5 +413,45 @@ namespace Improbable.Gdk.Tests
                 chunkArray.Dispose();
             }
         }
+
+        internal class AcknowledgeAuthorityLossHandler : AbstractAcknowledgeAuthorityLossHandler
+        {
+            public override EntityArchetypeQuery Query => new EntityArchetypeQuery
+            {
+                All = new ComponentType[]
+                {
+                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>>(),
+                    ComponentType.ReadOnly<SpatialEntityId>()
+                },
+                Any = Array.Empty<ComponentType>(),
+                None = Array.Empty<ComponentType>()
+            };
+
+            public override void AcknowledgeAuthorityLoss(ComponentGroup group, ComponentSystemBase system,
+                Improbable.Worker.Core.Connection connection)
+            {
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>>();
+                var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
+
+                var chunkArray = group.CreateArchetypeChunkArray(Allocator.TempJob);
+
+                foreach (var chunk in chunkArray)
+                {
+                    var authorityArray = chunk.GetNativeArray(authorityLossType);
+                    var spatialEntityIdArray = chunk.GetNativeArray(spatialEntityType);
+
+                    for (int i = 0; i < authorityArray.Length; ++i)
+                    {
+                        if (authorityArray[i].AcknowledgeAuthorityLoss)
+                        {
+                            connection.SendAuthorityLossImminentAcknowledgement(spatialEntityIdArray[i].EntityId,
+                                197720);
+                        }
+                    }
+                }
+
+                chunkArray.Dispose();
+            }
+        }
     }
 }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
@@ -451,5 +451,45 @@ namespace Improbable.Gdk.Tests
                 chunkArray.Dispose();
             }
         }
+
+        internal class AcknowledgeAuthorityLossHandler : AbstractAcknowledgeAuthorityLossHandler
+        {
+            public override EntityArchetypeQuery Query => new EntityArchetypeQuery
+            {
+                All = new ComponentType[]
+                {
+                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(),
+                    ComponentType.ReadOnly<SpatialEntityId>()
+                },
+                Any = Array.Empty<ComponentType>(),
+                None = Array.Empty<ComponentType>()
+            };
+
+            public override void AcknowledgeAuthorityLoss(ComponentGroup group, ComponentSystemBase system,
+                Improbable.Worker.Core.Connection connection)
+            {
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>();
+                var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
+
+                var chunkArray = group.CreateArchetypeChunkArray(Allocator.TempJob);
+
+                foreach (var chunk in chunkArray)
+                {
+                    var authorityArray = chunk.GetNativeArray(authorityLossType);
+                    var spatialEntityIdArray = chunk.GetNativeArray(spatialEntityType);
+
+                    for (int i = 0; i < authorityArray.Length; ++i)
+                    {
+                        if (authorityArray[i].AcknowledgeAuthorityLoss)
+                        {
+                            connection.SendAuthorityLossImminentAcknowledgement(spatialEntityIdArray[i].EntityId,
+                                197719);
+                        }
+                    }
+                }
+
+                chunkArray.Dispose();
+            }
+        }
     }
 }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
@@ -451,5 +451,45 @@ namespace Improbable.Gdk.Tests
                 chunkArray.Dispose();
             }
         }
+
+        internal class AcknowledgeAuthorityLossHandler : AbstractAcknowledgeAuthorityLossHandler
+        {
+            public override EntityArchetypeQuery Query => new EntityArchetypeQuery
+            {
+                All = new ComponentType[]
+                {
+                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(),
+                    ComponentType.ReadOnly<SpatialEntityId>()
+                },
+                Any = Array.Empty<ComponentType>(),
+                None = Array.Empty<ComponentType>()
+            };
+
+            public override void AcknowledgeAuthorityLoss(ComponentGroup group, ComponentSystemBase system,
+                Improbable.Worker.Core.Connection connection)
+            {
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>();
+                var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
+
+                var chunkArray = group.CreateArchetypeChunkArray(Allocator.TempJob);
+
+                foreach (var chunk in chunkArray)
+                {
+                    var authorityArray = chunk.GetNativeArray(authorityLossType);
+                    var spatialEntityIdArray = chunk.GetNativeArray(spatialEntityType);
+
+                    for (int i = 0; i < authorityArray.Length; ++i)
+                    {
+                        if (authorityArray[i].AcknowledgeAuthorityLoss)
+                        {
+                            connection.SendAuthorityLossImminentAcknowledgement(spatialEntityIdArray[i].EntityId,
+                                197718);
+                        }
+                    }
+                }
+
+                chunkArray.Dispose();
+            }
+        }
     }
 }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
@@ -451,5 +451,45 @@ namespace Improbable.Gdk.Tests
                 chunkArray.Dispose();
             }
         }
+
+        internal class AcknowledgeAuthorityLossHandler : AbstractAcknowledgeAuthorityLossHandler
+        {
+            public override EntityArchetypeQuery Query => new EntityArchetypeQuery
+            {
+                All = new ComponentType[]
+                {
+                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(),
+                    ComponentType.ReadOnly<SpatialEntityId>()
+                },
+                Any = Array.Empty<ComponentType>(),
+                None = Array.Empty<ComponentType>()
+            };
+
+            public override void AcknowledgeAuthorityLoss(ComponentGroup group, ComponentSystemBase system,
+                Improbable.Worker.Core.Connection connection)
+            {
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>();
+                var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
+
+                var chunkArray = group.CreateArchetypeChunkArray(Allocator.TempJob);
+
+                foreach (var chunk in chunkArray)
+                {
+                    var authorityArray = chunk.GetNativeArray(authorityLossType);
+                    var spatialEntityIdArray = chunk.GetNativeArray(spatialEntityType);
+
+                    for (int i = 0; i < authorityArray.Length; ++i)
+                    {
+                        if (authorityArray[i].AcknowledgeAuthorityLoss)
+                        {
+                            connection.SendAuthorityLossImminentAcknowledgement(spatialEntityIdArray[i].EntityId,
+                                197716);
+                        }
+                    }
+                }
+
+                chunkArray.Dispose();
+            }
+        }
     }
 }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
@@ -451,5 +451,45 @@ namespace Improbable.Gdk.Tests
                 chunkArray.Dispose();
             }
         }
+
+        internal class AcknowledgeAuthorityLossHandler : AbstractAcknowledgeAuthorityLossHandler
+        {
+            public override EntityArchetypeQuery Query => new EntityArchetypeQuery
+            {
+                All = new ComponentType[]
+                {
+                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(),
+                    ComponentType.ReadOnly<SpatialEntityId>()
+                },
+                Any = Array.Empty<ComponentType>(),
+                None = Array.Empty<ComponentType>()
+            };
+
+            public override void AcknowledgeAuthorityLoss(ComponentGroup group, ComponentSystemBase system,
+                Improbable.Worker.Core.Connection connection)
+            {
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>();
+                var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
+
+                var chunkArray = group.CreateArchetypeChunkArray(Allocator.TempJob);
+
+                foreach (var chunk in chunkArray)
+                {
+                    var authorityArray = chunk.GetNativeArray(authorityLossType);
+                    var spatialEntityIdArray = chunk.GetNativeArray(spatialEntityType);
+
+                    for (int i = 0; i < authorityArray.Length; ++i)
+                    {
+                        if (authorityArray[i].AcknowledgeAuthorityLoss)
+                        {
+                            connection.SendAuthorityLossImminentAcknowledgement(spatialEntityIdArray[i].EntityId,
+                                197717);
+                        }
+                    }
+                }
+
+                chunkArray.Dispose();
+            }
+        }
     }
 }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
@@ -421,5 +421,45 @@ namespace Improbable.Gdk.Tests
                 chunkArray.Dispose();
             }
         }
+
+        internal class AcknowledgeAuthorityLossHandler : AbstractAcknowledgeAuthorityLossHandler
+        {
+            public override EntityArchetypeQuery Query => new EntityArchetypeQuery
+            {
+                All = new ComponentType[]
+                {
+                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(),
+                    ComponentType.ReadOnly<SpatialEntityId>()
+                },
+                Any = Array.Empty<ComponentType>(),
+                None = Array.Empty<ComponentType>()
+            };
+
+            public override void AcknowledgeAuthorityLoss(ComponentGroup group, ComponentSystemBase system,
+                Improbable.Worker.Core.Connection connection)
+            {
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>();
+                var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
+
+                var chunkArray = group.CreateArchetypeChunkArray(Allocator.TempJob);
+
+                foreach (var chunk in chunkArray)
+                {
+                    var authorityArray = chunk.GetNativeArray(authorityLossType);
+                    var spatialEntityIdArray = chunk.GetNativeArray(spatialEntityType);
+
+                    for (int i = 0; i < authorityArray.Length; ++i)
+                    {
+                        if (authorityArray[i].AcknowledgeAuthorityLoss)
+                        {
+                            connection.SendAuthorityLossImminentAcknowledgement(spatialEntityIdArray[i].EntityId,
+                                197715);
+                        }
+                    }
+                }
+
+                chunkArray.Dispose();
+            }
+        }
     }
 }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
@@ -399,5 +399,45 @@ namespace Improbable.Gdk.Tests
                 chunkArray.Dispose();
             }
         }
+
+        internal class AcknowledgeAuthorityLossHandler : AbstractAcknowledgeAuthorityLossHandler
+        {
+            public override EntityArchetypeQuery Query => new EntityArchetypeQuery
+            {
+                All = new ComponentType[]
+                {
+                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.NestedComponent.Component>>(),
+                    ComponentType.ReadOnly<SpatialEntityId>()
+                },
+                Any = Array.Empty<ComponentType>(),
+                None = Array.Empty<ComponentType>()
+            };
+
+            public override void AcknowledgeAuthorityLoss(ComponentGroup group, ComponentSystemBase system,
+                Improbable.Worker.Core.Connection connection)
+            {
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.NestedComponent.Component>>();
+                var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
+
+                var chunkArray = group.CreateArchetypeChunkArray(Allocator.TempJob);
+
+                foreach (var chunk in chunkArray)
+                {
+                    var authorityArray = chunk.GetNativeArray(authorityLossType);
+                    var spatialEntityIdArray = chunk.GetNativeArray(spatialEntityType);
+
+                    for (int i = 0; i < authorityArray.Length; ++i)
+                    {
+                        if (authorityArray[i].AcknowledgeAuthorityLoss)
+                        {
+                            connection.SendAuthorityLossImminentAcknowledgement(spatialEntityIdArray[i].EntityId,
+                                20152);
+                        }
+                    }
+                }
+
+                chunkArray.Dispose();
+            }
+        }
     }
 }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionTranslation.cs
@@ -475,5 +475,45 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 chunkArray.Dispose();
             }
         }
+
+        internal class AcknowledgeAuthorityLossHandler : AbstractAcknowledgeAuthorityLossHandler
+        {
+            public override EntityArchetypeQuery Query => new EntityArchetypeQuery
+            {
+                All = new ComponentType[]
+                {
+                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(),
+                    ComponentType.ReadOnly<SpatialEntityId>()
+                },
+                Any = Array.Empty<ComponentType>(),
+                None = Array.Empty<ComponentType>()
+            };
+
+            public override void AcknowledgeAuthorityLoss(ComponentGroup group, ComponentSystemBase system,
+                Improbable.Worker.Core.Connection connection)
+            {
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>();
+                var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
+
+                var chunkArray = group.CreateArchetypeChunkArray(Allocator.TempJob);
+
+                foreach (var chunk in chunkArray)
+                {
+                    var authorityArray = chunk.GetNativeArray(authorityLossType);
+                    var spatialEntityIdArray = chunk.GetNativeArray(spatialEntityType);
+
+                    for (int i = 0; i < authorityArray.Length; ++i)
+                    {
+                        if (authorityArray[i].AcknowledgeAuthorityLoss)
+                        {
+                            connection.SendAuthorityLossImminentAcknowledgement(spatialEntityIdArray[i].EntityId,
+                                1105);
+                        }
+                    }
+                }
+
+                chunkArray.Dispose();
+            }
+        }
     }
 }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentTranslation.cs
@@ -968,5 +968,45 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 chunkArray.Dispose();
             }
         }
+
+        internal class AcknowledgeAuthorityLossHandler : AbstractAcknowledgeAuthorityLossHandler
+        {
+            public override EntityArchetypeQuery Query => new EntityArchetypeQuery
+            {
+                All = new ComponentType[]
+                {
+                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(),
+                    ComponentType.ReadOnly<SpatialEntityId>()
+                },
+                Any = Array.Empty<ComponentType>(),
+                None = Array.Empty<ComponentType>()
+            };
+
+            public override void AcknowledgeAuthorityLoss(ComponentGroup group, ComponentSystemBase system,
+                Improbable.Worker.Core.Connection connection)
+            {
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>();
+                var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
+
+                var chunkArray = group.CreateArchetypeChunkArray(Allocator.TempJob);
+
+                foreach (var chunk in chunkArray)
+                {
+                    var authorityArray = chunk.GetNativeArray(authorityLossType);
+                    var spatialEntityIdArray = chunk.GetNativeArray(spatialEntityType);
+
+                    for (int i = 0; i < authorityArray.Length; ++i)
+                    {
+                        if (authorityArray[i].AcknowledgeAuthorityLoss)
+                        {
+                            connection.SendAuthorityLossImminentAcknowledgement(spatialEntityIdArray[i].EntityId,
+                                1001);
+                        }
+                    }
+                }
+
+                chunkArray.Dispose();
+            }
+        }
     }
 }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsTranslation.cs
@@ -615,5 +615,45 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 chunkArray.Dispose();
             }
         }
+
+        internal class AcknowledgeAuthorityLossHandler : AbstractAcknowledgeAuthorityLossHandler
+        {
+            public override EntityArchetypeQuery Query => new EntityArchetypeQuery
+            {
+                All = new ComponentType[]
+                {
+                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(),
+                    ComponentType.ReadOnly<SpatialEntityId>()
+                },
+                Any = Array.Empty<ComponentType>(),
+                None = Array.Empty<ComponentType>()
+            };
+
+            public override void AcknowledgeAuthorityLoss(ComponentGroup group, ComponentSystemBase system,
+                Improbable.Worker.Core.Connection connection)
+            {
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>();
+                var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
+
+                var chunkArray = group.CreateArchetypeChunkArray(Allocator.TempJob);
+
+                foreach (var chunk in chunkArray)
+                {
+                    var authorityArray = chunk.GetNativeArray(authorityLossType);
+                    var spatialEntityIdArray = chunk.GetNativeArray(spatialEntityType);
+
+                    for (int i = 0; i < authorityArray.Length; ++i)
+                    {
+                        if (authorityArray[i].AcknowledgeAuthorityLoss)
+                        {
+                            connection.SendAuthorityLossImminentAcknowledgement(spatialEntityIdArray[i].EntityId,
+                                1005);
+                        }
+                    }
+                }
+
+                chunkArray.Dispose();
+            }
+        }
     }
 }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsTranslation.cs
@@ -475,5 +475,45 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 chunkArray.Dispose();
             }
         }
+
+        internal class AcknowledgeAuthorityLossHandler : AbstractAcknowledgeAuthorityLossHandler
+        {
+            public override EntityArchetypeQuery Query => new EntityArchetypeQuery
+            {
+                All = new ComponentType[]
+                {
+                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(),
+                    ComponentType.ReadOnly<SpatialEntityId>()
+                },
+                Any = Array.Empty<ComponentType>(),
+                None = Array.Empty<ComponentType>()
+            };
+
+            public override void AcknowledgeAuthorityLoss(ComponentGroup group, ComponentSystemBase system,
+                Improbable.Worker.Core.Connection connection)
+            {
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>();
+                var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
+
+                var chunkArray = group.CreateArchetypeChunkArray(Allocator.TempJob);
+
+                foreach (var chunk in chunkArray)
+                {
+                    var authorityArray = chunk.GetNativeArray(authorityLossType);
+                    var spatialEntityIdArray = chunk.GetNativeArray(spatialEntityType);
+
+                    for (int i = 0; i < authorityArray.Length; ++i)
+                    {
+                        if (authorityArray[i].AcknowledgeAuthorityLoss)
+                        {
+                            connection.SendAuthorityLossImminentAcknowledgement(spatialEntityIdArray[i].EntityId,
+                                1004);
+                        }
+                    }
+                }
+
+                chunkArray.Dispose();
+            }
+        }
     }
 }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentTranslation.cs
@@ -982,5 +982,45 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 chunkArray.Dispose();
             }
         }
+
+        internal class AcknowledgeAuthorityLossHandler : AbstractAcknowledgeAuthorityLossHandler
+        {
+            public override EntityArchetypeQuery Query => new EntityArchetypeQuery
+            {
+                All = new ComponentType[]
+                {
+                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(),
+                    ComponentType.ReadOnly<SpatialEntityId>()
+                },
+                Any = Array.Empty<ComponentType>(),
+                None = Array.Empty<ComponentType>()
+            };
+
+            public override void AcknowledgeAuthorityLoss(ComponentGroup group, ComponentSystemBase system,
+                Improbable.Worker.Core.Connection connection)
+            {
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>();
+                var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
+
+                var chunkArray = group.CreateArchetypeChunkArray(Allocator.TempJob);
+
+                foreach (var chunk in chunkArray)
+                {
+                    var authorityArray = chunk.GetNativeArray(authorityLossType);
+                    var spatialEntityIdArray = chunk.GetNativeArray(spatialEntityType);
+
+                    for (int i = 0; i < authorityArray.Length; ++i)
+                    {
+                        if (authorityArray[i].AcknowledgeAuthorityLoss)
+                        {
+                            connection.SendAuthorityLossImminentAcknowledgement(spatialEntityIdArray[i].EntityId,
+                                1002);
+                        }
+                    }
+                }
+
+                chunkArray.Dispose();
+            }
+        }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Authority/AuthorityComponents.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Authority/AuthorityComponents.cs
@@ -20,6 +20,7 @@ namespace Improbable.Gdk.Core
 
     /// <summary>
     ///     ECS component denotes that this worker will lose authority over <see cref="T"/> imminently.
+    ///     If AcknowledgeAuthorityLoss is set then authority handover will complete before the handover timeout.
     /// </summary>
     /// <remarks>
     ///     Note that this worker may still be authoritative over this component.
@@ -27,5 +28,6 @@ namespace Improbable.Gdk.Core
     /// <typeparam name="T">The SpatialOS component.</typeparam>
     public struct AuthorityLossImminent<T> : IComponentData where T : ISpatialComponentData
     {
+        public BlittableBool AcknowledgeAuthorityLoss;
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/AcknowledgeAuthorityLossHandler.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/AcknowledgeAuthorityLossHandler.cs
@@ -1,0 +1,13 @@
+using Improbable.Worker.Core;
+using Unity.Entities;
+
+namespace Improbable.Gdk.Core.CodegenAdapters
+{
+    public abstract class AbstractAcknowledgeAuthorityLossHandler
+    {
+        public abstract EntityArchetypeQuery Query { get; }
+
+        public abstract void AcknowledgeAuthorityLoss(ComponentGroup group, ComponentSystemBase system,
+            Connection connection);
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/AcknowledgeAuthorityLossHandler.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/AcknowledgeAuthorityLossHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1cfd8c098b8bbcc44b62218c7c9d53e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/IWriter.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/IWriter.cs
@@ -14,5 +14,6 @@ namespace Improbable.Gdk.GameObjectRepresentation
         where TComponentUpdate : ISpatialComponentUpdate
     {
         void Send(TComponentUpdate update);
+        void SendAuthorityLossImminentAcknowledgement();
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/ReaderWriterBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/ReaderWriterBase.cs
@@ -77,6 +77,30 @@ namespace Improbable.Gdk.GameObjectRepresentation
             }
         }
 
+        /// <summary>
+        ///     Yield authority during soft handover
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        ///     Thrown if the authority is not <see cref="Improbable.Worker.Core.Authority.AuthorityLossImminent"/>
+        /// </exception>
+        public void SendAuthorityLossImminentAcknowledgement()
+        {
+            if (!VerifyNotDisposed())
+            {
+                return;
+            }
+
+            if (!EntityManager.HasComponent<AuthorityLossImminent<TSpatialComponentData>>(Entity))
+            {
+                throw new InvalidOperationException(
+                    "Can not send authority loss acknowledgement when the Authority state is not " +
+                    $"{nameof(Authority.AuthorityLossImminent)}");
+            }
+
+            EntityManager.SetComponentData(Entity,
+                new AuthorityLossImminent<TSpatialComponentData> { AcknowledgeAuthorityLoss = true });
+        }
+
         protected abstract void ApplyUpdate(TComponentUpdate update, ref TSpatialComponentData data);
 
         /// <summary>

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/AcknowledgeAuthorityLossSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/AcknowledgeAuthorityLossSystem.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using Improbable.Gdk.Core.CodegenAdapters;
+using Unity.Entities;
+using UnityEngine.Profiling;
+
+namespace Improbable.Gdk.Core
+{
+    /// <summary>
+    ///    Checks for entities that have acknowledged authority loss during soft-handover and forwards this to SpatialOS.
+    /// </summary>
+    [DisableAutoCreation]
+    [AlwaysUpdateSystem]
+    [UpdateInGroup(typeof(SpatialOSSendGroup.InternalSpatialOSSendGroup))]
+    public class AcknowledgeAuthorityLossSystem : ComponentSystem
+    {
+        [Inject] private WorkerSystem workerSystem;
+
+        private readonly List<ComponentAuthorityLossDetails> authorityLossDetails =
+            new List<ComponentAuthorityLossDetails>();
+
+        protected override void OnCreateManager()
+        {
+            base.OnCreateManager();
+            GenerateComponentGroups();
+        }
+
+        private void GenerateComponentGroups()
+        {
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                foreach (var type in assembly.GetTypes())
+                {
+                    if (!typeof(AbstractAcknowledgeAuthorityLossHandler).IsAssignableFrom(type) || type.IsAbstract)
+                    {
+                        continue;
+                    }
+
+                    var authorityLossHandler = (AbstractAcknowledgeAuthorityLossHandler) Activator.CreateInstance(type);
+
+                    authorityLossDetails.Add(new ComponentAuthorityLossDetails
+                    {
+                        Handler = authorityLossHandler,
+                        AuthorityLossGroup = GetComponentGroup(authorityLossHandler.Query)
+                    });
+                }
+            }
+        }
+
+        protected override void OnUpdate()
+        {
+            foreach (var details in authorityLossDetails)
+            {
+                Profiler.BeginSample("AcknowledgingAuthorityLoss");
+                details.Handler.AcknowledgeAuthorityLoss(details.AuthorityLossGroup, this, workerSystem.Connection);
+                Profiler.EndSample();
+            }
+        }
+
+        private struct ComponentAuthorityLossDetails
+        {
+            public AbstractAcknowledgeAuthorityLossHandler Handler;
+            public ComponentGroup AuthorityLossGroup;
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/AcknowledgeAuthorityLossSystem.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/AcknowledgeAuthorityLossSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 66b05cb9baead6843ab702d19788d9ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs
@@ -198,6 +198,7 @@ namespace Improbable.Gdk.Core
             World.GetOrCreateManager<WorldCommandsCleanSystem>();
             World.GetOrCreateManager<WorldCommandsSendSystem>();
             World.GetOrCreateManager<CommandRequestTrackerSystem>();
+            World.GetOrCreateManager<AcknowledgeAuthorityLossSystem>();
         }
 
         public void Dispose()

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -810,5 +810,45 @@ for (var j = 0; j < commandDetailsList.Count; j++) {
                 chunkArray.Dispose();
             }
         }
+
+        internal class AcknowledgeAuthorityLossHandler : AbstractAcknowledgeAuthorityLossHandler
+        {
+            public override EntityArchetypeQuery Query => new EntityArchetypeQuery
+            {
+                All = new ComponentType[]
+                {
+                    ComponentType.ReadOnly<AuthorityLossImminent<<#= componentNamespace #>.Component>>(),
+                    ComponentType.ReadOnly<SpatialEntityId>()
+                },
+                Any = Array.Empty<ComponentType>(),
+                None = Array.Empty<ComponentType>()
+            };
+
+            public override void AcknowledgeAuthorityLoss(ComponentGroup group, ComponentSystemBase system,
+                Improbable.Worker.Core.Connection connection)
+            {
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<<#= componentNamespace #>.Component>>();
+                var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
+
+                var chunkArray = group.CreateArchetypeChunkArray(Allocator.TempJob);
+
+                foreach (var chunk in chunkArray)
+                {
+                    var authorityArray = chunk.GetNativeArray(authorityLossType);
+                    var spatialEntityIdArray = chunk.GetNativeArray(spatialEntityType);
+
+                    for (int i = 0; i < authorityArray.Length; ++i)
+                    {
+                        if (authorityArray[i].AcknowledgeAuthorityLoss)
+                        {
+                            connection.SendAuthorityLossImminentAcknowledgement(spatialEntityIdArray[i].EntityId,
+                                <#= componentDetails.ComponentId #>);
+                        }
+                    }
+                }
+
+                chunkArray.Dispose();
+            }
+        }
     }
 }


### PR DESCRIPTION
#### Description
You can ack authority loss in the ecs and in monobehaviours
In the ecs this is by writing to a bool on the authority component
In  monobehaviours this is a send api on the writer.