### PR TITLE
Fix ADB throwing an error if your project path has spaces in it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed a bug where launching on Android from the Unity Editor would break if you have spaces in your project path.
+
 ## `0.1.4` - 2019-01-28
 
 ### Added

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
@@ -46,7 +46,7 @@ namespace Improbable.Gdk.Mobile
                 }
 
                 // Install apk on connected phone / emulator
-                if (RedirectedProcess.Run(adbPath, "install", "-r", apkPath) != 0)
+                if (RedirectedProcess.Run(adbPath, "install", "-r", $"\"{apkPath}\"") != 0)
                 {
                     Debug.LogError("Failed to install the apk on the device/emulator. If the application is already installed on your device/emulator, " +
                         "try uninstalling it before launching the mobile client.");


### PR DESCRIPTION
#### Description
The Android launch menu item would fail if you had spaces in your project path.
This is now fixed

#### Tests
Changed my path to have spaces to reproduce the issue. Added a fix and confirmed that it now launches properly.

**Did you remember a changelog entry?**

#### Primary reviewers
@jessicafalk 
