### PR TITLE
Fix underflow memory allocation crash in transform sync.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,11 @@
 - `Improbable.Gdk.EntityTemplate` is now mutable and exposes a set of APIs to add, remove, and replace component snapshots
     - This replaces the `Improbable.Gdk.Core.EntityBuilder` class.
     - These changes also allow you to reuse an `EntityTemplate` more than once.
+
 - Upgraded the project to be compatible with `2018.3.2f1`.
 - Upgraded the entities package to `0.0.12-preview.21`
 - Disabled protocol logging on Linux workers to prevent crashes. This will be reverted once the underlying issue is fixed.
-- Fixed Memory crash in TransformSynchronization module.
-
+- Fixed an issue in the TransformSynchronization module where an integer underflow would cause a memory crash.
 ### Fixed
 
 - `Clean all workers` now cleans worker configs in addition to built-out workers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,11 @@
 - `Improbable.Gdk.EntityTemplate` is now mutable and exposes a set of APIs to add, remove, and replace component snapshots
     - This replaces the `Improbable.Gdk.Core.EntityBuilder` class.
     - These changes also allow you to reuse an `EntityTemplate` more than once.
-
 - Upgraded the project to be compatible with `2018.3.2f1`.
 - Upgraded the entities package to `0.0.12-preview.21`
 - Disabled protocol logging on Linux workers to prevent crashes. This will be reverted once the underlying issue is fixed.
 - Fixed an issue in the TransformSynchronization module where an integer underflow would cause a memory crash.
+
 ### Fixed
 
 - `Clean all workers` now cleans worker configs in addition to built-out workers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Upgraded the project to be compatible with `2018.3.2f1`.
 - Upgraded the entities package to `0.0.12-preview.21`
 - Disabled protocol logging on Linux workers to prevent crashes. This will be reverted once the underlying issue is fixed.
+- Fixed Memory crash in TransformSynchronization module.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 - Upgraded the project to be compatible with `2018.3.2f1`.
 - Upgraded the entities package to `0.0.12-preview.21`
 - Disabled protocol logging on Linux workers to prevent crashes. This will be reverted once the underlying issue is fixed.
-- Fixed an issue in the TransformSynchronization module where an integer underflow would cause a memory crash.
 
 ### Fixed
 
@@ -26,6 +25,7 @@
 - Fixed a bug where you could start each built-out worker only once on OSX.
 - Code generation now captures nested package dependencies, so the generated schema contains schema components from all required packages. Previously, code generation only generated schema for top-level dependencies, skipping nested packages.
 - Fixed a bug where spaces in the path would cause code generation to fail on OSX.
+- Fixed an issue in the TransformSynchronization module where an integer underflow would cause a memory crash.
 
 ### Removed
 

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/InterpolateTransformSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/InterpolateTransformSystem.cs
@@ -38,7 +38,7 @@ namespace Improbable.Gdk.TransformSynchronization
 
         protected override void OnUpdate()
         {
-            for (int i = 0; i < data.Length; ++i)
+            for (var i = 0; i < data.Length; ++i)
             {
                 var config = data.Config[i];
                 var transformBuffer = data.TransformBuffer[i];
@@ -64,7 +64,7 @@ namespace Improbable.Gdk.TransformSynchronization
 
                     var transformToInterpolateTo = ToBufferedTransform(currentTransformComponent);
 
-                    uint ticksToFill = math.max((uint) config.TargetBufferSize, 1);
+                    var ticksToFill = math.max((uint) config.TargetBufferSize, 1);
 
                     if (ticksToFill > 1)
                     {
@@ -100,23 +100,25 @@ namespace Improbable.Gdk.TransformSynchronization
                     var transformToInterpolateTo = ToBufferedTransform(lastTransformApplied);
 
                     var transformToInterpolateFrom = transformBuffer[transformBuffer.Length - 1];
-                    uint lastTickId = transformToInterpolateFrom.PhysicsTick;
+                    var lastTickId = transformToInterpolateFrom.PhysicsTick;
 
-                    uint remoteTickDifference = transformToInterpolateTo.PhysicsTick - lastTickId;
-                    if (remoteTickDifference == 0)
+                    if (transformToInterpolateTo.PhysicsTick <= lastTickId)
                     {
                         continue;
                     }
 
-                    uint ticksToFill =
-                        math.max((uint) (transformToInterpolateTo.PhysicsTick - lastTickId), 1);
-                    for (uint j = 0; j < ticksToFill - 1; ++j)
+                    var remoteTickDifference = (int) (transformToInterpolateTo.PhysicsTick - lastTickId);
+                    var bufferedTransforms = new NativeArray<BufferedTransform>(remoteTickDifference, Allocator.Temp,
+                        NativeArrayOptions.UninitializedMemory);
+                    for (var j = 0; j < remoteTickDifference - 1; ++j)
                     {
-                        transformBuffer.Add(InterpolateValues(transformToInterpolateFrom, transformToInterpolateTo,
-                            j + 1));
+                        bufferedTransforms[j] = InterpolateValues(transformToInterpolateFrom, transformToInterpolateTo,
+                            (uint) j + 1);
                     }
 
-                    transformBuffer.Add(transformToInterpolateTo);
+                    bufferedTransforms[remoteTickDifference - 1] = transformToInterpolateTo;
+                    transformBuffer.AddRange(bufferedTransforms);
+                    bufferedTransforms.Dispose();
                 }
             }
         }
@@ -174,7 +176,7 @@ namespace Improbable.Gdk.TransformSynchronization
         private static BufferedTransform InterpolateValues(BufferedTransform first, BufferedTransform second,
             uint ticksAfterFirst)
         {
-            float t = (float) ticksAfterFirst / (float) (second.PhysicsTick - first.PhysicsTick);
+            var t = (float) ticksAfterFirst / (float) (second.PhysicsTick - first.PhysicsTick);
             return new BufferedTransform
             {
                 Position = Vector3.Lerp(first.Position, second.Position, t),

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/InterpolateTransformSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/InterpolateTransformSystem.cs
@@ -86,7 +86,7 @@ namespace Improbable.Gdk.TransformSynchronization
 
                 foreach (var update in data.Updates[i].Updates)
                 {
-                    UpdateLastTransfrom(ref lastTransformApplied, update);
+                    UpdateLastTransform(ref lastTransformApplied, update);
                     data.LastTransformValue[i] = new DeferredUpdateTransform
                     {
                         Transform = lastTransformApplied
@@ -123,7 +123,7 @@ namespace Improbable.Gdk.TransformSynchronization
             }
         }
 
-        private void UpdateLastTransfrom(ref TransformInternal.Component lastTransform, TransformInternal.Update update)
+        private void UpdateLastTransform(ref TransformInternal.Component lastTransform, TransformInternal.Update update)
         {
             if (update.Location.HasValue)
             {


### PR DESCRIPTION
#### Description
Fix a crash bug in the Transform sync feature module.
Includes a slight optimization to avoid dynamic buffer resizes.

#### Tests
Ran the playground project locally and went through the same steps which previously caused the crash.
