### PR TITLE
adding all the mobile docs

### DIFF
--- a/docs/content/mobile/android/local-deploy.md
+++ b/docs/content/mobile/android/local-deploy.md
@@ -64,10 +64,10 @@ You need the Unity Remote app for this. See the [Unity documentation](https://do
     >
     > **It’s done when:** You see the following message in the terminal: `SpatialOS ready. Access the Inspector at http://localhost:21000/inspector`
 
-  1. In the Unity Editor, go to **File** > **Build Settings**. Choose the mobile device that you connected to your computer from the drop-down menu in the **Run Device** field..
+  1. In the Unity Editor, go to **File** > **Build Settings**. Choose the mobile device that you connected to your computer from the drop-down menu in the **Run Device** field.
   1. Click **Build and Run**.
 
-    > For subsequent runs you can just select **File** > **Build and Run**.)
+    > For subsequent runs you can just select **File** > **Build and Run**.
 
   1. Once the game is running on your device, you see an empty text field and a **Connect** button: enter the local IP address of your computer in the text field and click **Connect**.
   1. Play the game on your mobile device.

--- a/docs/content/mobile/android/local-deploy.md
+++ b/docs/content/mobile/android/local-deploy.md
@@ -17,9 +17,13 @@ You need the Unity Remote app for this. See the [Unity documentation](https://do
   1. In the **Unity Remote** section, click on the drop-down menu beside the **Device** option and select **Any Android Device**.
   1. On your mobile device, open the **Unity Remote** app. Make sure you allow it permissions for location and camera.
   1. In the Unity Editor, Select **SpatialOS** > **Local launch**.
-  > **It’s done when:** You see the following message in the terminal: `SpatialOS ready. Access the Inspector at http://localhost:21000/inspector`
+
+    > **It’s done when:** You see the following message in the terminal: `SpatialOS ready. Access the Inspector at http://localhost:21000/inspector`
+
   1. In the Editor’s Game view, select **Play**.
+
     > You can change the resolution of the Game view in your Unity Editor to make sure it does not appear stretched on your mobile device. Choose the resolution that’s identical to your mobile device to produce the best results.
+
   1. You should now see your Unity Editor game view mirrored on your Android device.
 
 ## Connecting your Android emulator to a local deployment
@@ -37,7 +41,10 @@ You need the Unity Remote app for this. See the [Unity documentation](https://do
     > **It’s done when:** You see the following message in the terminal: `SpatialOS ready. Access the Inspector at http://localhost:21000/inspector`
 
   1. In the Unity Editor, navigate to **File** > **Build Settings**. Select **Android** as your Build Platform and choose the virtual device from the drop-down menu in the **Run Device** field. The device is likely to be called **Google Android SDK built for x86 (emulator-XXXX)**.
-  1. In the Unity Editor, navigate to **File** > **Build Settings** and click **Build and Run**. (For subsequent runs using the same Emulator, you can just select **File** > **Build and Run**.)
+  1. In the Unity Editor, navigate to **File** > **Build Settings** and click **Build and Run**.
+
+    > For subsequent runs using the same Emulator, you can just select **File** > **Build and Run**.
+
   1. Once the game is deployed and started on the Emulator, you see an empty text field and a **Connect** button: Select **Connect**.
 
     > You don’t need to enter anything in the text field.
@@ -57,6 +64,9 @@ You need the Unity Remote app for this. See the [Unity documentation](https://do
     >
     > **It’s done when:** You see the following message in the terminal: `SpatialOS ready. Access the Inspector at http://localhost:21000/inspector`
 
-  1. In the Unity Editor, go to **File** > **Build Settings**. Choose the type of mobile device from the drop-down menu and click **Build and Run**. (For subsequent runs you can just select **File** > **Build and Run**.)
+  1. In the Unity Editor, go to **File** > **Build Settings**. Choose the type of mobile device from the drop-down menu and click **Build and Run**.
+
+    > For subsequent runs you can just select **File** > **Build and Run**.)
+
   1. Once the game is running on your device, you see an empty text field and a **Connect** button: enter the local IP address of your computer in the text field and click **Connect**.
   1. Play the game on your mobile device.

--- a/docs/content/mobile/android/local-deploy.md
+++ b/docs/content/mobile/android/local-deploy.md
@@ -1,0 +1,62 @@
+[//]: # (TODO - get rid of mobile_launch.json mention and explain it differently)
+
+# Connecting to a local deployment
+
+Before reading this document, make sure you are familiar with:
+
+  * [Setting up Android Support for the GDK]({{urlRoot}}/content/mobile/android/setup)
+  * [Ways to test your Android client]({{urlRoot}}/content/mobile/android/ways-to-test)
+
+## Connecting your Android device to a local deployment using Unity Remote
+You need the Unity Remote app for this. See the [Unity documentation](https://docs.unity3d.com/Manual/UnityRemote5.html) for details.
+
+  1. Enable USB debugging on your mobile device. See the [Android developer documentation](https://developer.android.com/studio/debug/dev-options#enable) for guidance.
+  1. Connect the mobile device to your computer using a USB cable. You might get a pop-up window on the device asking you to allow USB debugging. Select **Yes**.
+  1. Open the project that you want to deploy with the Unity Editor and go to **Edit** > **Project Settings** > **Editor** to bring up the **Editor Settings** window.
+  1. Open the scene that starts both your [client-]({{urlRoot}}/content/glossary#client-worker) and [server-workers]({{urlRoot}}/content/glossary#server-worker).
+  1. In the **Unity Remote** section, click on the drop-down menu beside the **Device** option and select **Any Android Device**.
+  1. On your mobile device, open the **Unity Remote** app. Make sure you allow it permissions for location and camera.
+  1. In the Unity Editor, Select **SpatialOS** > **Local launch**.
+  > **It’s done when:** You see the following message in the terminal: `SpatialOS ready. Access the Inspector at http://localhost:21000/inspector`
+  1. In the Editor’s Game view, select **Play**.
+    > You can change the resolution of the Game view in your Unity Editor to make sure it does not appear stretched on your mobile device. Choose the resolution that’s identical to your mobile device to produce the best results.
+  1. You should now see your Unity Editor game view mirrored on your Android device.
+
+## Connecting your Android emulator to a local deployment
+
+  1. [Start your Android Emulator in Android Studio.](https://developer.android.com/studio/run/managing-avds)
+
+    > Ensure to choose the same CPU architecture for your virtual machine as your development computer. If you don’t, you will get warning messages as mis-matched CPU architecture affects performance.
+
+  1. [Build your server-workers.]({{urlRoot}}/content/build)
+  1. You need to know the local IP address of your computer to connect. [This page](https://lifehacker.com/5833108/how-to-find-your-local-and-external-ip-address) (on the Lifehacker website)  describes how you can find your external and local IP address.
+  1. In a terminal window from the root folder of your SpatialOS project,  run: `spatial local launch mobile_launch.json --runtime_ip=<your-local-ip>`.  (Where `<your-local-ip>` is the IP address you just located.)
+
+    > You cannot use **SpatialOS** > **Local launch** in your Unity Editor, because you need to specify the runtime IP and a different launch configuration.
+    >
+    > **It’s done when:** You see the following message in the terminal: `SpatialOS ready. Access the Inspector at http://localhost:21000/inspector`
+
+  1. In the Unity Editor, navigate to **File** > **Build Settings**. Select **Android** as your Build Platform and choose the virtual device from the drop-down menu in the **Run Device** field. The device is likely to be called **Google Android SDK built for x86 (emulator-XXXX)**.
+  1. In the Unity Editor, navigate to **File** > **Build Settings** and click **Build and Run**. (For subsequent runs using the same Emulator, you can just select **File** > **Build and Run**.)
+  1. Once the game is deployed and started on the Emulator, you see an empty text field and a **Connect** button: Select **Connect**.
+
+    > You don’t need to enter anything in the text field.
+
+  1. Play the game on the Emulator.
+
+## Connecting your Android device to a local deployment
+
+  1. Enable USB debugging on your mobile device. See the [Android developer documentation](https://developer.android.com/studio/debug/dev-options#enable) for guidance.
+  1. Make sure your computer and your mobile device are both connected to the same wireless network.
+  1. Connect the mobile device to your computer using a USB cable. You might get a pop-up window on the device asking you to allow USB debugging. Select **Yes**.
+  1. [Build your server-workers.]({{urlRoot}}/content/build)
+  1. You need to know the local IP address of your computer to connect. [This page (on the Lifehacker website)](https://lifehacker.com/5833108/how-to-find-your-local-and-external-ip-address) describes how you can find your local and external IP address.
+  1. In a terminal window from the root folder of your SpatialOS project,  run: `spatial local launch mobile_launch.json --runtime_ip=<your-local-ip>`. (Where `<your-local-ip>` is the IP address you just located.)
+
+    > You cannot use **SpatialOS** > **Local launch** in your Unity Editor, because you need to specify the runtime IP and a different launch configuration.
+    >
+    > **It’s done when:** You see the following message in the terminal: `SpatialOS ready. Access the Inspector at http://localhost:21000/inspector`
+
+  1. In the Unity Editor, go to **File** > **Build Settings**. Choose the type of mobile device from the drop-down menu and click **Build and Run**. (For subsequent runs you can just select **File** > **Build and Run**.)
+  1. Once the game is running on your device, you see an empty text field and a **Connect** button: enter the local IP address of your computer in the text field and click **Connect**.
+  1. Play the game on your mobile device.

--- a/docs/content/mobile/android/local-deploy.md
+++ b/docs/content/mobile/android/local-deploy.md
@@ -41,7 +41,7 @@ You need the Unity Remote app for this. See the [Unity documentation](https://do
     > **It’s done when:** You see the following message in the terminal: `SpatialOS ready. Access the Inspector at http://localhost:21000/inspector`
 
   1. In the Unity Editor, navigate to **File** > **Build Settings**. Select **Android** as your Build Platform and choose the virtual device from the drop-down menu in the **Run Device** field. The device is likely to be called **Google Android SDK built for x86 (emulator-XXXX)**.
-  1. In the Unity Editor, navigate to **File** > **Build Settings** and click **Build and Run**.
+  1. Click **Build and Run**.
 
     > For subsequent runs using the same Emulator, you can just select **File** > **Build and Run**.
 
@@ -64,7 +64,8 @@ You need the Unity Remote app for this. See the [Unity documentation](https://do
     >
     > **It’s done when:** You see the following message in the terminal: `SpatialOS ready. Access the Inspector at http://localhost:21000/inspector`
 
-  1. In the Unity Editor, go to **File** > **Build Settings**. Choose the type of mobile device from the drop-down menu and click **Build and Run**.
+  1. In the Unity Editor, go to **File** > **Build Settings**. Choose the mobile device that you connected to your computer from the drop-down menu in the **Run Device** field..
+  1. Click **Build and Run**.
 
     > For subsequent runs you can just select **File** > **Build and Run**.)
 

--- a/docs/content/mobile/android/setup.md
+++ b/docs/content/mobile/android/setup.md
@@ -1,0 +1,23 @@
+# Setting up Android support for the GDK
+
+## Get the dependencies for developing Android games
+  1. Follow the steps in [Get the dependencies]({{urlRoot}}/setup-and-installing) and additionally install **Android build support** for Unity.
+  1. Install Android prerequisites:
+    * [Android Studio](https://developer.android.com/studio/) -  Once installed, open Android Studio. Ensure to install:
+       * The Android SDK
+       * The Android Studio emulator
+    * [Android NDK r13b](https://developer.android.com/ndk/downloads/older_releases) - Extract it to a directory of your choice. Note down this directory path as you will be needing it in the following steps.
+    * [JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+  * (Optional) [Unity Remote](https://play.google.com/store/apps/details?id=com.unity3d.genericremote) - this is Unity’s solution for faster development iteration times.
+
+## Set up your Unity Editor
+After installing these dependencies, open the Unity project in `<path-to-your-project>/workers/unity`.
+
+  1. In the Unity Editor, go to **File** > **Build Settings**. Select **Android** and then click on **Switch Platform**.
+  1. In the Unity Editor, go to **Edit** > **Preferences**. In the **External Tools** window, add the file paths to the tools in the **Android** section:
+
+| Field | How to find the path |
+|-------|------|
+| SDK  |  You can find the SDK location by opening Android Studio and selecting **Configure** from the launcher. |
+| JDK  |  **Windows:** default path is `C:\Program Files\Java` <br/>**Mac:** run `which java` to retrieve the path. |
+| NDK  |  Use the directory path that you noted down earlier when extracting the Android NDK.|

--- a/docs/content/mobile/android/ways-to-test.md
+++ b/docs/content/mobile/android/ways-to-test.md
@@ -1,0 +1,38 @@
+# Ways to test your Android client
+
+Before reading this document, make sure you are familiar with:
+
+  * [The SpatialOS GDK for Unity]({{urlRoot}}/content/intro-reference)
+  * [Mobile support overview]({{urlRoot}}/content/mobile/overview)
+  * [Setting up iOS support for the GDK]({{urlRoot}}/content/mobile/android/setup)
+
+Unity provides multiple ways to test your Android [client-worker]({{urlRoot}}/content/glossary#client-worker). We integrated them all to work with [SpatialOS]({{urlRoot}}/content/glossary#spatialos-runtime). This documentation describes the benefits of the different options.
+
+## In the Editor
+For standard workflows and for minor changes, run your game in the Editor. When the build platform is set for Android, it executes code that is in preprocessor `#if UNITY_ANDROID`clauses. This way, you have the full capabilities and ease of use of the Unity Editor, while still testing code that would otherwise only run on a mobile device.
+
+## Unity Remote
+
+With the Unity Remote, you don’t have to spend time building and deploying your game, reducing development iteration times. It mirrors the Unity Editor’s Game view on your mobile device, giving you quick feedback on how the game looks on a mobile device. However, it does not provide the full native capabilities the game running on a device.
+
+For more information, see the following documentation:
+
+  * [The Unity documentation on Unity Remote](https://docs.unity3d.com/Manual/UnityRemote5.html)
+  * [Run your game with Unity Remote]({{urlRoot}}/content/mobile/android/local-deploy#connecting-your-android-device-to-a-local-deployment-using-unity-remote)
+
+## Android Emulator
+
+The Android Emulator from Android Studio emulates Android devices on your development computer so that you can test your game on a variety of devices and Android APIs without needing a physical device. You need to build and deploy your game to use the Emulator.
+
+For more information, see the following documentation:
+
+  * [The Android Developers documentation](https://developer.android.com/studio/run/emulator)
+  * [Deploy your game with the Android Emulator]({{urlRoot}}/content/mobile/android/local-deploy#connecting-your-android-emulator-to-a-local-deployment)
+
+## Android device
+
+While it takes time to build and deploy, this option provides the full native capabilities of deploying the game to a device; good picture quality, instant feedback, and snappy controls.
+
+For more information, see the following documentation:
+
+  * [Deploy your game to an Android device]({{urlRoot}}/content/mobile/android/local-deploy#connecting-your-android-device-to-a-local-deployment)

--- a/docs/content/mobile/android/ways-to-test.md
+++ b/docs/content/mobile/android/ways-to-test.md
@@ -9,11 +9,11 @@ Before reading this document, make sure you are familiar with:
 Unity provides multiple ways to test your Android [client-worker]({{urlRoot}}/content/glossary#client-worker). We integrated them all to work with [SpatialOS]({{urlRoot}}/content/glossary#spatialos-runtime). This documentation describes the benefits of the different options.
 
 ## In the Editor
-For standard workflows and for minor changes, run your game in the Editor. When the build platform is set for Android, it executes code that is in preprocessor `#if UNITY_ANDROID`clauses. This way, you have the full capabilities and ease of use of the Unity Editor, while still testing code that would otherwise only run on a mobile device.
+For standard workflows and for minor changes, run your game in the Editor. When the build platform is set for Android, it executes code that is in preprocessor `#if UNITY_ANDROID` clauses. This way, you have the full capabilities and ease of use of the Unity Editor, while still testing code that would otherwise only run on a mobile device.
 
 ## Unity Remote
 
-With the Unity Remote, you don’t have to spend time building and deploying your game, reducing development iteration times. It mirrors the Unity Editor’s Game view on your mobile device, giving you quick feedback on how the game looks on a mobile device. However, it does not provide the full native capabilities the game running on a device.
+With the Unity Remote, you don’t have to spend time building and deploying your game, reducing development iteration times. It mirrors the Unity Editor’s Game view on your mobile device, giving you quick feedback on how the game looks on a mobile device. However, it does not provide the full native capabilities of the game running on a device.
 
 For more information, see the following documentation:
 

--- a/docs/content/mobile/ios/local-deploy.md
+++ b/docs/content/mobile/ios/local-deploy.md
@@ -1,0 +1,67 @@
+[//]: # (TODO - get rid of mobile_launch.json mention and explain it differently)
+
+# Connecting to a local deployment
+
+Before reading this document, make sure you are familiar with:
+
+  * [Setting up iOS Support for the GDK]({{urlRoot}}/content/mobile/ios/setup)
+  * [Ways to test your iOS client]({{urlRoot}}/content/mobile/ios/ways-to-test)
+
+## Connecting your iOS device to a local deployment using Unity Remote
+You need the Unity Remote app for this. See the [Unity documentation](https://docs.unity3d.com/Manual/UnityRemote5.html) for details.
+
+  1. Connect the mobile device to your computer using a USB cable.
+  1. Open the project that you want to deploy with the Unity Editor and go to **Edit** > **Project Settings** > **Editor** to bring up the **Editor Settings** window.
+  1. Open the scene that starts both your [client-]({{urlRoot}}/content/glossary#client-worker) and [server-workers]({{urlRoot}}/content/glossary#server-worker).
+  1. In the **Unity Remote** section, click on the drop-down menu beside the **Device** option and select **Any iOS Device**.
+  1. On your mobile device, open the **Unity Remote** app. Make sure you allow it permissions for location and camera.
+  1. In the Unity Editor, Select **SpatialOS** > **Local launch**.
+
+    > **It’s done when:** You see the following message in the terminal: `SpatialOS ready. Access the Inspector at http://localhost:21000/inspector`
+
+  1. In the Editor’s Game view, select **Play**.
+
+    > You can change the resolution of the Game view in your Unity Editor to make sure it does not appear stretched on your mobile device. Choose the resolution that’s identical to your mobile device to produce the best results.
+
+  1. You should now see your Unity Editor game view mirrored on your iOS device.
+
+## Connecting your iOS simulator to a local deployment
+
+  1. [Build your server-workers.]({{urlRoot}}/content/build)
+  1. In a terminal window from the root folder of your SpatialOS project,  run: `spatial local launch mobile_launch.json`.
+
+    > You cannot use **SpatialOS** > **Local launch** in your Unity Editor, because you need to specify a different launch configuration.
+    >
+    > **It’s done when:** You see the following message in the terminal: `SpatialOS ready. Access the Inspector at http://localhost:21000/inspector`
+
+  1. In the Unity Editor, navigate to **File** > **Build Settings**. Select **Player Settings** and navigate to **Settings for iOS** > **Other Settings** > **Configuration** > **Target SDK** and choose **Simulator SDK**
+  1. Click **Build and Run**. This prompts you to choose where to save the XCode project that Unity generates. After you've selected the directory, Unity generates the XCode project, opens it in XCode and starts the build. If the build succeeds, XCode starts a Simulator and installs the game on it.
+    * If you choose **Build**, instead of **Build and Run**, Unity generates a XCode project and opens the folder containing the project.
+  1. Once the game is deployed and started on the Simulator, you see an empty text field and a **Connect** button: Select **Connect**.
+
+    > You don’t need to enter anything in the text field.
+
+  1. Play the game on the Simulator.
+
+## Connecting your iOS device to a local deployment
+
+  1. Set up [Code signing and provisioning](https://help.apple.com/xcode/mac/current/#/dev60b6fbbc7).
+  1. Make sure your computer and your mobile device are both connected to the same wireless network.
+  1. Connect the mobile device to your computer using a USB cable.
+  1. [Build your server-workers.]({{urlRoot}}/content/build)
+  1. You need to know the local IP address of your computer to connect. [This page](https://lifehacker.com/5833108/how-to-find-your-local-and-external-ip-address) (on the Lifehacker website)  describes how you can find your external and local IP address.
+  1. In a terminal window from the root folder of your SpatialOS project,  run: `spatial local launch mobile_launch.json --runtime_ip=<your-local-ip>`. (Where `<your-local-ip>` is the IP address you just located.)
+
+    > You cannot use **SpatialOS** > **Local launch** in your Unity Editor, because you need to specify the runtime IP.
+    >
+    > **It’s done when:** You see the following message in the terminal: `SpatialOS ready. Access the Inspector at http://localhost:21000/inspector`
+
+  1. In the Unity Editor, navigate to **File** > **Build Settings**. Select **Player Settings**, navigate to **Settings for iOS** > **Other Settings** > **Configuration** > **Target SDK** and choose **Device SDK**
+  1.In the Unity Editor, navigate to **File** > **Build Settings** and click **Build**. This prompts you to choose where to save the XCode project that Unity generates. After you've selected the directory, Unity generates the XCode project and opens the folder containing the project. Open the project in XCode, select the Project root, go to **General** > **Signing** and make sure to fix all the errors if there are any.
+
+    > If you choose **Build and Run** instead of **Build** Unity generates the XCode project, automatically opens it for you and starts the build to install the game on the connected device. This will most likely fail, because you need to first sign the application as described in the previous step.
+    >
+    > For subsequent runs you will be prompted to pick XCode project directory again (with the one used previously preselected). You can generate a new project or append/replace existing one. In subsequent runs, if you've set up provisioning and use Append, you can use **Build and Run** to trigger project run automatically after XCode project was generated.
+
+  1. Once the game is running on your device, you see an empty text field and a **Connect** button: enter the local IP address of your computer in the text field and click **Connect**.
+  1. Play the game on your mobile device.

--- a/docs/content/mobile/ios/local-deploy.md
+++ b/docs/content/mobile/ios/local-deploy.md
@@ -34,7 +34,7 @@ You need the Unity Remote app for this. See the [Unity documentation](https://do
     >
     > **It’s done when:** You see the following message in the terminal: `SpatialOS ready. Access the Inspector at http://localhost:21000/inspector`
 
-    1. In the Unity Editor, navigate to **Edit** > **Project Settings** > **Player** > **Settings for iOS** > **Other Settings** > **Configuration** > **Target SDK** and choose **Simulator SDK**.
+  1. In the Unity Editor, navigate to **Edit** > **Project Settings** > **Player** > **Settings for iOS** > **Other Settings** > **Configuration** > **Target SDK** and choose **Simulator SDK**.
   1. In the Unity Editor, navigate to **File** > **Build Settings** and click **Build and Run**. This prompts you to choose where to save the XCode project that Unity generates. After you've selected the directory, Unity generates the XCode project, opens it in XCode and starts the build. If the build succeeds, XCode starts a Simulator and installs the game on it.
     * If you choose **Build**, instead of **Build and Run**, Unity generates a XCode project and opens the folder containing the project.
   1. Once the game is deployed and started on the Simulator, you see an empty text field and a **Connect** button: Select **Connect**.

--- a/docs/content/mobile/ios/local-deploy.md
+++ b/docs/content/mobile/ios/local-deploy.md
@@ -34,8 +34,8 @@ You need the Unity Remote app for this. See the [Unity documentation](https://do
     >
     > **It’s done when:** You see the following message in the terminal: `SpatialOS ready. Access the Inspector at http://localhost:21000/inspector`
 
-  1. In the Unity Editor, navigate to **File** > **Build Settings**. Select **Player Settings** and navigate to **Settings for iOS** > **Other Settings** > **Configuration** > **Target SDK** and choose **Simulator SDK**
-  1. Click **Build and Run**. This prompts you to choose where to save the XCode project that Unity generates. After you've selected the directory, Unity generates the XCode project, opens it in XCode and starts the build. If the build succeeds, XCode starts a Simulator and installs the game on it.
+    1. In the Unity Editor, navigate to **Edit** > **Project Settings** > **Player** > **Settings for iOS** > **Other Settings** > **Configuration** > **Target SDK** and choose **Simulator SDK**.
+  1. In the Unity Editor, navigate to **File** > **Build Settings** and click **Build and Run**. This prompts you to choose where to save the XCode project that Unity generates. After you've selected the directory, Unity generates the XCode project, opens it in XCode and starts the build. If the build succeeds, XCode starts a Simulator and installs the game on it.
     * If you choose **Build**, instead of **Build and Run**, Unity generates a XCode project and opens the folder containing the project.
   1. Once the game is deployed and started on the Simulator, you see an empty text field and a **Connect** button: Select **Connect**.
 
@@ -56,7 +56,7 @@ You need the Unity Remote app for this. See the [Unity documentation](https://do
     >
     > **It’s done when:** You see the following message in the terminal: `SpatialOS ready. Access the Inspector at http://localhost:21000/inspector`
 
-  1. In the Unity Editor, navigate to **File** > **Build Settings**. Select **Player Settings**, navigate to **Settings for iOS** > **Other Settings** > **Configuration** > **Target SDK** and choose **Device SDK**
+  1. In the Unity Editor, navigate to **Edit** > **Project Settings** > **Player** > **Settings for iOS** > **Other Settings** > **Configuration** > **Target SDK** and choose **Device SDK**.
   1. In the Unity Editor, navigate to **File** > **Build Settings** and click **Build**. This prompts you to choose where to save the XCode project that Unity generates. Select a directory and Unity generates the XCode project. After the build has finished, Unity opens the folder containing the project. Open the project in XCode, select the Project root, go to **General** > **Signing** and sign the project.
 
     > If you choose **Build and Run** instead of **Build** Unity generates the XCode project, automatically opens it for you and starts the build to install the game on the connected device. This will most likely fail, because you need to first sign the application as described in the previous step.

--- a/docs/content/mobile/ios/local-deploy.md
+++ b/docs/content/mobile/ios/local-deploy.md
@@ -57,7 +57,7 @@ You need the Unity Remote app for this. See the [Unity documentation](https://do
     > **It’s done when:** You see the following message in the terminal: `SpatialOS ready. Access the Inspector at http://localhost:21000/inspector`
 
   1. In the Unity Editor, navigate to **File** > **Build Settings**. Select **Player Settings**, navigate to **Settings for iOS** > **Other Settings** > **Configuration** > **Target SDK** and choose **Device SDK**
-  1.In the Unity Editor, navigate to **File** > **Build Settings** and click **Build**. This prompts you to choose where to save the XCode project that Unity generates. After you've selected the directory, Unity generates the XCode project and opens the folder containing the project. Open the project in XCode, select the Project root, go to **General** > **Signing** and make sure to fix all the errors if there are any.
+  1. In the Unity Editor, navigate to **File** > **Build Settings** and click **Build**. This prompts you to choose where to save the XCode project that Unity generates. Select a directory and Unity generates the XCode project. After the build has finished, Unity opens the folder containing the project. Open the project in XCode, select the Project root, go to **General** > **Signing** and sign the project.
 
     > If you choose **Build and Run** instead of **Build** Unity generates the XCode project, automatically opens it for you and starts the build to install the game on the connected device. This will most likely fail, because you need to first sign the application as described in the previous step.
     >

--- a/docs/content/mobile/ios/setup.md
+++ b/docs/content/mobile/ios/setup.md
@@ -1,8 +1,9 @@
 # Setting up iOS support for the GDK
 
 ## Get the dependencies for developing iOS games
+
   1. Follow the steps in [Get the dependencies]({{urlRoot}}/setup-and-installing) and additionally install **iOS build support** for Unity.
-  2. Install iOS prerequisites
+  1. Install iOS prerequisites
     * [Xcode](https://developer.apple.com/xcode/)
       * Once installed, open Xcode. It might prompt you to accept user agreements.
     * (Optional) [Unity Remote](https://itunes.apple.com/gb/app/unity-remote-5/id871767552?mt=8) - this is Unity’s solution for faster development iteration times.

--- a/docs/content/mobile/ios/setup.md
+++ b/docs/content/mobile/ios/setup.md
@@ -1,0 +1,13 @@
+# Setting up iOS support for the GDK
+
+## Get the dependencies for developing iOS games
+  1. Follow the steps in [Get the dependencies]({{urlRoot}}/setup-and-installing) and additionally install **iOS build support** for Unity.
+  2. Install iOS prerequisites
+    * [Xcode](https://developer.apple.com/xcode/)
+      * Once installed, open Xcode. It might prompt you to accept user agreements.
+    * (Optional) [Unity Remote](https://itunes.apple.com/gb/app/unity-remote-5/id871767552?mt=8) - this is Unity’s solution for faster development iteration times.
+
+## Set up your Unity Editor
+After installing these dependencies, open the Unity project in `<path-to-your-project>/workers/unity`.
+
+  1. In the Unity Editor, go to **File** > **Build Settings**. Select **iOS** and then click on **Switch Platform**.

--- a/docs/content/mobile/ios/ways-to-test.md
+++ b/docs/content/mobile/ios/ways-to-test.md
@@ -1,0 +1,38 @@
+# Ways to test your iOS client
+
+Before reading this document, make sure you are familiar with:
+
+  * [The SpatialOS GDK for Unity]({{urlRoot}}/content/intro-reference)
+  * [Mobile support overview]({{urlRoot}}/content/mobile/overview)
+  * [Setting up iOS support for the GDK]({{urlRoot}}/content/mobile/ios/setup)
+
+Unity provides multiple ways to test your iOS [client-worker]({{urlRoot}}/content/glossary#client-worker). We integrated them all to work with [SpatialOS]({{urlRoot}}/content/glossary#spatialos-runtime). This documentation describes the benefits of the different options.
+
+## In the Editor
+For standard workflows and for minor changes, run your game in the Editor. When the build platform is set for iOS, it executes code that is in preprocessor `#if UNITY_IOS` clauses. This way, you have the full capabilities and ease of use of the Unity Editor, while still testing code that would otherwise only run on a mobile device.
+
+## Unity Remote
+
+With the Unity Remote, you don’t have to spend time building and deploying your game, reducing development iteration times. It mirrors the Unity Editor’s Game view on your mobile device, giving you quick feedback on how the game looks on a mobile device. However, it does not provide the full native capabilities the game running on a device.
+
+For more information, see the following documentation:
+
+  * [The Unity documentation on Unity Remote](https://docs.unity3d.com/Manual/UnityRemote5.html)
+  * [Run your game with Unity Remote]({{urlRoot}}/content/mobile/ios/local-deploy#connecting-your-ios-device-to-a-local-deployment-using-unity-remote)
+
+## iOS Simulator
+
+The iOS Simulator simulates iOS devices on your development computer so that you can test your game on a variety of devices and iOS versions without needing a physical device. You need to build and deploy your game to use the Simulator.
+
+For more information, see the following documentation:
+
+  * [The Apple Developer documentation](https://developer.apple.com/library/archive/documentation/IDEs/Conceptual/simulator_help_topics/Chapter/Chapter.html)
+  * [Deploy your game with the iOS Simulator]({{urlRoot}}/content/mobile/ios/local-deploy#connecting-your-ios-simulator-to-a-local-deployment)
+
+## iOS device
+
+While it takes time to build and deploy, this option provides the full native capabilities of deploying the game to a device; good picture quality, instant feedback, and snappy controls.
+
+For more information, see the following documentation:
+
+  * [Deploy your game to an iOS device]({{urlRoot}}/content/mobile/ios/local-deploy#connecting-your-ios-device-to-a-local-deployment)

--- a/docs/content/mobile/ios/ways-to-test.md
+++ b/docs/content/mobile/ios/ways-to-test.md
@@ -13,7 +13,7 @@ For standard workflows and for minor changes, run your game in the Editor. When 
 
 ## Unity Remote
 
-With the Unity Remote, you don’t have to spend time building and deploying your game, reducing development iteration times. It mirrors the Unity Editor’s Game view on your mobile device, giving you quick feedback on how the game looks on a mobile device. However, it does not provide the full native capabilities the game running on a device.
+With the Unity Remote, you don’t have to spend time building and deploying your game, reducing development iteration times. It mirrors the Unity Editor’s Game view on your mobile device, giving you quick feedback on how the game looks on a mobile device. However, it does not provide the full native capabilities of the game running on a device.
 
 For more information, see the following documentation:
 

--- a/docs/content/mobile/overview.md
+++ b/docs/content/mobile/overview.md
@@ -1,0 +1,28 @@
+<%(Callout type="alert" message="
+Mobile support is in [pre-alpha (SpatialOS documentation)](https://docs.improbable.io/reference/13.3/shared/release-policy#maturity-stages). Currently, you can only connect your mobile client-workers to a local deployment: you **cannot** connect mobile client-workers to a cloud deployment. Please follow our [Roadmap](https://trello.com/b/29tMKyQC) to learn more about updates to this in future releases.")%>
+
+# Mobile Support Overview
+
+Before starting with mobile development, make sure you are familiar with
+
+  * [The SpatialOS GDK for Unity]({{urlRoot}}/content/intro-reference)
+  * [The different workflows]({{urlRoot}}/content/intro-workflows-spatialos-entities)
+  * [Workers in the GDK]({{urlRoot}}/content/workers/workers-in-the-gdk)
+
+## Developing SpatialOS games for Android and iOS
+
+We provide a feature module for the SpatialOS GDK for Unity to allow you to develop games for Android and iOS. This allows you to build [client-workers]({{urlRoot}}/content/glossary#client-worker) for different platforms that can all connect to the same deployment and enables you to create cross-platform games.  All current feature modules are supported and work with mobile devices.
+
+Mobile support is in [pre-alpha (SpatialOS documentation)](https://docs.improbable.io/reference/latest/shared/release-policy#maturity-stages). Currently, you can only connect your mobile client-workers to a local deployment: you **cannot** connect mobile client-workers to a cloud deployment. Please follow our [Roadmap](https://trello.com/b/29tMKyQC) to learn more about updates to this in future releases.
+
+## Getting started with your Android client-worker
+
+  * [Setting up Android support for the GDK]({{urlRoot}}/content/mobile/android/setup)
+  * [Choose the right way to test your Android client-worker]({{urlRoot}}/content/mobile/android/ways-to-test)
+  * [Connect your Android client-worker to a local deployment]({{urlRoot}}/content/mobile/android/local-deploy)
+
+## Getting started with your iOS client-worker
+
+  * [Setting up iOS support for the GDK]({{urlRoot}}/content/mobile/ios/setup)
+  * [Choose the right way to test your iOS client-worker]({{urlRoot}}/content/mobile/ios/ways-to-test)
+  * [Connect your iOS client-worker to a local deployment]({{urlRoot}}/content/mobile/ios/local-deploy)

--- a/docs/content/modules/core-and-feature-module-overview.md
+++ b/docs/content/modules/core-and-feature-module-overview.md
@@ -77,7 +77,7 @@ To access this module, use the `Improbable.Gdk.GameObjectCreation` namespace. It
 
 This module consists of:
 
-*    `IEntityGameObjectCreator` -  in the repository [here](https://github.com/spatialos/gdk-for-unity/tree/master/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/IEntityGameObjectCreator.cs).
+* `IEntityGameObjectCreator` - in the repository [here](https://github.com/spatialos/gdk-for-unity/tree/master/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/IEntityGameObjectCreator.cs).
 <br/>This is an interface to implement your customized version of the [Creation Feature Module]({{urlRoot}}/content/gameobject/linking-spatialos-entities) which you use for creating [GameObjects linked to SpatialOS entities]({{urlRoot}}/content/gameobject/linking-spatialos-entities).
 <br/>See the documentation on [How to link SpatialOS entities with GameObjects]({{urlRoot}}/content//gameobject/linking-spatialos-entities).
 
@@ -101,7 +101,7 @@ This module consists of:
 * `MobileWorkerConnector` - in the repository [here](https://github.com/spatialos/gdk-for-unity/tree/master/workers/unity/Packages/com.improbable.gdk.mobile).<br/>
 Inherit from this class to define your custom mobile worker connectors.
 
-*    `Improbable.Gdk.Mobile.Android` - in the repository [here](https://github.com/spatialos/gdk-for-unity/tree/master/workers/unity/Packages/com.improbable.gdk.mobile/Android).
+* `Improbable.Gdk.Mobile.Android` - in the repository [here](https://github.com/spatialos/gdk-for-unity/tree/master/workers/unity/Packages/com.improbable.gdk.mobile/Android).
 <br/>It provides additional functionality that you might need when developing for Android.
 
 * `Improbable.Gdk.Mobile.iOS` - in the repository [here](https://github.com/spatialos/gdk-for-unity/tree/master/workers/unity/Packages/com.improbable.gdk.mobile/iOS).

--- a/docs/content/modules/core-and-feature-module-overview.md
+++ b/docs/content/modules/core-and-feature-module-overview.md
@@ -73,7 +73,7 @@ Find out more in the [Transform synchronization feature module]({{urlRoot}}/cont
 
 To access this module, use the `Improbable.Gdk.GameObjectCreation` namespace. It offers a default implementation of spawning GameObjects for your SpatialOS entities.
 
-`Improbable.Gdk.GameObjectCreation`  is in the repository [here](https://github.com/spatialos/gdk-for-unity/tree/master/workers/unity/Packages/com.improbable.gdk.gameobjectcreation).
+`Improbable.Gdk.GameObjectCreation` is in the repository [here](https://github.com/spatialos/gdk-for-unity/tree/master/workers/unity/Packages/com.improbable.gdk.gameobjectcreation).
 
 This module consists of:
 
@@ -89,3 +89,22 @@ Use this enable custom spawning by passing in parameters to change the default.
 
 
 Call these during [entity templates creation]({{urlRoot}}/content/entity-templates).
+
+### Mobile support module
+
+To access this module, use the `Improbable.Gdk.Mobile` namespace. It offers support to connect mobile [client-workers]({{urlRoot}}/content/glossary#client-worker) to SpatialOS.
+
+`Improbable.Gdk.Mobile` is in the repository [here](https://github.com/spatialos/gdk-for-unity/tree/master/workers/unity/Packages/com.improbable.gdk.mobile).
+
+This module consists of:
+
+* `MobileWorkerConnector` - in the repository [here](https://github.com/spatialos/gdk-for-unity/tree/master/workers/unity/Packages/com.improbable.gdk.mobile).<br/>
+Inherit from this class to define your custom mobile worker connectors.
+
+*    `Improbable.Gdk.Mobile.Android` - in the repository [here](https://github.com/spatialos/gdk-for-unity/tree/master/workers/unity/Packages/com.improbable.gdk.mobile/Android).
+<br/>It provides additional functionality that you might need when developing for Android.
+
+* `Improbable.Gdk.Mobile.iOS` - in the repository [here](https://github.com/spatialos/gdk-for-unity/tree/master/workers/unity/Packages/com.improbable.gdk.mobile/iOS).
+<br/>It provides additional functionality that you might need when developing for iOS.
+
+Find out more in the [Mobile support]({{urlRoot}}/content/mobile/overview) documentation.

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -49,7 +49,7 @@
     - [Snapshots]({{urlRoot}}/content/snapshots)
     - <h4>Code generation:</h4>
         - [* The code generator]({{urlRoot}}/content/code-generator)
-        - [* ECS component generation]({{urlRoot}}/content/ecs/component-generation) 
+        - [* ECS component generation]({{urlRoot}}/content/ecs/component-generation)
     - [Logging]({{urlRoot}}/content/ecs/logging)
 - <h3> + MonoBehaviour workflow</h3>
     - [Which workflow?]({{urlRoot}}/content/intro-workflows-spatialos-entities)
@@ -82,6 +82,16 @@
     - [Worker entity]({{urlRoot}}/content/workers/worker-entity)
     - [Temporary component]({{urlRoot}}/content/ecs/temporary-components)
     - [Custom replication system]({{urlRoot}}/content/ecs/custom-replication-system)
+- <h3> + Mobile support</h3>
+    - [Overview]({{urlRoot}}/content/mobile/overview)
+    - <h4> + Android Support:</h4>
+        - [* Setting up Android support]({{urlRoot}}/content/mobile/android/setup)
+        - [* Ways to  test your Android client]({{urlRoot}}/content/mobile/android/ways-to-test)
+        - [* Connecting to a local deployment]({{urlRoot}}/content/mobile/android/local-deploy)
+    - <h4> + iOS Support:</h4>
+        - [* Setting up iOS support]({{urlRoot}}/content/mobile/ios/setup)
+        - [* Ways to test your iOS client]({{urlRoot}}/content/mobile/ios/ways-to-test)
+        - [* Connecting to a local deployment]({{urlRoot}}/content/mobile/ios/local-deploy)
 - <h3> + Tests</h3>
     - [Test overview]({{urlRoot}}/content/testing/testing-overview)
     - [How to run tests]({{urlRoot}}/content/testing/how-to-run-tests)


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](https://docs.improbable.io/unity/alpha/contributing) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
All the documentation on how to run local deployments for iOS and Android and some additional information.
This is a first version that we publish just to have docs ready and will improve them over time

#### Tests
checked the preview. everything looked good

#### Documentation
this is it

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
