### PR TITLE
Subscriptions fixes

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntitySubscriptionManager.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntitySubscriptionManager.cs
@@ -44,7 +44,10 @@ namespace Improbable.Gdk.Subscriptions
                 workerSystem.TryGetEntity(entityId, out var entity);
                 foreach (var subscription in subscriptions)
                 {
-                    subscription.SetAvailable(entity);
+                    if (!subscription.HasValue)
+                    {
+                        subscription.SetAvailable(entity);
+                    }
                 }
             });
 
@@ -57,7 +60,10 @@ namespace Improbable.Gdk.Subscriptions
 
                 foreach (var subscription in subscriptions)
                 {
-                    subscription.SetUnavailable();
+                    if (subscription.HasValue)
+                    {
+                        subscription.SetUnavailable();
+                    }
                 }
             });
         }

--- a/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs
@@ -87,7 +87,7 @@ namespace Improbable.Gdk.Subscriptions
             value = subscribedObject;
             HasValue = true;
 
-            availabilityHandler?.OnUnavailable();
+            availabilityHandler?.OnAvailable();
 
             if (onAvailable != null)
             {

--- a/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/RequireLifecycleSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/RequireLifecycleSystem.cs
@@ -9,8 +9,7 @@ namespace Improbable.Gdk.Subscriptions
     // or the order of events should be decided by system order rather than in this system
     // would enable users changing readers more easily maybe
     [DisableAutoCreation]
-    [UpdateInGroup(typeof(SpatialOSReceiveGroup.InternalSpatialOSReceiveGroup))]
-    [UpdateAfter(typeof(SpatialOSReceiveSystem))]
+    [UpdateInGroup(typeof(SpatialOSReceiveGroup.GameObjectInitializationGroup))]
     public class RequireLifecycleSystem : ComponentSystem
     {
         private readonly List<MonoBehaviour> behavioursToEnable = new List<MonoBehaviour>();
@@ -35,6 +34,7 @@ namespace Improbable.Gdk.Subscriptions
         protected override void OnUpdate()
         {
             componentConstraintsCallbackSystem.Invoke();
+
             foreach (var behaviour in behavioursToDisable)
             {
                 if (behaviour == null)

--- a/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/RequireLifecycleSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/RequireLifecycleSystem.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using Improbable.Gdk.Core;
 using Unity.Entities;
 using UnityEngine;
 
@@ -9,7 +8,7 @@ namespace Improbable.Gdk.Subscriptions
     // or the order of events should be decided by system order rather than in this system
     // would enable users changing readers more easily maybe
     [DisableAutoCreation]
-    [UpdateInGroup(typeof(SpatialOSReceiveGroup.GameObjectInitializationGroup))]
+    [UpdateInGroup(typeof(RequireLifecycleGroup))]
     public class RequireLifecycleSystem : ComponentSystem
     {
         private readonly List<MonoBehaviour> behavioursToEnable = new List<MonoBehaviour>();

--- a/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/UpdateGroups.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/UpdateGroups.cs
@@ -1,0 +1,11 @@
+using Improbable.Gdk.Core;
+using Unity.Entities;
+
+namespace Improbable.Gdk.Subscriptions
+{
+    [UpdateInGroup(typeof(SpatialOSReceiveGroup))]
+    [UpdateAfter(typeof(SpatialOSReceiveGroup.InternalSpatialOSReceiveGroup))]
+    public class RequireLifecycleGroup
+    {
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/UpdateGroups.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/UpdateGroups.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bf132bc0b2cd5c846a8861177a003184
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/UpdateGroups.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/UpdateGroups.cs
@@ -10,18 +10,6 @@ namespace Improbable.Gdk.Core
         public class InternalSpatialOSReceiveGroup
         {
         }
-
-        [UpdateInGroup(typeof(SpatialOSReceiveGroup))]
-        [UpdateAfter(typeof(InternalSpatialOSReceiveGroup))]
-        public class GameObjectInitializationGroup
-        {
-        }
-
-        [UpdateInGroup(typeof(SpatialOSReceiveGroup))]
-        [UpdateAfter(typeof(GameObjectInitializationGroup))]
-        public class GameObjectReceiveGroup
-        {
-        }
     }
 
     [UpdateAfter(typeof(PostLateUpdate))]

--- a/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectInitializationSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectInitializationSystem.cs
@@ -14,6 +14,7 @@ namespace Improbable.Gdk.GameObjectCreation
     /// </summary>
     [DisableAutoCreation]
     [UpdateInGroup(typeof(SpatialOSReceiveGroup.GameObjectInitializationGroup))]
+    [UpdateBefore(typeof(RequireLifecycleSystem))]
     internal class GameObjectInitializationSystem : ComponentSystem
     {
         private struct InitializedEntitySystemState : ISystemStateComponentData

--- a/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectInitializationSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectInitializationSystem.cs
@@ -13,8 +13,7 @@ namespace Improbable.Gdk.GameObjectCreation
     ///     IEntityGameObjectCreator for cleanup.
     /// </summary>
     [DisableAutoCreation]
-    [UpdateInGroup(typeof(SpatialOSReceiveGroup.GameObjectInitializationGroup))]
-    [UpdateBefore(typeof(RequireLifecycleSystem))]
+    [UpdateInGroup(typeof(GameObjectInitializationGroup))]
     internal class GameObjectInitializationSystem : ComponentSystem
     {
         private struct InitializedEntitySystemState : ISystemStateComponentData

--- a/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/UpdateGroups.cs
+++ b/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/UpdateGroups.cs
@@ -1,0 +1,12 @@
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Subscriptions;
+using Unity.Entities;
+
+namespace Improbable.Gdk.GameObjectCreation
+{
+    [UpdateInGroup(typeof(SpatialOSReceiveGroup))]
+    [UpdateAfter(typeof(RequireLifecycleGroup))]
+    public class GameObjectInitializationGroup
+    {
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/UpdateGroups.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/UpdateGroups.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4f9e157120c901e47adfda0cecc537b8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityCommandSenderReceiverGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityCommandSenderReceiverGenerator.tt
@@ -52,7 +52,10 @@ namespace <#= qualifiedNamespace #>
                 workerSystem.TryGetEntity(entityId, out var entity);
                 foreach (var subscription in subscriptions)
                 {
-                    subscription.SetAvailable(new <#= componentDetails.ComponentName #>CommandSender(entity, world));
+                    if (!subscription.HasValue)
+                    {
+                        subscription.SetAvailable(new <#= componentDetails.ComponentName #>CommandSender(entity, world));
+                    }
                 }
             });
 
@@ -65,8 +68,11 @@ namespace <#= qualifiedNamespace #>
 
                 foreach (var subscription in subscriptions)
                 {
-                    ResetValue(subscription);
-                    subscription.SetUnavailable();
+                    if (subscription.HasValue)
+                    {
+                        ResetValue(subscription);
+                        subscription.SetUnavailable();
+                    }
                 }
             });
         }


### PR DESCRIPTION
#### Description
Fixed a typo causing subscriptions to incorrectly register themselves as unavailable with subscription aggregates and not as available.

Fixed an issue with some subscriptions being set twice.

Fixed an issue with gameobjects being created later in the frame than the system enabling them.

