### PR TITLE
"Clean all workers" now cleans worker configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added support for the Steam authentication flow.
 
+### Changed
+
+- `Clean all workers` now cleans worker configs in addition to built-out workers.
+
 ## `0.1.3` - 2018-11-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Added support for the Steam authentication flow.
 
-### Changed
+### Fixed
 
 - `Clean all workers` now cleans worker configs in addition to built-out workers.
 

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
@@ -20,6 +20,9 @@ namespace Improbable.Gdk.BuildSystem
             Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), EditorPaths.AssetDatabaseDirectory,
                 "worker"));
 
+        private static readonly string AssetDatabaseDirectory =
+            Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), EditorPaths.AssetDatabaseDirectory));
+
         private const string BuildWorkerTypes = "buildWorkerTypes";
 
         /// <summary>
@@ -118,7 +121,7 @@ namespace Improbable.Gdk.BuildSystem
 
         public static void Clean()
         {
-            Directory.Delete(PlayerBuildDirectory, true);
+            Directory.Delete(AssetDatabaseDirectory, true);
             Directory.Delete(EditorPaths.BuildScratchDirectory, true);
         }
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](https://docs.improbable.io/unity/alpha/contributing) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
- updated `Clean` function to clean the entire `build/assembly` directory, instead of just `build/assembly/worker`

#### Tests
tried out locally, renamed stuff to reproduce error and "clean all workers" button now fixes the issue reported in the ticket

#### Documentation
n/a

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.

