### PR TITLE
Switching to KCP on mobile worker + use small connection timeout

### DIFF
--- a/mobile_launch.json
+++ b/mobile_launch.json
@@ -1,5 +1,5 @@
 {
-  "template": "small",
+  "template": "small_entity_db_v2",
   "world": {
     "chunkEdgeLengthMeters": 50,
     "snapshots": {

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs
@@ -21,7 +21,20 @@ namespace Improbable.Gdk.Mobile
                 {
                     ConnectionType = NetworkConnectionType.Kcp,
                     UseExternalIp = true,
-                    ConnectionTimeoutMillis = 10000,
+                    Kcp = new KcpNetworkParameters
+                    {
+                        EarlyRetransmission = true,
+                        NonConcessionalFlowControl = true,
+                        FastRetransmission = true,
+                        UpdateIntervalMillis = 10,
+                        WindowSize = 1000,
+                        MinRtoMillis = 10,
+                        Heartbeat = new HeartbeatParameters()
+                        {
+                            IntervalMillis = 5000,
+                            TimeoutMillis = 10000,
+                        }
+                    }
                 },
                 EnableProtocolLoggingAtStartup = false,
                 DefaultComponentVtable = new ComponentVtable(),

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs
@@ -21,7 +21,7 @@ namespace Improbable.Gdk.Mobile
                 {
                     ConnectionType = NetworkConnectionType.Kcp,
                     UseExternalIp = true,
-                    ConnectionTimeoutMillis = 1000,
+                    ConnectionTimeoutMillis = 10000,
                 },
                 EnableProtocolLoggingAtStartup = false,
                 DefaultComponentVtable = new ComponentVtable(),

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs
@@ -9,7 +9,7 @@ namespace Improbable.Gdk.Mobile
     public abstract class MobileWorkerConnector : WorkerConnector
     {
         [SerializeField] private string DevelopmentAuthToken;
-        
+
         protected abstract string GetHostIp();
 
         protected override ConnectionParameters GetConnectionParameters(string workerType, ConnectionService service)
@@ -19,8 +19,9 @@ namespace Improbable.Gdk.Mobile
                 WorkerType = workerType,
                 Network =
                 {
-                    ConnectionType = NetworkConnectionType.Tcp,
+                    ConnectionType = NetworkConnectionType.Kcp,
                     UseExternalIp = true,
+                    ConnectionTimeoutMillis = 1000,
                 },
                 EnableProtocolLoggingAtStartup = false,
                 DefaultComponentVtable = new ComponentVtable(),
@@ -55,7 +56,7 @@ namespace Improbable.Gdk.Mobile
                 {
                     PlayerIdentity = new PlayerIdentityCredentials
                     {
-                        PlayerIdentityToken  = pit,
+                        PlayerIdentityToken = pit,
                         LoginToken = loginToken,
                     },
                     UseInsecureConnection = false,


### PR DESCRIPTION
#### Description
This PR switches mobile module to use KCP instead of TCP + adds meaningful connection timeout. Timeout seem to not have effect at the moment

#### Tests
Run mobile local deployment -> Run mobile client -> Ensure client is connected correctly to the deployment

#### Documentation
Do we need to change any docs for this? I wasn't able to find any relevant reference.

#### Primary reviewers
