### PR TITLE
Slight rejig of zip instructions

### DIFF
--- a/docs/content/get-started/get-started.md
+++ b/docs/content/get-started/get-started.md
@@ -1,11 +1,10 @@
 # Get started: Introduction
 
-Get started with SpatialOS for Unity by launching a cloud deployment of our FPS Starter project. This will introduce you to the workflows and tooling you’ll use with SpatialOS and Unity, allowing you to run your game at scale with up to 200 simulated player-clients running in the cloud.
+Get started with SpatialOS for Unity by launching a cloud deployment of our FPS Starter Project. This introduces you to the workflows and tooling you use with SpatialOS and Unity, allowing you to run your game at scale, with up to 200 simulated player-clients running in the cloud.
 
-Once you’ve done this, you’ll then be ready to learn how to build your own features. Our tutorial for adding Health Pickups functionality will introduce you to this development experience.
+Once you’ve done this, you are then ready to learn how to build your own features. Our tutorial for adding Health Pickups functionality introduces you to this development experience.
 
-<%(Callout type="alert" message="
-Please note that basic proficiency of [programming in Unity](https://unity3d.com/programming-in-unity), version control systems (such as [Git](https://try.github.io/)), and [command line interfaces](https://tutorial.djangogirls.org/en/intro_to_command_line/) is required to use the SpatialOS GDK for Unity.")%>
+> Note that you need basic proficiency in [programming in Unity (Unity documentation)](https://unity3d.com/programming-in-unity), version control systems (such as [Git (github.io)](https://try.github.io/)), and [command line interfaces (djangogirls.org)](https://tutorial.djangogirls.org/en/intro_to_command_line/) to use the SpatialOS GDK for Unity.
 
 #### Next: [Set up]({{urlRoot}}/content/get-started/set-up.md)
 <br/>

--- a/docs/content/get-started/set-up.md
+++ b/docs/content/get-started/set-up.md
@@ -10,7 +10,7 @@ There are three parts to this step:
 <br/>
 ## Sign up for a SpatialOS account, or make sure you are logged in
 
-If you have already signed up, make sure you are logged in (you should see your picture in the top right of the page if you are, if not - hit "Sign In".)
+If you have already signed up, make sure you are logged in. If you are logged in, you should see your picture in the top right of this page; if you are not logged in, select __Sign in__ and follow the instructions.)
 
 If you have not signed up before, you can do this [here](https://improbable.io/get-spatialos).
 <br/>
@@ -124,13 +124,15 @@ Once you have installed [Rider](https://www.jetbrains.com/rider/), install the [
 
 <%(/Expandable)%>
 
-<%(Callout type="alert" message="
+
+#### Make sure you have chosen the right build support
 * You need **Linux** build support. This is because server-workers in a cloud deployment run in a Linux environment. In the `Assets/Fps/Config/BuildConfiguration`, do not change the `UnityGameLogic Cloud Environment` from Linux.<br/>
 * You need **Mac** build support if you are developing on a Windows PC and want to share your game with Mac users.<br/>
 * You need **Windows** build support if you are developing on a Mac and want to share your game with Windows PC users. <br/>
-* Unity gives you build support for your development machine (Windows or Mac) by default.")%>
+* Unity gives you build support for your development machine (Windows or Mac) by default.
 
 
+#### Need some help?
 If you need help using the GDK, come and talk to us about the software and the documentation via:
 
 * **The SpatialOS forums** - Visit the [support section](https://forums.improbable.io/new-topic?category=Support&tags=unity-gdk) in our forums and use the unity-gdk tag.
@@ -140,38 +142,39 @@ If you need help using the GDK, come and talk to us about the software and the d
 <br/>
 
 
-## Get the GDK and Starter Project Source Code
+## Get the GDK and the FPS Starter Project source code
+To run the GDK and the FPS Starter project, you need to download the source code. There are two ways you can do this: _either_ get both sets of source code as one zip file download _or_ clone the two repositories separately using Git (see [Git (github.io)](https://try.github.io/ for further informatio on Git)).
 
-### Zip Download
+**NOTE:** We recommend using Git, as Git's version control makes it easier for you to get updates in the future.
 
-<%(Callout type="alert" message="
-If you can, please use Git to get the GDK and its starter project, as version control will make it easier for you to get updates in the future.")%>
+### Zip file download
 
-If you are unfamiliar with Git, you can download a Zip file of the GDK and its Starter Project <a href="https://github.com/spatialos/gdk-for-unity-fps-starter-project/releases/tag/0.1.3" data-track-link="Starter Project Zip Clicked|product=Docs|platform=Mac|label=Mac" target="_blank">here</a>. 
+While we recommend using Git, if you prefer to, you can get the source code for both the GDK and FPS Starter Project by downloading one zip file <a href="https://github.com/spatialos/gdk-for-unity-fps-starter-project/releases/tag/0.1.3" data-track-link="Starter Project Zip Clicked|product=Docs|platform=Mac|label=Mac" target="_blank">here</a>. 
 
-**If you have downloaded it and unzipped it, skip the rest of this page and move on to [Open the FPS Starter Project]({{urlRoot}}/content/get-started/open-project.md).**
+**NOTE:**
+If you have downloaded the source code via a zip file, skip the rest of this page and move on to the next step: [Open the FPS Starter Project]({{urlRoot}}/content/get-started/open-project.md).
 
-### Cloning the Repos using Git
+### Clone the two repositories using Git
 
-If you haven't downloaded the zip, you need to clone two repositories; the FPS Starter Project and the GDK for Unity.
+If you haven't downloaded the zip file, you need to clone two repositories; the FPS Starter Project and the GDK for Unity.
 
-#### Clone the FPS Starter Project repository
+#### 1. Clone the FPS Starter Project repository
 
-Clone the FPS starter project using one of the following commands:
+Clone the FPS Starter Project using one of the following commands:
 
 |     |     |
 | --- | --- |
 | HTTPS | `git clone https://github.com/spatialos/gdk-for-unity-fps-starter-project.git` |
 | SSH | `git clone git@github.com:spatialos/gdk-for-unity-fps-starter-project.git` |
 
-<%(Callout type="warning" message="
-You can only clone via SSH if you have already [set up SSH keys](https://help.github.com/articles/connecting-to-github-with-ssh/) with your GitHub account.")%>
+**NOTE:**
+You can only clone via SSH if you have already [set up SSH keys (GitHub help)](https://help.github.com/articles/connecting-to-github-with-ssh/) with your GitHub account.
 
 Then navigate to the root folder of the FPS starter project and run the following command: `git checkout 0.1.3`
 
 This ensures that you are on the alpha release version of the FPS starter project.
 
-#### Clone the GDK for Unity and checkout the latest release
+#### 2. Clone the GDK for Unity repository and checkout the latest release
 
 You can use scripts to automatically do this or follow manual instructions.
 
@@ -181,7 +184,7 @@ From the root of the `gdk-for-unity-fps-starter-project` repository:
     * If you are using Mac run: `bash scripts/shell/setup.sh`
 * To follow manual instructions, see below:
 
-<%(#Expandable title="Manually clone the GDK")%>
+<%(#Expandable title="Manually clone the GDK for Unity")%>
 
 1. Clone the [GDK for Unity](https://github.com/spatialos/gdk-for-unity) repository alongside the FPS Starter Project so that they sit side-by-side:
 

--- a/docs/content/get-started/set-up.md
+++ b/docs/content/get-started/set-up.md
@@ -1,9 +1,9 @@
 # Get started: 1 - Set up
 There are three parts to this step: 
 
-* Sign up for a SpatialOS account
+* Sign up for a SpatialOS account (or make sure you are logged in)
 * Set up your machine
-* Clone the repos 
+* Get the GDK and the FPS Starter Project source code
 
 (This step is the longest of the 6 steps - the others are much quicker.)
 <br/>
@@ -143,7 +143,7 @@ If you need help using the GDK, come and talk to us about the software and the d
 
 
 ## Get the GDK and the FPS Starter Project source code
-To run the GDK and the FPS Starter project, you need to download the source code. There are two ways you can do this: _either_ get both sets of source code as one zip file download _or_ clone the two repositories separately using Git (see [Git (github.io)](https://try.github.io/ for further informatio on Git)).
+To run the GDK and the FPS Starter project, you need to download the source code. There are two ways you can do this: _either_ get both sets of source code as one zip file download _or_ clone the two repositories separately using Git. (To find out more about Git, see [github.io](https://try.github.io)).
 
 **NOTE:** We recommend using Git, as Git's version control makes it easier for you to get updates in the future.
 


### PR DESCRIPTION
#### Description
1. Removed "will" prediction from get-started and made it present simple (stronger text).
2. Removed red call out boxes due to them being everywhere (it's more red than not red in some places!)
3. Standardized "FPS Starter Project".
4. Made it clearer that it's either clone two repos via Git or download one file via zip (maintaining warning). Used consistent terms to make it clearer.
5. Made the login instructions clearer and with the right format. :-)

#### Tests
Improbadoc

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

#### Primary reviewers
@Ernie (but it's still new year vacay so .... or @oblm or @anne-edwards  - whoever is in!)

![screen shot 2019-01-02 at 10 49 23 am](https://user-images.githubusercontent.com/36853437/50588907-29b56c80-0e7c-11e9-9300-9f9d3cc820e0.png)
![screen shot 2019-01-02 at 10 54 59 am](https://user-images.githubusercontent.com/36853437/50589059-e7405f80-0e7c-11e9-8818-daef86dbc403.png)
![screen shot 2019-01-02 at 10 56 19 am](https://user-images.githubusercontent.com/36853437/50589088-12c34a00-0e7d-11e9-87b0-1cee34092990.png)



