### PR TITLE
Update unity version in package.json

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/package.json
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/package.json
@@ -2,7 +2,7 @@
     "name": "com.improbable.gdk.buildsystem",
     "displayName": "SpatialOS GDK Build System",
     "version": "0.1.3",
-    "unity": "2018.2",
+    "unity": "2018.3",
     "author": "Improbable Worlds Ltd",
     "description": "SpatialOS GDK Build System Module. Made by Improbable.",
     "dependencies": {

--- a/workers/unity/Packages/com.improbable.gdk.core/package.json
+++ b/workers/unity/Packages/com.improbable.gdk.core/package.json
@@ -2,7 +2,7 @@
     "name": "com.improbable.gdk.core",
     "displayName": "SpatialOS GDK Core",
     "version": "0.1.3",
-    "unity": "2018.2",
+    "unity": "2018.3",
     "author": "Improbable Worlds Ltd",
     "description": "SpatialOS GDK Core Module. Made by Improbable.",
     "dependencies": {

--- a/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/package.json
+++ b/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/package.json
@@ -2,7 +2,7 @@
     "name": "com.improbable.gdk.gameobjectcreation",
     "displayName": "SpatialOS GDK GameObject Creation",
     "version": "0.1.3",
-    "unity": "2018.2",
+    "unity": "2018.3",
     "author": "Improbable Worlds Ltd",
     "description": "SpatialOS GDK GameObject Creation Module. Made by Improbable.",
     "dependencies": {

--- a/workers/unity/Packages/com.improbable.gdk.mobile/package.json
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/package.json
@@ -2,7 +2,7 @@
     "name": "com.improbable.gdk.mobile",
     "displayName": "SpatialOS GDK Mobile Support",
     "version": "0.0.1",
-    "unity": "2018.2",
+    "unity": "2018.3",
     "author": "Improbable Worlds Ltd",
     "description": "SpatialOS GDK Mobile Support Module. Made by Improbable.",
     "dependencies": {

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/package.json
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/package.json
@@ -2,7 +2,7 @@
     "name": "com.improbable.gdk.playerlifecycle",
     "displayName": "SpatialOS GDK Player Lifecycle",
     "version": "0.1.3",
-    "unity": "2018.2",
+    "unity": "2018.3",
     "author": "Improbable Worlds Ltd",
     "description": "SpatialOS GDK Player Lifecycle Module. Made by Improbable.",
     "dependencies": {

--- a/workers/unity/Packages/com.improbable.gdk.testutils/package.json
+++ b/workers/unity/Packages/com.improbable.gdk.testutils/package.json
@@ -2,7 +2,7 @@
     "name": "com.improbable.gdk.testutils",
     "displayName": "SpatialOS GDK Test Utils",
     "version": "0.1.3",
-    "unity": "2018.2",
+    "unity": "2018.3",
     "author": "Improbable Worlds Ltd",
     "description": "SpatialOS GDK Test Utils. Made by Improbable.",
     "dependencies": {

--- a/workers/unity/Packages/com.improbable.gdk.tools/package.json
+++ b/workers/unity/Packages/com.improbable.gdk.tools/package.json
@@ -2,7 +2,7 @@
     "name": "com.improbable.gdk.tools",
     "displayName": "SpatialOS GDK Tools",
     "version": "0.1.3",
-    "unity": "2018.2",
+    "unity": "2018.3",
     "author": "Improbable Worlds Ltd",
     "description": "SpatialOS GDK Support Tools. Made by Improbable.",
     "dependencies": {

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/package.json
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/package.json
@@ -2,7 +2,7 @@
     "name": "com.improbable.gdk.transformsynchronization",
     "displayName": "SpatialOS GDK Transform Synchronization",
     "version": "0.1.3",
-    "unity": "2018.2",
+    "unity": "2018.3",
     "author": "Improbable Worlds Ltd",
     "description": "SpatialOS GDK Transform Synchronization Module. Made by Improbable.",
     "dependencies": {


### PR DESCRIPTION
#### Description
Forgot to do this in the upgrade - actually required given that `2018.2` won't work without the incremental compiler (I believe).

