### PR TITLE
Build System Tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Updated the `MobileWorkerConnector` to use the KCP network protocol by default.
 - Changed the `mobile_launch.json` config to use the new Runtime.
 - Updated all the launch configs to use the new Runtime.
+- Changed the way builds are processed in the Unity Editor. If you don't have build support for a particular target, that specific build target will be skipped rather than the whole build process cancelled.
 
 ### Fixed
 

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/BuildSupportChecker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/BuildSupportChecker.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Improbable.Gdk.BuildSystem;
 using Improbable.Gdk.BuildSystem.Configuration;
 using UnityEditor;
 using UnityEngine;
@@ -50,6 +51,25 @@ public static class BuildSupportChecker
                 return false;
             })
             .ToArray();
+    }
+
+    public static string[] FilterWorkerTypes(BuildEnvironment environment, string[] desiredWorkerTypes)
+    {
+        return desiredWorkerTypes.Where(wantedWorkerType =>
+        {
+            var buildTargetsForWorker =
+                WorkerBuilder.GetBuildTargetsForWorkerForEnvironment(wantedWorkerType, environment);
+            var buildTargetsMissingBuildSupport = GetBuildTargetsMissingBuildSupport(buildTargetsForWorker);
+
+            if (buildTargetsMissingBuildSupport.Length > 0)
+            {
+                Debug.LogError(ConstructMissingSupportMessage(wantedWorkerType,
+                    environment, buildTargetsMissingBuildSupport));
+                return false;
+            }
+
+            return true;
+        }).ToArray();
     }
 
     public static string ConstructMissingSupportMessage(string workerType, BuildEnvironment environment,

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityWorkerMenuGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityWorkerMenuGenerator.tt
@@ -6,6 +6,7 @@
 #>
 <#= generatedHeader #>
 
+using System.Linq;
 using Improbable.Gdk.BuildSystem;
 using Improbable.Gdk.BuildSystem.Configuration;
 using Improbable.Gdk.Tools;
@@ -90,23 +91,30 @@ var workerType = workerTypeList[i];
             // Delaying build by a frame to ensure the editor has re-rendered the UI to avoid odd glitches.
             EditorApplication.delayCall += () =>
             {
-                if (!CheckWorkersCanBuildForEnvironment(environment, workerTypes))
-                {
-                    DisplayBuildFailureDialog();
-
-                    return;
-                }
+                var filteredWorkerTypes = BuildSupportChecker.FilterWorkerTypes(environment, workerTypes);
 
                 try
                 {
                     LocalLaunch.BuildConfig();
 
-                    foreach (var workerType in workerTypes)
+                    foreach (var workerType in filteredWorkerTypes)
                     {
                         WorkerBuilder.BuildWorkerForEnvironment(workerType, environment);
                     }
 
-                    Debug.LogFormat("Completed build for {0} target", environment);
+                    if (workerTypes.Length == filteredWorkerTypes.Length)
+                    {
+                        Debug.Log($"Completed build for {environment} target.");
+                    }
+                    else
+                    {
+                        var missingWorkerTypes = string.Join(" ", workerTypes.Except(filteredWorkerTypes));
+                        var completedWorkerTypes = string.Join(" ", workerTypes.Intersect(filteredWorkerTypes));
+                        Debug.LogWarning(
+                            $"Completed build for {environment} target.\n"
+                            + $"Completed builds for: {completedWorkerTypes}\n"
+                            + $"Skipped builds for: {missingWorkerTypes}. See above for more information.");
+                    }
                 }
                 catch (System.Exception)
                 {


### PR DESCRIPTION
#### Description
A last minute addition to the `0.1.4` release ~_grumble grumble_~ - adjusting the build system to skip builds that you don't have build support for (without cancelling the other builds). 

For example - if you build all workers without mobile support installed you would get the following messages in the console.

![errors](https://user-images.githubusercontent.com/13353733/51681271-ffb71c00-1fdb-11e9-8596-ccc478bf33d3.PNG)
![all workers build](https://user-images.githubusercontent.com/13353733/51681275-02b20c80-1fdc-11e9-8626-69f02244adbe.PNG)

Also the static `Build` method still throws if build support is missing (such that the process _actually_ returns an error exit code) - so that behavior is unchanged.

#### Tests
Tested a build locally and via command line.

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

**Did you remember a changelog entry?**
Yes

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@jessicafalk @jared-improbable 
