### PR TITLE
UTY-1627: Fix Codegen Nullref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Code generation now captures nested package dependencies, so the generated schema contains schema components from all required packages. Previously, code generation only generated schema for top-level dependencies, skipping nested packages.
 - Fixed a bug where spaces in the path would cause code generation to fail on OSX.
 - Fixed an issue in the TransformSynchronization module where an integer underflow would cause a memory crash.
+- Fixed a bug where using `Coordinates`, `Vector3f`, or `Vector3d` in a command definition would cause the Code Generator to crash.
 
 ### Removed
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/Generation/Model/UnitySchemaFile.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/Generation/Model/UnitySchemaFile.cs
@@ -152,12 +152,6 @@ namespace Improbable.Gdk.CodeGenerator
             {
                 Name = rawEventDefinition.name;
                 RawType = rawEventDefinition.type;
-
-                if (RawType.IsBuiltInType)
-                {
-                    Type = new UnityTypeReference(RawType.TypeName, null, null);
-                }
-
                 EventIndex = rawEventDefinition.eventIndex;
             }
         }
@@ -179,17 +173,6 @@ namespace Improbable.Gdk.CodeGenerator
                 Name = rawCommandDefinition.name;
                 RawRequestType = rawCommandDefinition.requestType;
                 RawResponseType = rawCommandDefinition.responseType;
-
-                if (RawRequestType != null && RawRequestType.IsBuiltInType)
-                {
-                    RequestType = new UnityTypeReference(RawRequestType.TypeName, null, null);
-                }
-
-                if (RawResponseType != null && RawResponseType.IsBuiltInType)
-                {
-                    ResponseType = new UnityTypeReference(RawResponseType.TypeName, null, null);
-                }
-
                 CommandIndex = rawCommandDefinition.commandIndex;
             }
         }


### PR DESCRIPTION
#### Description
For legacy reasons, `Vector3f`, `Coordinates`, etc are treated as built in types (in the SDK JSON parsing library). 

When the command definitions are parsed, we explicitly check for built in types despite only ever being able to have a composite(?) type `type`, i.e. - a `Coordinates` (allowed) vs an `int` (not-allowed). 

This logic caused problems when using the standard library types that straddled these definitions.

I.e. - 

```
package faeborn.schema.movement;

import "improbable/standard_library.schema";

type Empty {}

component ClientMovementRequest {
    id = 1000;
    improbable.Coordinates latest = 1;

    command Empty start_move(improbable.Coordinates);
}
```

Would cause null refs.

This PR fixes this in commands (and potentially events) by allowing the SchemaProcessor to assign the non-raw fields by searching against its type references. This will pick up `Coordinates` and `Vector3f` properly.

#### Tests
How did you test these changes prior to submitting this pull request?
What automated tests are included in this PR?

Ran codegen against playground + the schema above. All was happy.