### PR TITLE
Fix null ptr exception

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs
@@ -152,14 +152,14 @@ namespace Improbable.Gdk.Tools
                 process.OutputDataReceived += (sender, args) =>
                 {
                     var outputString = args.Data;
-                    if ((outputRedirectBehaviour & OutputRedirectBehaviour.ProcessSpatialOutput) != OutputRedirectBehaviour.None)
-                    {
-                        outputString = ProcessSpatialOutput(outputString);
-                    }
-
                     if (string.IsNullOrEmpty(outputString))
                     {
                         return;
+                    }
+
+                    if ((outputRedirectBehaviour & OutputRedirectBehaviour.ProcessSpatialOutput) != OutputRedirectBehaviour.None)
+                    {
+                        outputString = ProcessSpatialOutput(outputString);
                     }
 
                     if ((outputRedirectBehaviour & OutputRedirectBehaviour.RedirectStdOut) != OutputRedirectBehaviour.None)


### PR DESCRIPTION
#### Description
There's a potential crash in Redirected Process output processing if it receives null as an output. This probably got mixed up during some of the rebases.

#### Tests
Run `local launch` => ensure nothing crashes
