### PR TITLE
ensure chmod runs even with spaces in path (OSX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added support for the Steam authentication flow.
 - Added support for the Alpha Locator flow.
+- Added option to build workers out via IL2CPP in the cmd.
 
 ### Changed
 
@@ -16,6 +17,7 @@
 - `Clean all workers` now cleans worker configs in addition to built-out workers.
 - Fixed a bug where you could start each built-out worker only once on OSX.
 - Code generation now captures nested package dependencies, so the generated schema contains schema components from all required packages. Previously, code generation only generated schema for top-level dependencies, skipping nested packages.
+- Fixed a bug where spaces in the path would cause code generation to fail on OSX.
 
 ## `0.1.3` - 2018-11-26
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
@@ -89,7 +89,7 @@ namespace Improbable.Gdk.Tools
                     case RuntimePlatform.LinuxEditor:
                     case RuntimePlatform.OSXEditor:
                         // Ensure the schema compiler is executable.
-                        var _ = RedirectedProcess.Run("chmod", "+x", schemaCompilerPath);
+                        var _ = RedirectedProcess.Run("chmod", "+x", $"\"{schemaCompilerPath}\"");
                         break;
                     default:
                         throw new PlatformNotSupportedException(


### PR DESCRIPTION
#### Description
chmod on macos would succeed, if there are no spaces in the path. With spaces in the path the whole code generation would fail due to a permission denied error.

#### Tests
tested it locally on my mac

#### Documentation
none needed 

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
