### PR TITLE
Adding instruction about running the app on simulator from SpatialOS menu

### DIFF
--- a/docs/content/mobile/ios/local-deploy.md
+++ b/docs/content/mobile/ios/local-deploy.md
@@ -64,4 +64,10 @@ You need the Unity Remote app for this. See the [Unity documentation](https://do
     > For subsequent runs you will be prompted to pick XCode project directory again (with the one used previously preselected). You can generate a new project or append/replace existing one. In subsequent runs, if you've set up provisioning and use Append, you can use **Build and Run** to trigger project run automatically after XCode project was generated.
 
   1. Once the game is running on your device, you see an empty text field and a **Connect** button: enter the local IP address of your computer in the text field and click **Connect**.
+  1. Alternatively you can use **SpatialOS** > **Launch Mobile Client** > **iOS Client** to launch mobile client with IP address field prefilled with a value from **SpatialOS** > **GDK Tools Configuration** > **Runtime IP for local deployment**.
+  
+    > To use this flow you need to have [ideviceinstaller](https://github.com/libimobiledevice/ideviceinstaller) and [idevicedebug](https://helpmanual.io/help/idevicedebug/) tools installed.
+    >
+    > Make sure .ipa archive is built to `workers\unity\build\` directory.
+
   1. Play the game on your mobile device.

--- a/docs/content/mobile/ios/local-deploy.md
+++ b/docs/content/mobile/ios/local-deploy.md
@@ -42,7 +42,7 @@ You need the Unity Remote app for this. See the [Unity documentation](https://do
     > You don’t need to enter anything in the text field.
 
   1. Play the game on the Simulator.
-  1. Once you've installed or ran app on the Simulator you can run **SpatialOS** > **Launch Mobile Client** > **iOS Client** to launch mobile client with IP address field prefilled with a value from **SpatialOS** > **GDK Tools Configuration** > **Runtime IP for local deployment**.
+  1. Once you've installed or run an app on the Simulator, back in your Unity Editor, you can run **SpatialOS** > **Launch Mobile Client** > **iOS Client** to launch a mobile client with the IP address field prefilled with a value from **SpatialOS** > **GDK Tools Configuration** > **Runtime IP for local deployment**.
   
 
 ## Connecting your iOS device to a local deployment

--- a/docs/content/mobile/ios/local-deploy.md
+++ b/docs/content/mobile/ios/local-deploy.md
@@ -42,6 +42,8 @@ You need the Unity Remote app for this. See the [Unity documentation](https://do
     > You don’t need to enter anything in the text field.
 
   1. Play the game on the Simulator.
+  1. Once you've installed or ran app on the Simulator you can run **SpatialOS** > **Launch Mobile Client** > **iOS Client** to launch mobile client with IP address field prefilled with a value from **SpatialOS** > **GDK Tools Configuration** > **Runtime IP for local deployment**.
+  
 
 ## Connecting your iOS device to a local deployment
 


### PR DESCRIPTION

#### Description
Documentation describing launching on iOS Device from menu - https://github.com/spatialos/gdk-for-unity/pull/670

#### Tests
Ensure documentation looks as expected

#### Primary reviewers
