### PR TITLE
Add cmd option to choose il2cpp/mono in build tests

### DIFF
--- a/ci/bootstrap.sh
+++ b/ci/bootstrap.sh
@@ -13,6 +13,3 @@ if [ -d "${SHARED_CI_DIR}" ]; then
 fi
 
 git clone "${CLONE_URL}" "${SHARED_CI_DIR}"
-pushd "${SHARED_CI_DIR}"
-	git checkout feature/scripting-backend
-popd

--- a/ci/bootstrap.sh
+++ b/ci/bootstrap.sh
@@ -13,3 +13,6 @@ if [ -d "${SHARED_CI_DIR}" ]; then
 fi
 
 git clone "${CLONE_URL}" "${SHARED_CI_DIR}"
+pushd "${SHARED_CI_DIR}"
+	git checkout feature/scripting-backend
+popd

--- a/ci/build-test.sh
+++ b/ci/build-test.sh
@@ -12,10 +12,11 @@ ci/bootstrap.sh
 source ".shared-ci/scripts/pinned-tools.sh"
 
 ci/test.sh
-.shared-ci/scripts/build.sh "workers/unity" UnityClient local "$(pwd)/logs/UnityClientBuild.log"
-.shared-ci/scripts/build.sh "workers/unity" UnityGameLogic cloud "$(pwd)/logs/UnityGameLogicBuild.log"
-.shared-ci/scripts/build.sh "workers/unity" AndroidClient local "$(pwd)/logs/AndroidClientBuild.log"
+.shared-ci/scripts/build.sh "workers/unity" UnityClient local il2cpp "$(pwd)/logs/UnityClientBuild-il2cpp.log"
+.shared-ci/scripts/build.sh "workers/unity" UnityClient local mono "$(pwd)/logs/UnityClientBuild-mono.log"
+.shared-ci/scripts/build.sh "workers/unity" UnityGameLogic cloud mono "$(pwd)/logs/UnityGameLogicBuild.log"
+.shared-ci/scripts/build.sh "workers/unity" AndroidClient local mono "$(pwd)/logs/AndroidClientBuild.log"
 
 if isMacOS; then
-  .shared-ci/scripts/build.sh "workers/unity" iOSClient local "$(pwd)/logs/iOSClientBuild.log"
+  .shared-ci/scripts/build.sh "workers/unity" iOSClient local il2cpp "$(pwd)/logs/iOSClientBuild.log"
 fi

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
@@ -138,13 +138,16 @@ namespace Improbable.Gdk.BuildSystem
                         Debug.Log($"Setting scripting backend to {scriptingBackend.Value}");
                         PlayerSettings.SetScriptingBackend(buildTargetGroup, scriptingBackend.Value);
                     }
-                    
+
                     BuildWorkerForTarget(workerType, unityBuildTarget, buildOptions, targetEnvironment);
                 }
                 catch (Exception e)
                 {
-                    PlayerSettings.SetScriptingBackend(buildTargetGroup, activeScriptingBackend);
                     throw new BuildFailedException(e);
+                }
+                finally
+                {
+                    PlayerSettings.SetScriptingBackend(buildTargetGroup, activeScriptingBackend);
                 }
 
             }

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
@@ -65,11 +65,25 @@ namespace Improbable.Gdk.BuildSystem
                     }
                 }
 
+                ScriptingImplementation scriptingBackend;
+                var wantedScriptingBackend = CommandLineUtility.GetCommandLineValue(commandLine, "scriptingBackend", "mono");
+                switch (wantedScriptingBackend)
+                {
+                    case "mono":
+                        scriptingBackend = ScriptingImplementation.Mono2x;
+                        break;
+                    case "il2cpp":
+                        scriptingBackend = ScriptingImplementation.IL2CPP;
+                        break;
+                    default:
+                        throw new BuildFailedException("Unknown scripting backend value: " + wantedScriptingBackend);
+                }
+
                 LocalLaunch.BuildConfig();
 
                 foreach (var wantedWorkerType in wantedWorkerTypes)
                 {
-                    BuildWorkerForEnvironment(wantedWorkerType, buildEnvironment);
+                    BuildWorkerForEnvironment(wantedWorkerType, buildEnvironment, scriptingBackend);
                 }
             }
             catch (Exception e)
@@ -95,7 +109,7 @@ namespace Improbable.Gdk.BuildSystem
             return GetUnityBuildTargets(environmentConfig.BuildPlatforms);
         }
 
-        public static void BuildWorkerForEnvironment(string workerType, BuildEnvironment targetEnvironment)
+        public static void BuildWorkerForEnvironment(string workerType, BuildEnvironment targetEnvironment, ScriptingImplementation? scriptingBackend = null)
         {
             var spatialOSBuildConfiguration = SpatialOSBuildConfiguration.GetInstance();
             var environmentConfig = spatialOSBuildConfiguration.GetEnvironmentConfigForWorker(workerType, targetEnvironment);
@@ -115,7 +129,24 @@ namespace Improbable.Gdk.BuildSystem
 
             foreach (var unityBuildTarget in GetUnityBuildTargets(buildPlatforms))
             {
-                BuildWorkerForTarget(workerType, unityBuildTarget, buildOptions, targetEnvironment);
+                var buildTargetGroup = BuildPipeline.GetBuildTargetGroup(unityBuildTarget);
+                var activeScriptingBackend = PlayerSettings.GetScriptingBackend(buildTargetGroup);
+                try
+                {
+                    if (scriptingBackend != null)
+                    {
+                        Debug.Log($"Setting scripting backend to {scriptingBackend.Value}");
+                        PlayerSettings.SetScriptingBackend(buildTargetGroup, scriptingBackend.Value);
+                    }
+                    
+                    BuildWorkerForTarget(workerType, unityBuildTarget, buildOptions, targetEnvironment);
+                }
+                catch (Exception e)
+                {
+                    PlayerSettings.SetScriptingBackend(buildTargetGroup, activeScriptingBackend);
+                    throw new BuildFailedException(e);
+                }
+
             }
         }
 
@@ -188,8 +219,7 @@ namespace Improbable.Gdk.BuildSystem
         private static void BuildWorkerForTarget(string workerType, BuildTarget buildTarget,
             BuildOptions buildOptions, BuildEnvironment targetEnvironment)
         {
-            Debug.LogFormat("Building \"{0}\" for worker platform: \"{1}\", environment: \"{2}\"", buildTarget,
-                workerType, targetEnvironment);
+            Debug.Log($"Building \"{buildTarget}\" for worker platform: \"{workerType}\", environment: \"{targetEnvironment}\"");
 
             var spatialOSBuildConfiguration = SpatialOSBuildConfiguration.GetInstance();
             var workerBuildData = new WorkerBuildData(workerType, buildTarget);


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](https://docs.improbable.io/unity/alpha/contributing) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Added an optional parameter to enable switching the scripting backend to either il2cpp or mono. This is only exposed when building via cmd. When running it via the menu items in the editor the one that is active in the player settings will be chosen.

#### Tests
ran it locally. next step is to test it in ci. 

#### Documentation
no documentation needed

#### Primary reviewers
@firtina-improbable @paulbalaji 
