### PR TITLE
Command closures in monobehaviours

### DIFF
--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularGameObjectComponentDispatcher.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularGameObjectComponentDispatcher.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Unity.Entities;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularReaderWriter.cs
@@ -66,7 +66,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -75,7 +75,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -90,7 +90,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -99,7 +99,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -114,7 +114,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -123,7 +123,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -138,7 +138,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -147,7 +147,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -162,7 +162,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -171,7 +171,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -186,7 +186,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -195,7 +195,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -210,7 +210,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -219,7 +219,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -234,7 +234,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -243,7 +243,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -258,7 +258,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -267,7 +267,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -282,7 +282,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -291,7 +291,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -306,7 +306,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -315,7 +315,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -330,7 +330,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -339,7 +339,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -354,7 +354,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -363,7 +363,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -378,7 +378,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -387,7 +387,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -402,7 +402,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -411,7 +411,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyGameObjectComponentDispatcher.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyGameObjectComponentDispatcher.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Unity.Entities;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyReaderWriter.cs
@@ -68,7 +68,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -77,7 +77,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -92,7 +92,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -101,7 +101,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -116,7 +116,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -125,7 +125,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -140,7 +140,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -149,7 +149,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -164,7 +164,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -173,7 +173,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -188,7 +188,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -197,7 +197,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -212,7 +212,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -221,7 +221,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -236,7 +236,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -245,7 +245,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -260,7 +260,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -269,7 +269,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -284,7 +284,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -293,7 +293,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -308,7 +308,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -317,7 +317,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -332,7 +332,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -341,7 +341,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -356,7 +356,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -365,7 +365,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -380,7 +380,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -389,7 +389,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -404,7 +404,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -413,7 +413,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -428,7 +428,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -437,7 +437,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -452,7 +452,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -461,7 +461,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueGameObjectComponentDispatcher.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueGameObjectComponentDispatcher.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Unity.Entities;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueReaderWriter.cs
@@ -68,7 +68,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -77,7 +77,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -92,7 +92,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -101,7 +101,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -116,7 +116,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -125,7 +125,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -140,7 +140,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -149,7 +149,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -164,7 +164,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -173,7 +173,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -188,7 +188,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -197,7 +197,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -212,7 +212,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -221,7 +221,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -236,7 +236,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -245,7 +245,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -260,7 +260,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -269,7 +269,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -284,7 +284,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -293,7 +293,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -308,7 +308,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -317,7 +317,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -332,7 +332,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -341,7 +341,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -356,7 +356,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -365,7 +365,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -380,7 +380,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -389,7 +389,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -404,7 +404,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -413,7 +413,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -428,7 +428,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -437,7 +437,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -452,7 +452,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -461,7 +461,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalGameObjectComponentDispatcher.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalGameObjectComponentDispatcher.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Unity.Entities;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalReaderWriter.cs
@@ -68,7 +68,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -77,7 +77,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -92,7 +92,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -101,7 +101,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -116,7 +116,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -125,7 +125,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -140,7 +140,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -149,7 +149,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -164,7 +164,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -173,7 +173,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -188,7 +188,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -197,7 +197,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -212,7 +212,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -221,7 +221,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -236,7 +236,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -245,7 +245,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -260,7 +260,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -269,7 +269,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -284,7 +284,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -293,7 +293,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -308,7 +308,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -317,7 +317,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -332,7 +332,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -341,7 +341,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -356,7 +356,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -365,7 +365,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -380,7 +380,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -389,7 +389,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -404,7 +404,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -413,7 +413,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -428,7 +428,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -437,7 +437,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -452,7 +452,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -461,7 +461,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedGameObjectComponentDispatcher.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedGameObjectComponentDispatcher.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Unity.Entities;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedReaderWriter.cs
@@ -68,7 +68,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -77,7 +77,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -92,7 +92,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -101,7 +101,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -116,7 +116,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -125,7 +125,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -140,7 +140,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -149,7 +149,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -164,7 +164,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -173,7 +173,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -188,7 +188,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -197,7 +197,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -212,7 +212,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -221,7 +221,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -236,7 +236,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -245,7 +245,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -260,7 +260,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -269,7 +269,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -284,7 +284,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -293,7 +293,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -308,7 +308,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -317,7 +317,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -332,7 +332,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -341,7 +341,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -356,7 +356,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -365,7 +365,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -380,7 +380,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -389,7 +389,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -404,7 +404,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -413,7 +413,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -428,7 +428,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -437,7 +437,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -452,7 +452,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -461,7 +461,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularGameObjectComponentDispatcher.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularGameObjectComponentDispatcher.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Unity.Entities;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularReaderWriter.cs
@@ -68,7 +68,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -77,7 +77,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -92,7 +92,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -101,7 +101,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -116,7 +116,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -125,7 +125,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -140,7 +140,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -149,7 +149,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -164,7 +164,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -173,7 +173,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -188,7 +188,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -197,7 +197,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -212,7 +212,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -221,7 +221,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -236,7 +236,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -245,7 +245,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -260,7 +260,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -269,7 +269,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -284,7 +284,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -293,7 +293,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -308,7 +308,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -317,7 +317,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -332,7 +332,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -341,7 +341,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -356,7 +356,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -365,7 +365,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -380,7 +380,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -389,7 +389,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -404,7 +404,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -413,7 +413,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -428,7 +428,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -437,7 +437,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -452,7 +452,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -461,7 +461,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentGameObjectComponentDispatcher.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentGameObjectComponentDispatcher.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Unity.Entities;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentReaderWriter.cs
@@ -52,7 +52,7 @@ namespace Improbable.Gdk.Tests
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -61,7 +61,7 @@ namespace Improbable.Gdk.Tests
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionGameObjectComponentDispatcher.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionGameObjectComponentDispatcher.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Unity.Entities;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionReaderWriter.cs
@@ -61,7 +61,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -70,7 +70,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -86,7 +86,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
 
                 public void SendMyEvent(global::Improbable.Gdk.Tests.AlternateSchemaSyntax.RandomDataType payload)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return;
                     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentGameObjectComponentDispatcher.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentGameObjectComponentDispatcher.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Unity.Entities;
@@ -300,18 +301,23 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     for (var i = 0; i < entities.Length; i++)
                     {
                         var injectableStore = entityToInjectableStore[entities[i]];
-                        if (!injectableStore.TryGetInjectablesForComponent(commandResponseHandlerInjectableId, out var commandResponseHandlers))
-                        {
-                            continue;
-                        }
+                        injectableStore.TryGetInjectablesForComponent(commandResponseHandlerInjectableId,
+                            out var commandResponseHandlers);
 
                         var commandResponseList = commandResponseLists[i];
-                        foreach (Requirable.CommandResponseHandler commandResponseHandler in commandResponseHandlers)
+                        foreach (var commandResponse in commandResponseList.Responses)
                         {
-                            foreach (var commandResponse in commandResponseList.Responses)
+                            if (commandResponseHandlers != null)
                             {
-                                commandResponseHandler.OnFirstCommandResponseInternal(commandResponse);
+                                foreach (Requirable.CommandResponseHandler commandResponseHandler in
+                                    commandResponseHandlers)
+                                {
+                                    commandResponseHandler.OnFirstCommandResponseInternal(commandResponse);
+                                }
                             }
+
+                            var callback = commandResponse.Context as Action<FirstCommand.ReceivedResponse>;
+                            callback?.Invoke(commandResponse);
                         }
                     }
                 }
@@ -323,21 +329,27 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     for (var i = 0; i < entities.Length; i++)
                     {
                         var injectableStore = entityToInjectableStore[entities[i]];
-                        if (!injectableStore.TryGetInjectablesForComponent(commandResponseHandlerInjectableId, out var commandResponseHandlers))
-                        {
-                            continue;
-                        }
+                        injectableStore.TryGetInjectablesForComponent(commandResponseHandlerInjectableId,
+                            out var commandResponseHandlers);
 
                         var commandResponseList = commandResponseLists[i];
-                        foreach (Requirable.CommandResponseHandler commandResponseHandler in commandResponseHandlers)
+                        foreach (var commandResponse in commandResponseList.Responses)
                         {
-                            foreach (var commandResponse in commandResponseList.Responses)
+                            if (commandResponseHandlers != null)
                             {
-                                commandResponseHandler.OnSecondCommandResponseInternal(commandResponse);
+                                foreach (Requirable.CommandResponseHandler commandResponseHandler in
+                                    commandResponseHandlers)
+                                {
+                                    commandResponseHandler.OnSecondCommandResponseInternal(commandResponse);
+                                }
                             }
+
+                            var callback = commandResponse.Context as Action<SecondCommand.ReceivedResponse>;
+                            callback?.Invoke(commandResponse);
                         }
                     }
                 }
+
                 Profiler.EndSample();
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentMonoBehaviourCommandHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentMonoBehaviourCommandHandlers.cs
@@ -103,7 +103,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 public long SendFirstCommandRequest(EntityId entityId, global::Improbable.Gdk.Tests.BlittableTypes.FirstCommandRequest payload,
                     uint? timeoutMillis = null, bool allowShortCircuiting = false, object context = null)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return -1;
                     }
@@ -114,16 +114,44 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     return request.RequestId;
                 }
 
+                public long SendFirstCommandRequest(EntityId entityId, global::Improbable.Gdk.Tests.BlittableTypes.FirstCommandRequest payload,
+                    Action<FirstCommand.ReceivedResponse> callback, uint? timeoutMillis = null, bool allowShortCircuiting = false)
+                {
+                    if (!IsValid())
+                    {
+                        return -1;
+                    }
+
+                    var ecsCommandRequestSender = entityManager.GetComponentData<CommandSenders.FirstCommand>(entity);
+                    var request = FirstCommand.CreateRequest(entityId, payload, timeoutMillis, allowShortCircuiting, callback);
+                    ecsCommandRequestSender.RequestsToSend.Add(request);
+                    return request.RequestId;
+                }
+
                 public long SendSecondCommandRequest(EntityId entityId, global::Improbable.Gdk.Tests.BlittableTypes.SecondCommandRequest payload,
                     uint? timeoutMillis = null, bool allowShortCircuiting = false, object context = null)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return -1;
                     }
 
                     var ecsCommandRequestSender = entityManager.GetComponentData<CommandSenders.SecondCommand>(entity);
                     var request = SecondCommand.CreateRequest(entityId, payload, timeoutMillis, allowShortCircuiting, context);
+                    ecsCommandRequestSender.RequestsToSend.Add(request);
+                    return request.RequestId;
+                }
+
+                public long SendSecondCommandRequest(EntityId entityId, global::Improbable.Gdk.Tests.BlittableTypes.SecondCommandRequest payload,
+                    Action<SecondCommand.ReceivedResponse> callback, uint? timeoutMillis = null, bool allowShortCircuiting = false)
+                {
+                    if (!IsValid())
+                    {
+                        return -1;
+                    }
+
+                    var ecsCommandRequestSender = entityManager.GetComponentData<CommandSenders.SecondCommand>(entity);
+                    var request = SecondCommand.CreateRequest(entityId, payload, timeoutMillis, allowShortCircuiting, callback);
                     ecsCommandRequestSender.RequestsToSend.Add(request);
                     return request.RequestId;
                 }
@@ -158,7 +186,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -167,7 +195,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -185,7 +213,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -194,7 +222,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -238,7 +266,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -247,7 +275,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -266,7 +294,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -275,7 +303,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentReaderWriter.cs
@@ -60,7 +60,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -69,7 +69,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -84,7 +84,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -93,7 +93,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -108,7 +108,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -117,7 +117,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -132,7 +132,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -141,7 +141,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -156,7 +156,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -165,7 +165,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -213,7 +213,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -222,7 +222,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -238,7 +238,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
                 public void SendFirstEvent(global::Improbable.Gdk.Tests.BlittableTypes.FirstEventPayload payload)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return;
                     }
@@ -253,7 +253,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -262,7 +262,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -278,7 +278,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
                 public void SendSecondEvent(global::Improbable.Gdk.Tests.BlittableTypes.SecondEventPayload payload)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return;
                     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsGameObjectComponentDispatcher.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsGameObjectComponentDispatcher.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Unity.Entities;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsGameObjectComponentDispatcher.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsGameObjectComponentDispatcher.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Unity.Entities;
@@ -197,21 +198,27 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     for (var i = 0; i < entities.Length; i++)
                     {
                         var injectableStore = entityToInjectableStore[entities[i]];
-                        if (!injectableStore.TryGetInjectablesForComponent(commandResponseHandlerInjectableId, out var commandResponseHandlers))
-                        {
-                            continue;
-                        }
+                        injectableStore.TryGetInjectablesForComponent(commandResponseHandlerInjectableId,
+                            out var commandResponseHandlers);
 
                         var commandResponseList = commandResponseLists[i];
-                        foreach (Requirable.CommandResponseHandler commandResponseHandler in commandResponseHandlers)
+                        foreach (var commandResponse in commandResponseList.Responses)
                         {
-                            foreach (var commandResponse in commandResponseList.Responses)
+                            if (commandResponseHandlers != null)
                             {
-                                commandResponseHandler.OnCmdResponseInternal(commandResponse);
+                                foreach (Requirable.CommandResponseHandler commandResponseHandler in
+                                    commandResponseHandlers)
+                                {
+                                    commandResponseHandler.OnCmdResponseInternal(commandResponse);
+                                }
                             }
+
+                            var callback = commandResponse.Context as Action<Cmd.ReceivedResponse>;
+                            callback?.Invoke(commandResponse);
                         }
                     }
                 }
+
                 Profiler.EndSample();
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsMonoBehaviourCommandHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsMonoBehaviourCommandHandlers.cs
@@ -74,13 +74,27 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 public long SendCmdRequest(EntityId entityId, global::Improbable.Gdk.Tests.ComponentsWithNoFields.Empty payload,
                     uint? timeoutMillis = null, bool allowShortCircuiting = false, object context = null)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return -1;
                     }
 
                     var ecsCommandRequestSender = entityManager.GetComponentData<CommandSenders.Cmd>(entity);
                     var request = Cmd.CreateRequest(entityId, payload, timeoutMillis, allowShortCircuiting, context);
+                    ecsCommandRequestSender.RequestsToSend.Add(request);
+                    return request.RequestId;
+                }
+
+                public long SendCmdRequest(EntityId entityId, global::Improbable.Gdk.Tests.ComponentsWithNoFields.Empty payload,
+                    Action<Cmd.ReceivedResponse> callback, uint? timeoutMillis = null, bool allowShortCircuiting = false)
+                {
+                    if (!IsValid())
+                    {
+                        return -1;
+                    }
+
+                    var ecsCommandRequestSender = entityManager.GetComponentData<CommandSenders.Cmd>(entity);
+                    var request = Cmd.CreateRequest(entityId, payload, timeoutMillis, allowShortCircuiting, callback);
                     ecsCommandRequestSender.RequestsToSend.Add(request);
                     return request.RequestId;
                 }
@@ -115,7 +129,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -124,7 +138,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -168,7 +182,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -177,7 +191,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsGameObjectComponentDispatcher.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsGameObjectComponentDispatcher.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Unity.Entities;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsReaderWriter.cs
@@ -61,7 +61,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -70,7 +70,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -86,7 +86,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
                 public void SendEvt(global::Improbable.Gdk.Tests.ComponentsWithNoFields.Empty payload)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return;
                     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentGameObjectComponentDispatcher.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentGameObjectComponentDispatcher.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Unity.Entities;
@@ -300,18 +301,23 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     for (var i = 0; i < entities.Length; i++)
                     {
                         var injectableStore = entityToInjectableStore[entities[i]];
-                        if (!injectableStore.TryGetInjectablesForComponent(commandResponseHandlerInjectableId, out var commandResponseHandlers))
-                        {
-                            continue;
-                        }
+                        injectableStore.TryGetInjectablesForComponent(commandResponseHandlerInjectableId,
+                            out var commandResponseHandlers);
 
                         var commandResponseList = commandResponseLists[i];
-                        foreach (Requirable.CommandResponseHandler commandResponseHandler in commandResponseHandlers)
+                        foreach (var commandResponse in commandResponseList.Responses)
                         {
-                            foreach (var commandResponse in commandResponseList.Responses)
+                            if (commandResponseHandlers != null)
                             {
-                                commandResponseHandler.OnFirstCommandResponseInternal(commandResponse);
+                                foreach (Requirable.CommandResponseHandler commandResponseHandler in
+                                    commandResponseHandlers)
+                                {
+                                    commandResponseHandler.OnFirstCommandResponseInternal(commandResponse);
+                                }
                             }
+
+                            var callback = commandResponse.Context as Action<FirstCommand.ReceivedResponse>;
+                            callback?.Invoke(commandResponse);
                         }
                     }
                 }
@@ -323,21 +329,27 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     for (var i = 0; i < entities.Length; i++)
                     {
                         var injectableStore = entityToInjectableStore[entities[i]];
-                        if (!injectableStore.TryGetInjectablesForComponent(commandResponseHandlerInjectableId, out var commandResponseHandlers))
-                        {
-                            continue;
-                        }
+                        injectableStore.TryGetInjectablesForComponent(commandResponseHandlerInjectableId,
+                            out var commandResponseHandlers);
 
                         var commandResponseList = commandResponseLists[i];
-                        foreach (Requirable.CommandResponseHandler commandResponseHandler in commandResponseHandlers)
+                        foreach (var commandResponse in commandResponseList.Responses)
                         {
-                            foreach (var commandResponse in commandResponseList.Responses)
+                            if (commandResponseHandlers != null)
                             {
-                                commandResponseHandler.OnSecondCommandResponseInternal(commandResponse);
+                                foreach (Requirable.CommandResponseHandler commandResponseHandler in
+                                    commandResponseHandlers)
+                                {
+                                    commandResponseHandler.OnSecondCommandResponseInternal(commandResponse);
+                                }
                             }
+
+                            var callback = commandResponse.Context as Action<SecondCommand.ReceivedResponse>;
+                            callback?.Invoke(commandResponse);
                         }
                     }
                 }
+
                 Profiler.EndSample();
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentMonoBehaviourCommandHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentMonoBehaviourCommandHandlers.cs
@@ -103,7 +103,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 public long SendFirstCommandRequest(EntityId entityId, global::Improbable.Gdk.Tests.NonblittableTypes.FirstCommandRequest payload,
                     uint? timeoutMillis = null, bool allowShortCircuiting = false, object context = null)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return -1;
                     }
@@ -114,16 +114,44 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     return request.RequestId;
                 }
 
+                public long SendFirstCommandRequest(EntityId entityId, global::Improbable.Gdk.Tests.NonblittableTypes.FirstCommandRequest payload,
+                    Action<FirstCommand.ReceivedResponse> callback, uint? timeoutMillis = null, bool allowShortCircuiting = false)
+                {
+                    if (!IsValid())
+                    {
+                        return -1;
+                    }
+
+                    var ecsCommandRequestSender = entityManager.GetComponentData<CommandSenders.FirstCommand>(entity);
+                    var request = FirstCommand.CreateRequest(entityId, payload, timeoutMillis, allowShortCircuiting, callback);
+                    ecsCommandRequestSender.RequestsToSend.Add(request);
+                    return request.RequestId;
+                }
+
                 public long SendSecondCommandRequest(EntityId entityId, global::Improbable.Gdk.Tests.NonblittableTypes.SecondCommandRequest payload,
                     uint? timeoutMillis = null, bool allowShortCircuiting = false, object context = null)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return -1;
                     }
 
                     var ecsCommandRequestSender = entityManager.GetComponentData<CommandSenders.SecondCommand>(entity);
                     var request = SecondCommand.CreateRequest(entityId, payload, timeoutMillis, allowShortCircuiting, context);
+                    ecsCommandRequestSender.RequestsToSend.Add(request);
+                    return request.RequestId;
+                }
+
+                public long SendSecondCommandRequest(EntityId entityId, global::Improbable.Gdk.Tests.NonblittableTypes.SecondCommandRequest payload,
+                    Action<SecondCommand.ReceivedResponse> callback, uint? timeoutMillis = null, bool allowShortCircuiting = false)
+                {
+                    if (!IsValid())
+                    {
+                        return -1;
+                    }
+
+                    var ecsCommandRequestSender = entityManager.GetComponentData<CommandSenders.SecondCommand>(entity);
+                    var request = SecondCommand.CreateRequest(entityId, payload, timeoutMillis, allowShortCircuiting, callback);
                     ecsCommandRequestSender.RequestsToSend.Add(request);
                     return request.RequestId;
                 }
@@ -158,7 +186,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -167,7 +195,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -185,7 +213,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -194,7 +222,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -238,7 +266,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -247,7 +275,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -266,7 +294,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -275,7 +303,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentReaderWriter.cs
@@ -64,7 +64,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -73,7 +73,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -88,7 +88,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -97,7 +97,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -112,7 +112,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -121,7 +121,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -136,7 +136,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -145,7 +145,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -160,7 +160,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -169,7 +169,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -184,7 +184,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -193,7 +193,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -208,7 +208,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -217,7 +217,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -232,7 +232,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -241,7 +241,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -256,7 +256,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -265,7 +265,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -333,7 +333,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -342,7 +342,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -358,7 +358,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
                 public void SendFirstEvent(global::Improbable.Gdk.Tests.NonblittableTypes.FirstEventPayload payload)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return;
                     }
@@ -373,7 +373,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -382,7 +382,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -398,7 +398,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
                 public void SendSecondEvent(global::Improbable.Gdk.Tests.NonblittableTypes.SecondEventPayload payload)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return;
                     }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectWorldCommandSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectWorldCommandSystem.cs
@@ -1,3 +1,4 @@
+using System;
 using Improbable.Gdk.Core.Commands;
 using Unity.Collections;
 using Unity.Entities;
@@ -68,17 +69,18 @@ namespace Improbable.Gdk.GameObjectRepresentation
                 var entity = reserveEntityIdsResponseData.Entities[i];
                 var worldCommandResponseHandlers = GetWorldCommandResponseHandlersForEntity(entity);
 
-                if (worldCommandResponseHandlers == null)
-                {
-                    continue;
-                }
-
                 foreach (var receivedResponse in reserveEntityIdsResponseData.CommandResponses[i].Responses)
                 {
-                    foreach (var worldCommandHandler in worldCommandResponseHandlers)
+                    if (worldCommandResponseHandlers != null)
                     {
-                        worldCommandHandler.OnReserveEntityIdsResponseInternal(receivedResponse);
+                        foreach (var worldCommandHandler in worldCommandResponseHandlers)
+                        {
+                            worldCommandHandler.OnReserveEntityIdsResponseInternal(receivedResponse);
+                        }
                     }
+
+                    var callback = receivedResponse.Context as Action<WorldCommands.ReserveEntityIds.ReceivedResponse>;
+                    callback?.Invoke(receivedResponse);
                 }
             }
 
@@ -87,17 +89,18 @@ namespace Improbable.Gdk.GameObjectRepresentation
                 var entity = createEntityResponseData.Entities[i];
                 var worldCommandResponseHandlers = GetWorldCommandResponseHandlersForEntity(entity);
 
-                if (worldCommandResponseHandlers == null)
-                {
-                    continue;
-                }
-
                 foreach (var receivedResponse in createEntityResponseData.CommandResponses[i].Responses)
                 {
-                    foreach (var worldCommandHandler in worldCommandResponseHandlers)
+                    if (worldCommandResponseHandlers != null)
                     {
-                        worldCommandHandler.OnCreateEntityResponseInternal(receivedResponse);
+                        foreach (var worldCommandHandler in worldCommandResponseHandlers)
+                        {
+                            worldCommandHandler.OnCreateEntityResponseInternal(receivedResponse);
+                        }
                     }
+
+                    var callback = receivedResponse.Context as Action<WorldCommands.CreateEntity.ReceivedResponse>;
+                    callback?.Invoke(receivedResponse);
                 }
             }
 
@@ -106,17 +109,18 @@ namespace Improbable.Gdk.GameObjectRepresentation
                 var entity = deleteEntityResponseData.Entities[i];
                 var worldCommandResponseHandlers = GetWorldCommandResponseHandlersForEntity(entity);
 
-                if (worldCommandResponseHandlers == null)
-                {
-                    continue;
-                }
-
                 foreach (var receivedResponse in deleteEntityResponseData.CommandResponses[i].Responses)
                 {
-                    foreach (var worldCommandHandler in worldCommandResponseHandlers)
+                    if (worldCommandResponseHandlers != null)
                     {
-                        worldCommandHandler.OnDeleteEntityResponseInternal(receivedResponse);
+                        foreach (var worldCommandHandler in worldCommandResponseHandlers)
+                        {
+                            worldCommandHandler.OnDeleteEntityResponseInternal(receivedResponse);
+                        }
                     }
+
+                    var callback = receivedResponse.Context as Action<WorldCommands.DeleteEntity.ReceivedResponse>;
+                    callback?.Invoke(receivedResponse);
                 }
             }
 
@@ -125,17 +129,18 @@ namespace Improbable.Gdk.GameObjectRepresentation
                 var entity = entityQueryResponseData.Entities[i];
                 var worldCommandResponseHandlers = GetWorldCommandResponseHandlersForEntity(entity);
 
-                if (worldCommandResponseHandlers == null)
-                {
-                    continue;
-                }
-
                 foreach (var receivedResponse in entityQueryResponseData.CommandResponses[i].Responses)
                 {
-                    foreach (var worldCommandHandler in worldCommandResponseHandlers)
+                    if (worldCommandResponseHandlers != null)
                     {
-                        worldCommandHandler.OnEntityQueryResponseInternal(receivedResponse);
+                        foreach (var worldCommandHandler in worldCommandResponseHandlers)
+                        {
+                            worldCommandHandler.OnEntityQueryResponseInternal(receivedResponse);
+                        }
                     }
+
+                    var callback = receivedResponse.Context as Action<WorldCommands.EntityQuery.ReceivedResponse>;
+                    callback?.Invoke(receivedResponse);
                 }
             }
         }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/WorldCommandRequestSender.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/WorldCommandRequestSender.cs
@@ -1,4 +1,5 @@
-﻿using Improbable.Gdk.GameObjectRepresentation;
+﻿using System;
+using Improbable.Gdk.GameObjectRepresentation;
 using Improbable.Worker;
 using Unity.Entities;
 
@@ -61,6 +62,34 @@ namespace Improbable.Gdk.Core.Commands
                 }
 
                 /// <summary>
+                ///     Sends a ReserveEntityIds command request.
+                /// </summary>
+                /// <param name="numberOfEntityIds">The number of entity IDs to reserve.</param>
+                /// <param name="callback">
+                ///     A callback that will be called with the command response.
+                /// </param>
+                /// <param name="timeoutMillis">
+                ///     (Optional) The command timeout in milliseconds. If not specified, will default to 5 seconds.
+                /// </param>
+                /// <returns>The request ID of the command request.</returns>
+                public long ReserveEntityIds(uint numberOfEntityIds, Action<ReserveEntityIds.ReceivedResponse> callback,
+                    uint? timeoutMillis = null)
+                {
+                    if (!VerifyNotDisposed())
+                    {
+                        return -1;
+                    }
+
+                    var request =
+                        WorldCommands.ReserveEntityIds.CreateRequest(numberOfEntityIds, timeoutMillis, callback);
+
+                    entityManager.GetComponentData<ReserveEntityIds.CommandSender>(entity)
+                        .RequestsToSend.Add(request);
+
+                    return request.RequestId;
+                }
+
+                /// <summary>
                 ///     Sends a CreateEntity command request.
                 /// </summary>
                 /// <param name="entityTemplate">
@@ -95,6 +124,71 @@ namespace Improbable.Gdk.Core.Commands
                 }
 
                 /// <summary>
+                ///     Sends a CreateEntity command request.
+                /// </summary>
+                /// <param name="entityTemplate">
+                ///     The EntityTemplate object that defines the SpatialOS components on the to-be-created entity.
+                /// </param>
+                /// <param name="callback">
+                ///     A callback that will be called with the command response.
+                /// </param>
+                /// <param name="timeoutMillis">
+                ///     (Optional) The command timeout in milliseconds. If not specified, will default to 5 seconds.
+                /// </param>
+                /// <returns>The request ID of the command request.</returns>
+                public long CreateEntity(EntityTemplate entityTemplate, Action<CreateEntity.ReceivedResponse> callback,
+                    uint? timeoutMillis = null)
+                {
+                    if (!VerifyNotDisposed())
+                    {
+                        return -1;
+                    }
+
+                    var request =
+                        WorldCommands.CreateEntity.CreateRequest(entityTemplate, null, timeoutMillis, callback);
+
+                    entityManager.GetComponentData<CreateEntity.CommandSender>(entity)
+                        .RequestsToSend.Add(request);
+
+                    return request.RequestId;
+                }
+
+                /// <summary>
+                ///     Sends a CreateEntity command request.
+                /// </summary>
+                /// <param name="entityTemplate">
+                ///     The EntityTemplate object that defines the SpatialOS components on the to-be-created entity.
+                /// </param>
+                /// <param name="entityId">
+                ///     (Optional) The EntityId that the to-be-created entity should take.
+                ///     This should only be provided if received as the result of a ReserveEntityIds command.
+                /// </param>
+                /// <param name="callback">
+                ///     A callback that will be called with the command response.
+                /// </param>
+                /// <param name="timeoutMillis">
+                ///     (Optional) The command timeout in milliseconds. If not specified, will default to 5 seconds.
+                /// </param>
+                /// <returns>The request ID of the command request.</returns>
+                public long CreateEntity(EntityTemplate entityTemplate, EntityId entityId,
+                    Action<CreateEntity.ReceivedResponse> callback,
+                    uint? timeoutMillis = null)
+                {
+                    if (!VerifyNotDisposed())
+                    {
+                        return -1;
+                    }
+
+                    var request =
+                        WorldCommands.CreateEntity.CreateRequest(entityTemplate, entityId, timeoutMillis, callback);
+
+                    entityManager.GetComponentData<CreateEntity.CommandSender>(entity)
+                        .RequestsToSend.Add(request);
+
+                    return request.RequestId;
+                }
+
+                /// <summary>
                 ///     Sends a DeleteEntity command request.
                 /// </summary>
                 /// <param name="entityId"> The entity ID that is to be deleted.</param>
@@ -121,6 +215,33 @@ namespace Improbable.Gdk.Core.Commands
                 }
 
                 /// <summary>
+                ///     Sends a DeleteEntity command request.
+                /// </summary>
+                /// <param name="entityId"> The entity ID that is to be deleted.</param>
+                /// <param name="callback">
+                ///     A callback that will be called with the command response.
+                /// </param>
+                /// <param name="timeoutMillis">
+                ///     (Optional) The command timeout in milliseconds. If not specified, will default to 5 seconds.
+                /// </param>
+                /// <returns>The request ID of the command request.</returns>
+                public long DeleteEntity(EntityId entityId, Action<DeleteEntity.ReceivedResponse> callback,
+                    uint? timeoutMillis = null)
+                {
+                    if (!VerifyNotDisposed())
+                    {
+                        return -1;
+                    }
+
+                    var request = WorldCommands.DeleteEntity.CreateRequest(entityId, timeoutMillis, callback);
+
+                    entityManager.GetComponentData<DeleteEntity.CommandSender>(entity)
+                        .RequestsToSend.Add(request);
+
+                    return request.RequestId;
+                }
+
+                /// <summary>
                 ///     Sends an EntityQuery command request.
                 /// </summary>
                 /// <param name="entityQuery">The EntityQuery object defining the constraints and query type.</param>
@@ -128,7 +249,7 @@ namespace Improbable.Gdk.Core.Commands
                 ///     (Optional) The command timeout in milliseconds. If not specified, will default to 5 seconds.
                 /// </param>
                 /// <param name="context">
-                ///    (Optional) A context object that will be returned with the command response.
+                ///     (Optional) A context object that will be returned with the command response.
                 /// </param>
                 /// <returns>The request ID of the command request.</returns>
                 public long EntityQuery(Improbable.Worker.Query.EntityQuery entityQuery, uint? timeoutMillis = null,
@@ -140,6 +261,32 @@ namespace Improbable.Gdk.Core.Commands
                     }
 
                     var request = WorldCommands.EntityQuery.CreateRequest(entityQuery, timeoutMillis, context);
+                    entityManager.GetComponentData<EntityQuery.CommandSender>(entity)
+                        .RequestsToSend.Add(request);
+
+                    return request.RequestId;
+                }
+
+                /// <summary>
+                ///     Sends an EntityQuery command request.
+                /// </summary>
+                /// <param name="entityQuery">The EntityQuery object defining the constraints and query type.</param>
+                /// <param name="callback">
+                ///     A callback that will be called with the command response.
+                /// </param>
+                /// <param name="timeoutMillis">
+                ///     (Optional) The command timeout in milliseconds. If not specified, will default to 5 seconds.
+                /// </param>
+                /// <returns>The request ID of the command request.</returns>
+                public long EntityQuery(Improbable.Worker.Query.EntityQuery entityQuery,
+                    Action<EntityQuery.ReceivedResponse> callback, uint? timeoutMillis = null)
+                {
+                    if (!VerifyNotDisposed())
+                    {
+                        return -1;
+                    }
+
+                    var request = WorldCommands.EntityQuery.CreateRequest(entityQuery, timeoutMillis, callback);
                     entityManager.GetComponentData<EntityQuery.CommandSender>(entity)
                         .RequestsToSend.Add(request);
 

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/WorldCommandRequestSender.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/WorldCommandRequestSender.cs
@@ -47,7 +47,7 @@ namespace Improbable.Gdk.Core.Commands
                 /// <returns>The request ID of the command request.</returns>
                 public long ReserveEntityIds(uint numberOfEntityIds, uint? timeoutMillis = null, object context = null)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return -1;
                     }
@@ -75,7 +75,7 @@ namespace Improbable.Gdk.Core.Commands
                 public long ReserveEntityIds(uint numberOfEntityIds, Action<ReserveEntityIds.ReceivedResponse> callback,
                     uint? timeoutMillis = null)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return -1;
                     }
@@ -109,7 +109,7 @@ namespace Improbable.Gdk.Core.Commands
                 public long CreateEntity(EntityTemplate entityTemplate, EntityId? entityId = null,
                     uint? timeoutMillis = null, object context = null)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return -1;
                     }
@@ -139,7 +139,7 @@ namespace Improbable.Gdk.Core.Commands
                 public long CreateEntity(EntityTemplate entityTemplate, Action<CreateEntity.ReceivedResponse> callback,
                     uint? timeoutMillis = null)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return -1;
                     }
@@ -174,7 +174,7 @@ namespace Improbable.Gdk.Core.Commands
                     Action<CreateEntity.ReceivedResponse> callback,
                     uint? timeoutMillis = null)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return -1;
                     }
@@ -201,7 +201,7 @@ namespace Improbable.Gdk.Core.Commands
                 /// <returns>The request ID of the command request.</returns>
                 public long DeleteEntity(EntityId entityId, uint? timeoutMillis = null, object context = null)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return -1;
                     }
@@ -228,7 +228,7 @@ namespace Improbable.Gdk.Core.Commands
                 public long DeleteEntity(EntityId entityId, Action<DeleteEntity.ReceivedResponse> callback,
                     uint? timeoutMillis = null)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return -1;
                     }
@@ -255,7 +255,7 @@ namespace Improbable.Gdk.Core.Commands
                 public long EntityQuery(Improbable.Worker.Query.EntityQuery entityQuery, uint? timeoutMillis = null,
                     object context = null)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return -1;
                     }
@@ -281,7 +281,7 @@ namespace Improbable.Gdk.Core.Commands
                 public long EntityQuery(Improbable.Worker.Query.EntityQuery entityQuery,
                     Action<EntityQuery.ReceivedResponse> callback, uint? timeoutMillis = null)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return -1;
                     }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/WorldCommandResponseHandler.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/WorldCommandResponseHandler.cs
@@ -49,7 +49,7 @@ namespace Improbable.Gdk.Core.Commands
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -58,7 +58,7 @@ namespace Improbable.Gdk.Core.Commands
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -74,7 +74,7 @@ namespace Improbable.Gdk.Core.Commands
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -83,7 +83,7 @@ namespace Improbable.Gdk.Core.Commands
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -99,7 +99,7 @@ namespace Improbable.Gdk.Core.Commands
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -108,7 +108,7 @@ namespace Improbable.Gdk.Core.Commands
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -124,7 +124,7 @@ namespace Improbable.Gdk.Core.Commands
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -133,7 +133,7 @@ namespace Improbable.Gdk.Core.Commands
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/ReaderWriterBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/ReaderWriterBase.cs
@@ -35,7 +35,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
         {
             get
             {
-                if (!VerifyNotDisposed())
+                if (!IsValid())
                 {
                     return default(TSpatialComponentData);
                 }
@@ -60,7 +60,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
         /// </exception>
         public void Send(TComponentUpdate update)
         {
-            if (!VerifyNotDisposed())
+            if (!IsValid())
             {
                 return;
             }
@@ -85,7 +85,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
         /// </exception>
         public void SendAuthorityLossImminentAcknowledgement()
         {
-            if (!VerifyNotDisposed())
+            if (!IsValid())
             {
                 return;
             }
@@ -113,7 +113,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
         {
             get
             {
-                if (!VerifyNotDisposed())
+                if (!IsValid())
                 {
                     return Authority.NotAuthoritative;
                 }
@@ -148,7 +148,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
         {
             add
             {
-                if (!VerifyNotDisposed())
+                if (!IsValid())
                 {
                     return;
                 }
@@ -157,7 +157,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
             }
             remove
             {
-                if (!VerifyNotDisposed())
+                if (!IsValid())
                 {
                     return;
                 }
@@ -209,7 +209,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
         {
             add
             {
-                if (!VerifyNotDisposed())
+                if (!IsValid())
                 {
                     return;
                 }
@@ -218,7 +218,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
             }
             remove
             {
-                if (!VerifyNotDisposed())
+                if (!IsValid())
                 {
                     return;
                 }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/RequirableBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/RequirableBase.cs
@@ -19,7 +19,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
             this.logDispatcher = logDispatcher;
         }
 
-        protected bool VerifyNotDisposed()
+        protected bool IsValid()
         {
             if (isDisposed)
             {

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityGameObjectCommandHandlersGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityGameObjectCommandHandlersGenerator.tt
@@ -89,7 +89,7 @@ namespace <#= qualifiedNamespace #>
                 public long Send<#= commandDetails.CommandName #>Request(EntityId entityId, <#= commandDetails.FqnRequestType #> payload,
                     uint? timeoutMillis = null, bool allowShortCircuiting = false, object context = null)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return -1;
                     }
@@ -103,7 +103,7 @@ namespace <#= qualifiedNamespace #>
                 public long Send<#= commandDetails.CommandName #>Request(EntityId entityId, <#= commandDetails.FqnRequestType #> payload,
                     Action<<#= receivedResponseType #>> callback, uint? timeoutMillis = null, bool allowShortCircuiting = false)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return -1;
                     }
@@ -152,7 +152,7 @@ namespace <#= qualifiedNamespace #>
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -161,7 +161,7 @@ namespace <#= qualifiedNamespace #>
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -210,7 +210,7 @@ namespace <#= qualifiedNamespace #>
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -219,7 +219,7 @@ namespace <#= qualifiedNamespace #>
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityGameObjectCommandHandlersGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityGameObjectCommandHandlersGenerator.tt
@@ -82,7 +82,10 @@ namespace <#= qualifiedNamespace #>
                     this.logger = logger;
                 }
 
-<# foreach(var commandDetails in commandDetailsList) { #>
+<#
+    foreach(var commandDetails in commandDetailsList) {
+        var receivedResponseType = commandDetails.CommandName + ".ReceivedResponse";
+#>
                 public long Send<#= commandDetails.CommandName #>Request(EntityId entityId, <#= commandDetails.FqnRequestType #> payload,
                     uint? timeoutMillis = null, bool allowShortCircuiting = false, object context = null)
                 {
@@ -93,6 +96,20 @@ namespace <#= qualifiedNamespace #>
 
                     var ecsCommandRequestSender = entityManager.GetComponentData<CommandSenders.<#= commandDetails.CommandName #>>(entity);
                     var request = <#= commandDetails.CommandName #>.CreateRequest(entityId, payload, timeoutMillis, allowShortCircuiting, context);
+                    ecsCommandRequestSender.RequestsToSend.Add(request);
+                    return request.RequestId;
+                }
+
+                public long Send<#= commandDetails.CommandName #>Request(EntityId entityId, <#= commandDetails.FqnRequestType #> payload,
+                    Action<<#= receivedResponseType #>> callback, uint? timeoutMillis = null, bool allowShortCircuiting = false)
+                {
+                    if (!VerifyNotDisposed())
+                    {
+                        return -1;
+                    }
+
+                    var ecsCommandRequestSender = entityManager.GetComponentData<CommandSenders.<#= commandDetails.CommandName #>>(entity);
+                    var request = <#= commandDetails.CommandName #>.CreateRequest(entityId, payload, timeoutMillis, allowShortCircuiting, callback);
                     ecsCommandRequestSender.RequestsToSend.Add(request);
                     return request.RequestId;
                 }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityGameObjectComponentDispatcherGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityGameObjectComponentDispatcherGenerator.tt
@@ -284,14 +284,13 @@ namespace <#= qualifiedNamespace #>
                     for (var i = 0; i < entities.Length; i++)
                     {
                         var injectableStore = entityToInjectableStore[entities[i]];
-                        bool thereIsResponseHandler =
-                            injectableStore.TryGetInjectablesForComponent(commandResponseHandlerInjectableId,
-                                out var commandResponseHandlers);
+                        injectableStore.TryGetInjectablesForComponent(commandResponseHandlerInjectableId,
+                            out var commandResponseHandlers);
 
                         var commandResponseList = commandResponseLists[i];
                         foreach (var commandResponse in commandResponseList.Responses)
                         {
-                            if (thereIsResponseHandler)
+                            if (commandResponseHandlers != null)
                             {
                                 foreach (Requirable.CommandResponseHandler commandResponseHandler in
                                     commandResponseHandlers)

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityGameObjectComponentDispatcherGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityGameObjectComponentDispatcherGenerator.tt
@@ -12,6 +12,7 @@
 #>
 <#= generatedHeader #>
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Unity.Entities;
@@ -274,8 +275,8 @@ namespace <#= qualifiedNamespace #>
             {
 <# if (commandDetailsList.Count > 0) { #>
                 <#= profilingStart #>
-<# for (var j = 0; j < commandDetailsList.Count; j++) { #>
 
+<# for (var j = 0; j < commandDetailsList.Count; j++) { #>
                 if (!CommandResponsesComponentGroups[<#= j #>].IsEmptyIgnoreFilter)
                 {
                     var entities = CommandResponsesComponentGroups[<#= j #>].GetEntityArray();
@@ -283,21 +284,28 @@ namespace <#= qualifiedNamespace #>
                     for (var i = 0; i < entities.Length; i++)
                     {
                         var injectableStore = entityToInjectableStore[entities[i]];
-                        if (!injectableStore.TryGetInjectablesForComponent(commandResponseHandlerInjectableId, out var commandResponseHandlers))
-                        {
-                            continue;
-                        }
+                        bool thereIsResponseHandler =
+                            injectableStore.TryGetInjectablesForComponent(commandResponseHandlerInjectableId,
+                                out var commandResponseHandlers);
 
                         var commandResponseList = commandResponseLists[i];
-                        foreach (Requirable.CommandResponseHandler commandResponseHandler in commandResponseHandlers)
+                        foreach (var commandResponse in commandResponseList.Responses)
                         {
-                            foreach (var commandResponse in commandResponseList.Responses)
+                            if (thereIsResponseHandler)
                             {
-                                commandResponseHandler.On<#= commandDetailsList[j].CommandName #>ResponseInternal(commandResponse);
+                                foreach (Requirable.CommandResponseHandler commandResponseHandler in
+                                    commandResponseHandlers)
+                                {
+                                    commandResponseHandler.On<#= commandDetailsList[j].CommandName #>ResponseInternal(commandResponse);
+                                }
                             }
+
+                            var callback = commandResponse.Context as Action<<#= commandDetailsList[j].CommandName + ".ReceivedResponse" #>>;
+                            callback?.Invoke(commandResponse);
                         }
                     }
                 }
+
 <# } #>
                 <#= profilingEnd #>
 <# } #>

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityReaderWriterGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityReaderWriterGenerator.tt
@@ -71,7 +71,7 @@ namespace <#= qualifiedNamespace #>
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -80,7 +80,7 @@ namespace <#= qualifiedNamespace #>
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -117,7 +117,7 @@ namespace <#= qualifiedNamespace #>
                 {
                     add
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -126,7 +126,7 @@ namespace <#= qualifiedNamespace #>
                     }
                     remove
                     {
-                        if (!VerifyNotDisposed())
+                        if (!IsValid())
                         {
                             return;
                         }
@@ -142,7 +142,7 @@ namespace <#= qualifiedNamespace #>
 
                 public void Send<#= eventDetails.EventName #>(<#= eventDetails.FqnPayloadType #> payload)
                 {
-                    if (!VerifyNotDisposed())
+                    if (!IsValid())
                     {
                         return;
                     }


### PR DESCRIPTION
As usual, it's in commit order

#### Description
Who loves mad hacks. I love mad hacks.
Hack to add closures ahead of planned work to do this properly.

Also a driveby to change `VerifyNotDisposed` to `IsValid`
