### PR TITLE
[UTY-1541]Adding functionality to start iOS device client from Unity menu item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Added support for launching an iOS client from an iOS device from the Unity Editor. Navigate to **SpatialOS** > **Launch mobile client** > **iOS device** to try it out
+
 ### Changed
 
 - Changed `RedirectedProcess` to have Builder-like API.

--- a/workers/unity/Assets/Playground/Scripts/UI/ConnectionScreenController.cs
+++ b/workers/unity/Assets/Playground/Scripts/UI/ConnectionScreenController.cs
@@ -1,4 +1,5 @@
 using Improbable.Gdk.Core;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -98,14 +99,20 @@ namespace Playground
 
         private string GetReceptionistHostFromArguments()
         {
+            Dictionary<string, string> arguments = null;
 #if UNITY_ANDROID
-            var arguments = Improbable.Gdk.Mobile.Android.LaunchArguments.GetArguments();
+            arguments = Improbable.Gdk.Mobile.LaunchArguments.GetAndroidArguments();
+#elif UNITY_IOS
+            arguments = Improbable.Gdk.Mobile.LaunchArguments.GetiOSArguments();
+#endif
+            if (arguments == null)
+            {
+                return string.Empty;
+            }
+
             var hostIp =
                 CommandLineUtility.GetCommandLineValue(arguments, RuntimeConfigNames.ReceptionistHost, string.Empty);
             return hostIp;
-#else
-            return string.Empty;
-#endif
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
@@ -115,10 +115,11 @@ namespace Improbable.Gdk.Mobile
                     .RedirectOutputOptions(OutputRedirectBehaviour.None).Run();
                 var existsOnDevice = appList.Contains(bundleId);
                 var existsLocally = !string.IsNullOrEmpty(ipaPath);
-                
-                // If .ipa exists - we install/upgrade device app and launch it
-                // If .ipa doesn't exist, but the bunlde is installed on device - we launch existing app with parameters
-                // If .ipa doesn't exist and bundle isn't found on device - we fail with an error.
+
+                // If .ipa exists and the bundle is installed - we upgrade device app and launch it
+                // If .ipa exists, but isn't installed - we install device app and launch it
+                // If .ipa doesn't exist, but the bundle is installed - we launch existing app with parameters
+                // If .ipa doesn't exist and bundle isn't found - we fail with an error.
                 if (!existsLocally && !existsOnDevice)
                 {
                     Debug.LogError($"Could not find an app on device or built out iOS .ipa archive in \"{AbsoluteAppBuildPath}\" to launch.");

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -117,6 +118,7 @@ namespace Improbable.Gdk.Mobile
                 if (!existsLocally && !existsOnDevice)
                 {
                     Debug.LogError($"Could not find an app on device or built out iOS .ipa archive in \"{AbsoluteAppBuildPath}\" to launch.");
+                    return;
                 }
 
                 if (existsLocally)
@@ -131,9 +133,17 @@ namespace Improbable.Gdk.Mobile
                     }
                 }
 
-                // Wait until the app is installed
+                // Wait until the app has finished installing
+                DateTime timeout = DateTime.Now.AddSeconds(5);
                 while (RedirectedProcess.Command(LibIDeviceInstallerBinary).WithArgs("-l").Run() != 0)
                 {
+                    if (DateTime.Now > timeout)
+                    {
+                        Debug.LogError($"Device communication error. Please ensure it is connected");
+                        return;
+                    }
+
+                    System.Threading.Thread.Sleep(500);
                 }
 
                 EditorUtility.DisplayProgressBar("Launching iOS Device Client", "Launching Client", 0.9f);

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
@@ -115,6 +115,10 @@ namespace Improbable.Gdk.Mobile
                     .RedirectOutputOptions(OutputRedirectBehaviour.None).Run();
                 var existsOnDevice = appList.Contains(bundleId);
                 var existsLocally = !string.IsNullOrEmpty(ipaPath);
+                
+                // If .ipa exists - we install/upgrade device app and launch it
+                // If .ipa doesn't exist, but the bunlde is installed on device - we launch existing app with parameters
+                // If .ipa doesn't exist and bundle isn't found on device - we fail with an error.
                 if (!existsLocally && !existsOnDevice)
                 {
                     Debug.LogError($"Could not find an app on device or built out iOS .ipa archive in \"{AbsoluteAppBuildPath}\" to launch.");

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
@@ -134,16 +134,10 @@ namespace Improbable.Gdk.Mobile
                 }
 
                 // Wait until the app has finished installing
-                DateTime timeout = DateTime.Now.AddSeconds(5);
-                while (RedirectedProcess.Command(LibIDeviceInstallerBinary).WithArgs("-l").Run() != 0)
+                if (RedirectedProcess.Command(LibIDeviceInstallerBinary).WithArgs("-l").RedirectOutputOptions(OutputRedirectBehaviour.None).Run() != 0)
                 {
-                    if (DateTime.Now > timeout)
-                    {
-                        Debug.LogError($"Device communication error. Please ensure it is connected");
-                        return;
-                    }
-
-                    System.Threading.Thread.Sleep(500);
+                    Debug.LogError($"Device communication error. Please ensure it is connected");
+                    return;
                 }
 
                 EditorUtility.DisplayProgressBar("Launching iOS Device Client", "Launching Client", 0.9f);

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Utility/LaunchArguments.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Utility/LaunchArguments.cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 using Improbable.Gdk.Core;
 using UnityEngine;
 
-namespace Improbable.Gdk.Mobile.Android
+namespace Improbable.Gdk.Mobile
 {
     public static class LaunchArguments
     {
-        public static Dictionary<string, string> GetArguments()
+        private const string LaunchArgumentsEnvKey = "SPATIALOS_ARGUMENTS";
+
+        public static Dictionary<string, string> GetAndroidArguments()
         {
             if (Application.isEditor)
             {
@@ -36,7 +38,30 @@ namespace Improbable.Gdk.Mobile.Android
                 Debug.LogException(e);
             }
 
-            return new Dictionary<string, string>();
+            return null;
+        }
+
+        public static Dictionary<string, string> GetiOSArguments()
+        {
+            if (Application.isEditor)
+            {
+                return new Dictionary<string, string>();
+            }
+
+            try
+            {
+                var argumentsEnvVar = System.Environment.GetEnvironmentVariable(LaunchArgumentsEnvKey);
+                if (argumentsEnvVar != null)
+                {
+                    return CommandLineUtility.ParseCommandLineArgs(argumentsEnvVar.Split(' '));
+                }
+            }
+            catch (Exception e)
+            {
+                UnityEngine.Debug.LogException(e);
+            }
+
+            return null;
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Utility/LaunchArguments.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Utility/LaunchArguments.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: afdc1bbf8ada59c47a650e11479991f8
+guid: f59027953d77040e48aa946f6d04e505
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/workers/unity/Packages/com.improbable.gdk.tools/Common.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/Common.cs
@@ -118,7 +118,7 @@ namespace Improbable.Gdk.Tools
         /// </summary>
         /// <param name="binarybaseName">The base name of the binary to find (without an extension).</param>
         /// <returns></returns>
-        private static string DiscoverLocation(string binarybaseName)
+        public static string DiscoverLocation(string binarybaseName)
         {
             var pathValue = Environment.GetEnvironmentVariable("PATH");
             if (pathValue == null)

--- a/workers/unity/Packages/com.improbable.gdk.tools/MenuPriorities.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/MenuPriorities.cs
@@ -8,7 +8,7 @@ namespace Improbable.Gdk.Tools
         internal const int BuildWorkerConfigs = 70;
         internal const int LocalLaunch = 71;
         internal const int LaunchStandaloneClient = 72;
-        internal const int OpenInspector = 74;
+        internal const int OpenInspector = 75;
 
         internal const int GdkToolsConfiguration = 201;
     }

--- a/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs
@@ -61,6 +61,8 @@ namespace Improbable.Gdk.Tools
             OutputRedirectBehaviour.ProcessSpatialOutput |
             OutputRedirectBehaviour.RedirectAccumulatedOutput;
 
+        private bool returnImmediately = false;
+
         /// <summary>
         ///     Creates the redirected process for the command.
         /// </summary>
@@ -122,6 +124,15 @@ namespace Improbable.Gdk.Tools
         }
 
         /// <summary>
+        ///     Informs the class to return without waiting for redirected process to finish
+        /// </summary>
+        public RedirectedProcess ReturnImmediately()
+        {
+            returnImmediately = true;
+            return this;
+        }
+
+        /// <summary>
         ///     Runs the redirected process and waits for it to return.
         /// </summary>
         public int Run()
@@ -135,113 +146,123 @@ namespace Improbable.Gdk.Tools
                 WorkingDirectory = workingDirectory
             };
 
-            using (var process = Process.Start(info))
+            var process = Process.Start(info);
+
+            if (process == null)
             {
-                if (process == null)
-                {
-                    throw new Exception(
-                        $"Failed to run {info.FileName} {info.Arguments}\nIs the .NET Core SDK installed?");
-                }
-
-                StringBuilder outputLog = null;
-                if ((outputRedirectBehaviour & OutputRedirectBehaviour.RedirectAccumulatedOutput) != OutputRedirectBehaviour.None)
-                {
-                    outputLog = new StringBuilder();
-                }
-
-                process.OutputDataReceived += (sender, args) =>
-                {
-                    var outputString = args.Data;
-                    if ((outputRedirectBehaviour & OutputRedirectBehaviour.ProcessSpatialOutput) != OutputRedirectBehaviour.None)
-                    {
-                        outputString = ProcessSpatialOutput(outputString);
-                    }
-
-                    if (string.IsNullOrEmpty(outputString))
-                    {
-                        return;
-                    }
-
-                    if ((outputRedirectBehaviour & OutputRedirectBehaviour.RedirectStdOut) != OutputRedirectBehaviour.None)
-                    {
-                        Debug.Log(outputString);
-                    }
-
-                    if (outputLog != null)
-                    {
-                        lock (outputLog)
-                        {
-                            outputLog.AppendLine(ProcessSpatialOutput(outputString));
-                        }
-                    }
-
-                    foreach (var outputProcessor in outputProcessors)
-                    {
-                        outputProcessor(outputString);
-                    }
-                };
-                process.ErrorDataReceived += (sender, args) =>
-                {
-                    var errorString = args.Data;
-                    if ((outputRedirectBehaviour & OutputRedirectBehaviour.ProcessSpatialOutput) != OutputRedirectBehaviour.None)
-                    {
-                        errorString = ProcessSpatialOutput(errorString);
-                    }
-
-                    if (string.IsNullOrEmpty(errorString))
-                    {
-                        return;
-                    }
-
-                    if ((outputRedirectBehaviour & OutputRedirectBehaviour.RedirectStdErr) != OutputRedirectBehaviour.None)
-                    {
-                        Debug.LogError(errorString);
-                    }
-
-                    if (outputLog != null)
-                    {
-                        lock (outputLog)
-                        {
-                            outputLog.AppendLine(ProcessSpatialOutput(errorString));
-                        }
-                    }
-
-                    foreach (var errorProcessor in errorProcessors)
-                    {
-                        errorProcessor(errorString);
-                    }
-                };
-
-                process.EnableRaisingEvents = true;
-                process.BeginOutputReadLine();
-                process.BeginErrorReadLine();
-
-                process.WaitForExit();
-
-                if (outputLog == null)
-                {
-                    return process.ExitCode;
-                }
-
-                // Ensure that the first line of the log is something useful in the Unity editor console.
-                var trimmedOutput = outputLog.ToString().TrimStart();
-
-                if (trimmedOutput == string.Empty)
-                {
-                    return process.ExitCode;
-                }
-
-                if (process.ExitCode == 0)
-                {
-                    Debug.Log(trimmedOutput);
-                }
-                else
-                {
-                    Debug.LogError(trimmedOutput);
-                }
-
-                return process.ExitCode;
+                throw new Exception(
+                    $"Failed to run {info.FileName} {info.Arguments}\nIs the .NET Core SDK installed?");
             }
+
+            StringBuilder outputLog = null;
+            if ((outputRedirectBehaviour & OutputRedirectBehaviour.RedirectAccumulatedOutput) != OutputRedirectBehaviour.None)
+            {
+                outputLog = new StringBuilder();
+            }
+
+            process.OutputDataReceived += (sender, args) =>
+            {
+                var outputString = args.Data;
+                if ((outputRedirectBehaviour & OutputRedirectBehaviour.ProcessSpatialOutput) != OutputRedirectBehaviour.None)
+                {
+                    outputString = ProcessSpatialOutput(outputString);
+                }
+
+                if (string.IsNullOrEmpty(outputString))
+                {
+                    return;
+                }
+
+                if ((outputRedirectBehaviour & OutputRedirectBehaviour.RedirectStdOut) != OutputRedirectBehaviour.None)
+                {
+                    Debug.Log(outputString);
+                }
+
+                if (outputLog != null)
+                {
+                    lock (outputLog)
+                    {
+                        outputLog.AppendLine(ProcessSpatialOutput(outputString));
+                    }
+                }
+
+                foreach (var outputProcessor in outputProcessors)
+                {
+                    outputProcessor(outputString);
+                }
+            };
+            process.ErrorDataReceived += (sender, args) =>
+            {
+                var errorString = args.Data;
+                if ((outputRedirectBehaviour & OutputRedirectBehaviour.ProcessSpatialOutput) != OutputRedirectBehaviour.None)
+                {
+                    errorString = ProcessSpatialOutput(errorString);
+                }
+
+                if (string.IsNullOrEmpty(errorString))
+                {
+                    return;
+                }
+
+                if ((outputRedirectBehaviour & OutputRedirectBehaviour.RedirectStdErr) != OutputRedirectBehaviour.None)
+                {
+                    Debug.LogError(errorString);
+                }
+
+                if (outputLog != null)
+                {
+                    lock (outputLog)
+                    {
+                        outputLog.AppendLine(ProcessSpatialOutput(errorString));
+                    }
+                }
+
+                foreach (var errorProcessor in errorProcessors)
+                {
+                    errorProcessor(errorString);
+                }
+            };
+
+            process.EnableRaisingEvents = true;
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            if (returnImmediately)
+            {
+                process.Exited += (sender, args) =>
+                {
+                    process.Dispose();
+                };
+                return 0;
+            }
+
+            process.WaitForExit();
+            var exitCode = process.ExitCode;
+            process.Dispose();
+
+            if (outputLog == null)
+            {
+                return exitCode;
+            }
+
+            // Ensure that the first line of the log is something useful in the Unity editor console.
+            var trimmedOutput = outputLog.ToString().TrimStart();
+
+            if (trimmedOutput == string.Empty)
+            {
+                return exitCode;
+            }
+
+            if (exitCode == 0)
+            {
+                Debug.Log(trimmedOutput);
+            }
+            else
+            {
+                Debug.LogError(trimmedOutput);
+            }
+
+            return exitCode;
         }
 
         /// <summary>

--- a/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs
@@ -96,7 +96,8 @@ namespace Improbable.Gdk.Tools
         }
 
         /// <summary>
-        ///     Adds custom processing for regular output of process.
+        ///     Adds the specified action to a list of output processors. These actions are called while running
+        /// the specified process and receive as an argument the output string.
         /// </summary>
         /// <param name="outputProcessor">Processing action for regular output.</param>
         public RedirectedProcess AddOutputProcessing(Action<string> outputProcessor)
@@ -106,7 +107,8 @@ namespace Improbable.Gdk.Tools
         }
 
         /// <summary>
-        ///     Adds custom processing for error output of process.
+        ///     Adds the specified action to a list of error processors. These actions are called while running
+        /// the specified process and receive as an argument the error string.
         /// </summary>
         /// <param name="errorProcessor">Processing action for error output.</param>
         public RedirectedProcess AddErrorProcessing(Action<string> errorProcessor)
@@ -116,12 +118,13 @@ namespace Improbable.Gdk.Tools
         }
 
         /// <summary>
-        ///     Adds accumulated output processing
+        ///     Adds the specified action to a list of accumulated output processors. These actions are called
+        /// at the end of running the specified process and receive as an argument the complete log of that process.
         /// </summary>
-        /// <param name="errorProcessor">Processing action for error output.</param>
-        public RedirectedProcess AddAccumulatedOutputProcessing(Action<string> errorProcessor)
+        /// <param name="accumulatedOutputProcessor">Processing action for accumulated output.</param>
+        public RedirectedProcess AddAccumulatedOutputProcessing(Action<string> accumulatedOutputProcessor)
         {
-            accumulatedOutputProcessors.Add(errorProcessor);
+            accumulatedOutputProcessors.Add(accumulatedOutputProcessor);
             return this;
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs
@@ -63,7 +63,7 @@ namespace Improbable.Gdk.Tools
             OutputRedirectBehaviour.ProcessSpatialOutput |
             OutputRedirectBehaviour.RedirectAccumulatedOutput;
 
-        private bool returnImmediately = false;
+        private bool returnImmediately;
 
         /// <summary>
         ///     Creates the redirected process for the command.
@@ -166,7 +166,7 @@ namespace Improbable.Gdk.Tools
             if (process == null)
             {
                 throw new Exception(
-                    $"Failed to run {info.FileName} {info.Arguments}\nIs the .NET Core SDK installed?");
+                    $"Failed to run process {info.FileName} {info.Arguments}\n. Please check if the command specified is available.");
             }
 
             StringBuilder outputLog = null;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](https://docs.improbable.io/unity/alpha/contributing) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
This PR adds functionality to run ios builds on device with pre-filled ip.
Implemented functionality assumes having pre-built .ipa iOS archive. Running is only supported on device: running on iOS simulator will be added in a separate diff

#### Tests
Ensure Spatial Unity menu has "Launch mobile client/iOS device" item => ensure that launches the client => ensure client is connection to predefined ip address

#### Documentation
https://github.com/spatialos/gdk-for-unity/pull/678

#### Primary reviewers
