### PR TITLE
Add more detailed profiling markers

### DIFF
--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
@@ -43,7 +43,7 @@ namespace Improbable.Gdk.Tests
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ExhaustiveBlittableSingular");
+                Profiler.BeginSample("ExhaustiveBlittableSingular.OnAddComponent");
                 var data = Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.MarkDataClean();
                 entityManager.AddComponentData(entity, data);
@@ -106,7 +106,7 @@ namespace Improbable.Gdk.Tests
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ExhaustiveBlittableSingular");
+                Profiler.BeginSample("ExhaustiveBlittableSingular.OnRemoveComponent");
 
                 entityManager.RemoveComponent<Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>(entity);
 
@@ -134,7 +134,7 @@ namespace Improbable.Gdk.Tests
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ExhaustiveBlittableSingular");
+                Profiler.BeginSample("ExhaustiveBlittableSingular.OnComponentUpdate");
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>>(entity))
                 {
                     var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>(entity);
@@ -171,7 +171,7 @@ namespace Improbable.Gdk.Tests
                 var entityId = new EntityId(op.EntityId);
                 var entity = TryGetEntityFromEntityId(entityId);
 
-                Profiler.BeginSample("ExhaustiveBlittableSingular");
+                Profiler.BeginSample("ExhaustiveBlittableSingular.OnAuthorityChange");
                 ApplyAuthorityChange(entity, op.Authority, entityId);
                 Profiler.EndSample();
             }
@@ -296,7 +296,7 @@ namespace Improbable.Gdk.Tests
 
             public override void ExecuteReplication(ComponentGroup replicationGroup, ComponentSystemBase system, global::Improbable.Worker.CInterop.Connection connection)
             {
-                Profiler.BeginSample("ExhaustiveBlittableSingular");
+                Profiler.BeginSample("ExhaustiveBlittableSingular.ExecuteReplication");
 
                 var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
@@ -61,7 +61,7 @@ namespace Improbable.Gdk.Tests
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ExhaustiveMapKey");
+                Profiler.BeginSample("ExhaustiveMapKey.OnAddComponent");
                 var data = Improbable.Gdk.Tests.ExhaustiveMapKey.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.MarkDataClean();
                 entityManager.AddComponentData(entity, data);
@@ -126,7 +126,7 @@ namespace Improbable.Gdk.Tests
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ExhaustiveMapKey");
+                Profiler.BeginSample("ExhaustiveMapKey.OnRemoveComponent");
 
                 var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>(entity);
                 ExhaustiveMapKey.ReferenceTypeProviders.Field1Provider.Free(data.field1Handle);
@@ -174,7 +174,7 @@ namespace Improbable.Gdk.Tests
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ExhaustiveMapKey");
+                Profiler.BeginSample("ExhaustiveMapKey.OnComponentUpdate");
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entity))
                 {
                     var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>(entity);
@@ -211,7 +211,7 @@ namespace Improbable.Gdk.Tests
                 var entityId = new EntityId(op.EntityId);
                 var entity = TryGetEntityFromEntityId(entityId);
 
-                Profiler.BeginSample("ExhaustiveMapKey");
+                Profiler.BeginSample("ExhaustiveMapKey.OnAuthorityChange");
                 ApplyAuthorityChange(entity, op.Authority, entityId);
                 Profiler.EndSample();
             }
@@ -336,7 +336,7 @@ namespace Improbable.Gdk.Tests
 
             public override void ExecuteReplication(ComponentGroup replicationGroup, ComponentSystemBase system, global::Improbable.Worker.CInterop.Connection connection)
             {
-                Profiler.BeginSample("ExhaustiveMapKey");
+                Profiler.BeginSample("ExhaustiveMapKey.ExecuteReplication");
 
                 var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
@@ -61,7 +61,7 @@ namespace Improbable.Gdk.Tests
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ExhaustiveMapValue");
+                Profiler.BeginSample("ExhaustiveMapValue.OnAddComponent");
                 var data = Improbable.Gdk.Tests.ExhaustiveMapValue.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.MarkDataClean();
                 entityManager.AddComponentData(entity, data);
@@ -126,7 +126,7 @@ namespace Improbable.Gdk.Tests
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ExhaustiveMapValue");
+                Profiler.BeginSample("ExhaustiveMapValue.OnRemoveComponent");
 
                 var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>(entity);
                 ExhaustiveMapValue.ReferenceTypeProviders.Field1Provider.Free(data.field1Handle);
@@ -174,7 +174,7 @@ namespace Improbable.Gdk.Tests
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ExhaustiveMapValue");
+                Profiler.BeginSample("ExhaustiveMapValue.OnComponentUpdate");
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entity))
                 {
                     var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>(entity);
@@ -211,7 +211,7 @@ namespace Improbable.Gdk.Tests
                 var entityId = new EntityId(op.EntityId);
                 var entity = TryGetEntityFromEntityId(entityId);
 
-                Profiler.BeginSample("ExhaustiveMapValue");
+                Profiler.BeginSample("ExhaustiveMapValue.OnAuthorityChange");
                 ApplyAuthorityChange(entity, op.Authority, entityId);
                 Profiler.EndSample();
             }
@@ -336,7 +336,7 @@ namespace Improbable.Gdk.Tests
 
             public override void ExecuteReplication(ComponentGroup replicationGroup, ComponentSystemBase system, global::Improbable.Worker.CInterop.Connection connection)
             {
-                Profiler.BeginSample("ExhaustiveMapValue");
+                Profiler.BeginSample("ExhaustiveMapValue.ExecuteReplication");
 
                 var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
@@ -61,7 +61,7 @@ namespace Improbable.Gdk.Tests
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ExhaustiveOptional");
+                Profiler.BeginSample("ExhaustiveOptional.OnAddComponent");
                 var data = Improbable.Gdk.Tests.ExhaustiveOptional.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.MarkDataClean();
                 entityManager.AddComponentData(entity, data);
@@ -126,7 +126,7 @@ namespace Improbable.Gdk.Tests
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ExhaustiveOptional");
+                Profiler.BeginSample("ExhaustiveOptional.OnRemoveComponent");
 
                 var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveOptional.Component>(entity);
                 ExhaustiveOptional.ReferenceTypeProviders.Field1Provider.Free(data.field1Handle);
@@ -174,7 +174,7 @@ namespace Improbable.Gdk.Tests
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ExhaustiveOptional");
+                Profiler.BeginSample("ExhaustiveOptional.OnComponentUpdate");
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entity))
                 {
                     var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveOptional.Component>(entity);
@@ -211,7 +211,7 @@ namespace Improbable.Gdk.Tests
                 var entityId = new EntityId(op.EntityId);
                 var entity = TryGetEntityFromEntityId(entityId);
 
-                Profiler.BeginSample("ExhaustiveOptional");
+                Profiler.BeginSample("ExhaustiveOptional.OnAuthorityChange");
                 ApplyAuthorityChange(entity, op.Authority, entityId);
                 Profiler.EndSample();
             }
@@ -336,7 +336,7 @@ namespace Improbable.Gdk.Tests
 
             public override void ExecuteReplication(ComponentGroup replicationGroup, ComponentSystemBase system, global::Improbable.Worker.CInterop.Connection connection)
             {
-                Profiler.BeginSample("ExhaustiveOptional");
+                Profiler.BeginSample("ExhaustiveOptional.ExecuteReplication");
 
                 var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
@@ -61,7 +61,7 @@ namespace Improbable.Gdk.Tests
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ExhaustiveRepeated");
+                Profiler.BeginSample("ExhaustiveRepeated.OnAddComponent");
                 var data = Improbable.Gdk.Tests.ExhaustiveRepeated.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.MarkDataClean();
                 entityManager.AddComponentData(entity, data);
@@ -126,7 +126,7 @@ namespace Improbable.Gdk.Tests
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ExhaustiveRepeated");
+                Profiler.BeginSample("ExhaustiveRepeated.OnRemoveComponent");
 
                 var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>(entity);
                 ExhaustiveRepeated.ReferenceTypeProviders.Field1Provider.Free(data.field1Handle);
@@ -174,7 +174,7 @@ namespace Improbable.Gdk.Tests
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ExhaustiveRepeated");
+                Profiler.BeginSample("ExhaustiveRepeated.OnComponentUpdate");
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entity))
                 {
                     var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>(entity);
@@ -211,7 +211,7 @@ namespace Improbable.Gdk.Tests
                 var entityId = new EntityId(op.EntityId);
                 var entity = TryGetEntityFromEntityId(entityId);
 
-                Profiler.BeginSample("ExhaustiveRepeated");
+                Profiler.BeginSample("ExhaustiveRepeated.OnAuthorityChange");
                 ApplyAuthorityChange(entity, op.Authority, entityId);
                 Profiler.EndSample();
             }
@@ -336,7 +336,7 @@ namespace Improbable.Gdk.Tests
 
             public override void ExecuteReplication(ComponentGroup replicationGroup, ComponentSystemBase system, global::Improbable.Worker.CInterop.Connection connection)
             {
-                Profiler.BeginSample("ExhaustiveRepeated");
+                Profiler.BeginSample("ExhaustiveRepeated.ExecuteReplication");
 
                 var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
@@ -45,7 +45,7 @@ namespace Improbable.Gdk.Tests
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ExhaustiveSingular");
+                Profiler.BeginSample("ExhaustiveSingular.OnAddComponent");
                 var data = Improbable.Gdk.Tests.ExhaustiveSingular.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.MarkDataClean();
                 entityManager.AddComponentData(entity, data);
@@ -110,7 +110,7 @@ namespace Improbable.Gdk.Tests
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ExhaustiveSingular");
+                Profiler.BeginSample("ExhaustiveSingular.OnRemoveComponent");
 
                 var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveSingular.Component>(entity);
                 ExhaustiveSingular.ReferenceTypeProviders.Field3Provider.Free(data.field3Handle);
@@ -142,7 +142,7 @@ namespace Improbable.Gdk.Tests
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ExhaustiveSingular");
+                Profiler.BeginSample("ExhaustiveSingular.OnComponentUpdate");
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entity))
                 {
                     var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveSingular.Component>(entity);
@@ -179,7 +179,7 @@ namespace Improbable.Gdk.Tests
                 var entityId = new EntityId(op.EntityId);
                 var entity = TryGetEntityFromEntityId(entityId);
 
-                Profiler.BeginSample("ExhaustiveSingular");
+                Profiler.BeginSample("ExhaustiveSingular.OnAuthorityChange");
                 ApplyAuthorityChange(entity, op.Authority, entityId);
                 Profiler.EndSample();
             }
@@ -304,7 +304,7 @@ namespace Improbable.Gdk.Tests
 
             public override void ExecuteReplication(ComponentGroup replicationGroup, ComponentSystemBase system, global::Improbable.Worker.CInterop.Connection connection)
             {
-                Profiler.BeginSample("ExhaustiveSingular");
+                Profiler.BeginSample("ExhaustiveSingular.ExecuteReplication");
 
                 var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
@@ -43,7 +43,7 @@ namespace Improbable.Gdk.Tests
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("NestedComponent");
+                Profiler.BeginSample("NestedComponent.OnAddComponent");
                 var data = Improbable.Gdk.Tests.NestedComponent.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.MarkDataClean();
                 entityManager.AddComponentData(entity, data);
@@ -91,7 +91,7 @@ namespace Improbable.Gdk.Tests
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("NestedComponent");
+                Profiler.BeginSample("NestedComponent.OnRemoveComponent");
 
                 entityManager.RemoveComponent<Improbable.Gdk.Tests.NestedComponent.Component>(entity);
 
@@ -119,7 +119,7 @@ namespace Improbable.Gdk.Tests
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("NestedComponent");
+                Profiler.BeginSample("NestedComponent.OnComponentUpdate");
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.NestedComponent.Component>>(entity))
                 {
                     var data = entityManager.GetComponentData<Improbable.Gdk.Tests.NestedComponent.Component>(entity);
@@ -156,7 +156,7 @@ namespace Improbable.Gdk.Tests
                 var entityId = new EntityId(op.EntityId);
                 var entity = TryGetEntityFromEntityId(entityId);
 
-                Profiler.BeginSample("NestedComponent");
+                Profiler.BeginSample("NestedComponent.OnAuthorityChange");
                 ApplyAuthorityChange(entity, op.Authority, entityId);
                 Profiler.EndSample();
             }
@@ -281,7 +281,7 @@ namespace Improbable.Gdk.Tests
 
             public override void ExecuteReplication(ComponentGroup replicationGroup, ComponentSystemBase system, global::Improbable.Worker.CInterop.Connection connection)
             {
-                Profiler.BeginSample("NestedComponent");
+                Profiler.BeginSample("NestedComponent.ExecuteReplication");
 
                 var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionTranslation.cs
@@ -44,7 +44,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("Connection");
+                Profiler.BeginSample("Connection.OnAddComponent");
                 var data = Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.MarkDataClean();
                 entityManager.AddComponentData(entity, data);
@@ -92,7 +92,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("Connection");
+                Profiler.BeginSample("Connection.OnRemoveComponent");
 
                 entityManager.RemoveComponent<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>(entity);
 
@@ -120,7 +120,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("Connection");
+                Profiler.BeginSample("Connection.OnComponentUpdate");
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entity))
                 {
                     var data = entityManager.GetComponentData<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>(entity);
@@ -189,7 +189,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 var entityId = new EntityId(op.EntityId);
                 var entity = TryGetEntityFromEntityId(entityId);
 
-                Profiler.BeginSample("Connection");
+                Profiler.BeginSample("Connection.OnAuthorityChange");
                 ApplyAuthorityChange(entity, op.Authority, entityId);
                 Profiler.EndSample();
             }
@@ -328,7 +328,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
 
             public override void ExecuteReplication(ComponentGroup replicationGroup, ComponentSystemBase system, global::Improbable.Worker.CInterop.Connection connection)
             {
-                Profiler.BeginSample("Connection");
+                Profiler.BeginSample("Connection.ExecuteReplication");
 
                 var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentTranslation.cs
@@ -57,7 +57,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("BlittableComponent");
+                Profiler.BeginSample("BlittableComponent.OnAddComponent");
                 var data = Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.MarkDataClean();
                 entityManager.AddComponentData(entity, data);
@@ -109,7 +109,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("BlittableComponent");
+                Profiler.BeginSample("BlittableComponent.OnRemoveComponent");
 
                 entityManager.RemoveComponent<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>(entity);
 
@@ -137,7 +137,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("BlittableComponent");
+                Profiler.BeginSample("BlittableComponent.OnComponentUpdate");
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entity))
                 {
                     var data = entityManager.GetComponentData<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>(entity);
@@ -237,7 +237,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 var entityId = new EntityId(op.EntityId);
                 var entity = TryGetEntityFromEntityId(entityId);
 
-                Profiler.BeginSample("BlittableComponent");
+                Profiler.BeginSample("BlittableComponent.OnAuthorityChange");
                 ApplyAuthorityChange(entity, op.Authority, entityId);
                 Profiler.EndSample();
             }
@@ -246,7 +246,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             {
                 var commandIndex = op.Request.SchemaData.Value.GetCommandIndex();
 
-                Profiler.BeginSample("BlittableComponent");
+                Profiler.BeginSample("BlittableComponent.OnCommandRequest");
                 switch (commandIndex)
                 {
                     case 1:
@@ -266,7 +266,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             {
                 var commandIndex = op.Response.CommandIndex;
 
-                Profiler.BeginSample("BlittableComponent");
+                Profiler.BeginSample("BlittableComponent.OnCommandResponse");
                 switch (commandIndex)
                 {
                     case 1:
@@ -620,7 +620,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
             public override void ExecuteReplication(ComponentGroup replicationGroup, ComponentSystemBase system, global::Improbable.Worker.CInterop.Connection connection)
             {
-                Profiler.BeginSample("BlittableComponent");
+                Profiler.BeginSample("BlittableComponent.ExecuteReplication");
 
                 var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
@@ -686,7 +686,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
             public override void SendCommands(ComponentGroup commandGroup, ComponentSystemBase system, global::Improbable.Worker.CInterop.Connection connection)
             {
-                Profiler.BeginSample("BlittableComponent");
+                Profiler.BeginSample("BlittableComponent.SendCommands");
                 var entityType = system.GetArchetypeChunkEntityType();
                 {
                     var senderType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandSenders.FirstCommand>(true);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsTranslation.cs
@@ -43,7 +43,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ComponentWithNoFields");
+                Profiler.BeginSample("ComponentWithNoFields.OnAddComponent");
                 var data = Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.MarkDataClean();
                 entityManager.AddComponentData(entity, data);
@@ -90,7 +90,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ComponentWithNoFields");
+                Profiler.BeginSample("ComponentWithNoFields.OnRemoveComponent");
 
                 entityManager.RemoveComponent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>(entity);
 
@@ -118,7 +118,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ComponentWithNoFields");
+                Profiler.BeginSample("ComponentWithNoFields.OnComponentUpdate");
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entity))
                 {
                     var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>(entity);
@@ -155,7 +155,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entityId = new EntityId(op.EntityId);
                 var entity = TryGetEntityFromEntityId(entityId);
 
-                Profiler.BeginSample("ComponentWithNoFields");
+                Profiler.BeginSample("ComponentWithNoFields.OnAuthorityChange");
                 ApplyAuthorityChange(entity, op.Authority, entityId);
                 Profiler.EndSample();
             }
@@ -280,7 +280,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public override void ExecuteReplication(ComponentGroup replicationGroup, ComponentSystemBase system, global::Improbable.Worker.CInterop.Connection connection)
             {
-                Profiler.BeginSample("ComponentWithNoFields");
+                Profiler.BeginSample("ComponentWithNoFields.ExecuteReplication");
 
                 var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsTranslation.cs
@@ -49,7 +49,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ComponentWithNoFieldsWithCommands");
+                Profiler.BeginSample("ComponentWithNoFieldsWithCommands.OnAddComponent");
                 var data = Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.MarkDataClean();
                 entityManager.AddComponentData(entity, data);
@@ -96,7 +96,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ComponentWithNoFieldsWithCommands");
+                Profiler.BeginSample("ComponentWithNoFieldsWithCommands.OnRemoveComponent");
 
                 entityManager.RemoveComponent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>(entity);
 
@@ -124,7 +124,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ComponentWithNoFieldsWithCommands");
+                Profiler.BeginSample("ComponentWithNoFieldsWithCommands.OnComponentUpdate");
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entity))
                 {
                     var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>(entity);
@@ -161,7 +161,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entityId = new EntityId(op.EntityId);
                 var entity = TryGetEntityFromEntityId(entityId);
 
-                Profiler.BeginSample("ComponentWithNoFieldsWithCommands");
+                Profiler.BeginSample("ComponentWithNoFieldsWithCommands.OnAuthorityChange");
                 ApplyAuthorityChange(entity, op.Authority, entityId);
                 Profiler.EndSample();
             }
@@ -170,7 +170,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             {
                 var commandIndex = op.Request.SchemaData.Value.GetCommandIndex();
 
-                Profiler.BeginSample("ComponentWithNoFieldsWithCommands");
+                Profiler.BeginSample("ComponentWithNoFieldsWithCommands.OnCommandRequest");
                 switch (commandIndex)
                 {
                     case 1:
@@ -187,7 +187,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             {
                 var commandIndex = op.Response.CommandIndex;
 
-                Profiler.BeginSample("ComponentWithNoFieldsWithCommands");
+                Profiler.BeginSample("ComponentWithNoFieldsWithCommands.OnCommandResponse");
                 switch (commandIndex)
                 {
                     case 1:
@@ -409,7 +409,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public override void ExecuteReplication(ComponentGroup replicationGroup, ComponentSystemBase system, global::Improbable.Worker.CInterop.Connection connection)
             {
-                Profiler.BeginSample("ComponentWithNoFieldsWithCommands");
+                Profiler.BeginSample("ComponentWithNoFieldsWithCommands.ExecuteReplication");
 
                 var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
@@ -443,7 +443,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public override void SendCommands(ComponentGroup commandGroup, ComponentSystemBase system, global::Improbable.Worker.CInterop.Connection connection)
             {
-                Profiler.BeginSample("ComponentWithNoFieldsWithCommands");
+                Profiler.BeginSample("ComponentWithNoFieldsWithCommands.SendCommands");
                 var entityType = system.GetArchetypeChunkEntityType();
                 {
                     var senderType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandSenders.Cmd>(true);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsTranslation.cs
@@ -44,7 +44,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ComponentWithNoFieldsWithEvents");
+                Profiler.BeginSample("ComponentWithNoFieldsWithEvents.OnAddComponent");
                 var data = Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.MarkDataClean();
                 entityManager.AddComponentData(entity, data);
@@ -91,7 +91,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ComponentWithNoFieldsWithEvents");
+                Profiler.BeginSample("ComponentWithNoFieldsWithEvents.OnRemoveComponent");
 
                 entityManager.RemoveComponent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>(entity);
 
@@ -119,7 +119,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("ComponentWithNoFieldsWithEvents");
+                Profiler.BeginSample("ComponentWithNoFieldsWithEvents.OnComponentUpdate");
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entity))
                 {
                     var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>(entity);
@@ -188,7 +188,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entityId = new EntityId(op.EntityId);
                 var entity = TryGetEntityFromEntityId(entityId);
 
-                Profiler.BeginSample("ComponentWithNoFieldsWithEvents");
+                Profiler.BeginSample("ComponentWithNoFieldsWithEvents.OnAuthorityChange");
                 ApplyAuthorityChange(entity, op.Authority, entityId);
                 Profiler.EndSample();
             }
@@ -327,7 +327,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public override void ExecuteReplication(ComponentGroup replicationGroup, ComponentSystemBase system, global::Improbable.Worker.CInterop.Connection connection)
             {
-                Profiler.BeginSample("ComponentWithNoFieldsWithEvents");
+                Profiler.BeginSample("ComponentWithNoFieldsWithEvents.ExecuteReplication");
 
                 var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentTranslation.cs
@@ -61,7 +61,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("NonBlittableComponent");
+                Profiler.BeginSample("NonBlittableComponent.OnAddComponent");
                 var data = Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.MarkDataClean();
                 entityManager.AddComponentData(entity, data);
@@ -117,7 +117,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("NonBlittableComponent");
+                Profiler.BeginSample("NonBlittableComponent.OnRemoveComponent");
 
                 var data = entityManager.GetComponentData<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>(entity);
                 NonBlittableComponent.ReferenceTypeProviders.StringFieldProvider.Free(data.stringFieldHandle);
@@ -151,7 +151,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                Profiler.BeginSample("NonBlittableComponent");
+                Profiler.BeginSample("NonBlittableComponent.OnComponentUpdate");
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entity))
                 {
                     var data = entityManager.GetComponentData<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>(entity);
@@ -251,7 +251,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 var entityId = new EntityId(op.EntityId);
                 var entity = TryGetEntityFromEntityId(entityId);
 
-                Profiler.BeginSample("NonBlittableComponent");
+                Profiler.BeginSample("NonBlittableComponent.OnAuthorityChange");
                 ApplyAuthorityChange(entity, op.Authority, entityId);
                 Profiler.EndSample();
             }
@@ -260,7 +260,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             {
                 var commandIndex = op.Request.SchemaData.Value.GetCommandIndex();
 
-                Profiler.BeginSample("NonBlittableComponent");
+                Profiler.BeginSample("NonBlittableComponent.OnCommandRequest");
                 switch (commandIndex)
                 {
                     case 1:
@@ -280,7 +280,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             {
                 var commandIndex = op.Response.CommandIndex;
 
-                Profiler.BeginSample("NonBlittableComponent");
+                Profiler.BeginSample("NonBlittableComponent.OnCommandResponse");
                 switch (commandIndex)
                 {
                     case 1:
@@ -634,7 +634,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
             public override void ExecuteReplication(ComponentGroup replicationGroup, ComponentSystemBase system, global::Improbable.Worker.CInterop.Connection connection)
             {
-                Profiler.BeginSample("NonBlittableComponent");
+                Profiler.BeginSample("NonBlittableComponent.ExecuteReplication");
 
                 var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
@@ -700,7 +700,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
             public override void SendCommands(ComponentGroup commandGroup, ComponentSystemBase system, global::Improbable.Worker.CInterop.Connection connection)
             {
-                Profiler.BeginSample("NonBlittableComponent");
+                Profiler.BeginSample("NonBlittableComponent.SendCommands");
                 var entityType = system.GetArchetypeChunkEntityType();
                 {
                     var senderType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandSenders.FirstCommand>(true);

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -7,7 +7,7 @@
     var commandDetailsList = GetCommandDetailsList();
     var eventDetailsList = GetEventDetailsList();
     var componentNamespace = qualifiedNamespace + "." + componentDetails.ComponentName;
-    var profilingStart = $"Profiler.BeginSample(\"{componentDetails.ComponentName}\");";
+    var profilingStart = $"Profiler.BeginSample(\"{componentDetails.ComponentName}";
     var profilingEnd = "Profiler.EndSample();";
 #>
 <#= generatedHeader #>
@@ -73,7 +73,7 @@ namespace <#= qualifiedNamespace #>
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                <#= profilingStart #>
+                <#= profilingStart #>.OnAddComponent");
                 var data = <#= componentNamespace #>.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.MarkDataClean();
                 entityManager.AddComponentData(entity, data);
@@ -123,7 +123,7 @@ namespace <#= qualifiedNamespace #>
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                <#= profilingStart #>
+                <#= profilingStart #>.OnRemoveComponent");
 <# if (!componentDetails.IsBlittable) { #>
 
                 var data = entityManager.GetComponentData<<#= componentNamespace #>.Component>(entity);
@@ -160,7 +160,7 @@ namespace <#= qualifiedNamespace #>
             {
                 var entity = TryGetEntityFromEntityId(new EntityId(op.EntityId));
 
-                <#= profilingStart #>
+                <#= profilingStart #>.OnComponentUpdate");
                 if (entityManager.HasComponent<NotAuthoritative<<#= componentNamespace #>.Component>>(entity))
                 {
                     var data = entityManager.GetComponentData<<#= componentNamespace #>.Component>(entity);
@@ -233,7 +233,7 @@ namespace <#= qualifiedNamespace #>
                 var entityId = new EntityId(op.EntityId);
                 var entity = TryGetEntityFromEntityId(entityId);
 
-                <#= profilingStart #>
+                <#= profilingStart #>.OnAuthorityChange");
                 ApplyAuthorityChange(entity, op.Authority, entityId);
                 <#= profilingEnd #>
             }
@@ -243,7 +243,7 @@ namespace <#= qualifiedNamespace #>
                 var commandIndex = op.Request.SchemaData.Value.GetCommandIndex();
 <# if (commandDetailsList.Count > 0) { #>
 
-                <#= profilingStart #>
+                <#= profilingStart #>.OnCommandRequest");
                 switch (commandIndex)
                 {
 <# foreach(var commandDetails in commandDetailsList) { #>
@@ -266,7 +266,7 @@ namespace <#= qualifiedNamespace #>
                 var commandIndex = op.Response.CommandIndex;
 <# if (commandDetailsList.Count > 0) { #>
 
-                <#= profilingStart #>
+                <#= profilingStart #>.OnCommandResponse");
                 switch (commandIndex)
                 {
 <# foreach(var commandDetails in commandDetailsList) { #>
@@ -531,7 +531,7 @@ namespace <#= qualifiedNamespace #>
 
             public override void ExecuteReplication(ComponentGroup replicationGroup, ComponentSystemBase system, global::Improbable.Worker.CInterop.Connection connection)
             {
-                <#= profilingStart #>
+                <#= profilingStart #>.ExecuteReplication");
 
                 var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
@@ -593,7 +593,7 @@ namespace <#= qualifiedNamespace #>
             public override void SendCommands(ComponentGroup commandGroup, ComponentSystemBase system, global::Improbable.Worker.CInterop.Connection connection)
             {
 <# if (commandDetailsList.Count > 0) { #>
-                <#= profilingStart #>
+                <#= profilingStart #>.SendCommands");
                 var entityType = system.GetArchetypeChunkEntityType();
 <#
 for (var i = 0; i < commandDetailsList.Count; i++) {


### PR DESCRIPTION

**Contributions**: We are not currently taking public contributions - see our [contributions](https://docs.improbable.io/unity/alpha/contributing) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
This PR adds more detailed profiling markers that allow differentiating between component methods when profiling.
Older version of the PR - https://github.com/spatialos/gdk-for-unity/pull/648

#### Tests
Generate components with these changes -> Profile the project -> Ensure that different methods are displayed as separate entities

#### Documentation
Is this significant enough to go to change log?

#### Primary reviewers
