### PR TITLE
Run Build & Test in Parallel on Buildkite

### DIFF
--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -40,36 +40,31 @@ steps:
       - logs/**/*
 
   - label: "build :android:"
-    command: >
-      bash -c 'ci/build.sh "$0" "$1" "$2"' "AndroidClient" "local" "mono"
+    command: "bash -c 'ci/build.sh \"$0\" \"$1\" \"$2\"' \"AndroidClient\" \"local\" \"mono\""
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build :iphone:"
-    command: > 
-      bash -c 'ci/build.sh "$0" "$1" "$2"' "iOSClient" "local" "mono"
+    command: "bash -c 'ci/build.sh \"$0\" \"$1\" \"$2\"' \"iOSClient\" \"local\" \"il2cpp\""
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build UnityClient mono"
-    command: >
-      bash -c 'ci/build.sh "$0" "$1" "$2"' "UnityClient" "cloud" "mono"
+    command: "bash -c 'ci/build.sh \"$0\" \"$1\" \"$2\"' \"UnityClient\" \"cloud\" \"mono\""
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build UnityClient il2cpp"
-    command: >
-      bash -c 'ci/build.sh "$0" "$1" "$2"' "UnityClient" "local" "il2cpp"
+    command: "bash -c 'ci/build.sh \"$0\" \"$1\" \"$2\"' \"UnityClient\" \"local\" \"il2cpp\""
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build UnityGameLogic mono"
-    command: >
-      bash -c 'ci/build.sh "$0" "$1" "$2"' "UnityGameLogic" "cloud" "mono"
+    command: "bash -c 'ci/build.sh \"$0\" \"$1\" \"$2\"' \"UnityGameLogic\" \"cloud\" \"mono\""
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -25,14 +25,46 @@ common: &common
 # These are then relied on to have stable names by other things, so once named, please beware renaming has consequences.
 
 steps:
-  - label: "build :bash:"
-    command: bash -c ci/build-test.sh
-    <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
-    artifact_paths:
-      - logs/**/*
   - label: "verify docs only changes :cop:"
     command: bash -c ci/docs-build-verification.sh
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
+
   - label: "lint docs :lint-roller:"
     command: bash -c ci/docs-lint.sh
     <<: *common
+
+  - label: "test"
+    command: bash -c ci/test.sh
+    <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
+    artifact_paths:
+      - logs/**/*
+
+  - label: "build :android:"
+    command: bash -c ci/build.sh "AndroidClient" "local" "mono"
+    <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
+    artifact_paths:
+      - logs/**/*
+
+  - label: "build :iphone:"
+    command: bash -c ci/build.sh "iOSClient" "local" "mono"
+    <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
+    artifact_paths:
+      - logs/**/*
+
+  - label: "build UnityClient mono"
+    command: bash -c ci/build.sh "UnityClient" "cloud" "mono"
+    <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
+    artifact_paths:
+      - logs/**/*
+
+  - label: "build UnityClient il2cpp"
+    command: bash -c ci/build.sh "UnityClient" "local" "il2cpp"
+    <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
+    artifact_paths:
+      - logs/**/*
+
+  - label: "build UnityGameLogic mono"
+    command: bash -c ci/build.sh "UnityGameLogic" "cloud" "mono"
+    <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
+    artifact_paths:
+      - logs/**/*

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -40,31 +40,36 @@ steps:
       - logs/**/*
 
   - label: "build :android:"
-    command: bash -c 'ci/build.sh "$0" "$1" "$2"' "AndroidClient" "local" "mono"
+    command: |
+      bash -c 'ci/build.sh "$0" "$1" "$2"' "AndroidClient" "local" "mono"
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build :iphone:"
-    command: bash -c 'ci/build.sh "$0" "$1" "$2"' "iOSClient" "local" "mono"
+    command: | 
+      bash -c 'ci/build.sh "$0" "$1" "$2"' "iOSClient" "local" "mono"
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build UnityClient mono"
-    command: bash -c 'ci/build.sh "$0" "$1" "$2"' "UnityClient" "cloud" "mono"
+    command: |
+      bash -c 'ci/build.sh "$0" "$1" "$2"' "UnityClient" "cloud" "mono"
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build UnityClient il2cpp"
-    command: bash -c 'ci/build.sh "$0" "$1" "$2"' "UnityClient" "local" "il2cpp"
+    command: |
+      bash -c 'ci/build.sh "$0" "$1" "$2"' "UnityClient" "local" "il2cpp"
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build UnityGameLogic mono"
-    command: bash -c 'ci/build.sh "$0" "$1" "$2"' "UnityGameLogic" "cloud" "mono"
+    command: |
+      bash -c 'ci/build.sh "$0" "$1" "$2"' "UnityGameLogic" "cloud" "mono"
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -40,31 +40,31 @@ steps:
       - logs/**/*
 
   - label: "build :android:"
-    command: "bash -c 'ci/build.sh \"$0\" \"$1\" \"$2\"' \"AndroidClient\" \"local\" \"mono\""
+    command: "bash -c 'ci/build.sh \"\$0\" \"\$1\" \"\$2\"' \"AndroidClient\" \"local\" \"mono\""
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build :iphone:"
-    command: "bash -c 'ci/build.sh \"$0\" \"$1\" \"$2\"' \"iOSClient\" \"local\" \"il2cpp\""
+    command: "bash -c 'ci/build.sh \"\$0\" \"\$1\" \"\$2\"' \"iOSClient\" \"local\" \"il2cpp\""
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build UnityClient mono"
-    command: "bash -c 'ci/build.sh \"$0\" \"$1\" \"$2\"' \"UnityClient\" \"cloud\" \"mono\""
+    command: "bash -c 'ci/build.sh \"\$0\" \"\$1\" \"\$2\"' \"UnityClient\" \"cloud\" \"mono\""
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build UnityClient il2cpp"
-    command: "bash -c 'ci/build.sh \"$0\" \"$1\" \"$2\"' \"UnityClient\" \"local\" \"il2cpp\""
+    command: "bash -c 'ci/build.sh \"\$0\" \"\$1\" \"\$2\"' \"UnityClient\" \"local\" \"il2cpp\""
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build UnityGameLogic mono"
-    command: "bash -c 'ci/build.sh \"$0\" \"$1\" \"$2\"' \"UnityGameLogic\" \"cloud\" \"mono\""
+    command: "bash -c 'ci/build.sh \"\$0\" \"\$1\" \"\$2\"' \"UnityGameLogic\" \"cloud\" \"mono\""
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -40,31 +40,31 @@ steps:
       - logs/**/*
 
   - label: "build :android:"
-    command: bash -c ci/build.sh "AndroidClient" "local" "mono"
+    command: bash -c 'ci/build.sh "$0" "$1" "$2"' "AndroidClient" "local" "mono"
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build :iphone:"
-    command: bash -c ci/build.sh "iOSClient" "local" "mono"
+    command: bash -c 'ci/build.sh "$0" "$1" "$2"' "iOSClient" "local" "mono"
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build UnityClient mono"
-    command: bash -c ci/build.sh "UnityClient" "cloud" "mono"
+    command: bash -c 'ci/build.sh "$0" "$1" "$2"' "UnityClient" "cloud" "mono"
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build UnityClient il2cpp"
-    command: bash -c ci/build.sh "UnityClient" "local" "il2cpp"
+    command: bash -c 'ci/build.sh "$0" "$1" "$2"' "UnityClient" "local" "il2cpp"
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build UnityGameLogic mono"
-    command: bash -c ci/build.sh "UnityGameLogic" "cloud" "mono"
+    command: bash -c 'ci/build.sh "$0" "$1" "$2"' "UnityGameLogic" "cloud" "mono"
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -40,35 +40,35 @@ steps:
       - logs/**/*
 
   - label: "build :android:"
-    command: |
+    command: >
       bash -c 'ci/build.sh "$0" "$1" "$2"' "AndroidClient" "local" "mono"
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build :iphone:"
-    command: | 
+    command: > 
       bash -c 'ci/build.sh "$0" "$1" "$2"' "iOSClient" "local" "mono"
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build UnityClient mono"
-    command: |
+    command: >
       bash -c 'ci/build.sh "$0" "$1" "$2"' "UnityClient" "cloud" "mono"
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build UnityClient il2cpp"
-    command: |
+    command: >
       bash -c 'ci/build.sh "$0" "$1" "$2"' "UnityClient" "local" "il2cpp"
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build UnityGameLogic mono"
-    command: |
+    command: >
       bash -c 'ci/build.sh "$0" "$1" "$2"' "UnityGameLogic" "cloud" "mono"
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -35,36 +35,56 @@ steps:
 
   - label: "test"
     command: bash -c ci/test.sh
-    <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
+    <<: *common
     artifact_paths:
       - logs/**/*
 
   - label: "build :android:"
-    command: "bash -c 'ci/build.sh \"$0\" \"$1\" \"$2\"' \"AndroidClient\" \"local\" \"mono\""
-    <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
+    command: bash -c ci/build.sh
+    <<: *common
     artifact_paths:
       - logs/**/*
+    env: 
+      WORKER_TYPE: "AndroidClient"
+      BUILD_TARGET: "local"
+      SCRIPTING_TYPE: "mono"
 
   - label: "build :iphone:"
-    command: "bash -c 'ci/build.sh \"$0\" \"$1\" \"$2\"' \"iOSClient\" \"local\" \"il2cpp\""
-    <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
+    command: bash -c ci/build.sh
+    <<: *common 
     artifact_paths:
       - logs/**/*
+    env: 
+      WORKER_TYPE: "iOSClient"
+      BUILD_TARGET: "local"
+      SCRIPTING_TYPE: "il2cpp"
 
   - label: "build UnityClient mono"
-    command: "bash -c 'ci/build.sh \"$0\" \"$1\" \"$2\"' \"UnityClient\" \"cloud\" \"mono\""
-    <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
+    command: bash -c ci/build.sh
+    <<: *common 
     artifact_paths:
       - logs/**/*
+    env: 
+      WORKER_TYPE: "UnityClient"
+      BUILD_TARGET: "cloud"
+      SCRIPTING_TYPE: "mono"
 
   - label: "build UnityClient il2cpp"
-    command: "bash -c 'ci/build.sh \"$0\" \"$1\" \"$2\"' \"UnityClient\" \"local\" \"il2cpp\""
-    <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
+    command: bash -c ci/build.sh
+    <<: *common 
     artifact_paths:
       - logs/**/*
+    env: 
+      WORKER_TYPE: "UnityClient"
+      BUILD_TARGET: "local"
+      SCRIPTING_TYPE: "il2cpp"
 
   - label: "build UnityGameLogic mono"
-    command: "bash -c 'ci/build.sh \"$0\" \"$1\" \"$2\"' \"UnityGameLogic\" \"cloud\" \"mono\""
-    <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
+    command: bash -c ci/build.sh
+    <<: *common 
     artifact_paths:
       - logs/**/*
+    env: 
+      WORKER_TYPE: "UnityGameLogic"
+      BUILD_TARGET: "cloud"
+      SCRIPTING_TYPE: "mono"

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -40,31 +40,31 @@ steps:
       - logs/**/*
 
   - label: "build :android:"
-    command: "bash -c 'ci/build.sh \"\$0\" \"\$1\" \"\$2\"' \"AndroidClient\" \"local\" \"mono\""
+    command: "bash -c 'ci/build.sh \"$0\" \"$1\" \"$2\"' \"AndroidClient\" \"local\" \"mono\""
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build :iphone:"
-    command: "bash -c 'ci/build.sh \"\$0\" \"\$1\" \"\$2\"' \"iOSClient\" \"local\" \"il2cpp\""
+    command: "bash -c 'ci/build.sh \"$0\" \"$1\" \"$2\"' \"iOSClient\" \"local\" \"il2cpp\""
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build UnityClient mono"
-    command: "bash -c 'ci/build.sh \"\$0\" \"\$1\" \"\$2\"' \"UnityClient\" \"cloud\" \"mono\""
+    command: "bash -c 'ci/build.sh \"$0\" \"$1\" \"$2\"' \"UnityClient\" \"cloud\" \"mono\""
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build UnityClient il2cpp"
-    command: "bash -c 'ci/build.sh \"\$0\" \"\$1\" \"\$2\"' \"UnityClient\" \"local\" \"il2cpp\""
+    command: "bash -c 'ci/build.sh \"$0\" \"$1\" \"$2\"' \"UnityClient\" \"local\" \"il2cpp\""
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*
 
   - label: "build UnityGameLogic mono"
-    command: "bash -c 'ci/build.sh \"\$0\" \"\$1\" \"\$2\"' \"UnityGameLogic\" \"cloud\" \"mono\""
+    command: "bash -c 'ci/build.sh \"$0\" \"$1\" \"$2\"' \"UnityGameLogic\" \"cloud\" \"mono\""
     <<: *common # This folds the YAML named anchor into this step. Overrides, if any, should follow, not precede.
     artifact_paths:
       - logs/**/*

--- a/.buildkite/trigger.sh
+++ b/.buildkite/trigger.sh
@@ -9,4 +9,4 @@ cd "$(dirname "$0")/../"
 
 # The step-definitions file is uploaded dynamically to preserve ability for historical builds
 # vs changes in CI pipeline configuration.
-buildkite-agent pipeline upload "$1"
+buildkite-agent pipeline upload "$1" --no-interpolation

--- a/.buildkite/trigger.sh
+++ b/.buildkite/trigger.sh
@@ -9,4 +9,4 @@ cd "$(dirname "$0")/../"
 
 # The step-definitions file is uploaded dynamically to preserve ability for historical builds
 # vs changes in CI pipeline configuration.
-buildkite-agent pipeline upload "$1" --no-interpolation
+buildkite-agent pipeline upload "$1"

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -e -u -o pipefail -x
 
-WORKER_TYPE=$1
-BUILD_TARGET=$2
-SCRIPTING_TYPE=$3
-
 echo "Building for: ${WORKER_TYPE} ${BUILD_TARGET} ${SCRIPTING_TYPE}"
 
 cd "$(dirname "$0")/../"

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-set -e -u -o pipefail -x
+set -e -u -o pipefail
+
+if [[ -n "${DEBUG-}" ]]; then
+  set -x
+fi
 
 echo "Building for: ${WORKER_TYPE} ${BUILD_TARGET} ${SCRIPTING_TYPE}"
 
@@ -17,7 +21,7 @@ if [[ ${WORKER_TYPE} == "AndroidClient" ]]; then
 fi
 
 if [[ ${WORKER_TYPE} == "iOSClient" ]]; then
-    if !isMacOS; then
+    if ! isMacOS; then
         echo "I can't build for iOS!"
         exit 0
     fi

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -21,7 +21,7 @@ if [[ ${WORKER_TYPE} == "AndroidClient" ]]; then
 fi
 
 if [[ ${WORKER_TYPE} == "iOSClient" ]]; then
-    if !isMacOs; then
+    if !isMacOS; then
         echo "I can't build for iOS!"
         exit 0
     fi

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -29,4 +29,4 @@ fi
 
 LOG_LOCATION="$(pwd)/logs/${WORKER_TYPE}-${BUILD_TARGET}-${SCRIPTING_TYPE}.log"
 
-./shared-ci/scripts/build.sh "workers/unity" ${WORKER_TYPE} ${BUILD_TARGET} ${SCRIPTING_TYPE} "${LOG_LOCATION}"
+.shared-ci/scripts/build.sh "workers/unity" ${WORKER_TYPE} ${BUILD_TARGET} ${SCRIPTING_TYPE} "${LOG_LOCATION}"

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
+set -e -u -o pipefail -x
 
-set -e -u -o -x pipefail
+WORKER_TYPE=$1
+BUILD_TARGET=$2
+SCRIPTING_TYPE=$3
+
+echo "Building for: ${WORKER_TYPE} ${BUILD_TARGET} ${SCRIPTING_TYPE}"
 
 cd "$(dirname "$0")/../"
 
@@ -10,10 +15,6 @@ source ".shared-ci/scripts/pinned-tools.sh"
 if isDocsBranch; then
     exit 0
 fi
-
-WORKER_TYPE=$1
-BUILD_TARGET=$2
-SCRIPTING_TYPE=$3
 
 if [[ ${WORKER_TYPE} == "AndroidClient" ]]; then
     .shared-ci/scripts/prepare-unity-mobile.sh "$(pwd)/logs/PrepareUnityMobile.log"

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e -u -o -x pipefail
+
+cd "$(dirname "$0")/../"
+
+ci/bootstrap.sh
+source ".shared-ci/scripts/pinned-tools.sh"
+
+if isDocsBranch; then
+    exit 0
+fi
+
+WORKER_TYPE=$1
+BUILD_TARGET=$2
+SCRIPTING_TYPE=$3
+
+if [[ ${WORKER_TYPE} == "AndroidClient" ]]; then
+    .shared-ci/scripts/prepare-unity-mobile.sh "$(pwd)/logs/PrepareUnityMobile.log"
+fi
+
+if [[ ${WORKER_TYPE} == "iOSClient" ]]; then
+    if !isMacOs; then
+        echo "I can't build for iOS!"
+        exit 0
+    fi
+fi
+
+LOG_LOCATION="$(pwd)/logs/${WORKER_TYPE}-${BUILD_TARGET}-${SCRIPTING_TYPE}.log"
+
+./shared-ci/scripts/build.sh "workers/unity" ${WORKER_TYPE} ${BUILD_TARGET} ${SCRIPTING_TYPE} "${LOG_LOCATION}"

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -3,8 +3,14 @@ set -u -x -o pipefail
 
 cd "$(dirname "$0")/../"
 
+ci/bootstrap.sh
+
 source .shared-ci/scripts/pinned-tools.sh
 source .shared-ci/scripts/profiling.sh
+
+if isDocsBranch; then
+    exit 0
+fi
 
 markStartOfBlock "$0"
 


### PR DESCRIPTION
#### Description
Run all build and test steps in parallel. In the best case this reduces the CI time from ~15 minutes to 5 minutes. This does require _more_ agents available, the case where everything is sequential (on one agent), this method will be slower. However, we expect to have more than 1 agent available for a build. 

- Added `build.sh` which acts as a passthrough to the shared-ci version which correctly sets up the environment and sets the worker type, etc.
- Made `test.sh` able to be run from standalone on the CI agent.
- Removed `build-test.sh` from Buildkite altogether!
- Early out for building iOS on Windows.

#### Tests
Ran on Buildkite

#### Documentation
N/A

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
