### PR TITLE
[UTY-1613] Gracefully handle disconnect in Playground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added support for the Alpha Locator flow.
 - Added support for connecting mobile devices to cloud deployments via the anonymous authentication flow.
 - Added option to build workers out via IL2CPP in the cmd.
+- Added an example of handling disconnect for mobile workers.
 
 ### Changed
 

--- a/workers/unity/Assets/Playground/Scripts/Camera/InitCameraSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Camera/InitCameraSystem.cs
@@ -37,6 +37,14 @@ namespace Playground
 
                 Cursor.lockState = CursorLockMode.Locked;
             }
+
+            // Disable system after first run.
+            Enabled = false;
+        }
+
+        protected override void OnDestroyManager()
+        {
+            Cursor.lockState = CursorLockMode.None;
         }
     }
 }

--- a/workers/unity/Assets/Playground/Scripts/Camera/InitCameraSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Camera/InitCameraSystem.cs
@@ -36,10 +36,10 @@ namespace Playground
                 PostUpdateCommands.AddComponent(entity, CameraComponentDefaults.Transform);
 
                 Cursor.lockState = CursorLockMode.Locked;
-            }
 
-            // Disable system after first run.
-            Enabled = false;
+                // Disable system after first run.
+                Enabled = false;
+            }
         }
 
         protected override void OnDestroyManager()

--- a/workers/unity/Assets/Playground/Scripts/UI/ConnectionScreenController.cs
+++ b/workers/unity/Assets/Playground/Scripts/UI/ConnectionScreenController.cs
@@ -59,6 +59,13 @@ namespace Playground
                 $"Connection failed. Please check the IP address entered.\nSpatialOS error message:\n{connectionError}";
         }
 
+        public void OnDisconnected()
+        {
+            Destroy(worker);
+            ipAddressInput.text = PlayerPrefs.GetString(HostIpPlayerPrefsKey);
+            connectionPanel.SetActive(true);
+        }
+        
         private IMobileConnectionController PrepareConnect()
         {
             errorMessage.text = string.Empty;

--- a/workers/unity/Assets/Playground/Scripts/UI/ConnectionScreenController.cs
+++ b/workers/unity/Assets/Playground/Scripts/UI/ConnectionScreenController.cs
@@ -59,13 +59,13 @@ namespace Playground
                 $"Connection failed. Please check the IP address entered.\nSpatialOS error message:\n{connectionError}";
         }
 
-        public void OnDisconnected()
+        public void OnDisconnected(string disconnectReason)
         {
-            Destroy(worker);
+            UnityObjectDestroyer.Destroy(worker);
             ipAddressInput.text = PlayerPrefs.GetString(HostIpPlayerPrefsKey);
             connectionPanel.SetActive(true);
         }
-        
+
         private IMobileConnectionController PrepareConnect()
         {
             errorMessage.text = string.Empty;

--- a/workers/unity/Assets/Playground/Scripts/UI/InitUISystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/UI/InitUISystem.cs
@@ -45,5 +45,10 @@ namespace Playground
             // Disable system after first run.
             Enabled = false;
         }
+
+        protected override void OnDestroyManager()
+        {
+            UnityEngine.Object.Destroy(UIComponent.Main.gameObject);
+        }
     }
 }

--- a/workers/unity/Assets/Playground/Scripts/UI/InitUISystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/UI/InitUISystem.cs
@@ -48,7 +48,7 @@ namespace Playground
 
         protected override void OnDestroyManager()
         {
-            UnityEngine.Object.Destroy(UIComponent.Main.gameObject);
+            UnityObjectDestroyer.Destroy(UIComponent.Main.gameObject);
         }
     }
 }

--- a/workers/unity/Assets/Playground/Scripts/Worker/AndroidClientWorkerConnector.cs
+++ b/workers/unity/Assets/Playground/Scripts/Worker/AndroidClientWorkerConnector.cs
@@ -77,5 +77,12 @@ namespace Playground
 
             base.Dispose();
         }
+
+        protected override void OnDisconnected(string reason)
+        {
+            base.OnDisconnected(reason);
+
+            ConnectionScreenController.OnDisconnected();
+        }
     }
 }

--- a/workers/unity/Assets/Playground/Scripts/Worker/AndroidClientWorkerConnector.cs
+++ b/workers/unity/Assets/Playground/Scripts/Worker/AndroidClientWorkerConnector.cs
@@ -28,6 +28,7 @@ namespace Playground
         protected override void HandleWorkerConnectionEstablished()
         {
             ConnectionScreenController.OnConnectionSucceeded();
+            Worker.OnDisconnect += ConnectionScreenController.OnDisconnected;
             WorkerUtils.AddClientSystems(Worker.World);
 
             if (level == null)
@@ -76,13 +77,6 @@ namespace Playground
             }
 
             base.Dispose();
-        }
-
-        protected override void OnDisconnected(string reason)
-        {
-            base.OnDisconnected(reason);
-
-            ConnectionScreenController.OnDisconnected();
         }
     }
 }

--- a/workers/unity/Assets/Playground/Scripts/Worker/iOSClientWorkerConnector.cs
+++ b/workers/unity/Assets/Playground/Scripts/Worker/iOSClientWorkerConnector.cs
@@ -71,5 +71,12 @@ namespace Playground
 
             base.Dispose();
         }
+
+        protected override void OnDisconnected(string reason)
+        {
+            base.OnDisconnected(reason);
+
+            ConnectionScreenController.OnDisconnected();
+        }
     }
 }

--- a/workers/unity/Assets/Playground/Scripts/Worker/iOSClientWorkerConnector.cs
+++ b/workers/unity/Assets/Playground/Scripts/Worker/iOSClientWorkerConnector.cs
@@ -27,6 +27,7 @@ namespace Playground
         protected override void HandleWorkerConnectionEstablished()
         {
             ConnectionScreenController.OnConnectionSucceeded();
+            Worker.OnDisconnect += ConnectionScreenController.OnDisconnected;
             WorkerUtils.AddClientSystems(Worker.World);
 
             if (level == null)
@@ -70,13 +71,6 @@ namespace Playground
             }
 
             base.Dispose();
-        }
-
-        protected override void OnDisconnected(string reason)
-        {
-            base.OnDisconnected(reason);
-
-            ConnectionScreenController.OnDisconnected();
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
@@ -339,7 +339,7 @@ namespace Improbable.Gdk.Core
         }
 
 
-        private void OnDisconnected(string reason)
+        protected virtual void OnDisconnected(string reason)
         {
             Worker.LogDispatcher.HandleLog(LogType.Log, new LogEvent($"Worker disconnected")
                 .WithField("WorkerId", Worker.WorkerId)

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
@@ -339,7 +339,7 @@ namespace Improbable.Gdk.Core
         }
 
 
-        protected virtual void OnDisconnected(string reason)
+        private void OnDisconnected(string reason)
         {
             Worker.LogDispatcher.HandleLog(LogType.Log, new LogEvent($"Worker disconnected")
                 .WithField("WorkerId", Worker.WorkerId)


### PR DESCRIPTION
#### Description
We didn't have any specific handling for disconnect on mobile. Whenever the server was killed, mobile client worker is going to get to weird stale state where it doesn't technically hang, but nothing was happening and the client wasn't interactive.
This PR adds the code to restore Playground to "Ready to connect" mode

#### Tests
Run Playground locally and ensure that when server is disconnected we are ready to connect again ->
After the server is back, we should be able to reconnect

#### Documentation

#### Primary reviewers
