### PR TITLE
UTY-1060: Prepend warning to copied schema files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added support for the Steam authentication flow.
 - Added a reference to Blank Starter Project in the README.
 - Added Frames Per Second (FPS) and Unity heap usage as metrics sent by `MetricSendSystem.cs`.
+- Added a warning message to the top of schema files copied into the `from_gdk_packages` directory.
 
 ### Changed
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
@@ -14,7 +14,11 @@ namespace Improbable.Gdk.Tools
         private const string FromGdkPackagesDir = "from_gdk_packages";
         private const string ImprobableJsonDir = "build/ImprobableJson";
 
-
+        private const string SchemaWarningMessage =
+            "// ------------------------------------------------------------------------\n" +
+            "// WARNING: DO NOT EDIT.\n" +
+            "// Any changes made to this file will be overwritten by the Code Generator.\n" +
+            "// ------------------------------------------------------------------------\n\n";
 
         private static readonly string SchemaCompilerRelativePath =
             $"../build/CoreSdk/{Common.CoreSdkVersion}/schema_compiler/schema_compiler";
@@ -206,7 +210,7 @@ namespace Improbable.Gdk.Tools
                     }
                 }
 
-                File.Copy(file, to);
+                File.WriteAllText(to, SchemaWarningMessage + File.ReadAllText(file));
             }
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
@@ -14,9 +14,9 @@ namespace Improbable.Gdk.Tools
         private const string FromGdkPackagesDir = "from_gdk_packages";
         private const string ImprobableJsonDir = "build/ImprobableJson";
 
-        private const string SchemaWarningMessage = 
+        private static string SchemaWarningMessage =
             "// ------------------------------------------------------------------------" + Environment.NewLine +
-            "// WARNING: DO NOT EDIT."                                                    + Environment.NewLine +
+            "// WARNING: DO NOT EDIT." + Environment.NewLine +
             "// Any changes made to this file will be overwritten by the Code Generator." + Environment.NewLine +
             "// ------------------------------------------------------------------------" + Environment.NewLine +
             Environment.NewLine;

--- a/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
@@ -14,11 +14,12 @@ namespace Improbable.Gdk.Tools
         private const string FromGdkPackagesDir = "from_gdk_packages";
         private const string ImprobableJsonDir = "build/ImprobableJson";
 
-        private const string SchemaWarningMessage =
-            "// ------------------------------------------------------------------------\n" +
-            "// WARNING: DO NOT EDIT.\n" +
-            "// Any changes made to this file will be overwritten by the Code Generator.\n" +
-            "// ------------------------------------------------------------------------\n\n";
+        private const string SchemaWarningMessage = String.Join(
+            "// ------------------------------------------------------------------------", Environment.NewLine,
+            "// WARNING: DO NOT EDIT."                                                   , Environment.NewLine,
+            "// Any changes made to this file will be overwritten by the Code Generator.", Environment.NewLine,
+            "// ------------------------------------------------------------------------", Environment.NewLine,
+            Environment.NewLine);
 
         private static readonly string SchemaCompilerRelativePath =
             $"../build/CoreSdk/{Common.CoreSdkVersion}/schema_compiler/schema_compiler";

--- a/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
@@ -14,12 +14,12 @@ namespace Improbable.Gdk.Tools
         private const string FromGdkPackagesDir = "from_gdk_packages";
         private const string ImprobableJsonDir = "build/ImprobableJson";
 
-        private const string SchemaWarningMessage = String.Join(
-            "// ------------------------------------------------------------------------", Environment.NewLine,
-            "// WARNING: DO NOT EDIT."                                                   , Environment.NewLine,
-            "// Any changes made to this file will be overwritten by the Code Generator.", Environment.NewLine,
-            "// ------------------------------------------------------------------------", Environment.NewLine,
-            Environment.NewLine);
+        private const string SchemaWarningMessage = 
+            "// ------------------------------------------------------------------------" + Environment.NewLine +
+            "// WARNING: DO NOT EDIT."                                                    + Environment.NewLine +
+            "// Any changes made to this file will be overwritten by the Code Generator." + Environment.NewLine +
+            "// ------------------------------------------------------------------------" + Environment.NewLine +
+            Environment.NewLine;
 
         private static readonly string SchemaCompilerRelativePath =
             $"../build/CoreSdk/{Common.CoreSdkVersion}/schema_compiler/schema_compiler";


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](https://docs.improbable.io/unity/alpha/contributing) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Prepend the following warning to copied schema files:
```
// ------------------------------------------------------------------------
// WARNING: DO NOT EDIT.
// Any changes made to this file will be overwritten by the Code Generator.
// ------------------------------------------------------------------------
```

#### Tests
tested locally - schema files in `from_gdk_packages` directory all have the text prepended

#### Documentation
none

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
