### PR TITLE
Adding script for distributable iOS builds

### DIFF
--- a/ci/bootstrap.sh
+++ b/ci/bootstrap.sh
@@ -13,6 +13,3 @@ if [ -d "${SHARED_CI_DIR}" ]; then
 fi
 
 git clone "${CLONE_URL}" "${SHARED_CI_DIR}"
-pushd $SHARED_CI_DIR
-  git checkout ios-ci-build
-popd

--- a/ci/bootstrap.sh
+++ b/ci/bootstrap.sh
@@ -13,3 +13,6 @@ if [ -d "${SHARED_CI_DIR}" ]; then
 fi
 
 git clone "${CLONE_URL}" "${SHARED_CI_DIR}"
+pushd $SHARED_CI_DIR
+  git checkout ios-ci-build
+popd

--- a/ci/build-ios.sh
+++ b/ci/build-ios.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e -u -o -x pipefail
+
+cd "$(dirname "$0")/../"
+
+# Get shared CI and prepare Unity
+ci/bootstrap.sh
+.shared-ci/scripts/prepare-unity.sh
+
+source ".shared-ci/scripts/pinned-tools.sh"
+
+if ! isMacOS; then
+    echo "iOS can only be built on macOS"
+    exit 0
+fi
+
+.shared-ci/scripts/build.sh "workers/unity" iOSClient local "$(pwd)/logs/iOSClientBuild.log"
+
+cp -R .shared-ci/fastlane workers/unity/build/worker/iOSClient@iOS/iOSClient@iOS
+pushd workers/unity/build/worker/iOSClient@iOS/iOSClient@iOS
+    fastlane dev
+popd

--- a/ci/build-ios.sh
+++ b/ci/build-ios.sh
@@ -12,7 +12,7 @@ source ".shared-ci/scripts/pinned-tools.sh"
 
 if ! isMacOS; then
     echo "iOS can only be built on macOS"
-    exit 0
+    exit 1
 fi
 
 .shared-ci/scripts/build.sh "workers/unity" iOSClient local "$(pwd)/logs/iOSClientBuild.log"

--- a/ci/build-ios.sh
+++ b/ci/build-ios.sh
@@ -15,7 +15,7 @@ if ! isMacOS; then
     exit 1
 fi
 
-.shared-ci/scripts/build.sh "workers/unity" iOSClient local "$(pwd)/logs/iOSClientBuild.log"
+.shared-ci/scripts/build.sh "workers/unity" iOSClient local il2cpp "$(pwd)/logs/iOSClientBuild.log"
 
 cp -R .shared-ci/fastlane workers/unity/build/worker/iOSClient@iOS/iOSClient@iOS
 pushd workers/unity/build/worker/iOSClient@iOS/iOSClient@iOS

--- a/workers/unity/ProjectSettings/ProjectSettings.asset
+++ b/workers/unity/ProjectSettings/ProjectSettings.asset
@@ -172,7 +172,7 @@ PlayerSettings:
   keepLoadedShadersAlive: 0
   StripUnusedMeshComponents: 1
   VertexChannelCompressionMask: 4054
-  iPhoneSdkVersion: 989
+  iPhoneSdkVersion: 988
   iOSTargetOSVersionString: 10.0
   tvOSSdkVersion: 0
   tvOSRequireExtendedGameController: 0


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](https://docs.improbable.io/unity/alpha/contributing) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
This PR adds script that builds iOS XCode project, copies needed fastlane files and triggers fastlane distributable iOS build

linked to: https://github.com/spatialos/gdk-for-unity-shared-ci/pull/11

#### Tests
Run the script locally -> ensure distributable .ipa build is created
Next step is to verify this on CI

#### Documentation

#### Primary reviewers

