### PR TITLE
Return EntityId when adding entity to snapshot

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Utility/Snapshot.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Utility/Snapshot.cs
@@ -21,9 +21,12 @@ namespace Improbable.Gdk.Core
         ///    The entity ID is automatically assigned.
         /// </remarks>
         /// <param name="entityTemplate">The entity to be added to the snapshot.</param>
-        public void AddEntity(EntityTemplate entityTemplate)
+        /// <returns>The entity ID assigned to the entity in the snapshot.</returns>
+        public EntityId AddEntity(EntityTemplate entityTemplate)
         {
-            entities[new EntityId(entities.Count + 1)] = entityTemplate.GetEntity();
+            var entityId = new EntityId(entities.Count + 1);
+            entities[entityId] = entityTemplate.GetEntity();
+            return entityId;
         }
 
         /// <summary>


### PR DESCRIPTION
#### Description
Another small FR - return the EntityId used when adding an entity to a snapshot.

#### Tests
Printed the return value to test - looks good.

#### Documentation
Updated the docstrings

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.

