### PR TITLE
Temporarily stop building AndroidClient

### DIFF
--- a/ci/build-test.sh
+++ b/ci/build-test.sh
@@ -14,7 +14,6 @@ source ".shared-ci/scripts/pinned-tools.sh"
 ci/test.sh
 .shared-ci/scripts/build.sh "workers/unity" UnityClient local "$(pwd)/logs/UnityClientBuild.log"
 .shared-ci/scripts/build.sh "workers/unity" UnityGameLogic cloud "$(pwd)/logs/UnityGameLogicBuild.log"
-.shared-ci/scripts/build.sh "workers/unity" AndroidClient local "$(pwd)/logs/AndroidClientBuild.log"
 
 if isMacOS; then
   .shared-ci/scripts/build.sh "workers/unity" iOSClient local "$(pwd)/logs/iOSClientBuild.log"


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](https://docs.improbable.io/unity/alpha/contributing) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
temporarily stop building android clients until TeamCity android issue is fixed

#### Tests
TC

#### Documentation
N/A

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
