### PR TITLE
Some misc improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 ### Added
 
 - Added support for the Steam authentication flow.
-- Added a reference to Blank Starter Project in the README.
 - Added Frames Per Second (FPS) and Unity heap usage as metrics sent by `MetricSendSystem.cs`.
 - Added a warning message to the top of schema files copied into the `from_gdk_packages` directory.
 - Added an `ISnapshottable<T>` interface to all generated components. This allows you to convert a component to a snapshot.
+- Added an `EntityId` property on the Readers/Writers to access the `EntityId` of the underlying SpatialOS entity.
+- Added a `HasEntity` method to the `WorkerSystem`. This allows you to check if an entity is checked out on your worker.
 
 ### Changed
 

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/ActivationManagerTestBase.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/ActivationManagerTestBase.cs
@@ -33,6 +33,7 @@ namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.MonoBehaviourAct
             var spatialOSComponent = TestGameObject.AddComponent<SpatialOSComponent>();
             spatialOSComponent.Worker = workerSystem;
             spatialOSComponent.Entity = entityManager.CreateEntity();
+            entityManager.AddComponentData(spatialOSComponent.Entity, new SpatialEntityId());
 
             var injectableStore = new InjectableStore();
             var requiredFieldInjector = new RequiredFieldInjector(entityManager, loggingDispatcher);

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/EventTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/EventTests.cs
@@ -27,6 +27,7 @@ namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.Readers
             world = new World("test-world");
             entityManager = world.GetOrCreateManager<EntityManager>();
             entity = entityManager.CreateEntity(ComponentType.Create<BlittableComponent.Component>());
+            entityManager.AddComponentData(entity, new SpatialEntityId());
             readerWriterInternal =
                 new ComponentWithEvents.Requirable.ReaderWriterImpl(entity, entityManager, new LoggingDispatcher());
             readerPublic = readerWriterInternal;

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/NonBlittableReaderTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/NonBlittableReaderTests.cs
@@ -16,6 +16,7 @@ namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.Readers
             {
                 var entityManager = world.GetOrCreateManager<EntityManager>();
                 var entity = entityManager.CreateEntity(typeof(NonBlittableComponent.Component));
+                entityManager.AddComponentData(entity, new SpatialEntityId());
                 var reader =
                     new NonBlittableComponent.Requirable.ReaderWriterImpl(entity, entityManager,
                         new LoggingDispatcher());
@@ -51,6 +52,7 @@ namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.Readers
             {
                 var entityManager = world.GetOrCreateManager<EntityManager>();
                 var entity = entityManager.CreateEntity(typeof(NonBlittableComponent.Component));
+                entityManager.AddComponentData(entity, new SpatialEntityId());
                 var reader =
                     new NonBlittableComponent.Requirable.ReaderWriterImpl(entity, entityManager,
                         new LoggingDispatcher());

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/NonBlittableWriterTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/NonBlittableWriterTests.cs
@@ -17,6 +17,7 @@ namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.Readers
                 var entityManager = world.GetOrCreateManager<EntityManager>();
                 var entity = entityManager.CreateEntity(typeof(NonBlittableComponent.Component));
                 entityManager.SetComponentData(entity, new NonBlittableComponent.Component());
+                entityManager.AddComponentData(entity, new SpatialEntityId());
                 var writer =
                     new NonBlittableComponent.Requirable.ReaderWriterImpl(entity, entityManager,
                         new LoggingDispatcher());
@@ -38,6 +39,7 @@ namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.Readers
             {
                 var entityManager = world.GetOrCreateManager<EntityManager>();
                 var entity = entityManager.CreateEntity(typeof(NonBlittableComponent.Component));
+                entityManager.AddComponentData(entity, new SpatialEntityId());
 
                 var schemaComponentData = NonBlittableComponent.Component.CreateSchemaComponentData(
                     boolField: false,

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/ReaderDataTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/ReaderDataTests.cs
@@ -20,7 +20,7 @@ namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.Readers
         [Test]
         public void EntityId_returns_spatial_entity_id()
         {
-            Assert.AreEqual(EntityId, ReaderPublic.EntityId.Id);
+            Assert.AreEqual(EntityId, ReaderPublic.EntityId);
         }
     }
 }

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/ReaderDataTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/ReaderDataTests.cs
@@ -16,5 +16,11 @@ namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.Readers
             Assert.AreEqual(data, ReaderPublic.Data);
             Assert.AreEqual(data.FloatField, ReaderPublic.Data.FloatField);
         }
+
+        [Test]
+        public void EntityId_returns_spatial_entity_id()
+        {
+            Assert.AreEqual(EntityId, ReaderPublic.EntityId.Id);
+        }
     }
 }

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/ReaderWriterTestsBase.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/ReaderWriterTestsBase.cs
@@ -7,6 +7,8 @@ namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.Readers
 {
     internal abstract class ReaderWriterTestsBase
     {
+        protected long EntityId = 10;
+
         protected BlittableComponent.Requirable.Reader ReaderPublic;
         protected BlittableComponent.Requirable.Writer WriterPublic;
         protected BlittableComponent.Requirable.ReaderWriterImpl ReaderWriterInternal;
@@ -20,6 +22,10 @@ namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.Readers
             world = new World("test-world");
             EntityManager = world.GetOrCreateManager<EntityManager>();
             Entity = EntityManager.CreateEntity(typeof(BlittableComponent.Component));
+            EntityManager.AddComponentData(Entity, new SpatialEntityId
+            {
+                EntityId = new EntityId(EntityId)
+            });
             ReaderWriterInternal =
                 new BlittableComponent.Requirable.ReaderWriterImpl(Entity, EntityManager, new LoggingDispatcher());
             ReaderPublic = ReaderWriterInternal;

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/ReaderWriterTestsBase.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/ReaderWriterTestsBase.cs
@@ -7,7 +7,7 @@ namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.Readers
 {
     internal abstract class ReaderWriterTestsBase
     {
-        protected long EntityId = 10;
+        protected EntityId EntityId = new EntityId(10);
 
         protected BlittableComponent.Requirable.Reader ReaderPublic;
         protected BlittableComponent.Requirable.Writer WriterPublic;
@@ -24,7 +24,7 @@ namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.Readers
             Entity = EntityManager.CreateEntity(typeof(BlittableComponent.Component));
             EntityManager.AddComponentData(Entity, new SpatialEntityId
             {
-                EntityId = new EntityId(EntityId)
+                EntityId = EntityId
             });
             ReaderWriterInternal =
                 new BlittableComponent.Requirable.ReaderWriterImpl(Entity, EntityManager, new LoggingDispatcher());

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/RequiredFieldInjectorTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/RequiredFieldInjectorTests.cs
@@ -59,6 +59,7 @@ namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation
             var entityManager = world.GetOrCreateManager<EntityManager>();
             injector = new RequiredFieldInjector(entityManager, new LoggingDispatcher());
             testEntity = entityManager.CreateEntity();
+            entityManager.AddComponentData(testEntity, new SpatialEntityId());
             testGameObject = new GameObject();
         }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularReaderWriter.cs
@@ -29,6 +29,8 @@ namespace Improbable.Gdk.Tests
             [InjectionCondition(InjectionCondition.RequireComponentPresent)]
             public interface Reader : IReader<Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component, Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Update>
             {
+                EntityId EntityId { get; }
+
                 event Action<BlittableBool> Field1Updated;
                 event Action<float> Field2Updated;
                 event Action<int> Field4Updated;
@@ -55,6 +57,8 @@ namespace Improbable.Gdk.Tests
             internal class ReaderWriterImpl :
                 ReaderWriterBase<Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component, Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Update>, Reader, Writer
             {
+                public new EntityId EntityId => base.EntityId;
+
                 public ReaderWriterImpl(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
                     : base(entity, entityManager, logDispatcher)
                 {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyReaderWriter.cs
@@ -29,6 +29,8 @@ namespace Improbable.Gdk.Tests
             [InjectionCondition(InjectionCondition.RequireComponentPresent)]
             public interface Reader : IReader<Improbable.Gdk.Tests.ExhaustiveMapKey.Component, Improbable.Gdk.Tests.ExhaustiveMapKey.Update>
             {
+                EntityId EntityId { get; }
+
                 event Action<global::System.Collections.Generic.Dictionary<BlittableBool,string>> Field1Updated;
                 event Action<global::System.Collections.Generic.Dictionary<float,string>> Field2Updated;
                 event Action<global::System.Collections.Generic.Dictionary<byte[],string>> Field3Updated;
@@ -57,6 +59,8 @@ namespace Improbable.Gdk.Tests
             internal class ReaderWriterImpl :
                 ReaderWriterBase<Improbable.Gdk.Tests.ExhaustiveMapKey.Component, Improbable.Gdk.Tests.ExhaustiveMapKey.Update>, Reader, Writer
             {
+                public new EntityId EntityId => base.EntityId;
+
                 public ReaderWriterImpl(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
                     : base(entity, entityManager, logDispatcher)
                 {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueReaderWriter.cs
@@ -29,6 +29,8 @@ namespace Improbable.Gdk.Tests
             [InjectionCondition(InjectionCondition.RequireComponentPresent)]
             public interface Reader : IReader<Improbable.Gdk.Tests.ExhaustiveMapValue.Component, Improbable.Gdk.Tests.ExhaustiveMapValue.Update>
             {
+                EntityId EntityId { get; }
+
                 event Action<global::System.Collections.Generic.Dictionary<string,BlittableBool>> Field1Updated;
                 event Action<global::System.Collections.Generic.Dictionary<string,float>> Field2Updated;
                 event Action<global::System.Collections.Generic.Dictionary<string,byte[]>> Field3Updated;
@@ -57,6 +59,8 @@ namespace Improbable.Gdk.Tests
             internal class ReaderWriterImpl :
                 ReaderWriterBase<Improbable.Gdk.Tests.ExhaustiveMapValue.Component, Improbable.Gdk.Tests.ExhaustiveMapValue.Update>, Reader, Writer
             {
+                public new EntityId EntityId => base.EntityId;
+
                 public ReaderWriterImpl(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
                     : base(entity, entityManager, logDispatcher)
                 {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalReaderWriter.cs
@@ -29,6 +29,8 @@ namespace Improbable.Gdk.Tests
             [InjectionCondition(InjectionCondition.RequireComponentPresent)]
             public interface Reader : IReader<Improbable.Gdk.Tests.ExhaustiveOptional.Component, Improbable.Gdk.Tests.ExhaustiveOptional.Update>
             {
+                EntityId EntityId { get; }
+
                 event Action<BlittableBool?> Field1Updated;
                 event Action<float?> Field2Updated;
                 event Action<global::Improbable.Gdk.Core.Option<byte[]>> Field3Updated;
@@ -57,6 +59,8 @@ namespace Improbable.Gdk.Tests
             internal class ReaderWriterImpl :
                 ReaderWriterBase<Improbable.Gdk.Tests.ExhaustiveOptional.Component, Improbable.Gdk.Tests.ExhaustiveOptional.Update>, Reader, Writer
             {
+                public new EntityId EntityId => base.EntityId;
+
                 public ReaderWriterImpl(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
                     : base(entity, entityManager, logDispatcher)
                 {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedReaderWriter.cs
@@ -29,6 +29,8 @@ namespace Improbable.Gdk.Tests
             [InjectionCondition(InjectionCondition.RequireComponentPresent)]
             public interface Reader : IReader<Improbable.Gdk.Tests.ExhaustiveRepeated.Component, Improbable.Gdk.Tests.ExhaustiveRepeated.Update>
             {
+                EntityId EntityId { get; }
+
                 event Action<global::System.Collections.Generic.List<BlittableBool>> Field1Updated;
                 event Action<global::System.Collections.Generic.List<float>> Field2Updated;
                 event Action<global::System.Collections.Generic.List<byte[]>> Field3Updated;
@@ -57,6 +59,8 @@ namespace Improbable.Gdk.Tests
             internal class ReaderWriterImpl :
                 ReaderWriterBase<Improbable.Gdk.Tests.ExhaustiveRepeated.Component, Improbable.Gdk.Tests.ExhaustiveRepeated.Update>, Reader, Writer
             {
+                public new EntityId EntityId => base.EntityId;
+
                 public ReaderWriterImpl(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
                     : base(entity, entityManager, logDispatcher)
                 {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularReaderWriter.cs
@@ -29,6 +29,8 @@ namespace Improbable.Gdk.Tests
             [InjectionCondition(InjectionCondition.RequireComponentPresent)]
             public interface Reader : IReader<Improbable.Gdk.Tests.ExhaustiveSingular.Component, Improbable.Gdk.Tests.ExhaustiveSingular.Update>
             {
+                EntityId EntityId { get; }
+
                 event Action<BlittableBool> Field1Updated;
                 event Action<float> Field2Updated;
                 event Action<byte[]> Field3Updated;
@@ -57,6 +59,8 @@ namespace Improbable.Gdk.Tests
             internal class ReaderWriterImpl :
                 ReaderWriterBase<Improbable.Gdk.Tests.ExhaustiveSingular.Component, Improbable.Gdk.Tests.ExhaustiveSingular.Update>, Reader, Writer
             {
+                public new EntityId EntityId => base.EntityId;
+
                 public ReaderWriterImpl(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
                     : base(entity, entityManager, logDispatcher)
                 {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentReaderWriter.cs
@@ -29,6 +29,8 @@ namespace Improbable.Gdk.Tests
             [InjectionCondition(InjectionCondition.RequireComponentPresent)]
             public interface Reader : IReader<Improbable.Gdk.Tests.NestedComponent.Component, Improbable.Gdk.Tests.NestedComponent.Update>
             {
+                EntityId EntityId { get; }
+
                 event Action<global::Improbable.Gdk.Tests.TypeName> NestedTypeUpdated;
             }
 
@@ -41,6 +43,8 @@ namespace Improbable.Gdk.Tests
             internal class ReaderWriterImpl :
                 ReaderWriterBase<Improbable.Gdk.Tests.NestedComponent.Component, Improbable.Gdk.Tests.NestedComponent.Update>, Reader, Writer
             {
+                public new EntityId EntityId => base.EntityId;
+
                 public ReaderWriterImpl(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
                     : base(entity, entityManager, logDispatcher)
                 {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionReaderWriter.cs
@@ -29,6 +29,8 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
             [InjectionCondition(InjectionCondition.RequireComponentPresent)]
             public interface Reader : IReader<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component, Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update>
             {
+                EntityId EntityId { get; }
+
                 event Action<int> ValueUpdated;
                 event Action<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.RandomDataType> OnMyEvent;
             }
@@ -43,6 +45,8 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
             internal class ReaderWriterImpl :
                 ReaderWriterBase<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component, Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update>, Reader, Writer
             {
+                public new EntityId EntityId => base.EntityId;
+
                 public ReaderWriterImpl(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
                     : base(entity, entityManager, logDispatcher)
                 {
@@ -111,7 +115,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
 
                 public void OnMyEventEvent(global::Improbable.Gdk.Tests.AlternateSchemaSyntax.RandomDataType payload)
                 {
-                    GameObjectDelegates.DispatchWithErrorHandling(payload, MyEventDelegates, logDispatcher);
+                    GameObjectDelegates.DispatchWithErrorHandling(payload, MyEventDelegates, LogDispatcher);
                 }
 
                 public void SendMyEvent(global::Improbable.Gdk.Tests.AlternateSchemaSyntax.RandomDataType payload)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentReaderWriter.cs
@@ -29,6 +29,8 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             [InjectionCondition(InjectionCondition.RequireComponentPresent)]
             public interface Reader : IReader<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component, Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update>
             {
+                EntityId EntityId { get; }
+
                 event Action<BlittableBool> BoolFieldUpdated;
                 event Action<int> IntFieldUpdated;
                 event Action<long> LongFieldUpdated;
@@ -49,6 +51,8 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             internal class ReaderWriterImpl :
                 ReaderWriterBase<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component, Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update>, Reader, Writer
             {
+                public new EntityId EntityId => base.EntityId;
+
                 public ReaderWriterImpl(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
                     : base(entity, entityManager, logDispatcher)
                 {
@@ -233,7 +237,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
                 public void OnFirstEventEvent(global::Improbable.Gdk.Tests.BlittableTypes.FirstEventPayload payload)
                 {
-                    GameObjectDelegates.DispatchWithErrorHandling(payload, FirstEventDelegates, logDispatcher);
+                    GameObjectDelegates.DispatchWithErrorHandling(payload, FirstEventDelegates, LogDispatcher);
                 }
 
                 public void SendFirstEvent(global::Improbable.Gdk.Tests.BlittableTypes.FirstEventPayload payload)
@@ -273,7 +277,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
                 public void OnSecondEventEvent(global::Improbable.Gdk.Tests.BlittableTypes.SecondEventPayload payload)
                 {
-                    GameObjectDelegates.DispatchWithErrorHandling(payload, SecondEventDelegates, logDispatcher);
+                    GameObjectDelegates.DispatchWithErrorHandling(payload, SecondEventDelegates, LogDispatcher);
                 }
 
                 public void SendSecondEvent(global::Improbable.Gdk.Tests.BlittableTypes.SecondEventPayload payload)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsReaderWriter.cs
@@ -29,6 +29,8 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             [InjectionCondition(InjectionCondition.RequireComponentPresent)]
             public interface Reader : IReader<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component, Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update>
             {
+                EntityId EntityId { get; }
+
             }
 
             [InjectableId(InjectableType.ReaderWriter, 1003)]
@@ -40,6 +42,8 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             internal class ReaderWriterImpl :
                 ReaderWriterBase<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component, Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update>, Reader, Writer
             {
+                public new EntityId EntityId => base.EntityId;
+
                 public ReaderWriterImpl(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
                     : base(entity, entityManager, logDispatcher)
                 {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsReaderWriter.cs
@@ -29,6 +29,8 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             [InjectionCondition(InjectionCondition.RequireComponentPresent)]
             public interface Reader : IReader<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component, Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update>
             {
+                EntityId EntityId { get; }
+
             }
 
             [InjectableId(InjectableType.ReaderWriter, 1005)]
@@ -40,6 +42,8 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             internal class ReaderWriterImpl :
                 ReaderWriterBase<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component, Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update>, Reader, Writer
             {
+                public new EntityId EntityId => base.EntityId;
+
                 public ReaderWriterImpl(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
                     : base(entity, entityManager, logDispatcher)
                 {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsReaderWriter.cs
@@ -29,6 +29,8 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             [InjectionCondition(InjectionCondition.RequireComponentPresent)]
             public interface Reader : IReader<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component, Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update>
             {
+                EntityId EntityId { get; }
+
                 event Action<global::Improbable.Gdk.Tests.ComponentsWithNoFields.Empty> OnEvt;
             }
 
@@ -42,6 +44,8 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             internal class ReaderWriterImpl :
                 ReaderWriterBase<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component, Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update>, Reader, Writer
             {
+                public new EntityId EntityId => base.EntityId;
+
                 public ReaderWriterImpl(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
                     : base(entity, entityManager, logDispatcher)
                 {
@@ -81,7 +85,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
                 public void OnEvtEvent(global::Improbable.Gdk.Tests.ComponentsWithNoFields.Empty payload)
                 {
-                    GameObjectDelegates.DispatchWithErrorHandling(payload, EvtDelegates, logDispatcher);
+                    GameObjectDelegates.DispatchWithErrorHandling(payload, EvtDelegates, LogDispatcher);
                 }
 
                 public void SendEvt(global::Improbable.Gdk.Tests.ComponentsWithNoFields.Empty payload)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentReaderWriter.cs
@@ -29,6 +29,8 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             [InjectionCondition(InjectionCondition.RequireComponentPresent)]
             public interface Reader : IReader<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component, Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update>
             {
+                EntityId EntityId { get; }
+
                 event Action<BlittableBool> BoolFieldUpdated;
                 event Action<int> IntFieldUpdated;
                 event Action<long> LongFieldUpdated;
@@ -53,6 +55,8 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             internal class ReaderWriterImpl :
                 ReaderWriterBase<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component, Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update>, Reader, Writer
             {
+                public new EntityId EntityId => base.EntityId;
+
                 public ReaderWriterImpl(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
                     : base(entity, entityManager, logDispatcher)
                 {
@@ -353,7 +357,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
                 public void OnFirstEventEvent(global::Improbable.Gdk.Tests.NonblittableTypes.FirstEventPayload payload)
                 {
-                    GameObjectDelegates.DispatchWithErrorHandling(payload, FirstEventDelegates, logDispatcher);
+                    GameObjectDelegates.DispatchWithErrorHandling(payload, FirstEventDelegates, LogDispatcher);
                 }
 
                 public void SendFirstEvent(global::Improbable.Gdk.Tests.NonblittableTypes.FirstEventPayload payload)
@@ -393,7 +397,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
                 public void OnSecondEventEvent(global::Improbable.Gdk.Tests.NonblittableTypes.SecondEventPayload payload)
                 {
-                    GameObjectDelegates.DispatchWithErrorHandling(payload, SecondEventDelegates, logDispatcher);
+                    GameObjectDelegates.DispatchWithErrorHandling(payload, SecondEventDelegates, LogDispatcher);
                 }
 
                 public void SendSecondEvent(global::Improbable.Gdk.Tests.NonblittableTypes.SecondEventPayload payload)

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/UpdateSpinnerColor.cs
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/UpdateSpinnerColor.cs
@@ -30,7 +30,7 @@ namespace Playground.MonoBehaviours
             {
                 return;
             }
-
+           
             colorIndex = (colorIndex + 1) % colorValues.Length;
             nextColorChangeTime = Time.time + 2;
 

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/UpdateSpinnerColor.cs
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/UpdateSpinnerColor.cs
@@ -30,7 +30,7 @@ namespace Playground.MonoBehaviours
             {
                 return;
             }
-           
+
             colorIndex = (colorIndex + 1) % colorValues.Length;
             nextColorChangeTime = Time.time + 2;
 

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/ReaderWriterBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/ReaderWriterBase.cs
@@ -13,16 +13,18 @@ namespace Improbable.Gdk.GameObjectRepresentation
         where TSpatialComponentData : struct, ISpatialComponentData, IComponentData
         where TComponentUpdate : ISpatialComponentUpdate
     {
+        protected readonly EntityId EntityId;
         protected readonly Entity Entity;
         protected readonly EntityManager EntityManager;
-        protected readonly ILogDispatcher logDispatcher;
+        protected readonly ILogDispatcher LogDispatcher;
 
         protected ReaderWriterBase(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher) : base(
             logDispatcher)
         {
             Entity = entity;
             EntityManager = entityManager;
-            this.logDispatcher = logDispatcher;
+            LogDispatcher = logDispatcher;
+            EntityId = entityManager.GetComponentData<SpatialEntityId>(entity).EntityId;
         }
 
         /// <summary>
@@ -81,7 +83,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
         ///     Yield authority during soft handover
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///     Thrown if the authority is not <see cref="Improbable.Worker.CInterop.Authority.AuthorityLossImminent"/>
+        ///     Thrown if the authority is not <see cref="Improbable.Worker.CInterop.Authority.AuthorityLossImminent" />
         /// </exception>
         public void SendAuthorityLossImminentAcknowledgement()
         {
@@ -179,7 +181,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
                 return;
             }
 
-            GameObjectDelegates.DispatchWithErrorHandling(payload.Value, callbacks, logDispatcher);
+            GameObjectDelegates.DispatchWithErrorHandling(payload.Value, callbacks, LogDispatcher);
         }
 
         public void OnAuthorityChange(Authority authority)
@@ -193,7 +195,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
                 catch (Exception e)
                 {
                     // Log the exception but do not rethrow it, as other delegates should still get called
-                    logDispatcher.HandleLog(LogType.Exception,
+                    LogDispatcher.HandleLog(LogType.Exception,
                         new LogEvent("Caught exception in a MonoBehaviour authority change callback").WithException(e));
                 }
             }
@@ -238,7 +240,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
                 catch (Exception e)
                 {
                     // Log the exception but do not rethrow it, as other delegates should still get called
-                    logDispatcher.HandleLog(LogType.Exception,
+                    LogDispatcher.HandleLog(LogType.Exception,
                         new LogEvent("Caught exception in a MonoBehaviour component update callback").WithException(e));
                 }
             }

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using Improbable.Worker.CInterop;
-
 using Unity.Entities;
 using UnityEngine;
 using Entity = Unity.Entities.Entity;
@@ -39,7 +38,7 @@ namespace Improbable.Gdk.Core
         /// <param name="entityId">The SpatialOS entity ID.</param>
         /// <param name="entity">
         ///     When this method returns, contains the ECS entity associated with the SpatialOS entity ID if one was
-        ///     found, else the default value for <see cref="Entity"/>.
+        ///     found, else the default value for <see cref="Entity" />.
         /// </param>
         /// <returns>
         ///     True, if an ECS entity associated with the SpatialOS entity ID was found, false otherwise.
@@ -47,6 +46,16 @@ namespace Improbable.Gdk.Core
         public bool TryGetEntity(EntityId entityId, out Entity entity)
         {
             return EntityIdToEntity.TryGetValue(entityId, out entity);
+        }
+
+        /// <summary>
+        ///     Checks whether a SpatialOS entity is checked out on this worker.
+        /// </summary>
+        /// <param name="entityId">The SpatialOS entity ID to check for.</param>
+        /// <returns>True, if the SpatialOS entity is checked out on this worker, false otherwise.</returns>
+        public bool HasEntity(EntityId entityId)
+        {
+            return EntityIdToEntity.ContainsKey(entityId);
         }
 
         protected override void OnCreateManager()

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityReaderWriterGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityReaderWriterGenerator.tt
@@ -37,6 +37,8 @@ namespace <#= qualifiedNamespace #>
             [InjectionCondition(InjectionCondition.RequireComponentPresent)]
             public interface Reader : IReader<<#= componentNamespace #>.Component, <#= componentNamespace #>.Update>
             {
+                EntityId EntityId { get; }
+
 <# foreach (var fieldDetails in fieldDetailsList) { #>
                 event Action<<#= fieldDetails.Type #>> <#= fieldDetails.PascalCaseName #>Updated;
 <# } #>
@@ -59,6 +61,8 @@ namespace <#= qualifiedNamespace #>
             internal class ReaderWriterImpl :
                 ReaderWriterBase<<#= componentNamespace #>.Component, <#= componentNamespace #>.Update>, Reader, Writer
             {
+                public new EntityId EntityId => base.EntityId;
+
                 public ReaderWriterImpl(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
                     : base(entity, entityManager, logDispatcher)
                 {
@@ -137,7 +141,7 @@ namespace <#= qualifiedNamespace #>
 
                 public void On<#= eventDetails.EventName #>Event(<#= payloadType #> payload)
                 {
-                    GameObjectDelegates.DispatchWithErrorHandling(payload, <#= delegateList #>, logDispatcher);
+                    GameObjectDelegates.DispatchWithErrorHandling(payload, <#= delegateList #>, LogDispatcher);
                 }
 
                 public void Send<#= eventDetails.EventName #>(<#= eventDetails.FqnPayloadType #> payload)


### PR DESCRIPTION
#### Description
Added two things:
- A `HasEntity` method on the `WorkerSystem`
- The ability to access the EntityId from a reader/writer.

#### Tests
Added a test for the `EntityId` property. Interestingly, this revealed that the Reader Writers previously didn't assert against the underlying entity having an `EntityId`! 

#### Documentation
Changelog. Will open another PR for API docs 

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
