### PR TITLE
Add AuthorityLossImminent acknowledgement docs 

### DIFF
--- a/docs/content/gameobject/readers-writers.md
+++ b/docs/content/gameobject/readers-writers.md
@@ -170,4 +170,4 @@ void SendAuthorityLossImminentAcknowledgement();
 ```
 Allows you to send acknowledgements to [`AuthorityLossImminent` notifications](https://docs.improbable.io/reference/latest/shared/design/understanding-access#enabling-and-configuring-authoritylossimminent-notifications).
 
-> This method will throw an `InvalidOperationException` if the authority state of `TComponent` is not `AuthorityLossImminent`.
+> This method throws an `InvalidOperationException` if the authority state of `TComponent` is not `AuthorityLossImminent`.

--- a/docs/content/gameobject/readers-writers.md
+++ b/docs/content/gameobject/readers-writers.md
@@ -27,7 +27,9 @@ Readers and Writers allow you to inspect and change the state of SpatialOS compo
   * Change the property values of a SpatialOS component.
   * Send events defined in a SpatialOS component.
   * Send acknowledgement for [`AuthorityLossImminent` notifications](https://docs.improbable.io/reference/latest/shared/design/understanding-access#enabling-and-configuring-authoritylossimminent-notifications).
-  * All the functionality that a Reader provides (except for listening to authority state changes).
+  * All the functionality that a Reader provides.
+
+> Note that a writer will only receive authority state change callbacks for `AuthorityLossImminent`.
 
 For every SpatialOS component defined in schema, the GDK generates a Reader and Writer. After code generation has finished, the generated Readers and Writers are located in the following namespace:
 

--- a/docs/content/gameobject/readers-writers.md
+++ b/docs/content/gameobject/readers-writers.md
@@ -26,7 +26,7 @@ Readers and Writers allow you to inspect and change the state of SpatialOS compo
 
   * Change the property values of a SpatialOS component.
   * Send events defined in a SpatialOS component.
-  * Send acknowledgement for [`AuthorityLossImminent` notifications](https://docs.improbable.io/reference/latest/shared/design/understanding-access#enabling-and-configuring-authoritylossimminent-notifications).
+  * Send acknowledgements for [`AuthorityLossImminent` notifications](https://docs.improbable.io/reference/latest/shared/design/understanding-access#enabling-and-configuring-authoritylossimminent-notifications).
   * All the functionality that a Reader provides.
 
 > Note that a writer will only receive authority state change callbacks for `AuthorityLossImminent`.
@@ -168,6 +168,6 @@ Parameters:
 ```csharp
 void SendAuthorityLossImminentAcknowledgement();
 ```
-Allows you to send acknowledgements to [`AuthorityLossImminent` notifications](https://docs.improbable.io/reference/latest/shared/design/understanding-access#enabling-and-configuring-authoritylossimminent-notifications).
+Allows you to send acknowledgements for [`AuthorityLossImminent` notifications](https://docs.improbable.io/reference/latest/shared/design/understanding-access#enabling-and-configuring-authoritylossimminent-notifications).
 
 > This method throws an `InvalidOperationException` if the authority state of `TComponent` is not `AuthorityLossImminent`.

--- a/docs/content/gameobject/readers-writers.md
+++ b/docs/content/gameobject/readers-writers.md
@@ -26,7 +26,8 @@ Readers and Writers allow you to inspect and change the state of SpatialOS compo
 
   * Change the property values of a SpatialOS component.
   * Send events defined in a SpatialOS component.
-  * All the functionality that a Reader provides (except for listening to authority state changes)
+  * Send acknowledgement for [`AuthorityLossImminent` notifications](https://docs.improbable.io/reference/latest/shared/design/understanding-access#enabling-and-configuring-authoritylossimminent-notifications).
+  * All the functionality that a Reader provides (except for listening to authority state changes).
 
 For every SpatialOS component defined in schema, the GDK generates a Reader and Writer. After code generation has finished, the generated Readers and Writers are located in the following namespace:
 
@@ -104,7 +105,7 @@ The exact type of these generics depends on the component that the writer is gen
 | Field         	| Type               	| Description                	|
 |-------------------|------------------------|--------------------------------|
 | Data  	| TSpatialComponentData              	| Thee data stored inside the component that this Reader is associated with. |
-| Authority | [Authority]({{urlRoot}}/content/glossary#authority) | The [authority]() status of the current worker of the component that this Reader is associated with. |
+| Authority | [Authority]({{urlRoot}}/content/glossary#authority) | The [authority](https://docs.improbable.io/reference/latest/shared/concepts/interest-authority#authority) status of the current worker of the component that this Reader is associated with. |
 
 
 **Events:**
@@ -161,3 +162,10 @@ Allows you to send an event. These methods are code-generated for each event in 
 Parameters:
 
   * `TEventPayload payload`: The data that you want to send with your event. The exact type is specified by the schema definition of the event.
+
+```csharp
+void SendAuthorityLossImminentAcknowledgement();
+```
+Allows you to send acknowledgements to [`AuthorityLossImminent` notifications](https://docs.improbable.io/reference/latest/shared/design/understanding-access#enabling-and-configuring-authoritylossimminent-notifications).
+
+> This method will throw an `InvalidOperationException` if the authority state of `TComponent` is not `AuthorityLossImminent`.


### PR DESCRIPTION
#### Description
Added docs for the writer API for sending authority loss imminent acknowledgements. One or two little drivebys.

Not sure if we want to add docs for the ECS workflow as well? Would probably require a full code sample 

#### Tests
Looked at improbadoc output - looked good.

#### Documentation
Yes

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@samiwh 
