### PR TITLE
Add ISnapshottable interface to generated components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added a reference to Blank Starter Project in the README.
 - Added Frames Per Second (FPS) and Unity heap usage as metrics sent by `MetricSendSystem.cs`.
 - Added a warning message to the top of schema files copied into the `from_gdk_packages` directory.
+- Added an `ISnapshottable<T>` interface to all generated components. This allows you to convert a component to a snapshot.
 
 ### Changed
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingular.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingular.cs
@@ -14,7 +14,7 @@ namespace Improbable.Gdk.Tests
     {
         public const uint ComponentId = 197720;
 
-        public struct Component : IComponentData, ISpatialComponentData
+        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 197720;
 
@@ -93,6 +93,17 @@ namespace Improbable.Gdk.Tests
             {
                 dirtyBits0 = 0x0;
                 dirtyBits1 = 0x0;
+            }
+
+            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
+            {
+                var componentDataSchema = new ComponentData(new SchemaComponentData(197720));
+                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
+                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
+
+                componentDataSchema.SchemaData?.Dispose();
+
+                return snapshot;
             }
 
             private BlittableBool field1;
@@ -367,6 +378,55 @@ namespace Improbable.Gdk.Tests
 
         public static class Serialization
         {
+            public static void SerializeComponent(Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component component, global::Improbable.Worker.Core.SchemaObject obj, global::Unity.Entities.World world)
+            {
+                {
+                    obj.AddBool(1, component.Field1);
+                }
+                {
+                    obj.AddFloat(2, component.Field2);
+                }
+                {
+                    obj.AddInt32(4, component.Field4);
+                }
+                {
+                    obj.AddInt64(5, component.Field5);
+                }
+                {
+                    obj.AddDouble(6, component.Field6);
+                }
+                {
+                    obj.AddUint32(8, component.Field8);
+                }
+                {
+                    obj.AddUint64(9, component.Field9);
+                }
+                {
+                    obj.AddSint32(10, component.Field10);
+                }
+                {
+                    obj.AddSint64(11, component.Field11);
+                }
+                {
+                    obj.AddFixed32(12, component.Field12);
+                }
+                {
+                    obj.AddFixed64(13, component.Field13);
+                }
+                {
+                    obj.AddSfixed32(14, component.Field14);
+                }
+                {
+                    obj.AddSfixed64(15, component.Field15);
+                }
+                {
+                    obj.AddEntityId(16, component.Field16);
+                }
+                {
+                    global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(component.Field17, obj.AddObject(17));
+                }
+            }
+
             public static void SerializeUpdate(Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component component, global::Improbable.Worker.Core.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingular.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingular.cs
@@ -102,6 +102,7 @@ namespace Improbable.Gdk.Tests
                 var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
 
                 componentDataSchema.SchemaData?.Dispose();
+                componentDataSchema.SchemaData = null;
 
                 return snapshot;
             }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKey.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKey.cs
@@ -14,7 +14,7 @@ namespace Improbable.Gdk.Tests
     {
         public const uint ComponentId = 197719;
 
-        public struct Component : IComponentData, ISpatialComponentData
+        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 197719;
 
@@ -101,6 +101,17 @@ namespace Improbable.Gdk.Tests
                 dirtyBits0 = 0x0;
                 dirtyBits1 = 0x0;
                 dirtyBits2 = 0x0;
+            }
+
+            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
+            {
+                var componentDataSchema = new ComponentData(new SchemaComponentData(197719));
+                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
+                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
+
+                componentDataSchema.SchemaData?.Dispose();
+
+                return snapshot;
             }
 
             internal uint field1Handle;
@@ -511,6 +522,163 @@ namespace Improbable.Gdk.Tests
 
         public static class Serialization
         {
+            public static void SerializeComponent(Improbable.Gdk.Tests.ExhaustiveMapKey.Component component, global::Improbable.Worker.Core.SchemaObject obj, global::Unity.Entities.World world)
+            {
+                {
+                    foreach (var keyValuePair in component.Field1)
+                {
+                    var mapObj = obj.AddObject(1);
+                    mapObj.AddBool(1, keyValuePair.Key);
+                    mapObj.AddString(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field2)
+                {
+                    var mapObj = obj.AddObject(2);
+                    mapObj.AddFloat(1, keyValuePair.Key);
+                    mapObj.AddString(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field3)
+                {
+                    var mapObj = obj.AddObject(3);
+                    mapObj.AddBytes(1, keyValuePair.Key);
+                    mapObj.AddString(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field4)
+                {
+                    var mapObj = obj.AddObject(4);
+                    mapObj.AddInt32(1, keyValuePair.Key);
+                    mapObj.AddString(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field5)
+                {
+                    var mapObj = obj.AddObject(5);
+                    mapObj.AddInt64(1, keyValuePair.Key);
+                    mapObj.AddString(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field6)
+                {
+                    var mapObj = obj.AddObject(6);
+                    mapObj.AddDouble(1, keyValuePair.Key);
+                    mapObj.AddString(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field7)
+                {
+                    var mapObj = obj.AddObject(7);
+                    mapObj.AddString(1, keyValuePair.Key);
+                    mapObj.AddString(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field8)
+                {
+                    var mapObj = obj.AddObject(8);
+                    mapObj.AddUint32(1, keyValuePair.Key);
+                    mapObj.AddString(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field9)
+                {
+                    var mapObj = obj.AddObject(9);
+                    mapObj.AddUint64(1, keyValuePair.Key);
+                    mapObj.AddString(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field10)
+                {
+                    var mapObj = obj.AddObject(10);
+                    mapObj.AddSint32(1, keyValuePair.Key);
+                    mapObj.AddString(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field11)
+                {
+                    var mapObj = obj.AddObject(11);
+                    mapObj.AddSint64(1, keyValuePair.Key);
+                    mapObj.AddString(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field12)
+                {
+                    var mapObj = obj.AddObject(12);
+                    mapObj.AddFixed32(1, keyValuePair.Key);
+                    mapObj.AddString(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field13)
+                {
+                    var mapObj = obj.AddObject(13);
+                    mapObj.AddFixed64(1, keyValuePair.Key);
+                    mapObj.AddString(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field14)
+                {
+                    var mapObj = obj.AddObject(14);
+                    mapObj.AddSfixed32(1, keyValuePair.Key);
+                    mapObj.AddString(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field15)
+                {
+                    var mapObj = obj.AddObject(15);
+                    mapObj.AddSfixed64(1, keyValuePair.Key);
+                    mapObj.AddString(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field16)
+                {
+                    var mapObj = obj.AddObject(16);
+                    mapObj.AddEntityId(1, keyValuePair.Key);
+                    mapObj.AddString(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field17)
+                {
+                    var mapObj = obj.AddObject(17);
+                    global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(keyValuePair.Key, mapObj.AddObject(1));
+                    mapObj.AddString(2, keyValuePair.Value);
+                }
+                
+                }
+            }
+
             public static void SerializeUpdate(Improbable.Gdk.Tests.ExhaustiveMapKey.Component component, global::Improbable.Worker.Core.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKey.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKey.cs
@@ -110,6 +110,7 @@ namespace Improbable.Gdk.Tests
                 var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
 
                 componentDataSchema.SchemaData?.Dispose();
+                componentDataSchema.SchemaData = null;
 
                 return snapshot;
             }
@@ -342,156 +343,156 @@ namespace Improbable.Gdk.Tests
                 var obj = schemaComponentData.GetFields();
                 {
                     foreach (var keyValuePair in field1)
-                {
-                    var mapObj = obj.AddObject(1);
-                    mapObj.AddBool(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(1);
+                        mapObj.AddBool(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field2)
-                {
-                    var mapObj = obj.AddObject(2);
-                    mapObj.AddFloat(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(2);
+                        mapObj.AddFloat(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field3)
-                {
-                    var mapObj = obj.AddObject(3);
-                    mapObj.AddBytes(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(3);
+                        mapObj.AddBytes(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field4)
-                {
-                    var mapObj = obj.AddObject(4);
-                    mapObj.AddInt32(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(4);
+                        mapObj.AddInt32(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field5)
-                {
-                    var mapObj = obj.AddObject(5);
-                    mapObj.AddInt64(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(5);
+                        mapObj.AddInt64(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field6)
-                {
-                    var mapObj = obj.AddObject(6);
-                    mapObj.AddDouble(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(6);
+                        mapObj.AddDouble(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field7)
-                {
-                    var mapObj = obj.AddObject(7);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(7);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field8)
-                {
-                    var mapObj = obj.AddObject(8);
-                    mapObj.AddUint32(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(8);
+                        mapObj.AddUint32(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field9)
-                {
-                    var mapObj = obj.AddObject(9);
-                    mapObj.AddUint64(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(9);
+                        mapObj.AddUint64(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field10)
-                {
-                    var mapObj = obj.AddObject(10);
-                    mapObj.AddSint32(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(10);
+                        mapObj.AddSint32(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field11)
-                {
-                    var mapObj = obj.AddObject(11);
-                    mapObj.AddSint64(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(11);
+                        mapObj.AddSint64(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field12)
-                {
-                    var mapObj = obj.AddObject(12);
-                    mapObj.AddFixed32(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(12);
+                        mapObj.AddFixed32(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field13)
-                {
-                    var mapObj = obj.AddObject(13);
-                    mapObj.AddFixed64(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(13);
+                        mapObj.AddFixed64(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field14)
-                {
-                    var mapObj = obj.AddObject(14);
-                    mapObj.AddSfixed32(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(14);
+                        mapObj.AddSfixed32(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field15)
-                {
-                    var mapObj = obj.AddObject(15);
-                    mapObj.AddSfixed64(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(15);
+                        mapObj.AddSfixed64(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field16)
-                {
-                    var mapObj = obj.AddObject(16);
-                    mapObj.AddEntityId(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(16);
+                        mapObj.AddEntityId(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field17)
-                {
-                    var mapObj = obj.AddObject(17);
-                    global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(keyValuePair.Key, mapObj.AddObject(1));
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(17);
+                        global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(keyValuePair.Key, mapObj.AddObject(1));
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 return new global::Improbable.Worker.Core.ComponentData(schemaComponentData);
             }
@@ -526,156 +527,156 @@ namespace Improbable.Gdk.Tests
             {
                 {
                     foreach (var keyValuePair in component.Field1)
-                {
-                    var mapObj = obj.AddObject(1);
-                    mapObj.AddBool(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(1);
+                        mapObj.AddBool(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field2)
-                {
-                    var mapObj = obj.AddObject(2);
-                    mapObj.AddFloat(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(2);
+                        mapObj.AddFloat(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field3)
-                {
-                    var mapObj = obj.AddObject(3);
-                    mapObj.AddBytes(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(3);
+                        mapObj.AddBytes(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field4)
-                {
-                    var mapObj = obj.AddObject(4);
-                    mapObj.AddInt32(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(4);
+                        mapObj.AddInt32(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field5)
-                {
-                    var mapObj = obj.AddObject(5);
-                    mapObj.AddInt64(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(5);
+                        mapObj.AddInt64(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field6)
-                {
-                    var mapObj = obj.AddObject(6);
-                    mapObj.AddDouble(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(6);
+                        mapObj.AddDouble(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field7)
-                {
-                    var mapObj = obj.AddObject(7);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(7);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field8)
-                {
-                    var mapObj = obj.AddObject(8);
-                    mapObj.AddUint32(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(8);
+                        mapObj.AddUint32(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field9)
-                {
-                    var mapObj = obj.AddObject(9);
-                    mapObj.AddUint64(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(9);
+                        mapObj.AddUint64(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field10)
-                {
-                    var mapObj = obj.AddObject(10);
-                    mapObj.AddSint32(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(10);
+                        mapObj.AddSint32(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field11)
-                {
-                    var mapObj = obj.AddObject(11);
-                    mapObj.AddSint64(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(11);
+                        mapObj.AddSint64(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field12)
-                {
-                    var mapObj = obj.AddObject(12);
-                    mapObj.AddFixed32(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(12);
+                        mapObj.AddFixed32(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field13)
-                {
-                    var mapObj = obj.AddObject(13);
-                    mapObj.AddFixed64(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(13);
+                        mapObj.AddFixed64(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field14)
-                {
-                    var mapObj = obj.AddObject(14);
-                    mapObj.AddSfixed32(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(14);
+                        mapObj.AddSfixed32(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field15)
-                {
-                    var mapObj = obj.AddObject(15);
-                    mapObj.AddSfixed64(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(15);
+                        mapObj.AddSfixed64(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field16)
-                {
-                    var mapObj = obj.AddObject(16);
-                    mapObj.AddEntityId(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(16);
+                        mapObj.AddEntityId(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field17)
-                {
-                    var mapObj = obj.AddObject(17);
-                    global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(keyValuePair.Key, mapObj.AddObject(1));
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(17);
+                        global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(keyValuePair.Key, mapObj.AddObject(1));
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
             }
 
@@ -686,307 +687,307 @@ namespace Improbable.Gdk.Tests
                     if (component.IsDataDirty(0))
                     {
                         foreach (var keyValuePair in component.Field1)
-                    {
-                        var mapObj = obj.AddObject(1);
-                        mapObj.AddBool(1, keyValuePair.Key);
-                        mapObj.AddString(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(1);
+                            mapObj.AddBool(1, keyValuePair.Key);
+                            mapObj.AddString(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field1.Count == 0)
-                    {
-                        updateObj.AddClearedField(1);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(1);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(1))
                     {
                         foreach (var keyValuePair in component.Field2)
-                    {
-                        var mapObj = obj.AddObject(2);
-                        mapObj.AddFloat(1, keyValuePair.Key);
-                        mapObj.AddString(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(2);
+                            mapObj.AddFloat(1, keyValuePair.Key);
+                            mapObj.AddString(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field2.Count == 0)
-                    {
-                        updateObj.AddClearedField(2);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(2);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(2))
                     {
                         foreach (var keyValuePair in component.Field3)
-                    {
-                        var mapObj = obj.AddObject(3);
-                        mapObj.AddBytes(1, keyValuePair.Key);
-                        mapObj.AddString(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(3);
+                            mapObj.AddBytes(1, keyValuePair.Key);
+                            mapObj.AddString(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field3.Count == 0)
-                    {
-                        updateObj.AddClearedField(3);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(3);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(3))
                     {
                         foreach (var keyValuePair in component.Field4)
-                    {
-                        var mapObj = obj.AddObject(4);
-                        mapObj.AddInt32(1, keyValuePair.Key);
-                        mapObj.AddString(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(4);
+                            mapObj.AddInt32(1, keyValuePair.Key);
+                            mapObj.AddString(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field4.Count == 0)
-                    {
-                        updateObj.AddClearedField(4);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(4);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(4))
                     {
                         foreach (var keyValuePair in component.Field5)
-                    {
-                        var mapObj = obj.AddObject(5);
-                        mapObj.AddInt64(1, keyValuePair.Key);
-                        mapObj.AddString(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(5);
+                            mapObj.AddInt64(1, keyValuePair.Key);
+                            mapObj.AddString(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field5.Count == 0)
-                    {
-                        updateObj.AddClearedField(5);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(5);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(5))
                     {
                         foreach (var keyValuePair in component.Field6)
-                    {
-                        var mapObj = obj.AddObject(6);
-                        mapObj.AddDouble(1, keyValuePair.Key);
-                        mapObj.AddString(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(6);
+                            mapObj.AddDouble(1, keyValuePair.Key);
+                            mapObj.AddString(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field6.Count == 0)
-                    {
-                        updateObj.AddClearedField(6);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(6);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(6))
                     {
                         foreach (var keyValuePair in component.Field7)
-                    {
-                        var mapObj = obj.AddObject(7);
-                        mapObj.AddString(1, keyValuePair.Key);
-                        mapObj.AddString(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(7);
+                            mapObj.AddString(1, keyValuePair.Key);
+                            mapObj.AddString(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field7.Count == 0)
-                    {
-                        updateObj.AddClearedField(7);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(7);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(7))
                     {
                         foreach (var keyValuePair in component.Field8)
-                    {
-                        var mapObj = obj.AddObject(8);
-                        mapObj.AddUint32(1, keyValuePair.Key);
-                        mapObj.AddString(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(8);
+                            mapObj.AddUint32(1, keyValuePair.Key);
+                            mapObj.AddString(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field8.Count == 0)
-                    {
-                        updateObj.AddClearedField(8);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(8);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(8))
                     {
                         foreach (var keyValuePair in component.Field9)
-                    {
-                        var mapObj = obj.AddObject(9);
-                        mapObj.AddUint64(1, keyValuePair.Key);
-                        mapObj.AddString(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(9);
+                            mapObj.AddUint64(1, keyValuePair.Key);
+                            mapObj.AddString(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field9.Count == 0)
-                    {
-                        updateObj.AddClearedField(9);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(9);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(9))
                     {
                         foreach (var keyValuePair in component.Field10)
-                    {
-                        var mapObj = obj.AddObject(10);
-                        mapObj.AddSint32(1, keyValuePair.Key);
-                        mapObj.AddString(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(10);
+                            mapObj.AddSint32(1, keyValuePair.Key);
+                            mapObj.AddString(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field10.Count == 0)
-                    {
-                        updateObj.AddClearedField(10);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(10);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(10))
                     {
                         foreach (var keyValuePair in component.Field11)
-                    {
-                        var mapObj = obj.AddObject(11);
-                        mapObj.AddSint64(1, keyValuePair.Key);
-                        mapObj.AddString(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(11);
+                            mapObj.AddSint64(1, keyValuePair.Key);
+                            mapObj.AddString(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field11.Count == 0)
-                    {
-                        updateObj.AddClearedField(11);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(11);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(11))
                     {
                         foreach (var keyValuePair in component.Field12)
-                    {
-                        var mapObj = obj.AddObject(12);
-                        mapObj.AddFixed32(1, keyValuePair.Key);
-                        mapObj.AddString(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(12);
+                            mapObj.AddFixed32(1, keyValuePair.Key);
+                            mapObj.AddString(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field12.Count == 0)
-                    {
-                        updateObj.AddClearedField(12);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(12);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(12))
                     {
                         foreach (var keyValuePair in component.Field13)
-                    {
-                        var mapObj = obj.AddObject(13);
-                        mapObj.AddFixed64(1, keyValuePair.Key);
-                        mapObj.AddString(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(13);
+                            mapObj.AddFixed64(1, keyValuePair.Key);
+                            mapObj.AddString(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field13.Count == 0)
-                    {
-                        updateObj.AddClearedField(13);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(13);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(13))
                     {
                         foreach (var keyValuePair in component.Field14)
-                    {
-                        var mapObj = obj.AddObject(14);
-                        mapObj.AddSfixed32(1, keyValuePair.Key);
-                        mapObj.AddString(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(14);
+                            mapObj.AddSfixed32(1, keyValuePair.Key);
+                            mapObj.AddString(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field14.Count == 0)
-                    {
-                        updateObj.AddClearedField(14);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(14);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(14))
                     {
                         foreach (var keyValuePair in component.Field15)
-                    {
-                        var mapObj = obj.AddObject(15);
-                        mapObj.AddSfixed64(1, keyValuePair.Key);
-                        mapObj.AddString(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(15);
+                            mapObj.AddSfixed64(1, keyValuePair.Key);
+                            mapObj.AddString(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field15.Count == 0)
-                    {
-                        updateObj.AddClearedField(15);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(15);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(15))
                     {
                         foreach (var keyValuePair in component.Field16)
-                    {
-                        var mapObj = obj.AddObject(16);
-                        mapObj.AddEntityId(1, keyValuePair.Key);
-                        mapObj.AddString(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(16);
+                            mapObj.AddEntityId(1, keyValuePair.Key);
+                            mapObj.AddString(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field16.Count == 0)
-                    {
-                        updateObj.AddClearedField(16);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(16);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(16))
                     {
                         foreach (var keyValuePair in component.Field17)
-                    {
-                        var mapObj = obj.AddObject(17);
-                        global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(keyValuePair.Key, mapObj.AddObject(1));
-                        mapObj.AddString(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(17);
+                            global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(keyValuePair.Key, mapObj.AddObject(1));
+                            mapObj.AddString(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field17.Count == 0)
-                    {
-                        updateObj.AddClearedField(17);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(17);
+                        }
+                        
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValue.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValue.cs
@@ -14,7 +14,7 @@ namespace Improbable.Gdk.Tests
     {
         public const uint ComponentId = 197718;
 
-        public struct Component : IComponentData, ISpatialComponentData
+        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 197718;
 
@@ -101,6 +101,17 @@ namespace Improbable.Gdk.Tests
                 dirtyBits0 = 0x0;
                 dirtyBits1 = 0x0;
                 dirtyBits2 = 0x0;
+            }
+
+            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
+            {
+                var componentDataSchema = new ComponentData(new SchemaComponentData(197718));
+                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
+                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
+
+                componentDataSchema.SchemaData?.Dispose();
+
+                return snapshot;
             }
 
             internal uint field1Handle;
@@ -511,6 +522,163 @@ namespace Improbable.Gdk.Tests
 
         public static class Serialization
         {
+            public static void SerializeComponent(Improbable.Gdk.Tests.ExhaustiveMapValue.Component component, global::Improbable.Worker.Core.SchemaObject obj, global::Unity.Entities.World world)
+            {
+                {
+                    foreach (var keyValuePair in component.Field1)
+                {
+                    var mapObj = obj.AddObject(1);
+                    mapObj.AddString(1, keyValuePair.Key);
+                    mapObj.AddBool(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field2)
+                {
+                    var mapObj = obj.AddObject(2);
+                    mapObj.AddString(1, keyValuePair.Key);
+                    mapObj.AddFloat(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field3)
+                {
+                    var mapObj = obj.AddObject(3);
+                    mapObj.AddString(1, keyValuePair.Key);
+                    mapObj.AddBytes(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field4)
+                {
+                    var mapObj = obj.AddObject(4);
+                    mapObj.AddString(1, keyValuePair.Key);
+                    mapObj.AddInt32(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field5)
+                {
+                    var mapObj = obj.AddObject(5);
+                    mapObj.AddString(1, keyValuePair.Key);
+                    mapObj.AddInt64(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field6)
+                {
+                    var mapObj = obj.AddObject(6);
+                    mapObj.AddString(1, keyValuePair.Key);
+                    mapObj.AddDouble(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field7)
+                {
+                    var mapObj = obj.AddObject(7);
+                    mapObj.AddString(1, keyValuePair.Key);
+                    mapObj.AddString(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field8)
+                {
+                    var mapObj = obj.AddObject(8);
+                    mapObj.AddString(1, keyValuePair.Key);
+                    mapObj.AddUint32(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field9)
+                {
+                    var mapObj = obj.AddObject(9);
+                    mapObj.AddString(1, keyValuePair.Key);
+                    mapObj.AddUint64(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field10)
+                {
+                    var mapObj = obj.AddObject(10);
+                    mapObj.AddString(1, keyValuePair.Key);
+                    mapObj.AddSint32(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field11)
+                {
+                    var mapObj = obj.AddObject(11);
+                    mapObj.AddString(1, keyValuePair.Key);
+                    mapObj.AddSint64(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field12)
+                {
+                    var mapObj = obj.AddObject(12);
+                    mapObj.AddString(1, keyValuePair.Key);
+                    mapObj.AddFixed32(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field13)
+                {
+                    var mapObj = obj.AddObject(13);
+                    mapObj.AddString(1, keyValuePair.Key);
+                    mapObj.AddFixed64(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field14)
+                {
+                    var mapObj = obj.AddObject(14);
+                    mapObj.AddString(1, keyValuePair.Key);
+                    mapObj.AddSfixed32(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field15)
+                {
+                    var mapObj = obj.AddObject(15);
+                    mapObj.AddString(1, keyValuePair.Key);
+                    mapObj.AddSfixed64(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field16)
+                {
+                    var mapObj = obj.AddObject(16);
+                    mapObj.AddString(1, keyValuePair.Key);
+                    mapObj.AddEntityId(2, keyValuePair.Value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.Field17)
+                {
+                    var mapObj = obj.AddObject(17);
+                    mapObj.AddString(1, keyValuePair.Key);
+                    global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(keyValuePair.Value, mapObj.AddObject(2));
+                }
+                
+                }
+            }
+
             public static void SerializeUpdate(Improbable.Gdk.Tests.ExhaustiveMapValue.Component component, global::Improbable.Worker.Core.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValue.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValue.cs
@@ -110,6 +110,7 @@ namespace Improbable.Gdk.Tests
                 var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
 
                 componentDataSchema.SchemaData?.Dispose();
+                componentDataSchema.SchemaData = null;
 
                 return snapshot;
             }
@@ -342,156 +343,156 @@ namespace Improbable.Gdk.Tests
                 var obj = schemaComponentData.GetFields();
                 {
                     foreach (var keyValuePair in field1)
-                {
-                    var mapObj = obj.AddObject(1);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddBool(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(1);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddBool(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field2)
-                {
-                    var mapObj = obj.AddObject(2);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddFloat(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(2);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddFloat(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field3)
-                {
-                    var mapObj = obj.AddObject(3);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddBytes(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(3);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddBytes(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field4)
-                {
-                    var mapObj = obj.AddObject(4);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddInt32(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(4);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddInt32(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field5)
-                {
-                    var mapObj = obj.AddObject(5);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddInt64(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(5);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddInt64(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field6)
-                {
-                    var mapObj = obj.AddObject(6);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddDouble(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(6);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddDouble(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field7)
-                {
-                    var mapObj = obj.AddObject(7);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(7);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field8)
-                {
-                    var mapObj = obj.AddObject(8);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddUint32(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(8);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddUint32(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field9)
-                {
-                    var mapObj = obj.AddObject(9);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddUint64(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(9);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddUint64(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field10)
-                {
-                    var mapObj = obj.AddObject(10);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddSint32(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(10);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddSint32(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field11)
-                {
-                    var mapObj = obj.AddObject(11);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddSint64(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(11);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddSint64(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field12)
-                {
-                    var mapObj = obj.AddObject(12);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddFixed32(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(12);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddFixed32(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field13)
-                {
-                    var mapObj = obj.AddObject(13);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddFixed64(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(13);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddFixed64(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field14)
-                {
-                    var mapObj = obj.AddObject(14);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddSfixed32(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(14);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddSfixed32(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field15)
-                {
-                    var mapObj = obj.AddObject(15);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddSfixed64(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(15);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddSfixed64(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field16)
-                {
-                    var mapObj = obj.AddObject(16);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddEntityId(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(16);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddEntityId(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in field17)
-                {
-                    var mapObj = obj.AddObject(17);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(keyValuePair.Value, mapObj.AddObject(2));
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(17);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(keyValuePair.Value, mapObj.AddObject(2));
+                    }
+                    
                 }
                 return new global::Improbable.Worker.Core.ComponentData(schemaComponentData);
             }
@@ -526,156 +527,156 @@ namespace Improbable.Gdk.Tests
             {
                 {
                     foreach (var keyValuePair in component.Field1)
-                {
-                    var mapObj = obj.AddObject(1);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddBool(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(1);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddBool(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field2)
-                {
-                    var mapObj = obj.AddObject(2);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddFloat(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(2);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddFloat(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field3)
-                {
-                    var mapObj = obj.AddObject(3);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddBytes(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(3);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddBytes(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field4)
-                {
-                    var mapObj = obj.AddObject(4);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddInt32(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(4);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddInt32(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field5)
-                {
-                    var mapObj = obj.AddObject(5);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddInt64(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(5);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddInt64(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field6)
-                {
-                    var mapObj = obj.AddObject(6);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddDouble(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(6);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddDouble(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field7)
-                {
-                    var mapObj = obj.AddObject(7);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(7);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field8)
-                {
-                    var mapObj = obj.AddObject(8);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddUint32(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(8);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddUint32(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field9)
-                {
-                    var mapObj = obj.AddObject(9);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddUint64(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(9);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddUint64(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field10)
-                {
-                    var mapObj = obj.AddObject(10);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddSint32(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(10);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddSint32(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field11)
-                {
-                    var mapObj = obj.AddObject(11);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddSint64(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(11);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddSint64(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field12)
-                {
-                    var mapObj = obj.AddObject(12);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddFixed32(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(12);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddFixed32(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field13)
-                {
-                    var mapObj = obj.AddObject(13);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddFixed64(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(13);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddFixed64(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field14)
-                {
-                    var mapObj = obj.AddObject(14);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddSfixed32(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(14);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddSfixed32(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field15)
-                {
-                    var mapObj = obj.AddObject(15);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddSfixed64(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(15);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddSfixed64(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field16)
-                {
-                    var mapObj = obj.AddObject(16);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    mapObj.AddEntityId(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(16);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddEntityId(2, keyValuePair.Value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.Field17)
-                {
-                    var mapObj = obj.AddObject(17);
-                    mapObj.AddString(1, keyValuePair.Key);
-                    global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(keyValuePair.Value, mapObj.AddObject(2));
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(17);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(keyValuePair.Value, mapObj.AddObject(2));
+                    }
+                    
                 }
             }
 
@@ -686,307 +687,307 @@ namespace Improbable.Gdk.Tests
                     if (component.IsDataDirty(0))
                     {
                         foreach (var keyValuePair in component.Field1)
-                    {
-                        var mapObj = obj.AddObject(1);
-                        mapObj.AddString(1, keyValuePair.Key);
-                        mapObj.AddBool(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(1);
+                            mapObj.AddString(1, keyValuePair.Key);
+                            mapObj.AddBool(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field1.Count == 0)
-                    {
-                        updateObj.AddClearedField(1);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(1);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(1))
                     {
                         foreach (var keyValuePair in component.Field2)
-                    {
-                        var mapObj = obj.AddObject(2);
-                        mapObj.AddString(1, keyValuePair.Key);
-                        mapObj.AddFloat(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(2);
+                            mapObj.AddString(1, keyValuePair.Key);
+                            mapObj.AddFloat(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field2.Count == 0)
-                    {
-                        updateObj.AddClearedField(2);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(2);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(2))
                     {
                         foreach (var keyValuePair in component.Field3)
-                    {
-                        var mapObj = obj.AddObject(3);
-                        mapObj.AddString(1, keyValuePair.Key);
-                        mapObj.AddBytes(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(3);
+                            mapObj.AddString(1, keyValuePair.Key);
+                            mapObj.AddBytes(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field3.Count == 0)
-                    {
-                        updateObj.AddClearedField(3);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(3);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(3))
                     {
                         foreach (var keyValuePair in component.Field4)
-                    {
-                        var mapObj = obj.AddObject(4);
-                        mapObj.AddString(1, keyValuePair.Key);
-                        mapObj.AddInt32(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(4);
+                            mapObj.AddString(1, keyValuePair.Key);
+                            mapObj.AddInt32(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field4.Count == 0)
-                    {
-                        updateObj.AddClearedField(4);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(4);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(4))
                     {
                         foreach (var keyValuePair in component.Field5)
-                    {
-                        var mapObj = obj.AddObject(5);
-                        mapObj.AddString(1, keyValuePair.Key);
-                        mapObj.AddInt64(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(5);
+                            mapObj.AddString(1, keyValuePair.Key);
+                            mapObj.AddInt64(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field5.Count == 0)
-                    {
-                        updateObj.AddClearedField(5);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(5);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(5))
                     {
                         foreach (var keyValuePair in component.Field6)
-                    {
-                        var mapObj = obj.AddObject(6);
-                        mapObj.AddString(1, keyValuePair.Key);
-                        mapObj.AddDouble(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(6);
+                            mapObj.AddString(1, keyValuePair.Key);
+                            mapObj.AddDouble(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field6.Count == 0)
-                    {
-                        updateObj.AddClearedField(6);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(6);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(6))
                     {
                         foreach (var keyValuePair in component.Field7)
-                    {
-                        var mapObj = obj.AddObject(7);
-                        mapObj.AddString(1, keyValuePair.Key);
-                        mapObj.AddString(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(7);
+                            mapObj.AddString(1, keyValuePair.Key);
+                            mapObj.AddString(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field7.Count == 0)
-                    {
-                        updateObj.AddClearedField(7);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(7);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(7))
                     {
                         foreach (var keyValuePair in component.Field8)
-                    {
-                        var mapObj = obj.AddObject(8);
-                        mapObj.AddString(1, keyValuePair.Key);
-                        mapObj.AddUint32(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(8);
+                            mapObj.AddString(1, keyValuePair.Key);
+                            mapObj.AddUint32(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field8.Count == 0)
-                    {
-                        updateObj.AddClearedField(8);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(8);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(8))
                     {
                         foreach (var keyValuePair in component.Field9)
-                    {
-                        var mapObj = obj.AddObject(9);
-                        mapObj.AddString(1, keyValuePair.Key);
-                        mapObj.AddUint64(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(9);
+                            mapObj.AddString(1, keyValuePair.Key);
+                            mapObj.AddUint64(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field9.Count == 0)
-                    {
-                        updateObj.AddClearedField(9);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(9);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(9))
                     {
                         foreach (var keyValuePair in component.Field10)
-                    {
-                        var mapObj = obj.AddObject(10);
-                        mapObj.AddString(1, keyValuePair.Key);
-                        mapObj.AddSint32(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(10);
+                            mapObj.AddString(1, keyValuePair.Key);
+                            mapObj.AddSint32(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field10.Count == 0)
-                    {
-                        updateObj.AddClearedField(10);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(10);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(10))
                     {
                         foreach (var keyValuePair in component.Field11)
-                    {
-                        var mapObj = obj.AddObject(11);
-                        mapObj.AddString(1, keyValuePair.Key);
-                        mapObj.AddSint64(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(11);
+                            mapObj.AddString(1, keyValuePair.Key);
+                            mapObj.AddSint64(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field11.Count == 0)
-                    {
-                        updateObj.AddClearedField(11);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(11);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(11))
                     {
                         foreach (var keyValuePair in component.Field12)
-                    {
-                        var mapObj = obj.AddObject(12);
-                        mapObj.AddString(1, keyValuePair.Key);
-                        mapObj.AddFixed32(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(12);
+                            mapObj.AddString(1, keyValuePair.Key);
+                            mapObj.AddFixed32(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field12.Count == 0)
-                    {
-                        updateObj.AddClearedField(12);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(12);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(12))
                     {
                         foreach (var keyValuePair in component.Field13)
-                    {
-                        var mapObj = obj.AddObject(13);
-                        mapObj.AddString(1, keyValuePair.Key);
-                        mapObj.AddFixed64(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(13);
+                            mapObj.AddString(1, keyValuePair.Key);
+                            mapObj.AddFixed64(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field13.Count == 0)
-                    {
-                        updateObj.AddClearedField(13);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(13);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(13))
                     {
                         foreach (var keyValuePair in component.Field14)
-                    {
-                        var mapObj = obj.AddObject(14);
-                        mapObj.AddString(1, keyValuePair.Key);
-                        mapObj.AddSfixed32(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(14);
+                            mapObj.AddString(1, keyValuePair.Key);
+                            mapObj.AddSfixed32(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field14.Count == 0)
-                    {
-                        updateObj.AddClearedField(14);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(14);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(14))
                     {
                         foreach (var keyValuePair in component.Field15)
-                    {
-                        var mapObj = obj.AddObject(15);
-                        mapObj.AddString(1, keyValuePair.Key);
-                        mapObj.AddSfixed64(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(15);
+                            mapObj.AddString(1, keyValuePair.Key);
+                            mapObj.AddSfixed64(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field15.Count == 0)
-                    {
-                        updateObj.AddClearedField(15);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(15);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(15))
                     {
                         foreach (var keyValuePair in component.Field16)
-                    {
-                        var mapObj = obj.AddObject(16);
-                        mapObj.AddString(1, keyValuePair.Key);
-                        mapObj.AddEntityId(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(16);
+                            mapObj.AddString(1, keyValuePair.Key);
+                            mapObj.AddEntityId(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.Field16.Count == 0)
-                    {
-                        updateObj.AddClearedField(16);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(16);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(16))
                     {
                         foreach (var keyValuePair in component.Field17)
-                    {
-                        var mapObj = obj.AddObject(17);
-                        mapObj.AddString(1, keyValuePair.Key);
-                        global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(keyValuePair.Value, mapObj.AddObject(2));
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(17);
+                            mapObj.AddString(1, keyValuePair.Key);
+                            global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(keyValuePair.Value, mapObj.AddObject(2));
+                        }
+                        
                     }
 
                     if (component.Field17.Count == 0)
-                    {
-                        updateObj.AddClearedField(17);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(17);
+                        }
+                        
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptional.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptional.cs
@@ -110,6 +110,7 @@ namespace Improbable.Gdk.Tests
                 var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
 
                 componentDataSchema.SchemaData?.Dispose();
+                componentDataSchema.SchemaData = null;
 
                 return snapshot;
             }
@@ -342,122 +343,122 @@ namespace Improbable.Gdk.Tests
                 var obj = schemaComponentData.GetFields();
                 {
                     if (field1.HasValue)
-                {
-                    obj.AddBool(1, field1.Value);
-                }
-                
+                    {
+                        obj.AddBool(1, field1.Value);
+                    }
+                    
                 }
                 {
                     if (field2.HasValue)
-                {
-                    obj.AddFloat(2, field2.Value);
-                }
-                
+                    {
+                        obj.AddFloat(2, field2.Value);
+                    }
+                    
                 }
                 {
                     if (field3.HasValue)
-                {
-                    obj.AddBytes(3, field3.Value);
-                }
-                
+                    {
+                        obj.AddBytes(3, field3.Value);
+                    }
+                    
                 }
                 {
                     if (field4.HasValue)
-                {
-                    obj.AddInt32(4, field4.Value);
-                }
-                
+                    {
+                        obj.AddInt32(4, field4.Value);
+                    }
+                    
                 }
                 {
                     if (field5.HasValue)
-                {
-                    obj.AddInt64(5, field5.Value);
-                }
-                
+                    {
+                        obj.AddInt64(5, field5.Value);
+                    }
+                    
                 }
                 {
                     if (field6.HasValue)
-                {
-                    obj.AddDouble(6, field6.Value);
-                }
-                
+                    {
+                        obj.AddDouble(6, field6.Value);
+                    }
+                    
                 }
                 {
                     if (field7.HasValue)
-                {
-                    obj.AddString(7, field7.Value);
-                }
-                
+                    {
+                        obj.AddString(7, field7.Value);
+                    }
+                    
                 }
                 {
                     if (field8.HasValue)
-                {
-                    obj.AddUint32(8, field8.Value);
-                }
-                
+                    {
+                        obj.AddUint32(8, field8.Value);
+                    }
+                    
                 }
                 {
                     if (field9.HasValue)
-                {
-                    obj.AddUint64(9, field9.Value);
-                }
-                
+                    {
+                        obj.AddUint64(9, field9.Value);
+                    }
+                    
                 }
                 {
                     if (field10.HasValue)
-                {
-                    obj.AddSint32(10, field10.Value);
-                }
-                
+                    {
+                        obj.AddSint32(10, field10.Value);
+                    }
+                    
                 }
                 {
                     if (field11.HasValue)
-                {
-                    obj.AddSint64(11, field11.Value);
-                }
-                
+                    {
+                        obj.AddSint64(11, field11.Value);
+                    }
+                    
                 }
                 {
                     if (field12.HasValue)
-                {
-                    obj.AddFixed32(12, field12.Value);
-                }
-                
+                    {
+                        obj.AddFixed32(12, field12.Value);
+                    }
+                    
                 }
                 {
                     if (field13.HasValue)
-                {
-                    obj.AddFixed64(13, field13.Value);
-                }
-                
+                    {
+                        obj.AddFixed64(13, field13.Value);
+                    }
+                    
                 }
                 {
                     if (field14.HasValue)
-                {
-                    obj.AddSfixed32(14, field14.Value);
-                }
-                
+                    {
+                        obj.AddSfixed32(14, field14.Value);
+                    }
+                    
                 }
                 {
                     if (field15.HasValue)
-                {
-                    obj.AddSfixed64(15, field15.Value);
-                }
-                
+                    {
+                        obj.AddSfixed64(15, field15.Value);
+                    }
+                    
                 }
                 {
                     if (field16.HasValue)
-                {
-                    obj.AddEntityId(16, field16.Value);
-                }
-                
+                    {
+                        obj.AddEntityId(16, field16.Value);
+                    }
+                    
                 }
                 {
                     if (field17.HasValue)
-                {
-                    global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(field17.Value, obj.AddObject(17));
-                }
-                
+                    {
+                        global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(field17.Value, obj.AddObject(17));
+                    }
+                    
                 }
                 return new global::Improbable.Worker.Core.ComponentData(schemaComponentData);
             }
@@ -492,122 +493,122 @@ namespace Improbable.Gdk.Tests
             {
                 {
                     if (component.Field1.HasValue)
-                {
-                    obj.AddBool(1, component.Field1.Value);
-                }
-                
+                    {
+                        obj.AddBool(1, component.Field1.Value);
+                    }
+                    
                 }
                 {
                     if (component.Field2.HasValue)
-                {
-                    obj.AddFloat(2, component.Field2.Value);
-                }
-                
+                    {
+                        obj.AddFloat(2, component.Field2.Value);
+                    }
+                    
                 }
                 {
                     if (component.Field3.HasValue)
-                {
-                    obj.AddBytes(3, component.Field3.Value);
-                }
-                
+                    {
+                        obj.AddBytes(3, component.Field3.Value);
+                    }
+                    
                 }
                 {
                     if (component.Field4.HasValue)
-                {
-                    obj.AddInt32(4, component.Field4.Value);
-                }
-                
+                    {
+                        obj.AddInt32(4, component.Field4.Value);
+                    }
+                    
                 }
                 {
                     if (component.Field5.HasValue)
-                {
-                    obj.AddInt64(5, component.Field5.Value);
-                }
-                
+                    {
+                        obj.AddInt64(5, component.Field5.Value);
+                    }
+                    
                 }
                 {
                     if (component.Field6.HasValue)
-                {
-                    obj.AddDouble(6, component.Field6.Value);
-                }
-                
+                    {
+                        obj.AddDouble(6, component.Field6.Value);
+                    }
+                    
                 }
                 {
                     if (component.Field7.HasValue)
-                {
-                    obj.AddString(7, component.Field7.Value);
-                }
-                
+                    {
+                        obj.AddString(7, component.Field7.Value);
+                    }
+                    
                 }
                 {
                     if (component.Field8.HasValue)
-                {
-                    obj.AddUint32(8, component.Field8.Value);
-                }
-                
+                    {
+                        obj.AddUint32(8, component.Field8.Value);
+                    }
+                    
                 }
                 {
                     if (component.Field9.HasValue)
-                {
-                    obj.AddUint64(9, component.Field9.Value);
-                }
-                
+                    {
+                        obj.AddUint64(9, component.Field9.Value);
+                    }
+                    
                 }
                 {
                     if (component.Field10.HasValue)
-                {
-                    obj.AddSint32(10, component.Field10.Value);
-                }
-                
+                    {
+                        obj.AddSint32(10, component.Field10.Value);
+                    }
+                    
                 }
                 {
                     if (component.Field11.HasValue)
-                {
-                    obj.AddSint64(11, component.Field11.Value);
-                }
-                
+                    {
+                        obj.AddSint64(11, component.Field11.Value);
+                    }
+                    
                 }
                 {
                     if (component.Field12.HasValue)
-                {
-                    obj.AddFixed32(12, component.Field12.Value);
-                }
-                
+                    {
+                        obj.AddFixed32(12, component.Field12.Value);
+                    }
+                    
                 }
                 {
                     if (component.Field13.HasValue)
-                {
-                    obj.AddFixed64(13, component.Field13.Value);
-                }
-                
+                    {
+                        obj.AddFixed64(13, component.Field13.Value);
+                    }
+                    
                 }
                 {
                     if (component.Field14.HasValue)
-                {
-                    obj.AddSfixed32(14, component.Field14.Value);
-                }
-                
+                    {
+                        obj.AddSfixed32(14, component.Field14.Value);
+                    }
+                    
                 }
                 {
                     if (component.Field15.HasValue)
-                {
-                    obj.AddSfixed64(15, component.Field15.Value);
-                }
-                
+                    {
+                        obj.AddSfixed64(15, component.Field15.Value);
+                    }
+                    
                 }
                 {
                     if (component.Field16.HasValue)
-                {
-                    obj.AddEntityId(16, component.Field16.Value);
-                }
-                
+                    {
+                        obj.AddEntityId(16, component.Field16.Value);
+                    }
+                    
                 }
                 {
                     if (component.Field17.HasValue)
-                {
-                    global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(component.Field17.Value, obj.AddObject(17));
-                }
-                
+                    {
+                        global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(component.Field17.Value, obj.AddObject(17));
+                    }
+                    
                 }
             }
 
@@ -618,273 +619,273 @@ namespace Improbable.Gdk.Tests
                     if (component.IsDataDirty(0))
                     {
                         if (component.Field1.HasValue)
-                    {
-                        obj.AddBool(1, component.Field1.Value);
-                    }
-                    
+                        {
+                            obj.AddBool(1, component.Field1.Value);
+                        }
+                        
                     }
 
                     if (!component.Field1.HasValue)
-                    {
-                        updateObj.AddClearedField(1);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(1);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(1))
                     {
                         if (component.Field2.HasValue)
-                    {
-                        obj.AddFloat(2, component.Field2.Value);
-                    }
-                    
+                        {
+                            obj.AddFloat(2, component.Field2.Value);
+                        }
+                        
                     }
 
                     if (!component.Field2.HasValue)
-                    {
-                        updateObj.AddClearedField(2);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(2);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(2))
                     {
                         if (component.Field3.HasValue)
-                    {
-                        obj.AddBytes(3, component.Field3.Value);
-                    }
-                    
+                        {
+                            obj.AddBytes(3, component.Field3.Value);
+                        }
+                        
                     }
 
                     if (!component.Field3.HasValue)
-                    {
-                        updateObj.AddClearedField(3);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(3);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(3))
                     {
                         if (component.Field4.HasValue)
-                    {
-                        obj.AddInt32(4, component.Field4.Value);
-                    }
-                    
+                        {
+                            obj.AddInt32(4, component.Field4.Value);
+                        }
+                        
                     }
 
                     if (!component.Field4.HasValue)
-                    {
-                        updateObj.AddClearedField(4);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(4);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(4))
                     {
                         if (component.Field5.HasValue)
-                    {
-                        obj.AddInt64(5, component.Field5.Value);
-                    }
-                    
+                        {
+                            obj.AddInt64(5, component.Field5.Value);
+                        }
+                        
                     }
 
                     if (!component.Field5.HasValue)
-                    {
-                        updateObj.AddClearedField(5);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(5);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(5))
                     {
                         if (component.Field6.HasValue)
-                    {
-                        obj.AddDouble(6, component.Field6.Value);
-                    }
-                    
+                        {
+                            obj.AddDouble(6, component.Field6.Value);
+                        }
+                        
                     }
 
                     if (!component.Field6.HasValue)
-                    {
-                        updateObj.AddClearedField(6);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(6);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(6))
                     {
                         if (component.Field7.HasValue)
-                    {
-                        obj.AddString(7, component.Field7.Value);
-                    }
-                    
+                        {
+                            obj.AddString(7, component.Field7.Value);
+                        }
+                        
                     }
 
                     if (!component.Field7.HasValue)
-                    {
-                        updateObj.AddClearedField(7);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(7);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(7))
                     {
                         if (component.Field8.HasValue)
-                    {
-                        obj.AddUint32(8, component.Field8.Value);
-                    }
-                    
+                        {
+                            obj.AddUint32(8, component.Field8.Value);
+                        }
+                        
                     }
 
                     if (!component.Field8.HasValue)
-                    {
-                        updateObj.AddClearedField(8);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(8);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(8))
                     {
                         if (component.Field9.HasValue)
-                    {
-                        obj.AddUint64(9, component.Field9.Value);
-                    }
-                    
+                        {
+                            obj.AddUint64(9, component.Field9.Value);
+                        }
+                        
                     }
 
                     if (!component.Field9.HasValue)
-                    {
-                        updateObj.AddClearedField(9);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(9);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(9))
                     {
                         if (component.Field10.HasValue)
-                    {
-                        obj.AddSint32(10, component.Field10.Value);
-                    }
-                    
+                        {
+                            obj.AddSint32(10, component.Field10.Value);
+                        }
+                        
                     }
 
                     if (!component.Field10.HasValue)
-                    {
-                        updateObj.AddClearedField(10);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(10);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(10))
                     {
                         if (component.Field11.HasValue)
-                    {
-                        obj.AddSint64(11, component.Field11.Value);
-                    }
-                    
+                        {
+                            obj.AddSint64(11, component.Field11.Value);
+                        }
+                        
                     }
 
                     if (!component.Field11.HasValue)
-                    {
-                        updateObj.AddClearedField(11);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(11);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(11))
                     {
                         if (component.Field12.HasValue)
-                    {
-                        obj.AddFixed32(12, component.Field12.Value);
-                    }
-                    
+                        {
+                            obj.AddFixed32(12, component.Field12.Value);
+                        }
+                        
                     }
 
                     if (!component.Field12.HasValue)
-                    {
-                        updateObj.AddClearedField(12);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(12);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(12))
                     {
                         if (component.Field13.HasValue)
-                    {
-                        obj.AddFixed64(13, component.Field13.Value);
-                    }
-                    
+                        {
+                            obj.AddFixed64(13, component.Field13.Value);
+                        }
+                        
                     }
 
                     if (!component.Field13.HasValue)
-                    {
-                        updateObj.AddClearedField(13);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(13);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(13))
                     {
                         if (component.Field14.HasValue)
-                    {
-                        obj.AddSfixed32(14, component.Field14.Value);
-                    }
-                    
+                        {
+                            obj.AddSfixed32(14, component.Field14.Value);
+                        }
+                        
                     }
 
                     if (!component.Field14.HasValue)
-                    {
-                        updateObj.AddClearedField(14);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(14);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(14))
                     {
                         if (component.Field15.HasValue)
-                    {
-                        obj.AddSfixed64(15, component.Field15.Value);
-                    }
-                    
+                        {
+                            obj.AddSfixed64(15, component.Field15.Value);
+                        }
+                        
                     }
 
                     if (!component.Field15.HasValue)
-                    {
-                        updateObj.AddClearedField(15);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(15);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(15))
                     {
                         if (component.Field16.HasValue)
-                    {
-                        obj.AddEntityId(16, component.Field16.Value);
-                    }
-                    
+                        {
+                            obj.AddEntityId(16, component.Field16.Value);
+                        }
+                        
                     }
 
                     if (!component.Field16.HasValue)
-                    {
-                        updateObj.AddClearedField(16);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(16);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(16))
                     {
                         if (component.Field17.HasValue)
-                    {
-                        global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(component.Field17.Value, obj.AddObject(17));
-                    }
-                    
+                        {
+                            global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(component.Field17.Value, obj.AddObject(17));
+                        }
+                        
                     }
 
                     if (!component.Field17.HasValue)
-                    {
-                        updateObj.AddClearedField(17);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(17);
+                        }
+                        
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptional.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptional.cs
@@ -14,7 +14,7 @@ namespace Improbable.Gdk.Tests
     {
         public const uint ComponentId = 197716;
 
-        public struct Component : IComponentData, ISpatialComponentData
+        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 197716;
 
@@ -101,6 +101,17 @@ namespace Improbable.Gdk.Tests
                 dirtyBits0 = 0x0;
                 dirtyBits1 = 0x0;
                 dirtyBits2 = 0x0;
+            }
+
+            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
+            {
+                var componentDataSchema = new ComponentData(new SchemaComponentData(197716));
+                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
+                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
+
+                componentDataSchema.SchemaData?.Dispose();
+
+                return snapshot;
             }
 
             internal uint field1Handle;
@@ -477,6 +488,129 @@ namespace Improbable.Gdk.Tests
 
         public static class Serialization
         {
+            public static void SerializeComponent(Improbable.Gdk.Tests.ExhaustiveOptional.Component component, global::Improbable.Worker.Core.SchemaObject obj, global::Unity.Entities.World world)
+            {
+                {
+                    if (component.Field1.HasValue)
+                {
+                    obj.AddBool(1, component.Field1.Value);
+                }
+                
+                }
+                {
+                    if (component.Field2.HasValue)
+                {
+                    obj.AddFloat(2, component.Field2.Value);
+                }
+                
+                }
+                {
+                    if (component.Field3.HasValue)
+                {
+                    obj.AddBytes(3, component.Field3.Value);
+                }
+                
+                }
+                {
+                    if (component.Field4.HasValue)
+                {
+                    obj.AddInt32(4, component.Field4.Value);
+                }
+                
+                }
+                {
+                    if (component.Field5.HasValue)
+                {
+                    obj.AddInt64(5, component.Field5.Value);
+                }
+                
+                }
+                {
+                    if (component.Field6.HasValue)
+                {
+                    obj.AddDouble(6, component.Field6.Value);
+                }
+                
+                }
+                {
+                    if (component.Field7.HasValue)
+                {
+                    obj.AddString(7, component.Field7.Value);
+                }
+                
+                }
+                {
+                    if (component.Field8.HasValue)
+                {
+                    obj.AddUint32(8, component.Field8.Value);
+                }
+                
+                }
+                {
+                    if (component.Field9.HasValue)
+                {
+                    obj.AddUint64(9, component.Field9.Value);
+                }
+                
+                }
+                {
+                    if (component.Field10.HasValue)
+                {
+                    obj.AddSint32(10, component.Field10.Value);
+                }
+                
+                }
+                {
+                    if (component.Field11.HasValue)
+                {
+                    obj.AddSint64(11, component.Field11.Value);
+                }
+                
+                }
+                {
+                    if (component.Field12.HasValue)
+                {
+                    obj.AddFixed32(12, component.Field12.Value);
+                }
+                
+                }
+                {
+                    if (component.Field13.HasValue)
+                {
+                    obj.AddFixed64(13, component.Field13.Value);
+                }
+                
+                }
+                {
+                    if (component.Field14.HasValue)
+                {
+                    obj.AddSfixed32(14, component.Field14.Value);
+                }
+                
+                }
+                {
+                    if (component.Field15.HasValue)
+                {
+                    obj.AddSfixed64(15, component.Field15.Value);
+                }
+                
+                }
+                {
+                    if (component.Field16.HasValue)
+                {
+                    obj.AddEntityId(16, component.Field16.Value);
+                }
+                
+                }
+                {
+                    if (component.Field17.HasValue)
+                {
+                    global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(component.Field17.Value, obj.AddObject(17));
+                }
+                
+                }
+            }
+
             public static void SerializeUpdate(Improbable.Gdk.Tests.ExhaustiveOptional.Component component, global::Improbable.Worker.Core.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeated.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeated.cs
@@ -110,6 +110,7 @@ namespace Improbable.Gdk.Tests
                 var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
 
                 componentDataSchema.SchemaData?.Dispose();
+                componentDataSchema.SchemaData = null;
 
                 return snapshot;
             }
@@ -342,122 +343,122 @@ namespace Improbable.Gdk.Tests
                 var obj = schemaComponentData.GetFields();
                 {
                     foreach (var value in field1)
-                {
-                    obj.AddBool(1, value);
-                }
-                
+                    {
+                        obj.AddBool(1, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in field2)
-                {
-                    obj.AddFloat(2, value);
-                }
-                
+                    {
+                        obj.AddFloat(2, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in field3)
-                {
-                    obj.AddBytes(3, value);
-                }
-                
+                    {
+                        obj.AddBytes(3, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in field4)
-                {
-                    obj.AddInt32(4, value);
-                }
-                
+                    {
+                        obj.AddInt32(4, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in field5)
-                {
-                    obj.AddInt64(5, value);
-                }
-                
+                    {
+                        obj.AddInt64(5, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in field6)
-                {
-                    obj.AddDouble(6, value);
-                }
-                
+                    {
+                        obj.AddDouble(6, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in field7)
-                {
-                    obj.AddString(7, value);
-                }
-                
+                    {
+                        obj.AddString(7, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in field8)
-                {
-                    obj.AddUint32(8, value);
-                }
-                
+                    {
+                        obj.AddUint32(8, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in field9)
-                {
-                    obj.AddUint64(9, value);
-                }
-                
+                    {
+                        obj.AddUint64(9, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in field10)
-                {
-                    obj.AddSint32(10, value);
-                }
-                
+                    {
+                        obj.AddSint32(10, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in field11)
-                {
-                    obj.AddSint64(11, value);
-                }
-                
+                    {
+                        obj.AddSint64(11, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in field12)
-                {
-                    obj.AddFixed32(12, value);
-                }
-                
+                    {
+                        obj.AddFixed32(12, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in field13)
-                {
-                    obj.AddFixed64(13, value);
-                }
-                
+                    {
+                        obj.AddFixed64(13, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in field14)
-                {
-                    obj.AddSfixed32(14, value);
-                }
-                
+                    {
+                        obj.AddSfixed32(14, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in field15)
-                {
-                    obj.AddSfixed64(15, value);
-                }
-                
+                    {
+                        obj.AddSfixed64(15, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in field16)
-                {
-                    obj.AddEntityId(16, value);
-                }
-                
+                    {
+                        obj.AddEntityId(16, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in field17)
-                {
-                    global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(value, obj.AddObject(17));
-                }
-                
+                    {
+                        global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(value, obj.AddObject(17));
+                    }
+                    
                 }
                 return new global::Improbable.Worker.Core.ComponentData(schemaComponentData);
             }
@@ -492,122 +493,122 @@ namespace Improbable.Gdk.Tests
             {
                 {
                     foreach (var value in component.Field1)
-                {
-                    obj.AddBool(1, value);
-                }
-                
+                    {
+                        obj.AddBool(1, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in component.Field2)
-                {
-                    obj.AddFloat(2, value);
-                }
-                
+                    {
+                        obj.AddFloat(2, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in component.Field3)
-                {
-                    obj.AddBytes(3, value);
-                }
-                
+                    {
+                        obj.AddBytes(3, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in component.Field4)
-                {
-                    obj.AddInt32(4, value);
-                }
-                
+                    {
+                        obj.AddInt32(4, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in component.Field5)
-                {
-                    obj.AddInt64(5, value);
-                }
-                
+                    {
+                        obj.AddInt64(5, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in component.Field6)
-                {
-                    obj.AddDouble(6, value);
-                }
-                
+                    {
+                        obj.AddDouble(6, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in component.Field7)
-                {
-                    obj.AddString(7, value);
-                }
-                
+                    {
+                        obj.AddString(7, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in component.Field8)
-                {
-                    obj.AddUint32(8, value);
-                }
-                
+                    {
+                        obj.AddUint32(8, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in component.Field9)
-                {
-                    obj.AddUint64(9, value);
-                }
-                
+                    {
+                        obj.AddUint64(9, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in component.Field10)
-                {
-                    obj.AddSint32(10, value);
-                }
-                
+                    {
+                        obj.AddSint32(10, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in component.Field11)
-                {
-                    obj.AddSint64(11, value);
-                }
-                
+                    {
+                        obj.AddSint64(11, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in component.Field12)
-                {
-                    obj.AddFixed32(12, value);
-                }
-                
+                    {
+                        obj.AddFixed32(12, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in component.Field13)
-                {
-                    obj.AddFixed64(13, value);
-                }
-                
+                    {
+                        obj.AddFixed64(13, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in component.Field14)
-                {
-                    obj.AddSfixed32(14, value);
-                }
-                
+                    {
+                        obj.AddSfixed32(14, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in component.Field15)
-                {
-                    obj.AddSfixed64(15, value);
-                }
-                
+                    {
+                        obj.AddSfixed64(15, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in component.Field16)
-                {
-                    obj.AddEntityId(16, value);
-                }
-                
+                    {
+                        obj.AddEntityId(16, value);
+                    }
+                    
                 }
                 {
                     foreach (var value in component.Field17)
-                {
-                    global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(value, obj.AddObject(17));
-                }
-                
+                    {
+                        global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(value, obj.AddObject(17));
+                    }
+                    
                 }
             }
 
@@ -618,273 +619,273 @@ namespace Improbable.Gdk.Tests
                     if (component.IsDataDirty(0))
                     {
                         foreach (var value in component.Field1)
-                    {
-                        obj.AddBool(1, value);
-                    }
-                    
+                        {
+                            obj.AddBool(1, value);
+                        }
+                        
                     }
 
                     if (component.Field1.Count == 0)
-                    {
-                        updateObj.AddClearedField(1);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(1);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(1))
                     {
                         foreach (var value in component.Field2)
-                    {
-                        obj.AddFloat(2, value);
-                    }
-                    
+                        {
+                            obj.AddFloat(2, value);
+                        }
+                        
                     }
 
                     if (component.Field2.Count == 0)
-                    {
-                        updateObj.AddClearedField(2);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(2);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(2))
                     {
                         foreach (var value in component.Field3)
-                    {
-                        obj.AddBytes(3, value);
-                    }
-                    
+                        {
+                            obj.AddBytes(3, value);
+                        }
+                        
                     }
 
                     if (component.Field3.Count == 0)
-                    {
-                        updateObj.AddClearedField(3);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(3);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(3))
                     {
                         foreach (var value in component.Field4)
-                    {
-                        obj.AddInt32(4, value);
-                    }
-                    
+                        {
+                            obj.AddInt32(4, value);
+                        }
+                        
                     }
 
                     if (component.Field4.Count == 0)
-                    {
-                        updateObj.AddClearedField(4);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(4);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(4))
                     {
                         foreach (var value in component.Field5)
-                    {
-                        obj.AddInt64(5, value);
-                    }
-                    
+                        {
+                            obj.AddInt64(5, value);
+                        }
+                        
                     }
 
                     if (component.Field5.Count == 0)
-                    {
-                        updateObj.AddClearedField(5);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(5);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(5))
                     {
                         foreach (var value in component.Field6)
-                    {
-                        obj.AddDouble(6, value);
-                    }
-                    
+                        {
+                            obj.AddDouble(6, value);
+                        }
+                        
                     }
 
                     if (component.Field6.Count == 0)
-                    {
-                        updateObj.AddClearedField(6);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(6);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(6))
                     {
                         foreach (var value in component.Field7)
-                    {
-                        obj.AddString(7, value);
-                    }
-                    
+                        {
+                            obj.AddString(7, value);
+                        }
+                        
                     }
 
                     if (component.Field7.Count == 0)
-                    {
-                        updateObj.AddClearedField(7);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(7);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(7))
                     {
                         foreach (var value in component.Field8)
-                    {
-                        obj.AddUint32(8, value);
-                    }
-                    
+                        {
+                            obj.AddUint32(8, value);
+                        }
+                        
                     }
 
                     if (component.Field8.Count == 0)
-                    {
-                        updateObj.AddClearedField(8);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(8);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(8))
                     {
                         foreach (var value in component.Field9)
-                    {
-                        obj.AddUint64(9, value);
-                    }
-                    
+                        {
+                            obj.AddUint64(9, value);
+                        }
+                        
                     }
 
                     if (component.Field9.Count == 0)
-                    {
-                        updateObj.AddClearedField(9);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(9);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(9))
                     {
                         foreach (var value in component.Field10)
-                    {
-                        obj.AddSint32(10, value);
-                    }
-                    
+                        {
+                            obj.AddSint32(10, value);
+                        }
+                        
                     }
 
                     if (component.Field10.Count == 0)
-                    {
-                        updateObj.AddClearedField(10);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(10);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(10))
                     {
                         foreach (var value in component.Field11)
-                    {
-                        obj.AddSint64(11, value);
-                    }
-                    
+                        {
+                            obj.AddSint64(11, value);
+                        }
+                        
                     }
 
                     if (component.Field11.Count == 0)
-                    {
-                        updateObj.AddClearedField(11);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(11);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(11))
                     {
                         foreach (var value in component.Field12)
-                    {
-                        obj.AddFixed32(12, value);
-                    }
-                    
+                        {
+                            obj.AddFixed32(12, value);
+                        }
+                        
                     }
 
                     if (component.Field12.Count == 0)
-                    {
-                        updateObj.AddClearedField(12);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(12);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(12))
                     {
                         foreach (var value in component.Field13)
-                    {
-                        obj.AddFixed64(13, value);
-                    }
-                    
+                        {
+                            obj.AddFixed64(13, value);
+                        }
+                        
                     }
 
                     if (component.Field13.Count == 0)
-                    {
-                        updateObj.AddClearedField(13);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(13);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(13))
                     {
                         foreach (var value in component.Field14)
-                    {
-                        obj.AddSfixed32(14, value);
-                    }
-                    
+                        {
+                            obj.AddSfixed32(14, value);
+                        }
+                        
                     }
 
                     if (component.Field14.Count == 0)
-                    {
-                        updateObj.AddClearedField(14);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(14);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(14))
                     {
                         foreach (var value in component.Field15)
-                    {
-                        obj.AddSfixed64(15, value);
-                    }
-                    
+                        {
+                            obj.AddSfixed64(15, value);
+                        }
+                        
                     }
 
                     if (component.Field15.Count == 0)
-                    {
-                        updateObj.AddClearedField(15);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(15);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(15))
                     {
                         foreach (var value in component.Field16)
-                    {
-                        obj.AddEntityId(16, value);
-                    }
-                    
+                        {
+                            obj.AddEntityId(16, value);
+                        }
+                        
                     }
 
                     if (component.Field16.Count == 0)
-                    {
-                        updateObj.AddClearedField(16);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(16);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(16))
                     {
                         foreach (var value in component.Field17)
-                    {
-                        global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(value, obj.AddObject(17));
-                    }
-                    
+                        {
+                            global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(value, obj.AddObject(17));
+                        }
+                        
                     }
 
                     if (component.Field17.Count == 0)
-                    {
-                        updateObj.AddClearedField(17);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(17);
+                        }
+                        
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeated.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeated.cs
@@ -14,7 +14,7 @@ namespace Improbable.Gdk.Tests
     {
         public const uint ComponentId = 197717;
 
-        public struct Component : IComponentData, ISpatialComponentData
+        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 197717;
 
@@ -101,6 +101,17 @@ namespace Improbable.Gdk.Tests
                 dirtyBits0 = 0x0;
                 dirtyBits1 = 0x0;
                 dirtyBits2 = 0x0;
+            }
+
+            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
+            {
+                var componentDataSchema = new ComponentData(new SchemaComponentData(197717));
+                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
+                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
+
+                componentDataSchema.SchemaData?.Dispose();
+
+                return snapshot;
             }
 
             internal uint field1Handle;
@@ -477,6 +488,129 @@ namespace Improbable.Gdk.Tests
 
         public static class Serialization
         {
+            public static void SerializeComponent(Improbable.Gdk.Tests.ExhaustiveRepeated.Component component, global::Improbable.Worker.Core.SchemaObject obj, global::Unity.Entities.World world)
+            {
+                {
+                    foreach (var value in component.Field1)
+                {
+                    obj.AddBool(1, value);
+                }
+                
+                }
+                {
+                    foreach (var value in component.Field2)
+                {
+                    obj.AddFloat(2, value);
+                }
+                
+                }
+                {
+                    foreach (var value in component.Field3)
+                {
+                    obj.AddBytes(3, value);
+                }
+                
+                }
+                {
+                    foreach (var value in component.Field4)
+                {
+                    obj.AddInt32(4, value);
+                }
+                
+                }
+                {
+                    foreach (var value in component.Field5)
+                {
+                    obj.AddInt64(5, value);
+                }
+                
+                }
+                {
+                    foreach (var value in component.Field6)
+                {
+                    obj.AddDouble(6, value);
+                }
+                
+                }
+                {
+                    foreach (var value in component.Field7)
+                {
+                    obj.AddString(7, value);
+                }
+                
+                }
+                {
+                    foreach (var value in component.Field8)
+                {
+                    obj.AddUint32(8, value);
+                }
+                
+                }
+                {
+                    foreach (var value in component.Field9)
+                {
+                    obj.AddUint64(9, value);
+                }
+                
+                }
+                {
+                    foreach (var value in component.Field10)
+                {
+                    obj.AddSint32(10, value);
+                }
+                
+                }
+                {
+                    foreach (var value in component.Field11)
+                {
+                    obj.AddSint64(11, value);
+                }
+                
+                }
+                {
+                    foreach (var value in component.Field12)
+                {
+                    obj.AddFixed32(12, value);
+                }
+                
+                }
+                {
+                    foreach (var value in component.Field13)
+                {
+                    obj.AddFixed64(13, value);
+                }
+                
+                }
+                {
+                    foreach (var value in component.Field14)
+                {
+                    obj.AddSfixed32(14, value);
+                }
+                
+                }
+                {
+                    foreach (var value in component.Field15)
+                {
+                    obj.AddSfixed64(15, value);
+                }
+                
+                }
+                {
+                    foreach (var value in component.Field16)
+                {
+                    obj.AddEntityId(16, value);
+                }
+                
+                }
+                {
+                    foreach (var value in component.Field17)
+                {
+                    global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(value, obj.AddObject(17));
+                }
+                
+                }
+            }
+
             public static void SerializeUpdate(Improbable.Gdk.Tests.ExhaustiveRepeated.Component component, global::Improbable.Worker.Core.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingular.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingular.cs
@@ -110,6 +110,7 @@ namespace Improbable.Gdk.Tests
                 var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
 
                 componentDataSchema.SchemaData?.Dispose();
+                componentDataSchema.SchemaData = null;
 
                 return snapshot;
             }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingular.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingular.cs
@@ -14,7 +14,7 @@ namespace Improbable.Gdk.Tests
     {
         public const uint ComponentId = 197715;
 
-        public struct Component : IComponentData, ISpatialComponentData
+        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 197715;
 
@@ -101,6 +101,17 @@ namespace Improbable.Gdk.Tests
                 dirtyBits0 = 0x0;
                 dirtyBits1 = 0x0;
                 dirtyBits2 = 0x0;
+            }
+
+            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
+            {
+                var componentDataSchema = new ComponentData(new SchemaComponentData(197715));
+                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
+                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
+
+                componentDataSchema.SchemaData?.Dispose();
+
+                return snapshot;
             }
 
             private BlittableBool field1;
@@ -409,6 +420,61 @@ namespace Improbable.Gdk.Tests
 
         public static class Serialization
         {
+            public static void SerializeComponent(Improbable.Gdk.Tests.ExhaustiveSingular.Component component, global::Improbable.Worker.Core.SchemaObject obj, global::Unity.Entities.World world)
+            {
+                {
+                    obj.AddBool(1, component.Field1);
+                }
+                {
+                    obj.AddFloat(2, component.Field2);
+                }
+                {
+                    obj.AddBytes(3, component.Field3);
+                }
+                {
+                    obj.AddInt32(4, component.Field4);
+                }
+                {
+                    obj.AddInt64(5, component.Field5);
+                }
+                {
+                    obj.AddDouble(6, component.Field6);
+                }
+                {
+                    obj.AddString(7, component.Field7);
+                }
+                {
+                    obj.AddUint32(8, component.Field8);
+                }
+                {
+                    obj.AddUint64(9, component.Field9);
+                }
+                {
+                    obj.AddSint32(10, component.Field10);
+                }
+                {
+                    obj.AddSint64(11, component.Field11);
+                }
+                {
+                    obj.AddFixed32(12, component.Field12);
+                }
+                {
+                    obj.AddFixed64(13, component.Field13);
+                }
+                {
+                    obj.AddSfixed32(14, component.Field14);
+                }
+                {
+                    obj.AddSfixed64(15, component.Field15);
+                }
+                {
+                    obj.AddEntityId(16, component.Field16);
+                }
+                {
+                    global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(component.Field17, obj.AddObject(17));
+                }
+            }
+
             public static void SerializeUpdate(Improbable.Gdk.Tests.ExhaustiveSingular.Component component, global::Improbable.Worker.Core.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponent.cs
@@ -14,7 +14,7 @@ namespace Improbable.Gdk.Tests
     {
         public const uint ComponentId = 20152;
 
-        public struct Component : IComponentData, ISpatialComponentData
+        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 20152;
 
@@ -87,6 +87,17 @@ namespace Improbable.Gdk.Tests
                 dirtyBits0 = 0x0;
             }
 
+            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
+            {
+                var componentDataSchema = new ComponentData(new SchemaComponentData(20152));
+                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
+                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
+
+                componentDataSchema.SchemaData?.Dispose();
+
+                return snapshot;
+            }
+
             private global::Improbable.Gdk.Tests.TypeName nestedType;
 
             public global::Improbable.Gdk.Tests.TypeName NestedType
@@ -121,6 +132,13 @@ namespace Improbable.Gdk.Tests
 
         public static class Serialization
         {
+            public static void SerializeComponent(Improbable.Gdk.Tests.NestedComponent.Component component, global::Improbable.Worker.Core.SchemaObject obj, global::Unity.Entities.World world)
+            {
+                {
+                    global::Improbable.Gdk.Tests.TypeName.Serialization.Serialize(component.NestedType, obj.AddObject(1));
+                }
+            }
+
             public static void SerializeUpdate(Improbable.Gdk.Tests.NestedComponent.Component component, global::Improbable.Worker.Core.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponent.cs
@@ -94,6 +94,7 @@ namespace Improbable.Gdk.Tests
                 var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
 
                 componentDataSchema.SchemaData?.Dispose();
+                componentDataSchema.SchemaData = null;
 
                 return snapshot;
             }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/Connection.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/Connection.cs
@@ -14,7 +14,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
     {
         public const uint ComponentId = 1105;
 
-        public struct Component : IComponentData, ISpatialComponentData
+        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 1105;
 
@@ -58,6 +58,17 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 dirtyBits0 = 0x0;
             }
 
+            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
+            {
+                var componentDataSchema = new ComponentData(new SchemaComponentData(1105));
+                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
+                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
+
+                componentDataSchema.SchemaData?.Dispose();
+
+                return snapshot;
+            }
+
             public static global::Improbable.Worker.Core.ComponentData CreateSchemaComponentData(
             )
             {
@@ -75,6 +86,10 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
 
         public static class Serialization
         {
+            public static void SerializeComponent(Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component component, global::Improbable.Worker.Core.SchemaObject obj, global::Unity.Entities.World world)
+            {
+            }
+
             public static void SerializeUpdate(Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component component, global::Improbable.Worker.Core.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/Connection.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/Connection.cs
@@ -65,6 +65,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
 
                 componentDataSchema.SchemaData?.Dispose();
+                componentDataSchema.SchemaData = null;
 
                 return snapshot;
             }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponent.cs
@@ -14,7 +14,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
     {
         public const uint ComponentId = 1001;
 
-        public struct Component : IComponentData, ISpatialComponentData
+        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 1001;
 
@@ -85,6 +85,17 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             public void MarkDataClean()
             {
                 dirtyBits0 = 0x0;
+            }
+
+            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
+            {
+                var componentDataSchema = new ComponentData(new SchemaComponentData(1001));
+                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
+                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
+
+                componentDataSchema.SchemaData?.Dispose();
+
+                return snapshot;
             }
 
             private BlittableBool boolField;
@@ -189,6 +200,25 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
         public static class Serialization
         {
+            public static void SerializeComponent(Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component component, global::Improbable.Worker.Core.SchemaObject obj, global::Unity.Entities.World world)
+            {
+                {
+                    obj.AddBool(1, component.BoolField);
+                }
+                {
+                    obj.AddInt32(2, component.IntField);
+                }
+                {
+                    obj.AddInt64(3, component.LongField);
+                }
+                {
+                    obj.AddFloat(4, component.FloatField);
+                }
+                {
+                    obj.AddDouble(5, component.DoubleField);
+                }
+            }
+
             public static void SerializeUpdate(Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component component, global::Improbable.Worker.Core.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponent.cs
@@ -94,6 +94,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
 
                 componentDataSchema.SchemaData?.Dispose();
+                componentDataSchema.SchemaData = null;
 
                 return snapshot;
             }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFields.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFields.cs
@@ -14,7 +14,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
     {
         public const uint ComponentId = 1003;
 
-        public struct Component : IComponentData, ISpatialComponentData
+        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 1003;
 
@@ -58,6 +58,17 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 dirtyBits0 = 0x0;
             }
 
+            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
+            {
+                var componentDataSchema = new ComponentData(new SchemaComponentData(1003));
+                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
+                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
+
+                componentDataSchema.SchemaData?.Dispose();
+
+                return snapshot;
+            }
+
             public static global::Improbable.Worker.Core.ComponentData CreateSchemaComponentData(
             )
             {
@@ -75,6 +86,10 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
         public static class Serialization
         {
+            public static void SerializeComponent(Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component component, global::Improbable.Worker.Core.SchemaObject obj, global::Unity.Entities.World world)
+            {
+            }
+
             public static void SerializeUpdate(Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component component, global::Improbable.Worker.Core.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFields.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFields.cs
@@ -65,6 +65,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
 
                 componentDataSchema.SchemaData?.Dispose();
+                componentDataSchema.SchemaData = null;
 
                 return snapshot;
             }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommands.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommands.cs
@@ -14,7 +14,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
     {
         public const uint ComponentId = 1005;
 
-        public struct Component : IComponentData, ISpatialComponentData
+        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 1005;
 
@@ -58,6 +58,17 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 dirtyBits0 = 0x0;
             }
 
+            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
+            {
+                var componentDataSchema = new ComponentData(new SchemaComponentData(1005));
+                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
+                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
+
+                componentDataSchema.SchemaData?.Dispose();
+
+                return snapshot;
+            }
+
             public static global::Improbable.Worker.Core.ComponentData CreateSchemaComponentData(
             )
             {
@@ -75,6 +86,10 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
         public static class Serialization
         {
+            public static void SerializeComponent(Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component component, global::Improbable.Worker.Core.SchemaObject obj, global::Unity.Entities.World world)
+            {
+            }
+
             public static void SerializeUpdate(Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component component, global::Improbable.Worker.Core.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommands.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommands.cs
@@ -65,6 +65,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
 
                 componentDataSchema.SchemaData?.Dispose();
+                componentDataSchema.SchemaData = null;
 
                 return snapshot;
             }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEvents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEvents.cs
@@ -65,6 +65,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
 
                 componentDataSchema.SchemaData?.Dispose();
+                componentDataSchema.SchemaData = null;
 
                 return snapshot;
             }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEvents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEvents.cs
@@ -14,7 +14,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
     {
         public const uint ComponentId = 1004;
 
-        public struct Component : IComponentData, ISpatialComponentData
+        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 1004;
 
@@ -58,6 +58,17 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 dirtyBits0 = 0x0;
             }
 
+            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
+            {
+                var componentDataSchema = new ComponentData(new SchemaComponentData(1004));
+                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
+                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
+
+                componentDataSchema.SchemaData?.Dispose();
+
+                return snapshot;
+            }
+
             public static global::Improbable.Worker.Core.ComponentData CreateSchemaComponentData(
             )
             {
@@ -75,6 +86,10 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
         public static class Serialization
         {
+            public static void SerializeComponent(Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component component, global::Improbable.Worker.Core.SchemaObject obj, global::Unity.Entities.World world)
+            {
+            }
+
             public static void SerializeUpdate(Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component component, global::Improbable.Worker.Core.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponent.cs
@@ -102,6 +102,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
 
                 componentDataSchema.SchemaData?.Dispose();
+                componentDataSchema.SchemaData = null;
 
                 return snapshot;
             }
@@ -248,26 +249,26 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 }
                 {
                     if (optionalField.HasValue)
-                {
-                    obj.AddInt32(7, optionalField.Value);
-                }
-                
+                    {
+                        obj.AddInt32(7, optionalField.Value);
+                    }
+                    
                 }
                 {
                     foreach (var value in listField)
-                {
-                    obj.AddInt32(8, value);
-                }
-                
+                    {
+                        obj.AddInt32(8, value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in mapField)
-                {
-                    var mapObj = obj.AddObject(9);
-                    mapObj.AddInt32(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(9);
+                        mapObj.AddInt32(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
                 return new global::Improbable.Worker.Core.ComponentData(schemaComponentData);
             }
@@ -312,26 +313,26 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 }
                 {
                     if (component.OptionalField.HasValue)
-                {
-                    obj.AddInt32(7, component.OptionalField.Value);
-                }
-                
+                    {
+                        obj.AddInt32(7, component.OptionalField.Value);
+                    }
+                    
                 }
                 {
                     foreach (var value in component.ListField)
-                {
-                    obj.AddInt32(8, value);
-                }
-                
+                    {
+                        obj.AddInt32(8, value);
+                    }
+                    
                 }
                 {
                     foreach (var keyValuePair in component.MapField)
-                {
-                    var mapObj = obj.AddObject(9);
-                    mapObj.AddInt32(1, keyValuePair.Key);
-                    mapObj.AddString(2, keyValuePair.Value);
-                }
-                
+                    {
+                        var mapObj = obj.AddObject(9);
+                        mapObj.AddInt32(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
                 }
             }
 
@@ -390,51 +391,51 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     if (component.IsDataDirty(6))
                     {
                         if (component.OptionalField.HasValue)
-                    {
-                        obj.AddInt32(7, component.OptionalField.Value);
-                    }
-                    
+                        {
+                            obj.AddInt32(7, component.OptionalField.Value);
+                        }
+                        
                     }
 
                     if (!component.OptionalField.HasValue)
-                    {
-                        updateObj.AddClearedField(7);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(7);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(7))
                     {
                         foreach (var value in component.ListField)
-                    {
-                        obj.AddInt32(8, value);
-                    }
-                    
+                        {
+                            obj.AddInt32(8, value);
+                        }
+                        
                     }
 
                     if (component.ListField.Count == 0)
-                    {
-                        updateObj.AddClearedField(8);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(8);
+                        }
+                        
                 }
                 {
                     if (component.IsDataDirty(8))
                     {
                         foreach (var keyValuePair in component.MapField)
-                    {
-                        var mapObj = obj.AddObject(9);
-                        mapObj.AddInt32(1, keyValuePair.Key);
-                        mapObj.AddString(2, keyValuePair.Value);
-                    }
-                    
+                        {
+                            var mapObj = obj.AddObject(9);
+                            mapObj.AddInt32(1, keyValuePair.Key);
+                            mapObj.AddString(2, keyValuePair.Value);
+                        }
+                        
                     }
 
                     if (component.MapField.Count == 0)
-                    {
-                        updateObj.AddClearedField(9);
-                    }
-                    
+                        {
+                            updateObj.AddClearedField(9);
+                        }
+                        
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponent.cs
@@ -14,7 +14,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
     {
         public const uint ComponentId = 1002;
 
-        public struct Component : IComponentData, ISpatialComponentData
+        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 1002;
 
@@ -93,6 +93,17 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             {
                 dirtyBits0 = 0x0;
                 dirtyBits1 = 0x0;
+            }
+
+            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
+            {
+                var componentDataSchema = new ComponentData(new SchemaComponentData(1002));
+                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
+                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
+
+                componentDataSchema.SchemaData?.Dispose();
+
+                return snapshot;
             }
 
             private BlittableBool boolField;
@@ -279,6 +290,51 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
         public static class Serialization
         {
+            public static void SerializeComponent(Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component component, global::Improbable.Worker.Core.SchemaObject obj, global::Unity.Entities.World world)
+            {
+                {
+                    obj.AddBool(1, component.BoolField);
+                }
+                {
+                    obj.AddInt32(2, component.IntField);
+                }
+                {
+                    obj.AddInt64(3, component.LongField);
+                }
+                {
+                    obj.AddFloat(4, component.FloatField);
+                }
+                {
+                    obj.AddDouble(5, component.DoubleField);
+                }
+                {
+                    obj.AddString(6, component.StringField);
+                }
+                {
+                    if (component.OptionalField.HasValue)
+                {
+                    obj.AddInt32(7, component.OptionalField.Value);
+                }
+                
+                }
+                {
+                    foreach (var value in component.ListField)
+                {
+                    obj.AddInt32(8, value);
+                }
+                
+                }
+                {
+                    foreach (var keyValuePair in component.MapField)
+                {
+                    var mapObj = obj.AddObject(9);
+                    mapObj.AddInt32(1, keyValuePair.Key);
+                    mapObj.AddString(2, keyValuePair.Value);
+                }
+                
+                }
+            }
+
             public static void SerializeUpdate(Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component component, global::Improbable.Worker.Core.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/ISnapshottable.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/ISnapshottable.cs
@@ -1,0 +1,13 @@
+﻿using Unity.Entities;
+
+namespace Improbable.Gdk.Core
+{
+    /// <summary>
+    ///     Denotes that an object can be snapshotted.
+    /// </summary>
+    /// <typeparam name="T">The type of the snapshot.</typeparam>
+    public interface ISnapshottable<T> where T : ISpatialComponentSnapshot
+    {
+        T ToComponentSnapshot(World world);
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/ISnapshottable.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/ISnapshottable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: daf1cbc8dbd065e49ba846ca17325373
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
@@ -20,7 +20,7 @@ namespace <#= qualifiedNamespace #>
     {
         public const uint ComponentId = <#= componentDetails.ComponentId #>;
 
-        public struct Component : IComponentData, ISpatialComponentData
+        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => <#= componentDetails.ComponentId #>;
 
@@ -110,6 +110,17 @@ namespace <#= qualifiedNamespace #>
                 dirtyBits<#= i #> = 0x0;
 <# } #>
             }
+
+            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
+            {
+                var componentDataSchema = new ComponentData(new SchemaComponentData(<#= componentDetails.ComponentId #>));
+                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
+                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
+
+                componentDataSchema.SchemaData?.Dispose();
+
+                return snapshot;
+            }
 <# for (var i = 0; i < fieldDetailsList.Count; i++) {
 var fieldDetails = fieldDetailsList[i]; #>
 <# if (fieldDetails.IsBlittable) { #>
@@ -173,6 +184,16 @@ var fieldDetails = fieldDetailsList[i]; #>
 
         public static class Serialization
         {
+            public static void SerializeComponent(<#= componentNamespace #>.Component component, global::Improbable.Worker.Core.SchemaObject obj, global::Unity.Entities.World world)
+            {
+<# for (var i = 0; i < fieldDetailsList.Count; i++) {
+var fieldDetails = fieldDetailsList[i]; #>
+                {
+                    <#= fieldDetails.GetSerializationString("component." + fieldDetails.PascalCaseName, "obj", 4) #>
+                }
+<# } #>
+            }
+
             public static void SerializeUpdate(<#= componentNamespace #>.Component component, global::Improbable.Worker.Core.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
@@ -118,6 +118,7 @@ namespace <#= qualifiedNamespace #>
                 var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields(), world);
 
                 componentDataSchema.SchemaData?.Dispose();
+                componentDataSchema.SchemaData = null;
 
                 return snapshot;
             }
@@ -165,7 +166,7 @@ var fieldDetails = fieldDetailsList[i]; #>
                 var obj = schemaComponentData.GetFields();
 <# foreach (var fieldDetails in fieldDetailsList) { #>
                 {
-                    <#= fieldDetails.GetSerializationString(fieldDetails.CamelCaseName, "obj", 4) #>
+                    <#= fieldDetails.GetSerializationString(fieldDetails.CamelCaseName, "obj", 5) #>
                 }
 <# } #>
                 return new global::Improbable.Worker.Core.ComponentData(schemaComponentData);
@@ -189,7 +190,7 @@ var fieldDetails = fieldDetailsList[i]; #>
 <# for (var i = 0; i < fieldDetailsList.Count; i++) {
 var fieldDetails = fieldDetailsList[i]; #>
                 {
-                    <#= fieldDetails.GetSerializationString("component." + fieldDetails.PascalCaseName, "obj", 4) #>
+                    <#= fieldDetails.GetSerializationString("component." + fieldDetails.PascalCaseName, "obj", 5) #>
                 }
 <# } #>
             }
@@ -202,11 +203,11 @@ var fieldDetails = fieldDetailsList[i]; #>
                 {
                     if (component.IsDataDirty(<#= i #>))
                     {
-                        <#= fieldDetails.GetSerializationString("component." + fieldDetails.PascalCaseName, "obj", 5) #>
+                        <#= fieldDetails.GetSerializationString("component." + fieldDetails.PascalCaseName, "obj", 6) #>
                     }
 
 <# if (ShouldGenerateClearedFieldsSet()) { #>
-                    <#= fieldDetails.GetTrySetClearedFieldString("component." + fieldDetails.PascalCaseName, "updateObj", 5) #>
+                    <#= fieldDetails.GetTrySetClearedFieldString("component." + fieldDetails.PascalCaseName, "updateObj", 6) #>
 <# } #>
                 }
 <# } #>


### PR DESCRIPTION
#### Description
This PR adds an interface to all generated components which allows you to take a snapshot of that component. The snapshot is done simply through serialize/deserialize, no deep copy implementations required.

Commits are ordered.

#### Tests
Generated code and checked implementation.

#### Documentation
Changelog entry. Will probably need some docs I guess 

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@samiwh 
