### PR TITLE
Fixing launch configuration for OSX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - `Clean all workers` now cleans worker configs in addition to built-out workers.
+- Fixed a bug where you could only start each  built-out worker once on OSX.
 
 ## `0.1.3` - 2018-11-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 
 - `Clean all workers` now cleans worker configs in addition to built-out workers.
-- Fixed a bug where you could only start each built-out worker once on OSX.
+- Fixed a bug where you could start each built-out worker only once on OSX.
 - Code generation now captures nested package dependencies, so the generated schema contains schema components from all required packages. Previously, code generation only generated schema for top-level dependencies, skipping nested packages.
 
 ## `0.1.3` - 2018-11-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 
 - `Clean all workers` now cleans worker configs in addition to built-out workers.
-- Fixed a bug where you could only start each  built-out worker once on OSX.
+- Fixed a bug where you could only start each built-out worker once on OSX.
 - Code generation now captures nested package dependencies, so the generated schema contains schema components from all required packages. Previously, code generation only generated schema for top-level dependencies, skipping nested packages.
 
 ## `0.1.3` - 2018-11-26

--- a/workers/unity/spatialos.UnityClient.worker.json
+++ b/workers/unity/spatialos.UnityClient.worker.json
@@ -50,6 +50,7 @@
       "macos": {
         "command": "open",
         "arguments": [
+          "-n",
           "./build/worker/UnityClient@Mac/UnityClient@Mac.app",
           "--args",
           "+assemblyName",

--- a/workers/unity/spatialos.UnityGameLogic.worker.json
+++ b/workers/unity/spatialos.UnityGameLogic.worker.json
@@ -52,6 +52,7 @@
       "macos": {
         "command": "open",
         "arguments": [
+          "-n",
           "./build/worker/UnityGameLogic@Mac/UnityGameLogic@Mac.app",
           "--args",
           "+assemblyName",
@@ -95,10 +96,8 @@
     },
     "macos": {
       "artifact_name": "UnityGameLogic@Mac.zip",
-      "command": "open",
+      "command": "UnityGameLogic@Mac.app/Contents/MacOS/UnityGameLogic@Mac",
       "arguments": [
-        "UnityGameLogic@Mac.app",
-        "--args",
         "+workerType",
         "UnityGameLogic",
         "+workerId",


### PR DESCRIPTION
#### Description
Describe your changes here.

#### Tests
Ran it locally with `spatial local launch`, `spatial local worker launch UnityGameLogic default` and `spatial local worker launch UnityClient default` to start up multiple workers. Worked fine.

#### Documentation
release notes

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
