### PR TITLE
Adding an option to launch ios simulator client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added option to build workers out via IL2CPP in the cmd.
 - Added an example of handling disconnect for mobile workers.
 - Added support for launching an Android client from the Editor over ADB.
+- Added `Launch Mobile client` menu to `SpatialOS` menu in Unity Editor. `Android device` and `iOS device` menu items allow launching corresponding mobile clients to connect to local deployment.
 
 ### Changed
 

--- a/workers/unity/Assets/Playground/Scripts/UI/ConnectionScreenController.cs
+++ b/workers/unity/Assets/Playground/Scripts/UI/ConnectionScreenController.cs
@@ -1,4 +1,5 @@
 using Improbable.Gdk.Core;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -98,14 +99,20 @@ namespace Playground
 
         private string GetReceptionistHostFromArguments()
         {
+            Dictionary<string, string> arguments = null;
 #if UNITY_ANDROID
-            var arguments = Improbable.Gdk.Mobile.Android.LaunchArguments.GetArguments();
+            arguments = Improbable.Gdk.Mobile.LaunchArguments.GetAndroidArguments();
+#elif UNITY_IOS
+            arguments = Improbable.Gdk.Mobile.LaunchArguments.GetiOSArguments();
+#endif
+            if (arguments == null)
+            {
+                return string.Empty;
+            }
+
             var hostIp =
                 CommandLineUtility.GetCommandLineValue(arguments, RuntimeConfigNames.ReceptionistHost, string.Empty);
             return hostIp;
-#else
-            return string.Empty;
-#endif
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
@@ -259,10 +259,10 @@ namespace Improbable.Gdk.BuildSystem
         {
             using (new ShowProgressBarScope($"Package {basePath}"))
             {
-                RedirectedProcess.CommandWithArgs(Common.SpatialBinary, "file", "zip",
-                    $"--output=\"{Path.GetFullPath(zipAbsolutePath)}\"",
-                    $"--basePath=\"{Path.GetFullPath(basePath)}\"", "\"**\"",
-                    $"--compression={useCompression}")
+                RedirectedProcess.Command(Common.SpatialBinary)
+                    .WithArgs("file", "zip", $"--output=\"{Path.GetFullPath(zipAbsolutePath)}\"",
+                        $"--basePath=\"{Path.GetFullPath(basePath)}\"", "\"**\"",
+                        $"--compression={useCompression}")
                     .Run();
             }
         }

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
@@ -259,10 +259,11 @@ namespace Improbable.Gdk.BuildSystem
         {
             using (new ShowProgressBarScope($"Package {basePath}"))
             {
-                RedirectedProcess.Run(Common.SpatialBinary, "file", "zip",
+                RedirectedProcess.CommandWithArgs(Common.SpatialBinary, "file", "zip",
                     $"--output=\"{Path.GetFullPath(zipAbsolutePath)}\"",
                     $"--basePath=\"{Path.GetFullPath(basePath)}\"", "\"**\"",
-                    $"--compression={useCompression}");
+                    $"--compression={useCompression}")
+                    .Run();
             }
         }
     }

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
@@ -39,14 +39,14 @@ namespace Improbable.Gdk.Mobile
                 }
 
                 // Ensure an android device/emulator is present
-                if (RedirectedProcess.CommandWithArgs(adbPath, "get-state").Run() != 0)
+                if (RedirectedProcess.Command(adbPath).WithArgs("get-state").Run() != 0)
                 {
                     Debug.LogError("No Android device/emulator detected.");
                     return;
                 }
 
                 // Install apk on connected phone / emulator
-                if (RedirectedProcess.CommandWithArgs(adbPath, "install", "-r", apkPath).Run() != 0)
+                if (RedirectedProcess.Command(adbPath).WithArgs("install", "-r", apkPath).Run() != 0)
                 {
                     Debug.LogError("Failed to install the apk on the device/emulator. If the application is already installed on your device/emulator, " +
                         "try uninstalling it before launching the mobile client.");
@@ -66,9 +66,9 @@ namespace Improbable.Gdk.Mobile
 
                 // Get chosen android package id and launch
                 var bundleId = PlayerSettings.GetApplicationIdentifier(BuildTargetGroup.Android);
-                RedirectedProcess.CommandWithArgs(adbPath, "shell", "am", "start", "-S",
-                    "-n", $"{bundleId}/com.unity3d.player.UnityPlayerActivity",
-                    "-e", "\"arguments\"", $"\\\"{arguments.ToString()}\\\"")
+                RedirectedProcess.Command(adbPath)
+                    .WithArgs("shell", "am", "start", "-S", "-n", $"{bundleId}/com.unity3d.player.UnityPlayerActivity",
+                        "-e", "\"arguments\"", $"\\\"{arguments.ToString()}\\\"")
                     .Run();
 
                 EditorUtility.DisplayProgressBar("Launching Mobile Client", "Done", 1.0f);

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
@@ -39,14 +39,14 @@ namespace Improbable.Gdk.Mobile
                 }
 
                 // Ensure an android device/emulator is present
-                if (RedirectedProcess.Run(adbPath, "get-state") != 0)
+                if (RedirectedProcess.CommandWithArgs(adbPath, "get-state").Run() != 0)
                 {
                     Debug.LogError("No Android device/emulator detected.");
                     return;
                 }
 
                 // Install apk on connected phone / emulator
-                if (RedirectedProcess.Run(adbPath, "install", "-r", apkPath) != 0)
+                if (RedirectedProcess.CommandWithArgs(adbPath, "install", "-r", apkPath).Run() != 0)
                 {
                     Debug.LogError("Failed to install the apk on the device/emulator. If the application is already installed on your device/emulator, " +
                         "try uninstalling it before launching the mobile client.");
@@ -66,9 +66,10 @@ namespace Improbable.Gdk.Mobile
 
                 // Get chosen android package id and launch
                 var bundleId = PlayerSettings.GetApplicationIdentifier(BuildTargetGroup.Android);
-                RedirectedProcess.Run(adbPath, "shell", "am", "start", "-S",
+                RedirectedProcess.CommandWithArgs(adbPath, "shell", "am", "start", "-S",
                     "-n", $"{bundleId}/com.unity3d.player.UnityPlayerActivity",
-                    "-e", "\"arguments\"", $"\\\"{arguments.ToString()}\\\"");
+                    "-e", "\"arguments\"", $"\\\"{arguments.ToString()}\\\"")
+                    .Run();
 
                 EditorUtility.DisplayProgressBar("Launching Mobile Client", "Done", 1.0f);
             }

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
@@ -1,21 +1,27 @@
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Tools;
 using UnityEditor;
 using UnityEngine;
+using Debug = UnityEngine.Debug;
 
 namespace Improbable.Gdk.Mobile
 {
     public static class LaunchMenu
     {
-        private const string rootApkPath = "build";
-        private static string AbsoluteApkPath => Path.GetFullPath(Path.Combine(Application.dataPath, Path.Combine("..", rootApkPath)));
+        private const string rootBuildPath = "build";
+        private static string AbsoluteAppBuildPath => Path.GetFullPath(Path.Combine(Application.dataPath, Path.Combine("..", rootBuildPath)));
+        private static string LibIDeviceInstallerBinary => Common.DiscoverLocation("ideviceinstaller");
+        private static string LibIDeviceDebugBinary => Common.DiscoverLocation("idevicedebug");
 
         private const string MenuLaunchAndroid = "SpatialOS/Launch mobile client/Android Device";
+        private const string MenuLaunchiOSDevice = "SpatialOS/Launch mobile client/iOS Device";
 
         [MenuItem(MenuLaunchAndroid, false, 73)]
-        private static void LaunchMobileClient()
+        private static void LaunchAndroidClient()
         {
             try
             {
@@ -29,12 +35,13 @@ namespace Improbable.Gdk.Mobile
 
                 var adbPath = Path.Combine(sdkRootPath, "platform-tools", "adb");
 
-                EditorUtility.DisplayProgressBar("Launching Mobile Client", "Installing APK", 0.3f);
+                EditorUtility.DisplayProgressBar("Launching Android Client", "Installing APK", 0.3f);
 
                 // Find apk to install
-                if (!TryGetApkPath(AbsoluteApkPath, out var apkPath))
+                var apkPath = Directory.GetFiles(AbsoluteAppBuildPath, "*.apk", SearchOption.AllDirectories).FirstOrDefault();
+                if (apkPath == string.Empty)
                 {
-                    Debug.LogError($"Could not find a built out Android binary in \"{AbsoluteApkPath}\" to launch.");
+                    Debug.LogError($"Could not find a built out Android binary in \"{AbsoluteAppBuildPath}\" to launch.");
                     return;
                 }
 
@@ -53,7 +60,7 @@ namespace Improbable.Gdk.Mobile
                     return;
                 }
 
-                EditorUtility.DisplayProgressBar("Launching Mobile Client", "Launching Client", 0.9f);
+                EditorUtility.DisplayProgressBar("Launching Android Client", "Launching Client", 0.9f);
 
                 // Optional arguments to be passed, same as standalone
                 // Use this to pass through the local ip to connect to
@@ -70,8 +77,6 @@ namespace Improbable.Gdk.Mobile
                     .WithArgs("shell", "am", "start", "-S", "-n", $"{bundleId}/com.unity3d.player.UnityPlayerActivity",
                         "-e", "\"arguments\"", $"\\\"{arguments.ToString()}\\\"")
                     .Run();
-
-                EditorUtility.DisplayProgressBar("Launching Mobile Client", "Done", 1.0f);
             }
             finally
             {
@@ -79,16 +84,75 @@ namespace Improbable.Gdk.Mobile
             }
         }
 
-        private static bool TryGetApkPath(string rootPath, out string apkPath)
+        [MenuItem(MenuLaunchiOSDevice, false, 74)]
+        private static void LaunchiOSDeviceClient()
         {
-            foreach (var file in Directory.GetFiles(rootPath, "*.apk", SearchOption.AllDirectories))
+            try
             {
-                apkPath = file;
-                return true;
-            }
+                // Ensure needed tools are installed
+                if (string.IsNullOrEmpty(LibIDeviceInstallerBinary))
+                {
+                    Debug.LogError("Could not find ideviceinstaller tool. Please ensure it is installed. " +
+                        "See https://github.com/libimobiledevice/ideviceinstaller fore more details.");
+                    return;
+                }
 
-            apkPath = string.Empty;
-            return false;
+                if (string.IsNullOrEmpty(LibIDeviceDebugBinary))
+                {
+                    Debug.LogError("Could not find idevicedebug tool. Please ensure libimobiledevice is installed. " +
+                        "See https://helpmanual.io/help/idevicedebug/ for more details.");
+                    return;
+                }
+
+                EditorUtility.DisplayProgressBar("Launching iOS Device Client", "Installing archive", 0.3f);
+
+                // Find archive to install
+                var ipaPath = Directory.GetFiles(AbsoluteAppBuildPath, "*.ipa", SearchOption.AllDirectories).FirstOrDefault();
+                if (string.IsNullOrEmpty(ipaPath))
+                {
+                    Debug.LogError($"Could not find a built out iOS archive in \"{AbsoluteAppBuildPath}\" to launch.");
+                    return;
+                }
+
+                if (RedirectedProcess.Command(LibIDeviceInstallerBinary).WithArgs("-i", ipaPath).Run() != 0)
+                {
+                    Debug.LogError("Error while installing archive to the device. Please check the log for details about the error.");
+                    return;
+                }
+
+                EditorUtility.DisplayProgressBar("Launching iOS Device Client", "Launching Client", 0.9f);
+
+                // Get chosen ios package id and launch
+                var bundleId = PlayerSettings.GetApplicationIdentifier(BuildTargetGroup.iOS);
+
+                // Optional arguments to be passed, same as standalone
+                // Use this to pass through the local ip to connect to
+                var runtimeIp = GdkToolsConfiguration.GetOrCreateInstance().RuntimeIp;
+                var arguments = new StringBuilder();
+                if (!string.IsNullOrEmpty(runtimeIp))
+                {
+                    arguments.Append($"-e SPATIALOS_ARGUMENTS=\"+{RuntimeConfigNames.ReceptionistHost} {runtimeIp}\"");
+                }
+
+                void OnReceived(string output)
+                {
+                    if (string.IsNullOrEmpty(output))
+                    {
+                        return;
+                    }
+
+                    Debug.Log(output.Trim());
+                }
+
+                RedirectedProcess.Command(LibIDeviceDebugBinary).WithArgs($"{arguments.ToString()} run {bundleId}")
+                    .ProcessOutput(OnReceived).ProcessErrors(OnReceived)
+                    .ReturnImmediately()
+                    .Run();
+            }
+            finally
+            {
+                EditorUtility.ClearProgressBar();
+            }
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Utility/LaunchArguments.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Utility/LaunchArguments.cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 using Improbable.Gdk.Core;
 using UnityEngine;
 
-namespace Improbable.Gdk.Mobile.Android
+namespace Improbable.Gdk.Mobile
 {
     public static class LaunchArguments
     {
-        public static Dictionary<string, string> GetArguments()
+        private const string LaunchArgumentsEnvKey = "SPATIALOS_ARGUMENTS";
+
+        public static Dictionary<string, string> GetAndroidArguments()
         {
             if (Application.isEditor)
             {
@@ -36,7 +38,30 @@ namespace Improbable.Gdk.Mobile.Android
                 Debug.LogException(e);
             }
 
-            return new Dictionary<string, string>();
+            return null;
+        }
+
+        public static Dictionary<string, string> GetiOSArguments()
+        {
+            if (Application.isEditor)
+            {
+                return new Dictionary<string, string>();
+            }
+
+            try
+            {
+                var argumentsEnvVar = System.Environment.GetEnvironmentVariable(LaunchArgumentsEnvKey);
+                if (argumentsEnvVar != null)
+                {
+                    return CommandLineUtility.ParseCommandLineArgs(argumentsEnvVar.Split(' '));
+                }
+            }
+            catch (Exception e)
+            {
+                UnityEngine.Debug.LogException(e);
+            }
+
+            return null;
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Utility/LaunchArguments.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Utility/LaunchArguments.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: afdc1bbf8ada59c47a650e11479991f8
+guid: f59027953d77040e48aa946f6d04e505
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/workers/unity/Packages/com.improbable.gdk.tools/Common.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/Common.cs
@@ -113,7 +113,7 @@ namespace Improbable.Gdk.Tools
         /// </summary>
         /// <param name="binarybaseName">The base name of the binary to find (without an extension).</param>
         /// <returns></returns>
-        private static string DiscoverLocation(string binarybaseName)
+        public static string DiscoverLocation(string binarybaseName)
         {
             var pathValue = Environment.GetEnvironmentVariable("PATH");
             if (pathValue == null)

--- a/workers/unity/Packages/com.improbable.gdk.tools/DownloadCoreSdk.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/DownloadCoreSdk.cs
@@ -130,7 +130,7 @@ namespace Improbable.Gdk.Tools
 
                 using (new ShowProgressBarScope($"Installing SpatialOS libraries, version {Common.CoreSdkVersion}..."))
                 {
-                    exitCode = RedirectedProcess.CommandWithArgs(Common.DotNetBinary, ConstructArguments()).Run();
+                    exitCode = RedirectedProcess.Command(Common.DotNetBinary).WithArgs(ConstructArguments()).Run();
                     if (exitCode != 0)
                     {
                         Debug.LogError($"Failed to download SpatialOS Core Sdk version {Common.CoreSdkVersion}. You can use SpatialOS -> Download CoreSDK (force) to retry this.");

--- a/workers/unity/Packages/com.improbable.gdk.tools/DownloadCoreSdk.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/DownloadCoreSdk.cs
@@ -130,7 +130,7 @@ namespace Improbable.Gdk.Tools
 
                 using (new ShowProgressBarScope($"Installing SpatialOS libraries, version {Common.CoreSdkVersion}..."))
                 {
-                    exitCode = RedirectedProcess.Run(Common.DotNetBinary, ConstructArguments());
+                    exitCode = RedirectedProcess.CommandWithArgs(Common.DotNetBinary, ConstructArguments()).Run();
                     if (exitCode != 0)
                     {
                         Debug.LogError($"Failed to download SpatialOS Core Sdk version {Common.CoreSdkVersion}. You can use SpatialOS -> Download CoreSDK (force) to retry this.");

--- a/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
@@ -89,7 +89,7 @@ namespace Improbable.Gdk.Tools
                     case RuntimePlatform.LinuxEditor:
                     case RuntimePlatform.OSXEditor:
                         // Ensure the schema compiler is executable.
-                        var _ = RedirectedProcess.Run("chmod", "+x", $"\"{schemaCompilerPath}\"");
+                        var _ = RedirectedProcess.CommandWithArgs("chmod", "+x", $"\"{schemaCompilerPath}\"").Run();
                         break;
                     default:
                         throw new PlatformNotSupportedException(
@@ -98,8 +98,8 @@ namespace Improbable.Gdk.Tools
 
                 using (new ShowProgressBarScope("Generating code..."))
                 {
-                    var exitCode = RedirectedProcess.Run(Common.DotNetBinary,
-                        ConstructArgs(projectPath, schemaCompilerPath, workerJsonPath));
+                    var exitCode = RedirectedProcess.CommandWithArgs(Common.DotNetBinary,
+                        ConstructArgs(projectPath, schemaCompilerPath, workerJsonPath)).Run();
 
                     if (exitCode != 0)
                     {

--- a/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
@@ -89,7 +89,7 @@ namespace Improbable.Gdk.Tools
                     case RuntimePlatform.LinuxEditor:
                     case RuntimePlatform.OSXEditor:
                         // Ensure the schema compiler is executable.
-                        var _ = RedirectedProcess.CommandWithArgs("chmod", "+x", $"\"{schemaCompilerPath}\"").Run();
+                        var _ = RedirectedProcess.Command("chmod").WithArgs("+x", $"\"{schemaCompilerPath}\"").Run();
                         break;
                     default:
                         throw new PlatformNotSupportedException(
@@ -98,8 +98,9 @@ namespace Improbable.Gdk.Tools
 
                 using (new ShowProgressBarScope("Generating code..."))
                 {
-                    var exitCode = RedirectedProcess.CommandWithArgs(Common.DotNetBinary,
-                        ConstructArgs(projectPath, schemaCompilerPath, workerJsonPath)).Run();
+                    var exitCode = RedirectedProcess.Command(Common.DotNetBinary)
+                        .WithArgs(ConstructArgs(projectPath, schemaCompilerPath, workerJsonPath))
+                        .Run();
 
                     if (exitCode != 0)
                     {

--- a/workers/unity/Packages/com.improbable.gdk.tools/LocalLaunch.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/LocalLaunch.cs
@@ -63,7 +63,8 @@ namespace Improbable.Gdk.Tools
             {
                 // Run from the root of the project to build all available worker configs.
                 RedirectedProcess
-                    .CommandWithArgs(Common.SpatialBinary, "build", "build-config", "--json_output")
+                    .Command(Common.SpatialBinary)
+                    .WithArgs("build", "build-config", "--json_output")
                     .InDirectory(SpatialProjectRootDir)
                     .Run();
             }

--- a/workers/unity/Packages/com.improbable.gdk.tools/LocalLaunch.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/LocalLaunch.cs
@@ -62,8 +62,10 @@ namespace Improbable.Gdk.Tools
             using (new ShowProgressBarScope("Building worker configs..."))
             {
                 // Run from the root of the project to build all available worker configs.
-                RedirectedProcess.RunIn(SpatialProjectRootDir, Common.SpatialBinary, "build", "build-config",
-                    "--json_output");
+                RedirectedProcess
+                    .CommandWithArgs(Common.SpatialBinary, "build", "build-config", "--json_output")
+                    .InDirectory(SpatialProjectRootDir)
+                    .Run();
             }
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/MenuPriorities.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/MenuPriorities.cs
@@ -8,7 +8,7 @@ namespace Improbable.Gdk.Tools
         internal const int BuildWorkerConfigs = 70;
         internal const int LocalLaunch = 71;
         internal const int LaunchStandaloneClient = 72;
-        internal const int OpenInspector = 74;
+        internal const int OpenInspector = 75;
 
         internal const int GdkToolsConfiguration = 201;
     }

--- a/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs
@@ -49,7 +49,7 @@ namespace Improbable.Gdk.Tools
     /// <summary>
     ///     Runs a windowless process.
     /// </summary>
-    public class RedirectedProcess
+    public static class RedirectedProcess
     {
         private string command = string.Empty;
         private string[] arguments;
@@ -133,9 +133,113 @@ namespace Improbable.Gdk.Tools
         }
 
         /// <summary>
-        ///     Runs the redirected process and waits for it to return.
+        ///     Runs redirected process in specified output directory with its stdout/stderr redirected to the
+        ///     Unity console as a single debug print at the end.
         /// </summary>
         public int Run()
+        {
+            var processOutput = new StringBuilder();
+
+            void ProcessOutput(string output)
+            {
+                lock (processOutput)
+                {
+                    processOutput.AppendLine(ProcessSpatialOutput(output));
+                }
+            }
+
+            var exitCode = RunRedirectedProcess(workingDirectory, command, null, ProcessOutput, true, arguments);
+
+            var trimmedOutput = processOutput.ToString().Trim();
+
+            if (string.IsNullOrEmpty(trimmedOutput))
+            {
+                return exitCode;
+            }
+
+            if (exitCode == 0)
+            {
+                Debug.Log(trimmedOutput);
+            }
+            else
+            {
+                Debug.LogError(trimmedOutput);
+            }
+
+            return exitCode;
+        }
+
+        /// <summary>
+        ///     Runs redirected process in Application root directory and extracts returns output in output string.
+        /// </summary>
+        /// <param name="command">The filename to run.</param>
+        /// <param name="output">String containing output of the process.</param>
+        /// <param name="arguments">Parameters that will be passed to the command.</param>
+        /// <returns>The exit code.</returns>
+        public static int RunExtractOutput(string command, out string output, params string[] arguments)
+        {
+            var processOutput = new StringBuilder();
+
+            void ProcessOutput(string outputLine)
+            {
+                lock (processOutput)
+                {
+                    processOutput.AppendLine(outputLine);
+                }
+            }
+
+            var exitCode = RunRedirectedProcess(AppDataPath, command, null, ProcessOutput, true, arguments);
+
+            output = processOutput.ToString().Trim();
+            return exitCode;
+        }
+
+        /// <summary>
+        ///     Runs redirected process in Application root directory with its stdout/stderr redirected to the
+        ///     Unity console immediately.
+        /// </summary>
+        /// <param name="command">The filename to run.</param>
+        /// <param name="arguments">Parameters that will be passed to the command.</param>
+        /// <returns>The exit code.</returns>
+        public static int RunWithImmediateOutput(string command, params string[] arguments)
+        {
+            return RunWithEnvVars(command, null, arguments);
+        }
+
+        /// <summary>
+        ///     Runs redirected process in Application root directory with given environment variables.
+        ///     Stdout/stderr are redirected to the Unity console immediately.
+        /// </summary>
+        /// <param name="command">The filename to run.</param>
+        /// <param name="envVars">Dictionary containing environment variables to be used.</param>
+        /// <param name="arguments">Parameters that will be passed to the command.</param>
+        /// <returns>The exit code.</returns>
+        public static int RunWithEnvVars(string command, Dictionary<string, string> envVars,
+            params string[] arguments)
+        {
+            void ProcessOutput(string output)
+            {
+                output = output.Trim();
+                if (!string.IsNullOrEmpty(output))
+                {
+                    Debug.Log(output);
+                }
+            }
+
+            return RunRedirectedProcess(AppDataPath, command, envVars, ProcessOutput, false, arguments);
+        }
+
+        /// <summary>
+        ///     Runs the redirected process and waits for it to return.
+        /// </summary>
+        /// <param name="workingDirectory">The directory to run the filename from.</param>
+        /// <param name="command">The filename to run.</param>
+        /// <param name="envVars">Dictionary containing environment variables to be used.</param>
+        /// <param name="outputProcessor">Action for processing output line by line.</param>
+        /// <param name="arguments">Parameters that will be passed to the command.</param>
+        /// <returns>The exit code.</returns>
+        private static int RunRedirectedProcess(string workingDirectory, string command, Dictionary<string, string> envVars,
+            Action<string> outputProcessor, bool waitForExit, params string[] arguments)
         {
             var info = new ProcessStartInfo(command, string.Join(" ", arguments))
             {
@@ -145,6 +249,11 @@ namespace Improbable.Gdk.Tools
                 UseShellExecute = false,
                 WorkingDirectory = workingDirectory
             };
+
+            foreach (var envVarEntry in envVars ?? new Dictionary<string, string>())
+            {
+                info.EnvironmentVariables.Add(envVarEntry.Key, envVarEntry.Value);
+            }
 
             var process = Process.Start(info);
             if (process == null)


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](https://docs.improbable.io/unity/alpha/contributing) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
This PR adds a menu item to launch ios simulator client with host IP to connect to and the scripts to execute that.

#### Tests
Run Unity -> ensure an item to launch iOS simulator is available -> ensure it triggers simulator with configured IP address and tries connection to the host

#### Documentation
Will be added to changelog and documentation

#### Primary reviewers

