### PR TITLE
Remove overly specific network terminology.

### DIFF
--- a/docs/content/mobile/android/local-deploy.md
+++ b/docs/content/mobile/android/local-deploy.md
@@ -55,7 +55,7 @@ It’s done when you see the following message in the terminal: `SpatialOS ready
 ## Android device{#android-device}
 
 1. Enable USB debugging on your mobile device. See the [Android developer documentation](https://developer.android.com/studio/debug/dev-options#enable) for guidance.
-1. Make sure your computer and your mobile device are both connected to the same wireless network.
+1. Make sure your computer and your mobile device are both connected to the same network.
 1. Connect the mobile device to your computer using a USB cable. You might get a pop-up window on the device asking you to allow USB debugging. Select **Yes**.
 1. [Build your server-workers]({{urlRoot}}/content/build).
 1. [Set up your local deployment](#prepare).

--- a/docs/content/mobile/ios/local-deploy.md
+++ b/docs/content/mobile/ios/local-deploy.md
@@ -58,7 +58,7 @@ Note: You don’t need to enter anything in the text field.
 ## iOS device{#ios-device}
 
 1. Set up [Code signing and provisioning](https://help.apple.com/xcode/mac/current/#/dev60b6fbbc7).
-1. Make sure your computer and your mobile device are both connected to the same wireless network.
+1. Make sure your computer and your mobile device are both connected to the same network.
 1. Connect the mobile device to your computer using a USB cable.
 1. In your Unity Editor, build your workers from the SpatialOS menu by selecting **Build for local** > **All workers**.
 1. You need to know the local IP address of your computer to connect. [This page](https://lifehacker.com/5833108/how-to-find-your-local-and-external-ip-address) (on the Lifehacker website)  describes how you can find your external and local IP address.


### PR DESCRIPTION
#### Description
Remove overly specific network terminology.

**Pages state**
>2. Make sure your computer and your mobile device are both connected to the same wireless network.

**This should say:**
>2. Make sure your computer and your mobile device are both connected to the same network.


#### Tests
None

#### Documentation
This is documentation.