### PR TITLE
Adding support for launching an android client over ADB from the editor

### DIFF
--- a/workers/unity/Assets/Config/GdkToolsConfiguration.json
+++ b/workers/unity/Assets/Config/GdkToolsConfiguration.json
@@ -3,5 +3,6 @@
     "SchemaSourceDirs": [
         "../../schema"
     ],
-    "CodegenOutputDir": "Assets/Generated/Source"
+    "CodegenOutputDir": "Assets/Generated/Source",
+    "RuntimeIp": ""
 }

--- a/workers/unity/Assets/Playground/Config/BuildConfiguration.asset
+++ b/workers/unity/Assets/Playground/Config/BuildConfiguration.asset
@@ -35,10 +35,10 @@ MonoBehaviour:
     - {fileID: 102900000, guid: 82ccd0fd96a2ba24f88d0c7d01592f2e, type: 3}
     LocalBuildConfig:
       BuildPlatforms: 32
-      BuildOptions: 0
+      BuildOptions: 1
     CloudBuildConfig:
       BuildPlatforms: 0
-      BuildOptions: 16384
+      BuildOptions: 0
   - WorkerType: iOSClient
     ScenesForWorker:
     - {fileID: 102900000, guid: 424c4b2c090874512badc5e7ee757d5f, type: 3}

--- a/workers/unity/Assets/Playground/Scripts/UI/ConnectionScreenController.cs
+++ b/workers/unity/Assets/Playground/Scripts/UI/ConnectionScreenController.cs
@@ -23,6 +23,14 @@ namespace Playground
 
         public void Awake()
         {
+            var hostIp = GetIPFromExtras();
+            if (!string.IsNullOrEmpty(hostIp))
+            {
+                ipAddressInput.text = hostIp;
+                TryConnect();
+                return;
+            }
+
             ipAddressInput.text = PlayerPrefs.GetString(HostIpPlayerPrefsKey);
             connectButton.onClick.AddListener(TryConnect);
         }
@@ -63,6 +71,13 @@ namespace Playground
             workerConnector.IpAddress = IpAddress;
             workerConnector.ConnectionScreenController = this;
             workerConnector.TryConnect();
+        }
+
+        private string GetIPFromExtras()
+        {
+            var arguments = CommandLineUtility.GetArguments();
+            var hostIp = CommandLineUtility.GetCommandLineValue(arguments, RuntimeConfigNames.ReceptionistHost, string.Empty);
+            return hostIp;
         }
     }
 }

--- a/workers/unity/Assets/Playground/Scripts/UI/ConnectionScreenController.cs
+++ b/workers/unity/Assets/Playground/Scripts/UI/ConnectionScreenController.cs
@@ -23,7 +23,7 @@ namespace Playground
 
         public void Awake()
         {
-            var hostIp = GetIPFromExtras();
+            var hostIp = GetReceptionistHostFromArguments();
             if (!string.IsNullOrEmpty(hostIp))
             {
                 ipAddressInput.text = hostIp;
@@ -73,7 +73,7 @@ namespace Playground
             workerConnector.TryConnect();
         }
 
-        private string GetIPFromExtras()
+        private string GetReceptionistHostFromArguments()
         {
             var arguments = CommandLineUtility.GetArguments();
             var hostIp = CommandLineUtility.GetCommandLineValue(arguments, RuntimeConfigNames.ReceptionistHost, string.Empty);

--- a/workers/unity/Assets/Playground/Scripts/UI/ConnectionScreenController.cs
+++ b/workers/unity/Assets/Playground/Scripts/UI/ConnectionScreenController.cs
@@ -1,4 +1,5 @@
 using Improbable.Gdk.Core;
+using Improbable.Gdk.Mobile.Android;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -75,8 +76,9 @@ namespace Playground
 
         private string GetReceptionistHostFromArguments()
         {
-            var arguments = CommandLineUtility.GetArguments();
-            var hostIp = CommandLineUtility.GetCommandLineValue(arguments, RuntimeConfigNames.ReceptionistHost, string.Empty);
+            var arguments = LaunchArguments.GetArguments();
+            var hostIp =
+                CommandLineUtility.GetCommandLineValue(arguments, RuntimeConfigNames.ReceptionistHost, string.Empty);
             return hostIp;
         }
     }

--- a/workers/unity/Assets/Playground/Scripts/UI/ConnectionScreenController.cs
+++ b/workers/unity/Assets/Playground/Scripts/UI/ConnectionScreenController.cs
@@ -1,5 +1,4 @@
 using Improbable.Gdk.Core;
-using Improbable.Gdk.Mobile.Android;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -76,10 +75,14 @@ namespace Playground
 
         private string GetReceptionistHostFromArguments()
         {
-            var arguments = LaunchArguments.GetArguments();
+#if UNITY_ANDROID
+            var arguments = Improbable.Gdk.Mobile.Android.LaunchArguments.GetArguments();
             var hostIp =
                 CommandLineUtility.GetCommandLineValue(arguments, RuntimeConfigNames.ReceptionistHost, string.Empty);
             return hostIp;
+#else
+            return string.Empty;
+#endif
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandLineUtility.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandLineUtility.cs
@@ -10,18 +10,19 @@ namespace Improbable.Gdk.Core
 #if UNITY_ANDROID
             try
             {
-                var unityPlayer = new UnityEngine.AndroidJavaClass("com.unity3d.player.UnityPlayer");
-                var currentActivity = unityPlayer.GetStatic<UnityEngine.AndroidJavaObject>("currentActivity");
-
-                var intent = currentActivity.Call<UnityEngine.AndroidJavaObject>("getIntent");
-                var hasExtra = intent.Call<bool>("hasExtra", "arguments");
-
-                if (hasExtra)
+                using (var unityPlayer = new UnityEngine.AndroidJavaClass("com.unity3d.player.UnityPlayer"))
+                using (var currentActivity = unityPlayer.GetStatic<UnityEngine.AndroidJavaObject>("currentActivity"))
+                using (var intent = currentActivity.Call<UnityEngine.AndroidJavaObject>("getIntent"))
                 {
-                    var extras = intent.Call<UnityEngine.AndroidJavaObject>("getExtras");
-                    var arguments = extras.Call<string>("getString", "arguments");
-                    UnityEngine.Debug.Log(arguments);
-                    return ParseCommandLineArgs(arguments.Split(' '));
+                    var hasExtra = intent.Call<bool>("hasExtra", "arguments");
+                    if (hasExtra)
+                    {
+                        using (var extras = intent.Call<UnityEngine.AndroidJavaObject>("getExtras"))
+                        {
+                            var arguments = extras.Call<string>("getString", "arguments").Split(' ');
+                            return ParseCommandLineArgs(arguments);
+                        }
+                    }
                 }
             }
             catch (Exception e)
@@ -89,7 +90,8 @@ namespace Improbable.Gdk.Core
                 {
                     if (i + 1 >= args.Count)
                     {
-                        throw new ArgumentException($"Flag \"{flag}\" requires an argument");
+                        throw new ArgumentException(
+                            $"Flag \"{flag}\" requires an argument\nArguments: \"{string.Join(", ", args)}\"");
                     }
 
                     var flagArg = args[i + 1];

--- a/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandLineUtility.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandLineUtility.cs
@@ -7,34 +7,9 @@ namespace Improbable.Gdk.Core
     {
         public static Dictionary<string, string> GetArguments()
         {
-#if UNITY_ANDROID
-            try
-            {
-                using (var unityPlayer = new UnityEngine.AndroidJavaClass("com.unity3d.player.UnityPlayer"))
-                using (var currentActivity = unityPlayer.GetStatic<UnityEngine.AndroidJavaObject>("currentActivity"))
-                using (var intent = currentActivity.Call<UnityEngine.AndroidJavaObject>("getIntent"))
-                {
-                    var hasExtra = intent.Call<bool>("hasExtra", "arguments");
-                    if (hasExtra)
-                    {
-                        using (var extras = intent.Call<UnityEngine.AndroidJavaObject>("getExtras"))
-                        {
-                            var arguments = extras.Call<string>("getString", "arguments").Split(' ');
-                            return ParseCommandLineArgs(arguments);
-                        }
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                UnityEngine.Debug.LogException(e);
-            }
-
-            return new Dictionary<string, string>();
-#else
             return ParseCommandLineArgs(Environment.GetCommandLineArgs());
-#endif
         }
+
 
         public static T GetCommandLineValue<T>(Dictionary<string, string> commandLineDictionary, string configKey,
             T defaultValue)

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Android/Utility/LaunchArguments.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Android/Utility/LaunchArguments.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using Improbable.Gdk.Core;
+
+namespace Improbable.Gdk.Mobile.Android
+{
+    public static class LaunchArguments
+    {
+        public static Dictionary<string, string> GetArguments()
+        {
+            try
+            {
+                using (var unityPlayer = new UnityEngine.AndroidJavaClass("com.unity3d.player.UnityPlayer"))
+                using (var currentActivity = unityPlayer.GetStatic<UnityEngine.AndroidJavaObject>("currentActivity"))
+                using (var intent = currentActivity.Call<UnityEngine.AndroidJavaObject>("getIntent"))
+                {
+                    var hasExtra = intent.Call<bool>("hasExtra", "arguments");
+                    if (hasExtra)
+                    {
+                        using (var extras = intent.Call<UnityEngine.AndroidJavaObject>("getExtras"))
+                        {
+                            var arguments = extras.Call<string>("getString", "arguments").Split(' ');
+                            return CommandLineUtility.ParseCommandLineArgs(arguments);
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                UnityEngine.Debug.LogException(e);
+            }
+
+            return new Dictionary<string, string>();
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Android/Utility/LaunchArguments.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Android/Utility/LaunchArguments.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: afdc1bbf8ada59c47a650e11479991f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor.meta
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 70c9b7bc1355fad4baba6d397d05f86a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/Improbable.Gdk.Mobile.Editor.asmdef
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/Improbable.Gdk.Mobile.Editor.asmdef
@@ -1,0 +1,13 @@
+{
+    "name": "Improbable.Gdk.Mobile.Editor",
+    "references": [
+        "Improbable.Gdk.Core",
+        "Improbable.Gdk.Tools"
+    ],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false
+}

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/Improbable.Gdk.Mobile.Editor.asmdef.meta
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/Improbable.Gdk.Mobile.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 75e699ba3964e614cb64e523c299943c
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
@@ -1,0 +1,60 @@
+using System.Collections;
+using System.IO;
+using System.Text;
+using Improbable.Gdk.Tools;
+using UnityEditor;
+using UnityEngine;
+
+namespace Improbable.Gdk.Mobile
+{
+    public class LaunchMenu
+    {
+        [MenuItem("SpatialOS/Mobile/Launch on Device", false)]
+        private static void LaunchMobileClient()
+        {
+            EditorUtility.DisplayProgressBar("Launching Mobile Client", "Installing APK", 0.3f);
+
+            // Find apk to install
+            if (!TryGetApkPath("build", out var apkPath))
+            {
+                Debug.LogError("Could not find a build out Android binary to launch.");
+                return;
+            }
+
+            // Install apk on connected phone / emulator
+            RedirectedProcess.Run("adb", "install", "-r", apkPath);
+
+            EditorUtility.DisplayProgressBar("Launching Mobile Client", "Launching Client", 0.9f);
+
+            // Optional arguments to be passed, same as standalone
+            // Use this to pass through the local ip to connect to
+            var runtimeIp = GdkToolsConfiguration.GetOrCreateInstance().RuntimeIp;
+            var arguments = new StringBuilder();
+            if (!string.IsNullOrEmpty(runtimeIp))
+            {
+                arguments.Append($"+receptionistHost {runtimeIp}");
+            }
+
+            // Get chosen android package id and launch
+            var bundleId = PlayerSettings.GetApplicationIdentifier(BuildTargetGroup.Android);
+            RedirectedProcess.Run("adb", "shell", "am", "start", "-S",
+                "-n", $"{bundleId}/com.unity3d.player.UnityPlayerActivity",
+                "-e", "\"arguments\"", $"\\\"{arguments.ToString()}\\\"");
+
+            EditorUtility.DisplayProgressBar("Launching Mobile Client", "Done", 1.0f);
+            EditorUtility.ClearProgressBar();
+        }
+
+        private static bool TryGetApkPath(string rootPath, out string apkPath)
+        {
+            foreach (var file in Directory.GetFiles(rootPath, "*.apk", SearchOption.AllDirectories))
+            {
+                apkPath = file;
+                return true;
+            }
+
+            apkPath = string.Empty;
+            return false;
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
@@ -1,48 +1,56 @@
-using System.Collections;
 using System.IO;
 using System.Text;
+using Improbable.Gdk.Core;
 using Improbable.Gdk.Tools;
 using UnityEditor;
 using UnityEngine;
 
 namespace Improbable.Gdk.Mobile
 {
-    public class LaunchMenu
+    public static class LaunchMenu
     {
-        [MenuItem("SpatialOS/Mobile/Launch on Device", false)]
+        private const string rootApkPath = "build";
+
+        [MenuItem("SpatialOS/Mobile/Launch on Android Device", false, 10)]
         private static void LaunchMobileClient()
         {
-            EditorUtility.DisplayProgressBar("Launching Mobile Client", "Installing APK", 0.3f);
-
-            // Find apk to install
-            if (!TryGetApkPath("build", out var apkPath))
+            try
             {
-                Debug.LogError("Could not find a build out Android binary to launch.");
-                return;
+                EditorUtility.DisplayProgressBar("Launching Mobile Client", "Installing APK", 0.3f);
+
+                // Find apk to install
+                if (!TryGetApkPath(rootApkPath, out var apkPath))
+                {
+                    Debug.LogError($"Could not find a built out Android binary in \"{rootApkPath}\" to launch.");
+                    return;
+                }
+
+                // Install apk on connected phone / emulator
+                RedirectedProcess.Run("adb", "install", "-r", apkPath);
+
+                EditorUtility.DisplayProgressBar("Launching Mobile Client", "Launching Client", 0.9f);
+
+                // Optional arguments to be passed, same as standalone
+                // Use this to pass through the local ip to connect to
+                var runtimeIp = GdkToolsConfiguration.GetOrCreateInstance().RuntimeIp;
+                var arguments = new StringBuilder();
+                if (!string.IsNullOrEmpty(runtimeIp))
+                {
+                    arguments.Append($"+{RuntimeConfigNames.ReceptionistHost} {runtimeIp}");
+                }
+
+                // Get chosen android package id and launch
+                var bundleId = PlayerSettings.GetApplicationIdentifier(BuildTargetGroup.Android);
+                RedirectedProcess.Run("adb", "shell", "am", "start", "-S",
+                    "-n", $"{bundleId}/com.unity3d.player.UnityPlayerActivity",
+                    "-e", "\"arguments\"", $"\\\"{arguments.ToString()}\\\"");
+
+                EditorUtility.DisplayProgressBar("Launching Mobile Client", "Done", 1.0f);
             }
-
-            // Install apk on connected phone / emulator
-            RedirectedProcess.Run("adb", "install", "-r", apkPath);
-
-            EditorUtility.DisplayProgressBar("Launching Mobile Client", "Launching Client", 0.9f);
-
-            // Optional arguments to be passed, same as standalone
-            // Use this to pass through the local ip to connect to
-            var runtimeIp = GdkToolsConfiguration.GetOrCreateInstance().RuntimeIp;
-            var arguments = new StringBuilder();
-            if (!string.IsNullOrEmpty(runtimeIp))
+            finally
             {
-                arguments.Append($"+receptionistHost {runtimeIp}");
+                EditorUtility.ClearProgressBar();
             }
-
-            // Get chosen android package id and launch
-            var bundleId = PlayerSettings.GetApplicationIdentifier(BuildTargetGroup.Android);
-            RedirectedProcess.Run("adb", "shell", "am", "start", "-S",
-                "-n", $"{bundleId}/com.unity3d.player.UnityPlayerActivity",
-                "-e", "\"arguments\"", $"\\\"{arguments.ToString()}\\\"");
-
-            EditorUtility.DisplayProgressBar("Launching Mobile Client", "Done", 1.0f);
-            EditorUtility.ClearProgressBar();
         }
 
         private static bool TryGetApkPath(string rootPath, out string apkPath)

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
@@ -10,7 +10,7 @@ namespace Improbable.Gdk.Mobile
     public static class LaunchMenu
     {
         private const string rootApkPath = "build";
-        private static string AbsoluteApkPath => Path.Combine(Application.dataPath, Path.Combine("..", rootApkPath));
+        private static string AbsoluteApkPath => Path.GetFullPath(Path.Combine(Application.dataPath, Path.Combine("..", rootApkPath)));
 
         private const string MenuLaunchAndroid = "SpatialOS/Launch mobile client/Android Device";
 
@@ -64,12 +64,6 @@ namespace Improbable.Gdk.Mobile
             {
                 EditorUtility.ClearProgressBar();
             }
-        }
-
-        [MenuItem(MenuLaunchAndroid, true)]
-        private static bool LaunchMobileClientValidate()
-        {
-            return TryGetApkPath(AbsoluteApkPath, out _);
         }
 
         private static bool TryGetApkPath(string rootPath, out string apkPath)

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
@@ -10,8 +10,9 @@ namespace Improbable.Gdk.Mobile
     public static class LaunchMenu
     {
         private const string rootApkPath = "build";
+        private const string MenuLaunchAndroid = "SpatialOS/Launch mobile client/Android Device";
 
-        [MenuItem("SpatialOS/Mobile/Launch on Android Device", false, 10)]
+        [MenuItem(MenuLaunchAndroid, false, 73)]
         private static void LaunchMobileClient()
         {
             try
@@ -19,9 +20,10 @@ namespace Improbable.Gdk.Mobile
                 EditorUtility.DisplayProgressBar("Launching Mobile Client", "Installing APK", 0.3f);
 
                 // Find apk to install
-                if (!TryGetApkPath(rootApkPath, out var apkPath))
+                var rootPath = Path.Combine(Application.dataPath, Path.Combine("..", rootApkPath));
+                if (!TryGetApkPath(rootPath, out var apkPath))
                 {
-                    Debug.LogError($"Could not find a built out Android binary in \"{rootApkPath}\" to launch.");
+                    Debug.LogError($"Could not find a built out Android binary in \"{rootPath}\" to launch.");
                     return;
                 }
 
@@ -51,6 +53,13 @@ namespace Improbable.Gdk.Mobile
             {
                 EditorUtility.ClearProgressBar();
             }
+        }
+
+        [MenuItem(MenuLaunchAndroid, true)]
+        private static bool LaunchMobileClientValidate()
+        {
+            var rootPath = Path.Combine(Application.dataPath, Path.Combine("..", rootApkPath));
+            return TryGetApkPath(rootPath, out _);
         }
 
         private static bool TryGetApkPath(string rootPath, out string apkPath)

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
@@ -38,6 +38,13 @@ namespace Improbable.Gdk.Mobile
                     return;
                 }
 
+                // Ensure an android device/emulator is present
+                if (RedirectedProcess.Run(adbPath, "get-state") != 0)
+                {
+                    Debug.LogError("No Android device/emulator detected.");
+                    return;
+                }
+
                 // Install apk on connected phone / emulator
                 RedirectedProcess.Run(adbPath, "install", "-r", apkPath);
 

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
@@ -10,6 +10,8 @@ namespace Improbable.Gdk.Mobile
     public static class LaunchMenu
     {
         private const string rootApkPath = "build";
+        private static string AbsoluteApkPath => Path.Combine(Application.dataPath, Path.Combine("..", rootApkPath));
+
         private const string MenuLaunchAndroid = "SpatialOS/Launch mobile client/Android Device";
 
         [MenuItem(MenuLaunchAndroid, false, 73)]
@@ -20,10 +22,9 @@ namespace Improbable.Gdk.Mobile
                 EditorUtility.DisplayProgressBar("Launching Mobile Client", "Installing APK", 0.3f);
 
                 // Find apk to install
-                var rootPath = Path.Combine(Application.dataPath, Path.Combine("..", rootApkPath));
-                if (!TryGetApkPath(rootPath, out var apkPath))
+                if (!TryGetApkPath(AbsoluteApkPath, out var apkPath))
                 {
-                    Debug.LogError($"Could not find a built out Android binary in \"{rootPath}\" to launch.");
+                    Debug.LogError($"Could not find a built out Android binary in \"{AbsoluteApkPath}\" to launch.");
                     return;
                 }
 
@@ -58,8 +59,7 @@ namespace Improbable.Gdk.Mobile
         [MenuItem(MenuLaunchAndroid, true)]
         private static bool LaunchMobileClientValidate()
         {
-            var rootPath = Path.Combine(Application.dataPath, Path.Combine("..", rootApkPath));
-            return TryGetApkPath(rootPath, out _);
+            return TryGetApkPath(AbsoluteApkPath, out _);
         }
 
         private static bool TryGetApkPath(string rootPath, out string apkPath)

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
@@ -19,6 +19,16 @@ namespace Improbable.Gdk.Mobile
         {
             try
             {
+                // Find ADB tool
+                var sdkRootPath = EditorPrefs.GetString("AndroidSdkRoot");
+                if (string.IsNullOrEmpty(sdkRootPath))
+                {
+                    Debug.LogError($"Could not find Android SDK. Please set the SDK location in your editor preferences.");
+                    return;
+                }
+
+                var adbPath = Path.Combine(sdkRootPath, "platform-tools", "adb");
+
                 EditorUtility.DisplayProgressBar("Launching Mobile Client", "Installing APK", 0.3f);
 
                 // Find apk to install
@@ -29,7 +39,7 @@ namespace Improbable.Gdk.Mobile
                 }
 
                 // Install apk on connected phone / emulator
-                RedirectedProcess.Run("adb", "install", "-r", apkPath);
+                RedirectedProcess.Run(adbPath, "install", "-r", apkPath);
 
                 EditorUtility.DisplayProgressBar("Launching Mobile Client", "Launching Client", 0.9f);
 
@@ -44,7 +54,7 @@ namespace Improbable.Gdk.Mobile
 
                 // Get chosen android package id and launch
                 var bundleId = PlayerSettings.GetApplicationIdentifier(BuildTargetGroup.Android);
-                RedirectedProcess.Run("adb", "shell", "am", "start", "-S",
+                RedirectedProcess.Run(adbPath, "shell", "am", "start", "-S",
                     "-n", $"{bundleId}/com.unity3d.player.UnityPlayerActivity",
                     "-e", "\"arguments\"", $"\\\"{arguments.ToString()}\\\"");
 

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4768e3f66fbbc374d82396f8390d7b50
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using UnityEngine;
 
 namespace Improbable.Gdk.Tools
@@ -12,6 +13,7 @@ namespace Improbable.Gdk.Tools
         public string SchemaStdLibDir;
         public List<string> SchemaSourceDirs = new List<string>();
         public string CodegenOutputDir;
+        public string RuntimeIp;
 
         private static string JsonFilePath = Path.GetFullPath("Assets/Config/GdkToolsConfiguration.json");
 
@@ -49,6 +51,11 @@ namespace Improbable.Gdk.Tools
                 errors.Add($"You must have at least one item in {GdkToolsConfigurationWindow.SchemaSourceDirsLabel}.");
             }
 
+            if (!string.IsNullOrEmpty(RuntimeIp) && !IPAddress.TryParse(RuntimeIp, out _))
+            {
+                errors.Add($"Runtime IP \"{RuntimeIp}\" is not a valid IP address.");
+            }
+
             return errors;
         }
 
@@ -56,6 +63,7 @@ namespace Improbable.Gdk.Tools
         {
             SchemaStdLibDir = DefaultValues.SchemaStdLibDir;
             CodegenOutputDir = DefaultValues.CodegenOutputDir;
+            RuntimeIp = DefaultValues.RuntimeIp;
 
             SchemaSourceDirs.Clear();
             SchemaSourceDirs.Add(DefaultValues.SchemaSourceDir);
@@ -85,6 +93,7 @@ namespace Improbable.Gdk.Tools
             public const string SchemaStdLibDir = "../../build/dependencies/schema/standard_library";
             public const string CodegenOutputDir = "Assets/Generated/Source";
             public const string SchemaSourceDir = "../../schema";
+            public const string RuntimeIp = null;
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationEditorExtensions.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationEditorExtensions.cs
@@ -12,6 +12,7 @@ namespace Improbable.Gdk.Tools
         internal const string SchemaStdLibDirLabel = "Schema standard library directory";
         internal const string CodegenOutputDirLabel = "Code generator output directory";
         internal const string SchemaSourceDirsLabel = "Schema source directories";
+        internal const string RuntimeIpLabel = "Runtime IP for local deployment";
 
         private const string CodeGeneratorLabel = "Code generator options";
         private const string DownloadCoreSdkLabel = "CoreSDK options";
@@ -97,6 +98,8 @@ namespace Improbable.Gdk.Tools
             GUILayout.Space(5);
             GUILayout.Label(SchemaStdLibDirLabel);
             toolsConfig.SchemaStdLibDir = GUILayout.TextField(toolsConfig.SchemaStdLibDir);
+            GUILayout.Label(RuntimeIpLabel);
+            toolsConfig.RuntimeIp = GUILayout.TextField(toolsConfig.RuntimeIp);
         }
 
         private void DrawCodeGenerationOptions()

--- a/workers/unity/Packages/com.improbable.gdk.tools/LocalLaunch.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/LocalLaunch.cs
@@ -206,6 +206,12 @@ namespace Improbable.Gdk.Tools
             var command = Common.SpatialBinary;
             var commandArgs = "local launch";
 
+            var runtimeIp = GdkToolsConfiguration.GetOrCreateInstance().RuntimeIp;
+            if (!string.IsNullOrEmpty(runtimeIp))
+            {
+                commandArgs = $"{commandArgs} --runtime_ip={runtimeIp}";
+            }
+
             if (Application.platform == RuntimePlatform.OSXEditor)
             {
                 command = "osascript";

--- a/workers/unity/Packages/com.improbable.gdk.tools/MenuPriorities.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/MenuPriorities.cs
@@ -8,7 +8,7 @@ namespace Improbable.Gdk.Tools
         internal const int BuildWorkerConfigs = 70;
         internal const int LocalLaunch = 71;
         internal const int LaunchStandaloneClient = 72;
-        internal const int OpenInspector = 73;
+        internal const int OpenInspector = 74;
 
         internal const int GdkToolsConfiguration = 201;
     }

--- a/workers/unity/ProjectSettings/GraphicsSettings.asset
+++ b/workers/unity/ProjectSettings/GraphicsSettings.asset
@@ -37,6 +37,7 @@ GraphicsSettings:
   - {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 17000, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 16000, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 16002, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}

--- a/workers/unity/ProjectSettings/ProjectSettings.asset
+++ b/workers/unity/ProjectSettings/ProjectSettings.asset
@@ -7,8 +7,8 @@ PlayerSettings:
   productGUID: 00d744d32a4452244a9a72cbda2f61ff
   AndroidProfiler: 0
   AndroidFilterTouchesWhenObscured: 0
-  AndroidEnableSustainedPerformanceMode: 0
-  defaultScreenOrientation: 4
+  AndroidEnableSustainedPerformanceMode: 1
+  defaultScreenOrientation: 2
   targetDevice: 2
   useOnDemandResources: 0
   accelerometerFrequency: 60
@@ -60,7 +60,7 @@ PlayerSettings:
   allowedAutorotateToLandscapeRight: 1
   allowedAutorotateToLandscapeLeft: 1
   useOSAutorotation: 1
-  use32BitDisplayBuffer: 1
+  use32BitDisplayBuffer: 0
   preserveFramebufferAlpha: 0
   disableDepthAndStencilBuffers: 0
   androidBlitType: 0
@@ -125,6 +125,7 @@ PlayerSettings:
   m_HolographicPauseOnTrackingLoss: 1
   xboxOneDisableKinectGpuReservation: 0
   xboxOneEnable7thCore: 0
+  isWsaHolographicRemotingEnabled: 0
   vrSettings:
     cardboard:
       depthFormat: 0
@@ -157,7 +158,7 @@ PlayerSettings:
     tvOS: com.improbable.gdk
   buildNumber: {}
   AndroidBundleVersionCode: 1
-  AndroidMinSdkVersion: 16
+  AndroidMinSdkVersion: 21
   AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1
   aotOptions: 
@@ -495,6 +496,7 @@ PlayerSettings:
   switchAllowsVideoCapturing: 1
   switchAllowsRuntimeAddOnContentInstall: 0
   switchDataLossConfirmation: 0
+  switchUserAccountLockEnabled: 0
   switchSupportedNpadStyles: 3
   switchNativeFsCacheSize: 32
   switchIsHoldTypeHorizontal: 0


### PR DESCRIPTION
#### Description
This PR contains some additional changes that were related or required:

* Updating the local deployment launcher to use a runtime ip if provided.
* Fix AndroidClient build options.
* Mobile connection screen now skips input if IP is provided through launch argument.

#### Tests
I've build and run for the phone a few times with different settings.
