### PR TITLE
Fix Package Traversal Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed a bug where launching on Android from the Unity Editor would break if you have spaces in your project path.
+- Fixed a bug where a Unity package with no dependencies field in its `package.json` would cause code generation to throw exceptions.
 
 ## `0.1.4` - 2019-01-28
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/Common.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/Common.cs
@@ -95,7 +95,12 @@ namespace Improbable.Gdk.Tools
             try
             {
                 var package = Json.Deserialize(File.ReadAllText(filePath, Encoding.UTF8));
-                return ((Dictionary<string, object>) package["dependencies"]).ToDictionary(kv => kv.Key,
+                if (!package.TryGetValue("dependencies", out var dependenciesJson))
+                {
+                    return new Dictionary<string, string>();
+                }
+
+                return ((Dictionary<string, object>) dependenciesJson).ToDictionary(kv => kv.Key,
                     kv => (string) kv.Value);
             }
             catch (Exception e)


### PR DESCRIPTION
#### Description
In our `package.json` parsing code, if a package did not have a `dependencies` field, it would throw exceptions despite this being a valid package declaration.

This could cause code generation to fail as @polartron experienced. 

#### Tests
Added a mock package with no `dependencies` field. Ran code generation, it was all good.

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

N/A

**Did you remember a changelog entry?**
Yes

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
