### PR TITLE
Reinstate android builds

### DIFF
--- a/ci/build-test.sh
+++ b/ci/build-test.sh
@@ -4,7 +4,7 @@ set -e -u -o -x pipefail
 
 cd "$(dirname "$0")/../"
 
-# Get shared CI and prepare unity
+# Get shared CI and prepare Unity
 ci/bootstrap.sh
 .shared-ci/scripts/prepare-unity.sh
 .shared-ci/scripts/prepare-unity-mobile.sh "$(pwd)/logs/PrepareUnityMobile.log"
@@ -14,8 +14,7 @@ source ".shared-ci/scripts/pinned-tools.sh"
 ci/test.sh
 .shared-ci/scripts/build.sh "workers/unity" UnityClient local "$(pwd)/logs/UnityClientBuild.log"
 .shared-ci/scripts/build.sh "workers/unity" UnityGameLogic cloud "$(pwd)/logs/UnityGameLogicBuild.log"
-# TODO: re-enable android builds with ticket UTY-1437
-# .shared-ci/scripts/build.sh "workers/unity" AndroidClient local "$(pwd)/logs/AndroidClientBuild.log"
+.shared-ci/scripts/build.sh "workers/unity" AndroidClient local "$(pwd)/logs/AndroidClientBuild.log"
 
 if isMacOS; then
   .shared-ci/scripts/build.sh "workers/unity" iOSClient local "$(pwd)/logs/iOSClientBuild.log"


### PR DESCRIPTION
Signed-off-by: Paul Balaji <paulbalaji@improbable.io>

**Contributions**: We are not currently taking public contributions - see our [contributions](https://docs.improbable.io/unity/alpha/contributing) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
reinstate android builds

relies on changes to shared-ci: https://github.com/spatialos/gdk-for-unity-shared-ci/pull/9

#### Tests
passes CI fine on troublesome agents when trying out the dev branch on shared-ci

#### Documentation
n/a

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
