### PR TITLE
UTY-1503: Pull across parts of the old CodeGeneration library.

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/FileHandling/FileSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/FileHandling/FileSystem.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -25,26 +26,12 @@ namespace Improbable.Gdk.CodeGeneration.FileHandling
 
         public void WriteToFile(string path, string content)
         {
-            using (var fileStream = new FileStream(path, FileMode.Create, FileAccess.Write))
-            {
-                // Do not generate BOM at the start of the file
-                var encoding = new UTF8Encoding(false);
-                using (var streamWriter = new StreamWriter(fileStream, encoding))
-                {
-                    streamWriter.Write(content);
-                }
-            }
+            File.WriteAllText(path, content);
         }
 
         public string ReadFromFile(string path)
         {
-            using (var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read))
-            {
-                using (var streamReader = new StreamReader(fileStream, Encoding.UTF8))
-                {
-                    return streamReader.ReadToEnd();
-                }
-            }
+            return File.ReadAllText(path);
         }
 
         public IFile GetFileInfo(string path)
@@ -71,13 +58,15 @@ namespace Improbable.Gdk.CodeGeneration.FileHandling
 
         public void DeleteDirectory(string path)
         {
-            if (!string.IsNullOrEmpty(path))
+            if (string.IsNullOrEmpty(path))
             {
-                var directoryInfo = new DirectoryInfo(path);
-                if (directoryInfo.Exists)
-                {
-                    directoryInfo.Delete(true);
-                }
+                throw new ArgumentException("Argument 'path' cannot be null or empty.");
+            }
+
+            var directoryInfo = new DirectoryInfo(path);
+            if (directoryInfo.Exists)
+            {
+                directoryInfo.Delete(true);
             }
         }
     }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/FileHandling/FileSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/FileHandling/FileSystem.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Improbable.Gdk.CodeGeneration.FileHandling
+{
+    public class FileSystem : IFileSystem
+    {
+        public List<IFile> GetFilesInDirectory(string path, string searchPattern, bool recursive)
+        {
+            var directoryInfo = new DirectoryInfo(path);
+            if (directoryInfo.Exists)
+            {
+                var fileInfoList = directoryInfo.GetFiles(searchPattern,
+                    recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
+                var fileList = fileInfoList.Select(fileInfo =>
+                        new FileWrapper(fileInfo.FullName, fileInfo.DirectoryName, fileInfo.LastWriteTime)).ToList()
+                    .Cast<IFile>();
+                return fileList.ToList();
+            }
+
+            return new List<IFile>();
+        }
+
+        public void WriteToFile(string path, string content)
+        {
+            using (var fileStream = new FileStream(path, FileMode.Create, FileAccess.Write))
+            {
+                // Do not generate BOM at the start of the file
+                var encoding = new UTF8Encoding(false);
+                using (var streamWriter = new StreamWriter(fileStream, encoding))
+                {
+                    streamWriter.Write(content);
+                }
+            }
+        }
+
+        public string ReadFromFile(string path)
+        {
+            using (var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read))
+            {
+                using (var streamReader = new StreamReader(fileStream, Encoding.UTF8))
+                {
+                    return streamReader.ReadToEnd();
+                }
+            }
+        }
+
+        public IFile GetFileInfo(string path)
+        {
+            var fileInfo = new FileInfo(path);
+
+            return new FileWrapper(fileInfo.FullName, fileInfo.DirectoryName, fileInfo.LastWriteTime);
+        }
+
+        public bool DirectoryExists(string path)
+        {
+            var directoryInfo = new DirectoryInfo(path);
+            return directoryInfo.Exists;
+        }
+
+        public void CreateDirectory(string path)
+        {
+            var directoryInfo = new DirectoryInfo(path);
+            if (!directoryInfo.Exists)
+            {
+                directoryInfo.Create();
+            }
+        }
+
+        public void DeleteDirectory(string path)
+        {
+            if (!string.IsNullOrEmpty(path))
+            {
+                var directoryInfo = new DirectoryInfo(path);
+                if (directoryInfo.Exists)
+                {
+                    directoryInfo.Delete(true);
+                }
+            }
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/FileHandling/FileWrapper.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/FileHandling/FileWrapper.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+
+namespace Improbable.Gdk.CodeGeneration.FileHandling
+{
+    public class FileWrapper : IFile
+    {
+        public FileWrapper(string completePath, string directoryPath, DateTime lastWriteTimeStamp)
+        {
+            CompletePath = completePath;
+            LastWriteTime = lastWriteTimeStamp;
+            DirectoryPath = directoryPath;
+        }
+
+        public DateTime LastWriteTime { get; private set; }
+        public string CompletePath { get; private set; }
+
+        public string DirectoryPath { get; private set; }
+
+        public bool Exists()
+        {
+            var fileInfo = new FileInfo(CompletePath);
+            return fileInfo.Exists;
+        }
+
+        public void Delete()
+        {
+            var fileInfo = new FileInfo(CompletePath);
+            if (fileInfo.Exists)
+            {
+                fileInfo.Delete();
+            }
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/FileHandling/IFile.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/FileHandling/IFile.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Improbable.Gdk.CodeGeneration.FileHandling
+{
+    public interface IFile
+    {
+        DateTime LastWriteTime { get; }
+        string CompletePath { get; }
+        string DirectoryPath { get; }
+
+        bool Exists();
+        void Delete();
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/FileHandling/IFileSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/FileHandling/IFileSystem.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace Improbable.Gdk.CodeGeneration.FileHandling
+{
+    public interface IFileSystem
+    {
+        List<IFile> GetFilesInDirectory(string path, string searchPattern = "*.*", bool recursive = true);
+        void WriteToFile(string path, string content);
+        string ReadFromFile(string path);
+
+        IFile GetFileInfo(string path);
+
+        bool DirectoryExists(string path);
+        void CreateDirectory(string path);
+        void DeleteDirectory(string path);
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Jobs/CodegenJob.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Jobs/CodegenJob.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Improbable.Gdk.CodeGeneration.FileHandling;
+
+namespace Improbable.Gdk.CodeGeneration.Jobs
+{
+    public abstract class CodegenJob
+    {
+        public List<string> InputFiles { get; protected set; }
+        public List<string> OutputFiles { get; protected set; }
+        public string OutputDirectory { get; private set; }
+
+        protected Dictionary<string, string> Content { get; set; }
+
+        private IFileSystem fileSystem;
+
+        public CodegenJob(string outputDirectory, IFileSystem fileSystem)
+        {
+            OutputDirectory = outputDirectory;
+            this.fileSystem = fileSystem;
+
+            Content = new Dictionary<string, string>();
+        }
+
+        public void Clean()
+        {
+            foreach (var entry in OutputFiles)
+            {
+                var path = Path.Combine(OutputDirectory, entry);
+                var fileInfo = fileSystem.GetFileInfo(path);
+
+                if (fileInfo.Exists())
+                {
+                    fileInfo.Delete();
+                }
+
+                var remainingFilesInFolder = fileSystem.GetFilesInDirectory(fileInfo.DirectoryPath);
+                if (remainingFilesInFolder.Count == 0)
+                {
+                    fileSystem.DeleteDirectory(fileInfo.DirectoryPath);
+                }
+            }
+        }
+
+        public void Run()
+        {
+            RunImpl();
+
+            foreach (var entry in Content)
+            {
+                var fileInfo = fileSystem.GetFileInfo(Path.Combine(OutputDirectory, entry.Key));
+
+                if (!fileSystem.DirectoryExists(fileInfo.DirectoryPath))
+                {
+                    fileSystem.CreateDirectory(fileInfo.DirectoryPath);
+                }
+
+                fileSystem.WriteToFile(fileInfo.CompletePath, entry.Value);
+            }
+        }
+
+        public bool IsDirty()
+        {
+            if (isDirtyOverride)
+            {
+                return true;
+            }
+
+            var schemaFiles = InputFiles.Select(entry => fileSystem.GetFileInfo(entry)).ToList();
+            var existingFiles = OutputFiles.Select(entry => fileSystem.GetFileInfo(Path.Combine(OutputDirectory, entry))).ToList();
+
+            if (schemaFiles.Count == 0 || existingFiles.Count == 0)
+            {
+                return true;
+            }
+
+            //Ensure that all expected output files exist
+            foreach (var file in existingFiles)
+            {
+                if (!file.Exists())
+                {
+                    return true;
+                }
+            }
+
+            var sortedSchemaFileInfo = schemaFiles.OrderByDescending(item => item.LastWriteTime).ToList();
+            var sortedExistingFiles = existingFiles.OrderByDescending(item => item.LastWriteTime).ToList();
+
+            return sortedSchemaFileInfo.First().LastWriteTime > sortedExistingFiles.First().LastWriteTime;
+        }
+
+        public void MarkAsDirty()
+        {
+            isDirtyOverride = true;
+        }
+
+        protected abstract void RunImpl();
+        private bool isDirtyOverride;
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Jobs/JobRunner.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Jobs/JobRunner.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Improbable.Gdk.CodeGeneration.FileHandling;
+
+namespace Improbable.Gdk.CodeGeneration.Jobs
+{
+    public class JobRunner
+    {
+        private IFileSystem fileSystem;
+
+        public JobRunner(IFileSystem fileSystem)
+        {
+            this.fileSystem = fileSystem;
+        }
+
+        public void Run(params CodegenJob[] jobs)
+        {
+            PrepareOutputFolders(jobs);
+            RunJobs(jobs);
+        }
+
+        private void PrepareOutputFolders(CodegenJob[] jobs)
+        {
+            var outputDirectories = jobs.Select(job => job.OutputDirectory).Distinct();
+
+            foreach (var outputDirectory in outputDirectories)
+            {
+                var relatedJobs = jobs.Where(job => job.OutputDirectory == outputDirectory);
+
+                if (IsOutputDirectoryDirty(relatedJobs, outputDirectory))
+                {
+                    fileSystem.DeleteDirectory(outputDirectory);
+                    foreach (var job in relatedJobs)
+                    {
+                        job.MarkAsDirty();
+                    }
+                }
+            }
+        }
+
+        private bool IsOutputDirectoryDirty(IEnumerable<CodegenJob> jobs, string outputDir)
+        {
+            var outputFolderFiles = fileSystem.GetFilesInDirectory(outputDir)
+                .Select(file => Path.GetFullPath(file.CompletePath)).ToList();
+
+            var expectedFiles = jobs.SelectMany(job => job.OutputFiles)
+                .Select(path => Path.GetFullPath(Path.Combine(outputDir, path))).ToList();
+
+            return outputFolderFiles.Intersect(expectedFiles).Count() == outputFolderFiles.Count;
+        }
+
+        private void RunJobs(CodegenJob[] jobs)
+        {
+            var dirtyJobs = jobs.Where(job => job.IsDirty()).ToList();
+
+            foreach (var job in dirtyJobs)
+            {
+                job.Run();
+            }
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/BuiltInSchemaTypes.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/BuiltInSchemaTypes.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+
+namespace CodeGeneration.Model
+{
+    public class BuiltInSchemaTypes
+    {
+        public const string BuiltInDouble = "double";
+        public const string BuiltInFloat = "float";
+        public const string BuiltInInt32 = "int32";
+        public const string BuiltInInt64 = "int64";
+        public const string BuiltInUint32 = "uint32";
+        public const string BuiltInUint64 = "uint64";
+        public const string BuiltInSint32 = "sint32";
+        public const string BuiltInSint64 = "sint64";
+        public const string BuiltInFixed32 = "fixed32";
+        public const string BuiltInFixed64 = "fixed64";
+        public const string BuiltInSfixed32 = "sfixed32";
+        public const string BuiltInSfixed64 = "sfixed64";
+        public const string BuiltInBool = "bool";
+        public const string BuiltInString = "string";
+        public const string BuiltInBytes = "bytes";
+        public const string BuiltInEntityId = "EntityId";
+
+        public static HashSet<string> BuiltInTypes = new HashSet<string>
+        {
+            BuiltInDouble,
+            BuiltInFloat,
+            BuiltInInt32,
+            BuiltInInt64,
+            BuiltInUint32,
+            BuiltInUint64,
+            BuiltInSint32,
+            BuiltInSint64,
+            BuiltInFixed32,
+            BuiltInFixed64,
+            BuiltInSfixed32,
+            BuiltInSfixed64,
+            BuiltInBool,
+            BuiltInString,
+            BuiltInBytes,
+            BuiltInEntityId
+        };
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/BuiltInSchemaTypes.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/BuiltInSchemaTypes.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace CodeGeneration.Model
+namespace Improbable.Gdk.CodeGeneration.Model
 {
     public class BuiltInSchemaTypes
     {

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Tests/Model/SchemaBundleV1/JsonParsingTests.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Tests/Model/SchemaBundleV1/JsonParsingTests.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 using Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1;
 using NUnit.Framework;
 
-namespace CodeGeneration.Tests.Model.SchemaBundleV1
+namespace Improbable.Gdk.CodeGeneration.Tests.Model.SchemaBundleV1
 {
     [TestFixture]
     public class JsonParsingTests

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/CodeGenerator.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/CodeGenerator.cs
@@ -58,17 +58,17 @@ namespace Improbable.Gdk.CodeGenerator
             }
 
             GenerateNativeTypesAndAst();
-            return 0;
+
             var schemaFilesRaw = SchemaFiles.GetSchemaFilesRaw(options.JsonDirectory, fileSystem).ToList();
             var schemaProcessor = new UnitySchemaProcessor(schemaFilesRaw);
             var globalEnumSet = ExtractEnums(schemaProcessor.ProcessedSchemaFiles);
-
+            
             var workerGenerationJob = new WorkerGenerationJob(options.NativeOutputDirectory, options, fileSystem);
             var aggegrateJob = new AggregateJob(fileSystem, options, schemaProcessor, globalEnumSet);
-
+            
             var runner = new JobRunner(fileSystem);
-
-            runner.Run(new List<ICodegenJob> { aggegrateJob, workerGenerationJob },
+            
+            runner.Run(new List<ICodegenJob> { aggegrateJob, workerGenerationJob }, 
                 new[] { options.NativeOutputDirectory });
             return 0;
         }
@@ -83,7 +83,7 @@ namespace Improbable.Gdk.CodeGenerator
 
             var arguments = new[]
             {
-                $@"--bundle_json_out={options.JsonDirectory}/bundle.json"
+                $@"--ast_json_out={options.JsonDirectory}"
             }.Union(inputPaths).Union(files).ToList();
 
             SystemTools.RunRedirected(options.SchemaCompilerPath, arguments);

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/CodeGenerator.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/CodeGenerator.cs
@@ -58,17 +58,17 @@ namespace Improbable.Gdk.CodeGenerator
             }
 
             GenerateNativeTypesAndAst();
-
+            return 0;
             var schemaFilesRaw = SchemaFiles.GetSchemaFilesRaw(options.JsonDirectory, fileSystem).ToList();
             var schemaProcessor = new UnitySchemaProcessor(schemaFilesRaw);
             var globalEnumSet = ExtractEnums(schemaProcessor.ProcessedSchemaFiles);
-            
+
             var workerGenerationJob = new WorkerGenerationJob(options.NativeOutputDirectory, options, fileSystem);
             var aggegrateJob = new AggregateJob(fileSystem, options, schemaProcessor, globalEnumSet);
-            
+
             var runner = new JobRunner(fileSystem);
-            
-            runner.Run(new List<ICodegenJob> { aggegrateJob, workerGenerationJob }, 
+
+            runner.Run(new List<ICodegenJob> { aggegrateJob, workerGenerationJob },
                 new[] { options.NativeOutputDirectory });
             return 0;
         }
@@ -83,7 +83,7 @@ namespace Improbable.Gdk.CodeGenerator
 
             var arguments = new[]
             {
-                $@"--ast_json_out={options.JsonDirectory}"
+                $@"--bundle_json_out={options.JsonDirectory}/bundle.json"
             }.Union(inputPaths).Union(files).ToList();
 
             SystemTools.RunRedirected(options.SchemaCompilerPath, arguments);


### PR DESCRIPTION
#### Description
We previously were relying on the DLL for JSON parsing for code generation from the SDK. With the move to schema bundles, this is no longer the case. This PR pulls across the `FileHandling`, `Jobs` and `BuiltInSchemaTypes` files and does a bit of touching up on them. 

#### Tests
It builds.  The real tests come later.

#### Documentation
N/A. All internal for now.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@zeroZshadow @jessicafalk 
