### PR TITLE
ToC formatting tidy-up and standardize

### DIFF
--- a/docs/toc.md
+++ b/docs/toc.md
@@ -39,7 +39,7 @@
         - [API - worker system]({{urlRoot}}/content/workers/api-worker-system)
     - SpatialOS entities
         - [Update entity lifecycle]({{urlRoot}}/content/entity-lifecycle)
-        - [Creating SpatialOS entity templates]({{urlRoot}}/content/entity-templates)
+        - [Create SpatialOS entity templates]({{urlRoot}}/content/entity-templates)
         - [API - EntityBuilder]({{urlRoot}}/content/api-entity-builder)
     - Commands
         - [World and component command requests and responses]({{urlRoot}}/content/world-component-commands-requests-responses)

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -34,7 +34,7 @@
 - <h3> + GDK concepts</h3>
     - Workers
         - [Workers in the GDK]({{urlRoot}}/content/workers/workers-in-the-gdk)
-        - [Connecting to the SpatialOS Runtime]({{urlRoot}}/content/connecting-to-spatialos)
+        - [Connect to the SpatialOS Runtime]({{urlRoot}}/content/connecting-to-spatialos)
         - [API - worker]({{urlRoot}}/content/workers/api-worker)
         - [API - worker system]({{urlRoot}}/content/workers/api-worker-system)
     - SpatialOS entities

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -34,7 +34,7 @@
 - <h3> + GDK concepts</h3>
     - Workers
         - [Workers in the GDK]({{urlRoot}}/content/workers/workers-in-the-gdk)
-        - [Connecting to SpatialOS Runtime]({{urlRoot}}/content/connecting-to-spatialos)
+        - [Connecting to the SpatialOS Runtime]({{urlRoot}}/content/connecting-to-spatialos)
         - [API - worker]({{urlRoot}}/content/workers/api-worker)
         - [API - worker system]({{urlRoot}}/content/workers/api-worker-system)
     - SpatialOS entities
@@ -62,7 +62,7 @@
         - [Readers and writers]({{urlRoot}}/content/gameobject/readers-writers)
         - [Readers and writers: SpatialOS component data]({{urlRoot}}/content/gameobject/reading-and-writing-component-data)
         - [Readers and writers: Events]({{urlRoot}}/content/gameobject/sending-receiving-events)
-        - [Commands: SpatialOS Component commands]({{urlRoot}}/content/gameobject/sending-receiving-commands)
+        - [Commands: SpatialOS component commands]({{urlRoot}}/content/gameobject/sending-receiving-commands)
         - [Commands: World commands]({{urlRoot}}/content/gameobject/world-commands)
     - [Create and delete SpatialOS entities]({{urlRoot}}/content/gameobject/create-delete-spatialos-entities)
     - [API - SpatialOSComponent]({{urlRoot}}/content/gameobject/spatialoscomponent)

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -12,7 +12,7 @@
 
 ***
 - <h3> Starter projects</h3>
-- <h3> [ - FPS starter project]({{urlRoot}}/projects/fps/overview)</h3>
+- <h3> [ - FPS Starter Project]({{urlRoot}}/projects/fps/overview)</h3>
 
 ***
 - <h3> Reference</h3>
@@ -26,7 +26,7 @@
     - [Core and Feature Module overview]({{urlRoot}}/content/modules/core-and-feature-module-overview)
     - [Transform Synchronization Feature Module]({{urlRoot}}/content/modules/transform-feature-module)
     - [Player Lifecycle Feature Module]({{urlRoot}}/content/modules/player-lifecycle-feature-module)
-- <h3> + Creating a new project</h3>
+- <h3> + Create a new project</h3>
     - [Get the dependencies]({{urlRoot}}/setup-and-installing)
     - [Add the GDK to your project]({{urlRoot}}/content/set-up-new-project)
     - [Build your workers]({{urlRoot}}/content/build)
@@ -48,7 +48,7 @@
     - Code generation
         - [The code generator]({{urlRoot}}/content/code-generator)
         - [ECS component generation]({{urlRoot}}/content/ecs/component-generation)
-    - [Logging]({{urlRoot}}/content/ecs/logging)
+    - [Logs]({{urlRoot}}/content/ecs/logging)
 - <h3> + MonoBehaviour workflow</h3>
     - [Which workflow?]({{urlRoot}}/content/intro-workflows-spatialos-entities)
     - Create workers
@@ -75,7 +75,7 @@
         - [Send and receive events]({{urlRoot}}/content/ecs/events)
         - [Commands: SpatialOS component commands]({{urlRoot}}/content/ecs/sending-receiving-component-commands)
         - [Commands: World commands]({{urlRoot}}/content/ecs/world-commands)
-        - [Reactive components: Receiving updates from SpatialOS]({{urlRoot}}/content/ecs/reactive-components)
+        - [Reactive components: Receive updates from SpatialOS]({{urlRoot}}/content/ecs/reactive-components)
         - [Authority]({{urlRoot}}/content/ecs/authority)
     - [Worker entity]({{urlRoot}}/content/workers/worker-entity)
     - [Temporary component]({{urlRoot}}/content/ecs/temporary-components)
@@ -85,17 +85,17 @@
     - Android support
         - [Set up Android support]({{urlRoot}}/content/mobile/android/setup)
         - [Ways to  test your Android client]({{urlRoot}}/content/mobile/android/ways-to-test)
-        - [Connecting to a local deployment]({{urlRoot}}/content/mobile/android/local-deploy)
+        - [Connect to a local deployment]({{urlRoot}}/content/mobile/android/local-deploy)
     - iOS support
         - [Set up iOS support]({{urlRoot}}/content/mobile/ios/setup)
         - [Ways to test your iOS client]({{urlRoot}}/content/mobile/ios/ways-to-test)
-        - [Connecting to a local deployment]({{urlRoot}}/content/mobile/ios/local-deploy)
+        - [Connect to a local deployment]({{urlRoot}}/content/mobile/ios/local-deploy)
 - <h3> + Tests</h3>
     - [Test overview]({{urlRoot}}/content/testing/testing-overview)
     - [How to run tests]({{urlRoot}}/content/testing/how-to-run-tests)
     - [Test guidelines]({{urlRoot}}/content/testing/testing-guidelines)
     - [Test GDK systems]({{urlRoot}}/content/testing/testing-systems)
-    - [Writing a new test]({{urlRoot}}/content/testing/writing-a-new-unit-test)
+    - [Write a new test]({{urlRoot}}/content/testing/writing-a-new-unit-test)
 - <h3>[- Troubleshooting]({{urlRoot}}/content/troubleshooting)</h3>
 - <h3>[- Known issues]({{urlRoot}}/known-issues)</h3>
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -32,84 +32,84 @@
     - [Build your workers]({{urlRoot}}/content/build)
     - [Deploy your game]({{urlRoot}}/content/deploy)
 - <h3> + GDK concepts</h3>
-    - <h4>Workers: </h4>
-        - [ * Workers in the GDK]({{urlRoot}}/content/workers/workers-in-the-gdk)
-        - [ * Connecting to SpatialOS Runtime]({{urlRoot}}/content/connecting-to-spatialos)
-        - [ * API - worker]({{urlRoot}}/content/workers/api-worker)
-        - [ * API - worker system]({{urlRoot}}/content/workers/api-worker-system)
-    - <h4>SpatialOS entities:</h4>
-        - [ * Update entity lifecycle]({{urlRoot}}/content/entity-lifecycle)
-        - [* Creating SpatialOS entity templates]({{urlRoot}}/content/entity-templates)
-        - [* API - EntityBuilder]({{urlRoot}}/content/api-entity-builder)
-    - <h4>Commands:</h4>
-        - [ * World and component command requests and responses]({{urlRoot}}/content/world-component-commands-requests-responses)
+    - Workers
+        - [Workers in the GDK]({{urlRoot}}/content/workers/workers-in-the-gdk)
+        - [Connecting to SpatialOS Runtime]({{urlRoot}}/content/connecting-to-spatialos)
+        - [API - worker]({{urlRoot}}/content/workers/api-worker)
+        - [API - worker system]({{urlRoot}}/content/workers/api-worker-system)
+    - SpatialOS entities
+        - [Update entity lifecycle]({{urlRoot}}/content/entity-lifecycle)
+        - [Creating SpatialOS entity templates]({{urlRoot}}/content/entity-templates)
+        - [API - EntityBuilder]({{urlRoot}}/content/api-entity-builder)
+    - Commands
+        - [World and component command requests and responses]({{urlRoot}}/content/world-component-commands-requests-responses)
 - <h3> + Tools </h3>
     - [Snapshots]({{urlRoot}}/content/snapshots)
-    - <h4>Code generation:</h4>
-        - [* The code generator]({{urlRoot}}/content/code-generator)
-        - [* ECS component generation]({{urlRoot}}/content/ecs/component-generation)
+    - Code generation
+        - [The code generator]({{urlRoot}}/content/code-generator)
+        - [ECS component generation]({{urlRoot}}/content/ecs/component-generation)
     - [Logging]({{urlRoot}}/content/ecs/logging)
 - <h3> + MonoBehaviour workflow</h3>
     - [Which workflow?]({{urlRoot}}/content/intro-workflows-spatialos-entities)
-    - <h4>Create workers:</h4>
-        - [* WorkerConnector]({{urlRoot}}/content/gameobject/creating-workers-with-workerconnector)
-        - [* API - WorkerConnector]({{urlRoot}}/content/gameobject/api-workerconnector)
-    - <h4>Link to GameObjects:</h4>
-        - [* SpatialOS entities as GameObjects]({{urlRoot}}/content/gameobject/linking-spatialos-entities)
-        - [* Workers as GameObjects]({{urlRoot}}/content/gameobject/linking-workers-gameobjects)
-    - <h4>MonoBehaviours with SpatialOS:</h4>
-        - [* Interact with SpatialOS using MonoBehaviours]({{urlRoot}}/content/gameobject/interact-spatialos-monobehaviours)
-        - [* Readers and writers]({{urlRoot}}/content/gameobject/readers-writers)
-        - [* Readers and writers: SpatialOS component data]({{urlRoot}}/content/gameobject/reading-and-writing-component-data)
-        - [* Readers and writers: Events]({{urlRoot}}/content/gameobject/sending-receiving-events)
-        - [* Commands: SpatialOS Component commands]({{urlRoot}}/content/gameobject/sending-receiving-commands)
-        - [* Commands: World commands]({{urlRoot}}/content/gameobject/world-commands)
+    - Create workers
+        - [WorkerConnector]({{urlRoot}}/content/gameobject/creating-workers-with-workerconnector)
+        - [API - WorkerConnector]({{urlRoot}}/content/gameobject/api-workerconnector)
+    - Link to GameObjects
+        - [SpatialOS entities as GameObjects]({{urlRoot}}/content/gameobject/linking-spatialos-entities)
+        - [Workers as GameObjects]({{urlRoot}}/content/gameobject/linking-workers-gameobjects)
+    - MonoBehaviours with SpatialOS
+        - [Interact with SpatialOS using MonoBehaviours]({{urlRoot}}/content/gameobject/interact-spatialos-monobehaviours)
+        - [Readers and writers]({{urlRoot}}/content/gameobject/readers-writers)
+        - [Readers and writers: SpatialOS component data]({{urlRoot}}/content/gameobject/reading-and-writing-component-data)
+        - [Readers and writers: Events]({{urlRoot}}/content/gameobject/sending-receiving-events)
+        - [Commands: SpatialOS Component commands]({{urlRoot}}/content/gameobject/sending-receiving-commands)
+        - [Commands: World commands]({{urlRoot}}/content/gameobject/world-commands)
     - [Create and delete SpatialOS entities]({{urlRoot}}/content/gameobject/create-delete-spatialos-entities)
     - [API - SpatialOSComponent]({{urlRoot}}/content/gameobject/spatialoscomponent)
 - <h3> + ECS workflow</h3>
     - [Which workflow?]({{urlRoot}}/content/intro-workflows-spatialos-entities)
     - [System update order]({{urlRoot}}/content/ecs/system-update-order)
     - [ECS entity contract]({{urlRoot}}/content/ecs/entity-contracts)
-    - <h4> + ECS interaction with SpatialOS:</h4>
-        - [* ECS component updates]({{urlRoot}}/content/ecs/component-updates)
-        - [* Send and receive events]({{urlRoot}}/content/ecs/events)
-        - [* Commands: SpatialOS component commands]({{urlRoot}}/content/ecs/sending-receiving-component-commands)
-        - [* Commands: World commands]({{urlRoot}}/content/ecs/world-commands)
-        - [* Reactive components: Receiving updates from SpatialOS]({{urlRoot}}/content/ecs/reactive-components)
-        - [* Authority]({{urlRoot}}/content/ecs/authority)
+    - ECS interaction with SpatialOS
+        - [ECS component updates]({{urlRoot}}/content/ecs/component-updates)
+        - [Send and receive events]({{urlRoot}}/content/ecs/events)
+        - [Commands: SpatialOS component commands]({{urlRoot}}/content/ecs/sending-receiving-component-commands)
+        - [Commands: World commands]({{urlRoot}}/content/ecs/world-commands)
+        - [Reactive components: Receiving updates from SpatialOS]({{urlRoot}}/content/ecs/reactive-components)
+        - [Authority]({{urlRoot}}/content/ecs/authority)
     - [Worker entity]({{urlRoot}}/content/workers/worker-entity)
     - [Temporary component]({{urlRoot}}/content/ecs/temporary-components)
     - [Custom replication system]({{urlRoot}}/content/ecs/custom-replication-system)
 - <h3> + Mobile support</h3>
     - [Overview]({{urlRoot}}/content/mobile/overview)
-    - <h4> + Android Support:</h4>
-        - [* Setting up Android support]({{urlRoot}}/content/mobile/android/setup)
-        - [* Ways to  test your Android client]({{urlRoot}}/content/mobile/android/ways-to-test)
-        - [* Connecting to a local deployment]({{urlRoot}}/content/mobile/android/local-deploy)
-    - <h4> + iOS Support:</h4>
-        - [* Setting up iOS support]({{urlRoot}}/content/mobile/ios/setup)
-        - [* Ways to test your iOS client]({{urlRoot}}/content/mobile/ios/ways-to-test)
-        - [* Connecting to a local deployment]({{urlRoot}}/content/mobile/ios/local-deploy)
+    - Android support
+        - [Set up Android support]({{urlRoot}}/content/mobile/android/setup)
+        - [Ways to  test your Android client]({{urlRoot}}/content/mobile/android/ways-to-test)
+        - [Connecting to a local deployment]({{urlRoot}}/content/mobile/android/local-deploy)
+    - iOS support
+        - [Set up iOS support]({{urlRoot}}/content/mobile/ios/setup)
+        - [Ways to test your iOS client]({{urlRoot}}/content/mobile/ios/ways-to-test)
+        - [Connecting to a local deployment]({{urlRoot}}/content/mobile/ios/local-deploy)
 - <h3> + Tests</h3>
     - [Test overview]({{urlRoot}}/content/testing/testing-overview)
     - [How to run tests]({{urlRoot}}/content/testing/how-to-run-tests)
     - [Test guidelines]({{urlRoot}}/content/testing/testing-guidelines)
-    - [Testing GDK systems]({{urlRoot}}/content/testing/testing-systems)
+    - [Test GDK systems]({{urlRoot}}/content/testing/testing-systems)
     - [Writing a new test]({{urlRoot}}/content/testing/writing-a-new-unit-test)
-- <h3> [ - Troubleshooting]({{urlRoot}}/content/troubleshooting)</h3>
+- <h3>[- Troubleshooting]({{urlRoot}}/content/troubleshooting)</h3>
 - <h3>[- Known issues]({{urlRoot}}/known-issues)</h3>
 
  ***
 - <h3>Get involved</h3>
 - <h3> + Contributing to the GDK</h3>
-    - <h4> Visit our GitHub:</h4>
-    - [* Issue log](https://github.com/spatialos/UnityGDK/issues)
-    - [* Contribution policy]({{urlRoot}}/contributing)
     - [Coding standards]({{urlRoot}}/contributions/unity-gdk-coding-standards)
+    - Visit our GitHub:
+        - [Issue log](https://github.com/spatialos/UnityGDK/issues)
+        - [Contribution policy]({{urlRoot}}/contributing)
 - <h3> + GDK Community</h3>
-    - <h4> Check out:</h4>
-    - [* Discord](https://discord.gg/SCZTCYm)
-    - [* Forums](https://forums.improbable.io/latest?tags=unity-gdk)
-    - [* Mailing list](http://go.pardot.com/l/169082/2018-06-25/27mhsb)
+    - Check out:
+        - [Discord](https://discord.gg/SCZTCYm)
+        - [Forums](https://forums.improbable.io/latest?tags=unity-gdk)
+        - [Mailing list](http://go.pardot.com/l/169082/2018-06-25/27mhsb)
 - <h3> + Development roadmap</h3>
     - [Trello board](https://trello.com/b/29tMKyQC)


### PR DESCRIPTION
* Removed gerunds ("ing" words) to standardise verbs as is our new bossy thing
* Removed `<h4>` which was 
making the titles grey rather than black
* Removed the colons on titles (except where they are a calls to action - "checkout:" and  "Visit our GitHib:".
* Removed stars at start of title link - not needed.
* Removed extra "+" where not needed.
* Standardised capitalisation

Can't do much about the annoying indent for titles in a list, unforutunately.

<img width="312" alt="screen shot 2018-11-05 at 2 26 41 pm" src="https://user-images.githubusercontent.com/36853437/48003837-7cd2a380-e107-11e8-9cff-ec464873ad6f.png">

<img width="282" alt="screen shot 2018-11-05 at 2 32 55 pm" src="https://user-images.githubusercontent.com/36853437/48004007-ebaffc80-e107-11e8-8455-c523046356f0.png">
