### PR TITLE
(WIP) Schema Bundles - Details Re-Implementation

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/CodeGeneration.csproj
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/CodeGeneration.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+      <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+      <PackageReference Include="NUnit" Version="3.11.0" />
+      <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
+      <PackageReference Include="NunitXml.TestLogger" Version="2.1.17" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Remove="Tests\Model\SchemaBundleV1\Resources\exhaustive_bundle.json" />
+      <EmbeddedResource Include="Tests\Model\SchemaBundleV1\Resources\exhaustive_bundle.json" />
+    </ItemGroup>
+
+</Project>

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/Details/UnityCommandDetails.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/Details/UnityCommandDetails.cs
@@ -1,0 +1,24 @@
+using Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1;
+using Improbable.Gdk.CodeGeneration.Utils;
+
+namespace Improbable.Gdk.CodeGeneration.Model.Details
+{
+    public class UnityCommandDetails
+    {
+        public readonly string PascalCaseName;
+        public readonly string CamelCaseName;
+
+        public readonly string FullyQualifiedRequestTypeName;
+        public readonly string FullyQualifiedResponseTypeName;
+
+        public readonly uint CommandIndex;
+
+        public UnityCommandDetails(ComponentDefinitionRaw.CommandDefinitionRaw commandRaw, SchemaBundle.Bundle bundle)
+        {
+            (PascalCaseName, CamelCaseName, _) = commandRaw.Identifier.GetNameSet();
+            FullyQualifiedRequestTypeName = Formatting.FullyQualify(commandRaw.RequestType.Type.QualifiedName);
+            FullyQualifiedResponseTypeName = Formatting.FullyQualify(commandRaw.ResponseType.Type.QualifiedName);
+            CommandIndex = commandRaw.CommandIndex;
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/Details/UnityComponentDetails.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/Details/UnityComponentDetails.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1;
+
+namespace Improbable.Gdk.CodeGeneration.Model.Details
+{
+    public class UnityComponentDetails
+    {
+        public readonly string PascalCaseName;
+        public readonly string CamelCaseName;
+        public readonly string FullyQualifiedName;
+
+        public readonly uint ComponentId;
+
+        public readonly List<UnityFieldDetails> Fields;
+        public readonly List<UnityEventDetails> Events;
+        public readonly List<UnityCommandDetails> Commands;
+
+        public UnityComponentDetails(ComponentDefinitionRaw componentDefinitionRaw, SchemaBundle.Bundle bundle)
+        {
+            (PascalCaseName, CamelCaseName, FullyQualifiedName) = componentDefinitionRaw.Identifier.GetNameSet();
+            ComponentId = componentDefinitionRaw.ComponentId;
+
+            var underlyingType = bundle.GetSchemaType(componentDefinitionRaw.Data.Type.QualifiedName);
+            if (underlyingType == null)
+            {
+                throw new ArgumentException(
+                    $"Cannot find type definition '{componentDefinitionRaw.Data.Type.QualifiedName}' in the bundle.");
+            }
+
+            Fields = underlyingType.Fields.Select(field => new UnityFieldDetails(field, bundle)).ToList();
+            Events = componentDefinitionRaw.Events.Select(ev => new UnityEventDetails(ev, bundle)).ToList();
+            Commands = componentDefinitionRaw.Commands.Select(command => new UnityCommandDetails(command, bundle)).ToList();
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/Details/UnityEnumDetails.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/Details/UnityEnumDetails.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1;
+
+namespace Improbable.Gdk.CodeGeneration.Model.Details
+{
+    public class UnityEnumDetails
+    {
+        public readonly string PascalCaseName;
+        public readonly string CamelCaseName;
+        public readonly string FullyQualifiedName;
+
+        public readonly List<(string, uint)> Values;
+
+        public UnityEnumDetails(EnumDefinitionRaw enumDefinitionRaw, SchemaBundle.Bundle bundle)
+        {
+            (PascalCaseName, CamelCaseName, FullyQualifiedName) = enumDefinitionRaw.Identifier.GetNameSet();
+
+            Values = new List<(string, uint)>();
+            foreach (var value in enumDefinitionRaw.Values)
+            {
+                var (valueName, _, _) = enumDefinitionRaw.Identifier.GetNameSet();
+                Values.Add((valueName, value.EnumValue));
+            }
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/Details/UnityEventDetails.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/Details/UnityEventDetails.cs
@@ -1,0 +1,21 @@
+using Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1;
+using Improbable.Gdk.CodeGeneration.Utils;
+
+namespace Improbable.Gdk.CodeGeneration.Model.Details
+{
+    public class UnityEventDetails
+    {
+        public readonly string PascalCaseName;
+        public readonly string CamelCaseName;
+        public readonly string FullyQualifiedPayloadTypeName;
+
+        public readonly uint EventIndex;
+
+        public UnityEventDetails(ComponentDefinitionRaw.EventDefinitionRaw eventDefinitionRaw, SchemaBundle.Bundle bundle)
+        {
+            (PascalCaseName, CamelCaseName, _) = eventDefinitionRaw.Identifier.GetNameSet();
+            FullyQualifiedPayloadTypeName = Formatting.FullyQualify(eventDefinitionRaw.Type.Type.QualifiedName);
+            EventIndex = eventDefinitionRaw.EventIndex;
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/Details/UnityFieldDetails.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/Details/UnityFieldDetails.cs
@@ -1,0 +1,18 @@
+using Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1;
+using Improbable.Gdk.CodeGeneration.Utils;
+
+namespace Improbable.Gdk.CodeGeneration.Model.Details
+{
+    public class UnityFieldDetails
+    {
+        public readonly string PascalCaseName;
+        public readonly string CamelCaseName;
+        public readonly uint FieldId;
+
+        public UnityFieldDetails(TypeDefinitionRaw.Field fieldRaw, SchemaBundle.Bundle bundle)
+        {
+            (PascalCaseName, CamelCaseName, _) = fieldRaw.Identifier.GetNameSet();
+            FieldId = fieldRaw.FieldId;
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/Details/UnityTypeDetails.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/Details/UnityTypeDetails.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using System.Linq;
+using Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1;
+using Improbable.Gdk.CodeGeneration.Utils;
+
+namespace Improbable.Gdk.CodeGeneration.Model.Details
+{
+    public class UnityTypeDetails
+    {
+        public readonly string PascalCaseName;
+        public readonly string CamelCaseName;
+        public readonly string FullyQualifiedName;
+
+        public readonly List<UnityFieldDetails> Fields;
+
+        public UnityTypeDetails(TypeDefinitionRaw typeDefinitionRaw, SchemaBundle.Bundle bundle)
+        {
+            (PascalCaseName, CamelCaseName, FullyQualifiedName) = typeDefinitionRaw.Identifier.GetNameSet();
+            Fields = typeDefinitionRaw.Fields.Select(field => new UnityFieldDetails(field, bundle)).ToList();
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/Bundle.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/Bundle.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1
+{
+    public class SchemaBundle
+    {
+        [JsonProperty("v1")] public Bundle BundleContents;
+
+        public static Bundle FromJson(string json)
+        {
+            var schemaBundle = JsonConvert.DeserializeObject<SchemaBundle>(json);
+
+            return schemaBundle.BundleContents;
+        }
+
+        public class Bundle
+        {
+            [JsonProperty("enumDefinitions")] public List<EnumDefinitionRaw> EnumDefinitions;
+            [JsonProperty("typeDefinitions")] public List<TypeDefinitionRaw> TypeDefinitions;
+            [JsonProperty("componentDefinitions")] public List<ComponentDefinitionRaw> ComponentDefinitions;
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/Bundle.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/Bundle.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 
 namespace Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1
@@ -20,6 +21,11 @@ namespace Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1
             [JsonProperty("enumDefinitions")] public List<EnumDefinitionRaw> EnumDefinitions;
             [JsonProperty("typeDefinitions")] public List<TypeDefinitionRaw> TypeDefinitions;
             [JsonProperty("componentDefinitions")] public List<ComponentDefinitionRaw> ComponentDefinitions;
+
+            public TypeDefinitionRaw GetSchemaType(string qualifiedName)
+            {
+                return TypeDefinitions.First(def => def.Identifier.QualifiedName == qualifiedName);
+            }
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/Common.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/Common.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1
+{
+    public class Identifier
+    {
+        [JsonProperty("qualifiedName")] public string QualifiedName;
+        [JsonProperty("name")] public string Name;
+        [JsonProperty("path")] public List<string> Path;
+    }
+
+    public class UserType
+    {
+        [JsonProperty("qualifiedName")] public string QualifiedName;
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/Common.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/Common.cs
@@ -8,6 +8,15 @@ namespace Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1
         [JsonProperty("qualifiedName")] public string QualifiedName;
         [JsonProperty("name")] public string Name;
         [JsonProperty("path")] public List<string> Path;
+
+        public (string PascalCaseName, string CamelCaseName, string FullyQualifiedName) GetNameSet()
+        {
+            var pascalCaseName = Utils.Formatting.SnakeCaseToPascalCase(Name);
+            var camelCaseName = Utils.Formatting.PascalCaseToCamelCase(pascalCaseName);
+            var fullyQualifiedName = Utils.Formatting.FullyQualify(QualifiedName);
+
+            return (pascalCaseName, camelCaseName, fullyQualifiedName);
+        }
     }
 
     public class UserType

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/ComponentDefinitionRaw.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/ComponentDefinitionRaw.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1
+{
+    public class ComponentDefinitionRaw
+    {
+        [JsonProperty("identifier")] public Identifier Identifier;
+        [JsonProperty("componentId")] public uint ComponentId;
+        [JsonProperty("dataDefinition")] public WrappedType Data;
+
+        [JsonProperty("eventDefinitions")] public List<EventDefinitionRaw> Events;
+        [JsonProperty("commandDefinitions")] public List<CommandDefinitionRaw> Commands;
+
+        public class WrappedType
+        {
+            [JsonProperty("type")] public UserType Type;
+        }
+
+        public class EventDefinitionRaw
+        {
+            [JsonProperty("identifier")] public Identifier Identifier;
+            [JsonProperty("eventIndex")] public uint EventIndex;
+            [JsonProperty("type")] public WrappedType Type;
+        }
+
+        public class CommandDefinitionRaw
+        {
+            [JsonProperty("identifier")] public Identifier Identifier;
+            [JsonProperty("commandIndex")] public uint CommandIndex;
+            [JsonProperty("requestType")] public WrappedType RequestType;
+            [JsonProperty("responseType")] public WrappedType ResponseType;
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/EnumDefinitionRaw.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/EnumDefinitionRaw.cs
@@ -5,7 +5,7 @@ namespace Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1
 {
     public class EnumDefinitionRaw
     {
-        [JsonProperty("identifier")] public Identifier EnumIdentifier;
+        [JsonProperty("identifier")] public Identifier Identifier;
         [JsonProperty("valueDefinitions")] public List<Value> Values;
 
         public class Value

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/EnumDefinitionRaw.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/EnumDefinitionRaw.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1
+{
+    public class EnumDefinitionRaw
+    {
+        [JsonProperty("identifier")] public Identifier EnumIdentifier;
+        [JsonProperty("valueDefinitions")] public List<Value> Values;
+
+        public class Value
+        {
+            [JsonProperty("identifier")] public Identifier Identifier;
+            [JsonProperty("value")] public uint EnumValue;
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/TypeDefinitionRaw.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/TypeDefinitionRaw.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1
+{
+    public class TypeDefinitionRaw
+    {
+        [JsonProperty("identifier")] public Identifier Identifier;
+        [JsonProperty("fieldDefinitions")] public List<Field> Fields;
+
+        public class Field
+        {
+            [JsonProperty("identifier")] public Identifier Identifier;
+            [JsonProperty("fieldId")] public uint FieldId;
+            [JsonProperty("transient")] public bool IsTransient;
+            [JsonProperty("listType")] public ListType List;
+            [JsonProperty("mapType")] public MapType Map;
+            [JsonProperty("optionType")] public OptionType Option;
+            [JsonProperty("singularType")] public SingularType Singular;
+
+            public class ListType
+            {
+                [JsonProperty("innerType")] public InnerType InnerType;
+            }
+
+            public class MapType
+            {
+                [JsonProperty("keyType")] public InnerType KeyType;
+                [JsonProperty("valueType")] public InnerType ValueType;
+            }
+
+            public class OptionType
+            {
+                [JsonProperty("innerType")] public InnerType InnerType;
+            }
+
+            public class SingularType
+            {
+                [JsonProperty("type")] public InnerType Type;
+            }
+
+            // Note: Only one of these fields should ever be non-null.
+            // The type is either a primitive or its a user defined type.
+            public class InnerType
+            {
+                [JsonProperty("type")] public UserType UserType;
+                [JsonProperty("primitive")] public string Primitive;
+            }
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Tests/Model/SchemaBundleV1/JsonParsingTests.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Tests/Model/SchemaBundleV1/JsonParsingTests.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using System.Reflection;
+using Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1;
+using NUnit.Framework;
+
+namespace CodeGeneration.Tests.Model.SchemaBundleV1
+{
+    [TestFixture]
+    public class JsonParsingTests
+    {
+        private const string BundleResourceName =
+            "CodeGeneration.Tests.Model.SchemaBundleV1.Resources.exhaustive_bundle.json";
+
+        private string bundleContents;
+
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            bundleContents = new StreamReader(assembly.GetManifestResourceStream(BundleResourceName)).ReadToEnd();
+        }
+
+        [Test]
+        public void ParsingSchemaBundleV1_does_not_throw()
+        {
+            Assert.DoesNotThrow(() => SchemaBundle.FromJson(bundleContents));
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Tests/Model/SchemaBundleV1/Resources/exhaustive_bundle.json
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Tests/Model/SchemaBundleV1/Resources/exhaustive_bundle.json
@@ -1,0 +1,5114 @@
+{
+  "v1": {
+    "enumDefinitions": [
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.TypeName.Other.NestedTypeName.NestedEnum",
+          "name": "NestedEnum",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "TypeName",
+            "Other",
+            "NestedTypeName",
+            "NestedEnum"
+          ]
+        },
+        "valueDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.TypeName.Other.NestedTypeName.NestedEnum.enum_value",
+              "name": "enum_value",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "TypeName",
+                "Other",
+                "NestedTypeName",
+                "NestedEnum",
+                "enum_value"
+              ]
+            },
+            "value": 1
+          }
+        ]
+      }
+    ],
+    "typeDefinitions": [
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.nonblittable_types.FirstCommandRequest",
+          "name": "FirstCommandRequest",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "nonblittable_types",
+            "FirstCommandRequest"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.nonblittable_types.FirstCommandRequest.field",
+              "name": "field",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "nonblittable_types",
+                "FirstCommandRequest",
+                "field"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Int32"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.nonblittable_types.FirstCommandResponse",
+          "name": "FirstCommandResponse",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "nonblittable_types",
+            "FirstCommandResponse"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.nonblittable_types.FirstCommandResponse.response",
+              "name": "response",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "nonblittable_types",
+                "FirstCommandResponse",
+                "response"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "String"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.nonblittable_types.SecondCommandRequest",
+          "name": "SecondCommandRequest",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "nonblittable_types",
+            "SecondCommandRequest"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.nonblittable_types.SecondCommandRequest.field",
+              "name": "field",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "nonblittable_types",
+                "SecondCommandRequest",
+                "field"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Int64"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.nonblittable_types.SecondCommandResponse",
+          "name": "SecondCommandResponse",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "nonblittable_types",
+            "SecondCommandResponse"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.nonblittable_types.SecondCommandResponse.response",
+              "name": "response",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "nonblittable_types",
+                "SecondCommandResponse",
+                "response"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "String"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.nonblittable_types.FirstEventPayload",
+          "name": "FirstEventPayload",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "nonblittable_types",
+            "FirstEventPayload"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.nonblittable_types.FirstEventPayload.field1",
+              "name": "field1",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "nonblittable_types",
+                "FirstEventPayload",
+                "field1"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Bool"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.nonblittable_types.FirstEventPayload.field2",
+              "name": "field2",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "nonblittable_types",
+                "FirstEventPayload",
+                "field2"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "String"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.nonblittable_types.SecondEventPayload",
+          "name": "SecondEventPayload",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "nonblittable_types",
+            "SecondEventPayload"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.nonblittable_types.SecondEventPayload.field1",
+              "name": "field1",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "nonblittable_types",
+                "SecondEventPayload",
+                "field1"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Float"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.nonblittable_types.SecondEventPayload.field2",
+              "name": "field2",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "nonblittable_types",
+                "SecondEventPayload",
+                "field2"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Double"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.nonblittable_types.NonBlittableComponentData",
+          "name": "NonBlittableComponentData",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "nonblittable_types",
+            "NonBlittableComponentData"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.nonblittable_types.NonBlittableComponentData.bool_field",
+              "name": "bool_field",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "nonblittable_types",
+                "NonBlittableComponentData",
+                "bool_field"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Bool"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.nonblittable_types.NonBlittableComponentData.int_field",
+              "name": "int_field",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "nonblittable_types",
+                "NonBlittableComponentData",
+                "int_field"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Int32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.nonblittable_types.NonBlittableComponentData.long_field",
+              "name": "long_field",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "nonblittable_types",
+                "NonBlittableComponentData",
+                "long_field"
+              ]
+            },
+            "fieldId": 3,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Int64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.nonblittable_types.NonBlittableComponentData.float_field",
+              "name": "float_field",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "nonblittable_types",
+                "NonBlittableComponentData",
+                "float_field"
+              ]
+            },
+            "fieldId": 4,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Float"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.nonblittable_types.NonBlittableComponentData.double_field",
+              "name": "double_field",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "nonblittable_types",
+                "NonBlittableComponentData",
+                "double_field"
+              ]
+            },
+            "fieldId": 5,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Double"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.nonblittable_types.NonBlittableComponentData.string_field",
+              "name": "string_field",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "nonblittable_types",
+                "NonBlittableComponentData",
+                "string_field"
+              ]
+            },
+            "fieldId": 6,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "String"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.nonblittable_types.NonBlittableComponentData.optional_field",
+              "name": "optional_field",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "nonblittable_types",
+                "NonBlittableComponentData",
+                "optional_field"
+              ]
+            },
+            "fieldId": 7,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Int32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.nonblittable_types.NonBlittableComponentData.list_field",
+              "name": "list_field",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "nonblittable_types",
+                "NonBlittableComponentData",
+                "list_field"
+              ]
+            },
+            "fieldId": 8,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Int32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.nonblittable_types.NonBlittableComponentData.map_field",
+              "name": "map_field",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "nonblittable_types",
+                "NonBlittableComponentData",
+                "map_field"
+              ]
+            },
+            "fieldId": 9,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Int32"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.alternate_schema_syntax.RandomDataType",
+          "name": "RandomDataType",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "alternate_schema_syntax",
+            "RandomDataType"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.alternate_schema_syntax.RandomDataType.value",
+              "name": "value",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "alternate_schema_syntax",
+                "RandomDataType",
+                "value"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Int32"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.WorkerAttributeSet",
+          "name": "WorkerAttributeSet",
+          "path": [
+            "improbable",
+            "WorkerAttributeSet"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.WorkerAttributeSet.attribute",
+              "name": "attribute",
+              "path": [
+                "improbable",
+                "WorkerAttributeSet",
+                "attribute"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "String"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.WorkerRequirementSet",
+          "name": "WorkerRequirementSet",
+          "path": [
+            "improbable",
+            "WorkerRequirementSet"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.WorkerRequirementSet.attribute_set",
+              "name": "attribute_set",
+              "path": [
+                "improbable",
+                "WorkerRequirementSet",
+                "attribute_set"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "type": {
+                  "qualifiedName": "improbable.WorkerAttributeSet"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.Coordinates",
+          "name": "Coordinates",
+          "path": [
+            "improbable",
+            "Coordinates"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.Coordinates.x",
+              "name": "x",
+              "path": [
+                "improbable",
+                "Coordinates",
+                "x"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Double"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.Coordinates.y",
+              "name": "y",
+              "path": [
+                "improbable",
+                "Coordinates",
+                "y"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Double"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.Coordinates.z",
+              "name": "z",
+              "path": [
+                "improbable",
+                "Coordinates",
+                "z"
+              ]
+            },
+            "fieldId": 3,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Double"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.EdgeLength",
+          "name": "EdgeLength",
+          "path": [
+            "improbable",
+            "EdgeLength"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.EdgeLength.x",
+              "name": "x",
+              "path": [
+                "improbable",
+                "EdgeLength",
+                "x"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Double"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.EdgeLength.y",
+              "name": "y",
+              "path": [
+                "improbable",
+                "EdgeLength",
+                "y"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Double"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.EdgeLength.z",
+              "name": "z",
+              "path": [
+                "improbable",
+                "EdgeLength",
+                "z"
+              ]
+            },
+            "fieldId": 3,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Double"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.ComponentInterest",
+          "name": "ComponentInterest",
+          "path": [
+            "improbable",
+            "ComponentInterest"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.queries",
+              "name": "queries",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "queries"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "type": {
+                  "qualifiedName": "improbable.ComponentInterest.Query"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.ComponentInterest.Query",
+          "name": "Query",
+          "path": [
+            "improbable",
+            "ComponentInterest",
+            "Query"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.Query.constraint",
+              "name": "constraint",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "Query",
+                "constraint"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "type": {
+                  "qualifiedName": "improbable.ComponentInterest.QueryConstraint"
+                }
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.Query.full_snapshot_result",
+              "name": "full_snapshot_result",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "Query",
+                "full_snapshot_result"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Bool"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.Query.result_component_id",
+              "name": "result_component_id",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "Query",
+                "result_component_id"
+              ]
+            },
+            "fieldId": 3,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Uint32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.Query.frequency",
+              "name": "frequency",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "Query",
+                "frequency"
+              ]
+            },
+            "fieldId": 4,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Float"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.ComponentInterest.QueryConstraint",
+          "name": "QueryConstraint",
+          "path": [
+            "improbable",
+            "ComponentInterest",
+            "QueryConstraint"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.QueryConstraint.sphere_constraint",
+              "name": "sphere_constraint",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "QueryConstraint",
+                "sphere_constraint"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "type": {
+                  "qualifiedName": "improbable.ComponentInterest.SphereConstraint"
+                }
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.QueryConstraint.cylinder_constraint",
+              "name": "cylinder_constraint",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "QueryConstraint",
+                "cylinder_constraint"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "type": {
+                  "qualifiedName": "improbable.ComponentInterest.CylinderConstraint"
+                }
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.QueryConstraint.box_constraint",
+              "name": "box_constraint",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "QueryConstraint",
+                "box_constraint"
+              ]
+            },
+            "fieldId": 3,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "type": {
+                  "qualifiedName": "improbable.ComponentInterest.BoxConstraint"
+                }
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.QueryConstraint.relative_sphere_constraint",
+              "name": "relative_sphere_constraint",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "QueryConstraint",
+                "relative_sphere_constraint"
+              ]
+            },
+            "fieldId": 4,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "type": {
+                  "qualifiedName": "improbable.ComponentInterest.RelativeSphereConstraint"
+                }
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.QueryConstraint.relative_cylinder_constraint",
+              "name": "relative_cylinder_constraint",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "QueryConstraint",
+                "relative_cylinder_constraint"
+              ]
+            },
+            "fieldId": 5,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "type": {
+                  "qualifiedName": "improbable.ComponentInterest.RelativeCylinderConstraint"
+                }
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.QueryConstraint.relative_box_constraint",
+              "name": "relative_box_constraint",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "QueryConstraint",
+                "relative_box_constraint"
+              ]
+            },
+            "fieldId": 6,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "type": {
+                  "qualifiedName": "improbable.ComponentInterest.RelativeBoxConstraint"
+                }
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.QueryConstraint.entity_id_constraint",
+              "name": "entity_id_constraint",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "QueryConstraint",
+                "entity_id_constraint"
+              ]
+            },
+            "fieldId": 7,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Int64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.QueryConstraint.component_constraint",
+              "name": "component_constraint",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "QueryConstraint",
+                "component_constraint"
+              ]
+            },
+            "fieldId": 8,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Uint32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.QueryConstraint.and_constraint",
+              "name": "and_constraint",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "QueryConstraint",
+                "and_constraint"
+              ]
+            },
+            "fieldId": 9,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "type": {
+                  "qualifiedName": "improbable.ComponentInterest.QueryConstraint"
+                }
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.QueryConstraint.or_constraint",
+              "name": "or_constraint",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "QueryConstraint",
+                "or_constraint"
+              ]
+            },
+            "fieldId": 10,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "type": {
+                  "qualifiedName": "improbable.ComponentInterest.QueryConstraint"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.ComponentInterest.SphereConstraint",
+          "name": "SphereConstraint",
+          "path": [
+            "improbable",
+            "ComponentInterest",
+            "SphereConstraint"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.SphereConstraint.center",
+              "name": "center",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "SphereConstraint",
+                "center"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "type": {
+                  "qualifiedName": "improbable.Coordinates"
+                }
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.SphereConstraint.radius",
+              "name": "radius",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "SphereConstraint",
+                "radius"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Double"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.ComponentInterest.CylinderConstraint",
+          "name": "CylinderConstraint",
+          "path": [
+            "improbable",
+            "ComponentInterest",
+            "CylinderConstraint"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.CylinderConstraint.center",
+              "name": "center",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "CylinderConstraint",
+                "center"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "type": {
+                  "qualifiedName": "improbable.Coordinates"
+                }
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.CylinderConstraint.radius",
+              "name": "radius",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "CylinderConstraint",
+                "radius"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Double"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.ComponentInterest.BoxConstraint",
+          "name": "BoxConstraint",
+          "path": [
+            "improbable",
+            "ComponentInterest",
+            "BoxConstraint"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.BoxConstraint.center",
+              "name": "center",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "BoxConstraint",
+                "center"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "type": {
+                  "qualifiedName": "improbable.Coordinates"
+                }
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.BoxConstraint.edge_length",
+              "name": "edge_length",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "BoxConstraint",
+                "edge_length"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "type": {
+                  "qualifiedName": "improbable.EdgeLength"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.ComponentInterest.RelativeSphereConstraint",
+          "name": "RelativeSphereConstraint",
+          "path": [
+            "improbable",
+            "ComponentInterest",
+            "RelativeSphereConstraint"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.RelativeSphereConstraint.radius",
+              "name": "radius",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "RelativeSphereConstraint",
+                "radius"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Double"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.ComponentInterest.RelativeCylinderConstraint",
+          "name": "RelativeCylinderConstraint",
+          "path": [
+            "improbable",
+            "ComponentInterest",
+            "RelativeCylinderConstraint"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.RelativeCylinderConstraint.radius",
+              "name": "radius",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "RelativeCylinderConstraint",
+                "radius"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Double"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.ComponentInterest.RelativeBoxConstraint",
+          "name": "RelativeBoxConstraint",
+          "path": [
+            "improbable",
+            "ComponentInterest",
+            "RelativeBoxConstraint"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.ComponentInterest.RelativeBoxConstraint.edge_length",
+              "name": "edge_length",
+              "path": [
+                "improbable",
+                "ComponentInterest",
+                "RelativeBoxConstraint",
+                "edge_length"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "type": {
+                  "qualifiedName": "improbable.EdgeLength"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.EntityAclData",
+          "name": "EntityAclData",
+          "path": [
+            "improbable",
+            "EntityAclData"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.EntityAclData.read_acl",
+              "name": "read_acl",
+              "path": [
+                "improbable",
+                "EntityAclData",
+                "read_acl"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "type": {
+                  "qualifiedName": "improbable.WorkerRequirementSet"
+                }
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.EntityAclData.component_write_acl",
+              "name": "component_write_acl",
+              "path": [
+                "improbable",
+                "EntityAclData",
+                "component_write_acl"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Uint32"
+              },
+              "valueType": {
+                "type": {
+                  "qualifiedName": "improbable.WorkerRequirementSet"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.MetadataData",
+          "name": "MetadataData",
+          "path": [
+            "improbable",
+            "MetadataData"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.MetadataData.entity_type",
+              "name": "entity_type",
+              "path": [
+                "improbable",
+                "MetadataData",
+                "entity_type"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "String"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.PositionData",
+          "name": "PositionData",
+          "path": [
+            "improbable",
+            "PositionData"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.PositionData.coords",
+              "name": "coords",
+              "path": [
+                "improbable",
+                "PositionData",
+                "coords"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "type": {
+                  "qualifiedName": "improbable.Coordinates"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.PersistenceData",
+          "name": "PersistenceData",
+          "path": [
+            "improbable",
+            "PersistenceData"
+          ]
+        },
+        "fieldDefinitions": []
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.InterestData",
+          "name": "InterestData",
+          "path": [
+            "improbable",
+            "InterestData"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.InterestData.component_interest",
+              "name": "component_interest",
+              "path": [
+                "improbable",
+                "InterestData",
+                "component_interest"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Uint32"
+              },
+              "valueType": {
+                "type": {
+                  "qualifiedName": "improbable.ComponentInterest"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.components_with_no_fields.Empty",
+          "name": "Empty",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "components_with_no_fields",
+            "Empty"
+          ]
+        },
+        "fieldDefinitions": []
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.components_with_no_fields.ComponentWithNoFieldsData",
+          "name": "ComponentWithNoFieldsData",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "components_with_no_fields",
+            "ComponentWithNoFieldsData"
+          ]
+        },
+        "fieldDefinitions": []
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.components_with_no_fields.ComponentWithNoFieldsWithEventsData",
+          "name": "ComponentWithNoFieldsWithEventsData",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "components_with_no_fields",
+            "ComponentWithNoFieldsWithEventsData"
+          ]
+        },
+        "fieldDefinitions": []
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.components_with_no_fields.ComponentWithNoFieldsWithCommandsData",
+          "name": "ComponentWithNoFieldsWithCommandsData",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "components_with_no_fields",
+            "ComponentWithNoFieldsWithCommandsData"
+          ]
+        },
+        "fieldDefinitions": []
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.Vector3f",
+          "name": "Vector3f",
+          "path": [
+            "improbable",
+            "Vector3f"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.Vector3f.x",
+              "name": "x",
+              "path": [
+                "improbable",
+                "Vector3f",
+                "x"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Float"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.Vector3f.y",
+              "name": "y",
+              "path": [
+                "improbable",
+                "Vector3f",
+                "y"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Float"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.Vector3f.z",
+              "name": "z",
+              "path": [
+                "improbable",
+                "Vector3f",
+                "z"
+              ]
+            },
+            "fieldId": 3,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Float"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.Vector3d",
+          "name": "Vector3d",
+          "path": [
+            "improbable",
+            "Vector3d"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.Vector3d.x",
+              "name": "x",
+              "path": [
+                "improbable",
+                "Vector3d",
+                "x"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Double"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.Vector3d.y",
+              "name": "y",
+              "path": [
+                "improbable",
+                "Vector3d",
+                "y"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Double"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.Vector3d.z",
+              "name": "z",
+              "path": [
+                "improbable",
+                "Vector3d",
+                "z"
+              ]
+            },
+            "fieldId": 3,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Double"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.common.Empty",
+          "name": "Empty",
+          "path": [
+            "improbable",
+            "common",
+            "Empty"
+          ]
+        },
+        "fieldDefinitions": []
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.blittable_types.FirstCommandRequest",
+          "name": "FirstCommandRequest",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "blittable_types",
+            "FirstCommandRequest"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.blittable_types.FirstCommandRequest.field",
+              "name": "field",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "blittable_types",
+                "FirstCommandRequest",
+                "field"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Int32"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.blittable_types.FirstCommandResponse",
+          "name": "FirstCommandResponse",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "blittable_types",
+            "FirstCommandResponse"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.blittable_types.FirstCommandResponse.response",
+              "name": "response",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "blittable_types",
+                "FirstCommandResponse",
+                "response"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Bool"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.blittable_types.SecondCommandRequest",
+          "name": "SecondCommandRequest",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "blittable_types",
+            "SecondCommandRequest"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.blittable_types.SecondCommandRequest.field",
+              "name": "field",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "blittable_types",
+                "SecondCommandRequest",
+                "field"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Int64"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.blittable_types.SecondCommandResponse",
+          "name": "SecondCommandResponse",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "blittable_types",
+            "SecondCommandResponse"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.blittable_types.SecondCommandResponse.response",
+              "name": "response",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "blittable_types",
+                "SecondCommandResponse",
+                "response"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Double"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.blittable_types.FirstEventPayload",
+          "name": "FirstEventPayload",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "blittable_types",
+            "FirstEventPayload"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.blittable_types.FirstEventPayload.field1",
+              "name": "field1",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "blittable_types",
+                "FirstEventPayload",
+                "field1"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Bool"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.blittable_types.FirstEventPayload.field2",
+              "name": "field2",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "blittable_types",
+                "FirstEventPayload",
+                "field2"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Int32"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.blittable_types.SecondEventPayload",
+          "name": "SecondEventPayload",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "blittable_types",
+            "SecondEventPayload"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.blittable_types.SecondEventPayload.field1",
+              "name": "field1",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "blittable_types",
+                "SecondEventPayload",
+                "field1"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Float"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.blittable_types.SecondEventPayload.field2",
+              "name": "field2",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "blittable_types",
+                "SecondEventPayload",
+                "field2"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Double"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.blittable_types.BlittableComponentData",
+          "name": "BlittableComponentData",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "blittable_types",
+            "BlittableComponentData"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.blittable_types.BlittableComponentData.bool_field",
+              "name": "bool_field",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "blittable_types",
+                "BlittableComponentData",
+                "bool_field"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Bool"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.blittable_types.BlittableComponentData.int_field",
+              "name": "int_field",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "blittable_types",
+                "BlittableComponentData",
+                "int_field"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Int32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.blittable_types.BlittableComponentData.long_field",
+              "name": "long_field",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "blittable_types",
+                "BlittableComponentData",
+                "long_field"
+              ]
+            },
+            "fieldId": 3,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Int64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.blittable_types.BlittableComponentData.float_field",
+              "name": "float_field",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "blittable_types",
+                "BlittableComponentData",
+                "float_field"
+              ]
+            },
+            "fieldId": 4,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Float"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.blittable_types.BlittableComponentData.double_field",
+              "name": "double_field",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "blittable_types",
+                "BlittableComponentData",
+                "double_field"
+              ]
+            },
+            "fieldId": 5,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Double"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.SomeType",
+          "name": "SomeType",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "SomeType"
+          ]
+        },
+        "fieldDefinitions": []
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData",
+          "name": "ExhaustiveSingularData",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "ExhaustiveSingularData"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field1",
+              "name": "field1",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field1"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Bool"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field2",
+              "name": "field2",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field2"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Float"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field3",
+              "name": "field3",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field3"
+              ]
+            },
+            "fieldId": 3,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Bytes"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field4",
+              "name": "field4",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field4"
+              ]
+            },
+            "fieldId": 4,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Int32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field5",
+              "name": "field5",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field5"
+              ]
+            },
+            "fieldId": 5,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Int64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field6",
+              "name": "field6",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field6"
+              ]
+            },
+            "fieldId": 6,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Double"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field7",
+              "name": "field7",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field7"
+              ]
+            },
+            "fieldId": 7,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "String"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field8",
+              "name": "field8",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field8"
+              ]
+            },
+            "fieldId": 8,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Uint32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field9",
+              "name": "field9",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field9"
+              ]
+            },
+            "fieldId": 9,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Uint64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field10",
+              "name": "field10",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field10"
+              ]
+            },
+            "fieldId": 10,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Sint32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field11",
+              "name": "field11",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field11"
+              ]
+            },
+            "fieldId": 11,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Sint64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field12",
+              "name": "field12",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field12"
+              ]
+            },
+            "fieldId": 12,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Fixed32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field13",
+              "name": "field13",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field13"
+              ]
+            },
+            "fieldId": 13,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Fixed64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field14",
+              "name": "field14",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field14"
+              ]
+            },
+            "fieldId": 14,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Sfixed32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field15",
+              "name": "field15",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field15"
+              ]
+            },
+            "fieldId": 15,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Sfixed64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field16",
+              "name": "field16",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field16"
+              ]
+            },
+            "fieldId": 16,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "EntityId"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field17",
+              "name": "field17",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field17"
+              ]
+            },
+            "fieldId": 17,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "type": {
+                  "qualifiedName": "improbable.gdk.tests.SomeType"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData",
+          "name": "ExhaustiveOptionalData",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "ExhaustiveOptionalData"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field1",
+              "name": "field1",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field1"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Bool"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field2",
+              "name": "field2",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field2"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Float"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field3",
+              "name": "field3",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field3"
+              ]
+            },
+            "fieldId": 3,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Bytes"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field4",
+              "name": "field4",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field4"
+              ]
+            },
+            "fieldId": 4,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Int32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field5",
+              "name": "field5",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field5"
+              ]
+            },
+            "fieldId": 5,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Int64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field6",
+              "name": "field6",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field6"
+              ]
+            },
+            "fieldId": 6,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Double"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field7",
+              "name": "field7",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field7"
+              ]
+            },
+            "fieldId": 7,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "String"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field8",
+              "name": "field8",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field8"
+              ]
+            },
+            "fieldId": 8,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Uint32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field9",
+              "name": "field9",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field9"
+              ]
+            },
+            "fieldId": 9,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Uint64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field10",
+              "name": "field10",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field10"
+              ]
+            },
+            "fieldId": 10,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Sint32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field11",
+              "name": "field11",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field11"
+              ]
+            },
+            "fieldId": 11,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Sint64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field12",
+              "name": "field12",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field12"
+              ]
+            },
+            "fieldId": 12,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Fixed32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field13",
+              "name": "field13",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field13"
+              ]
+            },
+            "fieldId": 13,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Fixed64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field14",
+              "name": "field14",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field14"
+              ]
+            },
+            "fieldId": 14,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Sfixed32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field15",
+              "name": "field15",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field15"
+              ]
+            },
+            "fieldId": 15,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Sfixed64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field16",
+              "name": "field16",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field16"
+              ]
+            },
+            "fieldId": 16,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "EntityId"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field17",
+              "name": "field17",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field17"
+              ]
+            },
+            "fieldId": 17,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "type": {
+                  "qualifiedName": "improbable.gdk.tests.SomeType"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData",
+          "name": "ExhaustiveRepeatedData",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "ExhaustiveRepeatedData"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field1",
+              "name": "field1",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field1"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Bool"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field2",
+              "name": "field2",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field2"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Float"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field3",
+              "name": "field3",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field3"
+              ]
+            },
+            "fieldId": 3,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Bytes"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field4",
+              "name": "field4",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field4"
+              ]
+            },
+            "fieldId": 4,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Int32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field5",
+              "name": "field5",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field5"
+              ]
+            },
+            "fieldId": 5,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Int64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field6",
+              "name": "field6",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field6"
+              ]
+            },
+            "fieldId": 6,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Double"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field7",
+              "name": "field7",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field7"
+              ]
+            },
+            "fieldId": 7,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "String"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field8",
+              "name": "field8",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field8"
+              ]
+            },
+            "fieldId": 8,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Uint32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field9",
+              "name": "field9",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field9"
+              ]
+            },
+            "fieldId": 9,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Uint64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field10",
+              "name": "field10",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field10"
+              ]
+            },
+            "fieldId": 10,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Sint32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field11",
+              "name": "field11",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field11"
+              ]
+            },
+            "fieldId": 11,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Sint64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field12",
+              "name": "field12",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field12"
+              ]
+            },
+            "fieldId": 12,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Fixed32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field13",
+              "name": "field13",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field13"
+              ]
+            },
+            "fieldId": 13,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Fixed64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field14",
+              "name": "field14",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field14"
+              ]
+            },
+            "fieldId": 14,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Sfixed32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field15",
+              "name": "field15",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field15"
+              ]
+            },
+            "fieldId": 15,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Sfixed64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field16",
+              "name": "field16",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field16"
+              ]
+            },
+            "fieldId": 16,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "EntityId"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field17",
+              "name": "field17",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field17"
+              ]
+            },
+            "fieldId": 17,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "type": {
+                  "qualifiedName": "improbable.gdk.tests.SomeType"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData",
+          "name": "ExhaustiveMapValueData",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "ExhaustiveMapValueData"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field1",
+              "name": "field1",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field1"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Bool"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field2",
+              "name": "field2",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field2"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Float"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field3",
+              "name": "field3",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field3"
+              ]
+            },
+            "fieldId": 3,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Bytes"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field4",
+              "name": "field4",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field4"
+              ]
+            },
+            "fieldId": 4,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Int32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field5",
+              "name": "field5",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field5"
+              ]
+            },
+            "fieldId": 5,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Int64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field6",
+              "name": "field6",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field6"
+              ]
+            },
+            "fieldId": 6,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Double"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field7",
+              "name": "field7",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field7"
+              ]
+            },
+            "fieldId": 7,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field8",
+              "name": "field8",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field8"
+              ]
+            },
+            "fieldId": 8,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Uint32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field9",
+              "name": "field9",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field9"
+              ]
+            },
+            "fieldId": 9,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Uint64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field10",
+              "name": "field10",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field10"
+              ]
+            },
+            "fieldId": 10,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Sint32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field11",
+              "name": "field11",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field11"
+              ]
+            },
+            "fieldId": 11,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Sint64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field12",
+              "name": "field12",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field12"
+              ]
+            },
+            "fieldId": 12,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Fixed32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field13",
+              "name": "field13",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field13"
+              ]
+            },
+            "fieldId": 13,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Fixed64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field14",
+              "name": "field14",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field14"
+              ]
+            },
+            "fieldId": 14,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Sfixed32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field15",
+              "name": "field15",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field15"
+              ]
+            },
+            "fieldId": 15,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Sfixed64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field16",
+              "name": "field16",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field16"
+              ]
+            },
+            "fieldId": 16,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "EntityId"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field17",
+              "name": "field17",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field17"
+              ]
+            },
+            "fieldId": 17,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "type": {
+                  "qualifiedName": "improbable.gdk.tests.SomeType"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData",
+          "name": "ExhaustiveMapKeyData",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "ExhaustiveMapKeyData"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field1",
+              "name": "field1",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field1"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Bool"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field2",
+              "name": "field2",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field2"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Float"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field3",
+              "name": "field3",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field3"
+              ]
+            },
+            "fieldId": 3,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Bytes"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field4",
+              "name": "field4",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field4"
+              ]
+            },
+            "fieldId": 4,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Int32"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field5",
+              "name": "field5",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field5"
+              ]
+            },
+            "fieldId": 5,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Int64"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field6",
+              "name": "field6",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field6"
+              ]
+            },
+            "fieldId": 6,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Double"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field7",
+              "name": "field7",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field7"
+              ]
+            },
+            "fieldId": 7,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field8",
+              "name": "field8",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field8"
+              ]
+            },
+            "fieldId": 8,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Uint32"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field9",
+              "name": "field9",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field9"
+              ]
+            },
+            "fieldId": 9,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Uint64"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field10",
+              "name": "field10",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field10"
+              ]
+            },
+            "fieldId": 10,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Sint32"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field11",
+              "name": "field11",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field11"
+              ]
+            },
+            "fieldId": 11,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Sint64"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field12",
+              "name": "field12",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field12"
+              ]
+            },
+            "fieldId": 12,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Fixed32"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field13",
+              "name": "field13",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field13"
+              ]
+            },
+            "fieldId": 13,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Fixed64"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field14",
+              "name": "field14",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field14"
+              ]
+            },
+            "fieldId": 14,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Sfixed32"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field15",
+              "name": "field15",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field15"
+              ]
+            },
+            "fieldId": 15,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Sfixed64"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field16",
+              "name": "field16",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field16"
+              ]
+            },
+            "fieldId": 16,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "EntityId"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field17",
+              "name": "field17",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field17"
+              ]
+            },
+            "fieldId": 17,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "type": {
+                  "qualifiedName": "improbable.gdk.tests.SomeType"
+                }
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingularData",
+          "name": "ExhaustiveBlittableSingularData",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "ExhaustiveBlittableSingularData"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingularData.field1",
+              "name": "field1",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveBlittableSingularData",
+                "field1"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Bool"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingularData.field2",
+              "name": "field2",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveBlittableSingularData",
+                "field2"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Float"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingularData.field4",
+              "name": "field4",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveBlittableSingularData",
+                "field4"
+              ]
+            },
+            "fieldId": 4,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Int32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingularData.field5",
+              "name": "field5",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveBlittableSingularData",
+                "field5"
+              ]
+            },
+            "fieldId": 5,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Int64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingularData.field6",
+              "name": "field6",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveBlittableSingularData",
+                "field6"
+              ]
+            },
+            "fieldId": 6,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Double"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingularData.field8",
+              "name": "field8",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveBlittableSingularData",
+                "field8"
+              ]
+            },
+            "fieldId": 8,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Uint32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingularData.field9",
+              "name": "field9",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveBlittableSingularData",
+                "field9"
+              ]
+            },
+            "fieldId": 9,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Uint64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingularData.field10",
+              "name": "field10",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveBlittableSingularData",
+                "field10"
+              ]
+            },
+            "fieldId": 10,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Sint32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingularData.field11",
+              "name": "field11",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveBlittableSingularData",
+                "field11"
+              ]
+            },
+            "fieldId": 11,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Sint64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingularData.field12",
+              "name": "field12",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveBlittableSingularData",
+                "field12"
+              ]
+            },
+            "fieldId": 12,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Fixed32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingularData.field13",
+              "name": "field13",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveBlittableSingularData",
+                "field13"
+              ]
+            },
+            "fieldId": 13,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Fixed64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingularData.field14",
+              "name": "field14",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveBlittableSingularData",
+                "field14"
+              ]
+            },
+            "fieldId": 14,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Sfixed32"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingularData.field15",
+              "name": "field15",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveBlittableSingularData",
+                "field15"
+              ]
+            },
+            "fieldId": 15,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Sfixed64"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingularData.field16",
+              "name": "field16",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveBlittableSingularData",
+                "field16"
+              ]
+            },
+            "fieldId": 16,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "EntityId"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingularData.field17",
+              "name": "field17",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveBlittableSingularData",
+                "field17"
+              ]
+            },
+            "fieldId": 17,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "type": {
+                  "qualifiedName": "improbable.gdk.tests.SomeType"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.TypeName",
+          "name": "TypeName",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "TypeName"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.TypeName.other_type",
+              "name": "other_type",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "TypeName",
+                "other_type"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "type": {
+                  "qualifiedName": "improbable.gdk.tests.TypeName.Other"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.TypeName.Other",
+          "name": "Other",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "TypeName",
+            "Other"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.TypeName.Other.same_name",
+              "name": "same_name",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "TypeName",
+                "Other",
+                "same_name"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "type": {
+                  "qualifiedName": "improbable.gdk.tests.TypeName.Other.NestedTypeName"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.TypeName.Other.NestedTypeName",
+          "name": "NestedTypeName",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "TypeName",
+            "Other",
+            "NestedTypeName"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.TypeName.Other.NestedTypeName.other_zero",
+              "name": "other_zero",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "TypeName",
+                "Other",
+                "NestedTypeName",
+                "other_zero"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "type": {
+                  "qualifiedName": "improbable.gdk.tests.TypeName.Other.NestedTypeName.Other0"
+                }
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.TypeName.Other.NestedTypeName.enum_field",
+              "name": "enum_field",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "TypeName",
+                "Other",
+                "NestedTypeName",
+                "enum_field"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "enum": {
+                  "qualifiedName": "improbable.gdk.tests.TypeName.Other.NestedTypeName.NestedEnum"
+                }
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.TypeName.Other.NestedTypeName.Other0",
+          "name": "Other0",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "TypeName",
+            "Other",
+            "NestedTypeName",
+            "Other0"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.TypeName.Other.NestedTypeName.Other0.foo",
+              "name": "foo",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "TypeName",
+                "Other",
+                "NestedTypeName",
+                "Other0",
+                "foo"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Int32"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.NestedComponentData",
+          "name": "NestedComponentData",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "NestedComponentData"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.NestedComponentData.nested_type",
+              "name": "nested_type",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "NestedComponentData",
+                "nested_type"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "type": {
+                  "qualifiedName": "improbable.gdk.tests.TypeName"
+                }
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "componentDefinitions": [
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.nonblittable_types.NonBlittableComponent",
+          "name": "NonBlittableComponent",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "nonblittable_types",
+            "NonBlittableComponent"
+          ]
+        },
+        "componentId": 1002,
+        "dataDefinition": {
+          "type": {
+            "qualifiedName": "improbable.gdk.tests.nonblittable_types.NonBlittableComponentData"
+          }
+        },
+        "eventDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.nonblittable_types.NonBlittableComponent.first_event",
+              "name": "first_event",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "nonblittable_types",
+                "NonBlittableComponent",
+                "first_event"
+              ]
+            },
+            "eventIndex": 1,
+            "type": {
+              "type": {
+                "qualifiedName": "improbable.gdk.tests.nonblittable_types.FirstEventPayload"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.nonblittable_types.NonBlittableComponent.second_event",
+              "name": "second_event",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "nonblittable_types",
+                "NonBlittableComponent",
+                "second_event"
+              ]
+            },
+            "eventIndex": 2,
+            "type": {
+              "type": {
+                "qualifiedName": "improbable.gdk.tests.nonblittable_types.SecondEventPayload"
+              }
+            }
+          }
+        ],
+        "commandDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.nonblittable_types.NonBlittableComponent.first_command",
+              "name": "first_command",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "nonblittable_types",
+                "NonBlittableComponent",
+                "first_command"
+              ]
+            },
+            "commandIndex": 1,
+            "requestType": {
+              "type": {
+                "qualifiedName": "improbable.gdk.tests.nonblittable_types.FirstCommandRequest"
+              }
+            },
+            "responseType": {
+              "type": {
+                "qualifiedName": "improbable.gdk.tests.nonblittable_types.FirstCommandResponse"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.nonblittable_types.NonBlittableComponent.second_command",
+              "name": "second_command",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "nonblittable_types",
+                "NonBlittableComponent",
+                "second_command"
+              ]
+            },
+            "commandIndex": 2,
+            "requestType": {
+              "type": {
+                "qualifiedName": "improbable.gdk.tests.nonblittable_types.SecondCommandRequest"
+              }
+            },
+            "responseType": {
+              "type": {
+                "qualifiedName": "improbable.gdk.tests.nonblittable_types.SecondCommandResponse"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.alternate_schema_syntax.Connection",
+          "name": "Connection",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "alternate_schema_syntax",
+            "Connection"
+          ]
+        },
+        "componentId": 1105,
+        "dataDefinition": {
+          "type": {
+            "qualifiedName": "improbable.gdk.tests.alternate_schema_syntax.RandomDataType"
+          }
+        },
+        "eventDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.alternate_schema_syntax.Connection.my_event",
+              "name": "my_event",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "alternate_schema_syntax",
+                "Connection",
+                "my_event"
+              ]
+            },
+            "eventIndex": 1,
+            "type": {
+              "type": {
+                "qualifiedName": "improbable.gdk.tests.alternate_schema_syntax.RandomDataType"
+              }
+            }
+          }
+        ],
+        "commandDefinitions": []
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.EntityAcl",
+          "name": "EntityAcl",
+          "path": [
+            "improbable",
+            "EntityAcl"
+          ]
+        },
+        "componentId": 50,
+        "dataDefinition": {
+          "type": {
+            "qualifiedName": "improbable.EntityAclData"
+          }
+        },
+        "eventDefinitions": [],
+        "commandDefinitions": []
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.Metadata",
+          "name": "Metadata",
+          "path": [
+            "improbable",
+            "Metadata"
+          ]
+        },
+        "componentId": 53,
+        "dataDefinition": {
+          "type": {
+            "qualifiedName": "improbable.MetadataData"
+          }
+        },
+        "eventDefinitions": [],
+        "commandDefinitions": []
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.Position",
+          "name": "Position",
+          "path": [
+            "improbable",
+            "Position"
+          ]
+        },
+        "componentId": 54,
+        "dataDefinition": {
+          "type": {
+            "qualifiedName": "improbable.PositionData"
+          }
+        },
+        "eventDefinitions": [],
+        "commandDefinitions": []
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.Persistence",
+          "name": "Persistence",
+          "path": [
+            "improbable",
+            "Persistence"
+          ]
+        },
+        "componentId": 55,
+        "dataDefinition": {
+          "type": {
+            "qualifiedName": "improbable.PersistenceData"
+          }
+        },
+        "eventDefinitions": [],
+        "commandDefinitions": []
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.Interest",
+          "name": "Interest",
+          "path": [
+            "improbable",
+            "Interest"
+          ]
+        },
+        "componentId": 58,
+        "dataDefinition": {
+          "type": {
+            "qualifiedName": "improbable.InterestData"
+          }
+        },
+        "eventDefinitions": [],
+        "commandDefinitions": []
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.components_with_no_fields.ComponentWithNoFields",
+          "name": "ComponentWithNoFields",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "components_with_no_fields",
+            "ComponentWithNoFields"
+          ]
+        },
+        "componentId": 1003,
+        "dataDefinition": {
+          "type": {
+            "qualifiedName": "improbable.gdk.tests.components_with_no_fields.ComponentWithNoFieldsData"
+          }
+        },
+        "eventDefinitions": [],
+        "commandDefinitions": []
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.components_with_no_fields.ComponentWithNoFieldsWithEvents",
+          "name": "ComponentWithNoFieldsWithEvents",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "components_with_no_fields",
+            "ComponentWithNoFieldsWithEvents"
+          ]
+        },
+        "componentId": 1004,
+        "dataDefinition": {
+          "type": {
+            "qualifiedName": "improbable.gdk.tests.components_with_no_fields.ComponentWithNoFieldsWithEventsData"
+          }
+        },
+        "eventDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.components_with_no_fields.ComponentWithNoFieldsWithEvents.evt",
+              "name": "evt",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "components_with_no_fields",
+                "ComponentWithNoFieldsWithEvents",
+                "evt"
+              ]
+            },
+            "eventIndex": 1,
+            "type": {
+              "type": {
+                "qualifiedName": "improbable.gdk.tests.components_with_no_fields.Empty"
+              }
+            }
+          }
+        ],
+        "commandDefinitions": []
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.components_with_no_fields.ComponentWithNoFieldsWithCommands",
+          "name": "ComponentWithNoFieldsWithCommands",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "components_with_no_fields",
+            "ComponentWithNoFieldsWithCommands"
+          ]
+        },
+        "componentId": 1005,
+        "dataDefinition": {
+          "type": {
+            "qualifiedName": "improbable.gdk.tests.components_with_no_fields.ComponentWithNoFieldsWithCommandsData"
+          }
+        },
+        "eventDefinitions": [],
+        "commandDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.components_with_no_fields.ComponentWithNoFieldsWithCommands.cmd",
+              "name": "cmd",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "components_with_no_fields",
+                "ComponentWithNoFieldsWithCommands",
+                "cmd"
+              ]
+            },
+            "commandIndex": 1,
+            "requestType": {
+              "type": {
+                "qualifiedName": "improbable.gdk.tests.components_with_no_fields.Empty"
+              }
+            },
+            "responseType": {
+              "type": {
+                "qualifiedName": "improbable.gdk.tests.components_with_no_fields.Empty"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.blittable_types.BlittableComponent",
+          "name": "BlittableComponent",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "blittable_types",
+            "BlittableComponent"
+          ]
+        },
+        "componentId": 1001,
+        "dataDefinition": {
+          "type": {
+            "qualifiedName": "improbable.gdk.tests.blittable_types.BlittableComponentData"
+          }
+        },
+        "eventDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.blittable_types.BlittableComponent.first_event",
+              "name": "first_event",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "blittable_types",
+                "BlittableComponent",
+                "first_event"
+              ]
+            },
+            "eventIndex": 1,
+            "type": {
+              "type": {
+                "qualifiedName": "improbable.gdk.tests.blittable_types.FirstEventPayload"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.blittable_types.BlittableComponent.second_event",
+              "name": "second_event",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "blittable_types",
+                "BlittableComponent",
+                "second_event"
+              ]
+            },
+            "eventIndex": 2,
+            "type": {
+              "type": {
+                "qualifiedName": "improbable.gdk.tests.blittable_types.SecondEventPayload"
+              }
+            }
+          }
+        ],
+        "commandDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.blittable_types.BlittableComponent.first_command",
+              "name": "first_command",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "blittable_types",
+                "BlittableComponent",
+                "first_command"
+              ]
+            },
+            "commandIndex": 1,
+            "requestType": {
+              "type": {
+                "qualifiedName": "improbable.gdk.tests.blittable_types.FirstCommandRequest"
+              }
+            },
+            "responseType": {
+              "type": {
+                "qualifiedName": "improbable.gdk.tests.blittable_types.FirstCommandResponse"
+              }
+            }
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.blittable_types.BlittableComponent.second_command",
+              "name": "second_command",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "blittable_types",
+                "BlittableComponent",
+                "second_command"
+              ]
+            },
+            "commandIndex": 2,
+            "requestType": {
+              "type": {
+                "qualifiedName": "improbable.gdk.tests.blittable_types.SecondCommandRequest"
+              }
+            },
+            "responseType": {
+              "type": {
+                "qualifiedName": "improbable.gdk.tests.blittable_types.SecondCommandResponse"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.ExhaustiveSingular",
+          "name": "ExhaustiveSingular",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "ExhaustiveSingular"
+          ]
+        },
+        "componentId": 197715,
+        "dataDefinition": {
+          "type": {
+            "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData"
+          }
+        },
+        "eventDefinitions": [],
+        "commandDefinitions": []
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.ExhaustiveOptional",
+          "name": "ExhaustiveOptional",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "ExhaustiveOptional"
+          ]
+        },
+        "componentId": 197716,
+        "dataDefinition": {
+          "type": {
+            "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData"
+          }
+        },
+        "eventDefinitions": [],
+        "commandDefinitions": []
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeated",
+          "name": "ExhaustiveRepeated",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "ExhaustiveRepeated"
+          ]
+        },
+        "componentId": 197717,
+        "dataDefinition": {
+          "type": {
+            "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData"
+          }
+        },
+        "eventDefinitions": [],
+        "commandDefinitions": []
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValue",
+          "name": "ExhaustiveMapValue",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "ExhaustiveMapValue"
+          ]
+        },
+        "componentId": 197718,
+        "dataDefinition": {
+          "type": {
+            "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData"
+          }
+        },
+        "eventDefinitions": [],
+        "commandDefinitions": []
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKey",
+          "name": "ExhaustiveMapKey",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "ExhaustiveMapKey"
+          ]
+        },
+        "componentId": 197719,
+        "dataDefinition": {
+          "type": {
+            "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData"
+          }
+        },
+        "eventDefinitions": [],
+        "commandDefinitions": []
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingular",
+          "name": "ExhaustiveBlittableSingular",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "ExhaustiveBlittableSingular"
+          ]
+        },
+        "componentId": 197720,
+        "dataDefinition": {
+          "type": {
+            "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingularData"
+          }
+        },
+        "eventDefinitions": [],
+        "commandDefinitions": []
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.NestedComponent",
+          "name": "NestedComponent",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "NestedComponent"
+          ]
+        },
+        "componentId": 20152,
+        "dataDefinition": {
+          "type": {
+            "qualifiedName": "improbable.gdk.tests.NestedComponentData"
+          }
+        },
+        "eventDefinitions": [],
+        "commandDefinitions": []
+      }
+    ]
+  }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Tests/Utils/FormattingTests.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Tests/Utils/FormattingTests.cs
@@ -1,0 +1,54 @@
+using Improbable.Gdk.CodeGeneration.Utils;
+using NUnit.Framework;
+
+namespace Improbable.Gdk.CodeGeneration.Tests.Utils
+{
+    [TestFixture]
+    public class FormattingTests
+    {
+        private const string PascalCase = "TestPascalCase";
+        private const string CamelCase = "testPascalCase";
+        private const string SnakeCase = "test_pascal_case";
+
+        private const string QualifiedName = "improbable.gdk.tests.nonblittable_types.NonBlittableComponent.second_event";
+
+        private const string QualifiedPascalCase =
+            "Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondEvent";
+
+        private const string FullyQualifiedPascalCase =
+            "global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondEvent";
+
+        [Test]
+        public void PascalCaseToCamelCase_should_uncapitalize_first_letter()
+        {
+            // Normal case
+            Assert.AreEqual(CamelCase, Formatting.PascalCaseToCamelCase(PascalCase));
+
+            // Special case - single letter.
+            const string UppercaseLetter = "T";
+            const string LowercaseLetter = "t";
+            Assert.AreEqual(LowercaseLetter, Formatting.PascalCaseToCamelCase(UppercaseLetter));
+
+            // Special case - empty string
+            Assert.AreEqual(string.Empty, Formatting.PascalCaseToCamelCase(string.Empty));
+        }
+
+        [Test]
+        public void SnakeCaseToPascalCase_should_convert_snake_case_to_pascal_case()
+        {
+            Assert.AreEqual(PascalCase, Formatting.SnakeCaseToPascalCase(SnakeCase));
+        }
+
+        [Test]
+        public void QualifiedNameToPascalCase_should_convert_qualified_snake_case_to_qualified_pascal_case()
+        {
+            Assert.AreEqual(QualifiedPascalCase, Formatting.QualifiedNameToPascalCase(QualifiedName));
+        }
+
+        [Test]
+        public void FullyQualify_should_fully_qualify_a_name()
+        {
+            Assert.AreEqual(FullyQualifiedPascalCase, Formatting.FullyQualify(QualifiedName));
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Utils/Formatting.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Utils/Formatting.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Linq;
+
+namespace Improbable.Gdk.CodeGeneration.Utils
+{
+    public static class Formatting
+    {
+        public static string PascalCaseToCamelCase(string pascalCase)
+        {
+            switch (pascalCase.Length)
+            {
+                case 0:
+                    return "";
+                case 1:
+                    return char.ToLowerInvariant(pascalCase[0]).ToString();
+                default:
+                    return char.ToLowerInvariant(pascalCase[0]) + pascalCase.Substring(1);
+            }
+        }
+
+        public static string QualifiedNameToPascalCase(string qualifiedName)
+        {
+            var parts = qualifiedName.Split('.', StringSplitOptions.RemoveEmptyEntries)
+                .Select(SnakeCaseToPascalCase);
+
+            return string.Join(".", parts);
+        }
+
+        public static string SnakeCaseToPascalCase(string snakeCase)
+        {
+            return snakeCase.Split('_', StringSplitOptions.RemoveEmptyEntries)
+                .Select(s => char.ToUpperInvariant(s[0]) + s.Substring(1)).Aggregate(string.Empty, (s1, s2) => s1 + s2);
+        }
+
+        public static string FullyQualify(string qualifiedName)
+        {
+            return "global::" + QualifiedNameToPascalCase(qualifiedName);
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator.sln
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator.sln
@@ -12,6 +12,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mono.TextTemplating", "Mono
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Improbable.TextTemplating", "Improbable.TextTemplating\Improbable.TextTemplating.csproj", "{69CD28E2-1217-47A9-BFFE-6D82701C4839}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeGeneration", "CodeGeneration\CodeGeneration.csproj", "{8E7F9819-2E8E-49B7-8640-CDA500E8DCA4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,6 +32,10 @@ Global
 		{69CD28E2-1217-47A9-BFFE-6D82701C4839}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{69CD28E2-1217-47A9-BFFE-6D82701C4839}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{69CD28E2-1217-47A9-BFFE-6D82701C4839}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8E7F9819-2E8E-49B7-8640-CDA500E8DCA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E7F9819-2E8E-49B7-8640-CDA500E8DCA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E7F9819-2E8E-49B7-8640-CDA500E8DCA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E7F9819-2E8E-49B7-8640-CDA500E8DCA4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
#### Description
Re-implementing the details classes inside the `CodeGeneration` library on top of the schema bundles. 

This adds the skeleton required for each of these and adds back in the `Formatting` static class to format the schema json. 

TODO:
- [x] Add tests for the `Formatting` class
- [ ] Add tests for each of the details class.

#### Tests
See TODOs

#### Documentation
N/A

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
