### PR TITLE
Add pre exit hook for Buildkite

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -4,5 +4,5 @@ set -euo pipefail
 
 # The premerge step runs on linux agents!
 if [[ ${BUILDKITE_AGENT_META_DATA_OS} == "windows" ]]; then
-    powershell ci/purge.ps1
+    powershell -NoProfile -NonInteractive ci/purge.ps1
 fi

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+[[ -n "${DEBUG:-}" ]] && set -x
+
+# The premerge step runs on linux agents!
+if [[ ${BUILDKITE_AGENT_META_DATA_OS} == "windows" ]]; then
+    powershell ci/purge.ps1
+fi

--- a/ci/purge.ps1
+++ b/ci/purge.ps1
@@ -4,30 +4,30 @@
 # to find all processes of a particular name which have file locks on our build (project) directory.
 # We can then attempt to kill each of these processes if any exist.
 
-$SCRIPT_LOCATION = $MyInvocation.MyCommand.Path
-$SCRIPT_DIR = Split-Path $SCRIPT_LOCATION
-cd "${SCRIPT_DIR}/.."
+$ScriptLocation = $MyInvocation.MyCommand.Path
+$ScriptDir = Split-Path $ScriptLocation
+cd "$ScriptDir/.."
 
 function Kill-Dangling-Processes {
 	param( [string]$ProcessName )
 
 	echo "Looking for ${ProcessName} processes to kill..."
-	${DIR}=$(pwd).Path
-	${OUT}=$(handle64 -accepteula -p "${ProcessName}.exe" ${DIR})
+	$Dir=$(pwd).Path
+	$Out=$(handle64 -accepteula -p "$($ProcessName).exe" $Dir)
 	ForEach ($line in $($OUT -split "`r`n"))
 	{
-		$result = $([regex]::Match("${line}", "pid: (.*) type"))
-		if ($result.Success)
+		$Result = $([regex]::Match("$line", "pid: (.*) type"))
+		if ($Result.Success)
 		{
-			$ppid = $result.Groups[1].Value
+			$ppid = $Result.Groups[1].Value
 			taskkill /f /pid $ppid
 		}
 	}
 }
 
-$PROCESSES_TO_KILL = @("dotnet", "Unity", "UnityPackageManager")
+$ProcessesToKill = @("dotnet", "Unity", "UnityPackageManager")
 
-ForEach ($Process in $PROCESSES_TO_KILL) 
+ForEach ($Process in $ProcessesToKill) 
 {
 	Kill-Dangling-Processes $Process
 }

--- a/ci/purge.ps1
+++ b/ci/purge.ps1
@@ -1,0 +1,33 @@
+# This script is used to kill all dangling procceses at the end of a Buildkite build.
+# 
+# It does this by using [handle](https://docs.microsoft.com/en-us/sysinternals/downloads/handle)
+# to find all processes of a particular name which have file locks on our build (project) directory.
+# We can then attempt to kill each of these processes if any exist.
+
+$SCRIPT_LOCATION = $MyInvocation.MyCommand.Path
+$SCRIPT_DIR = Split-Path $SCRIPT_LOCATION
+cd "${SCRIPT_DIR}/.."
+
+function Kill-Dangling-Processes {
+	param( [string]$ProcessName )
+
+	echo "Looking for ${ProcessName} processes to kill..."
+	${DIR}=$(pwd).Path
+	${OUT}=$(handle64 -accepteula -p "${ProcessName}.exe" ${DIR})
+	ForEach ($line in $($OUT -split "`r`n"))
+	{
+		$result = $([regex]::Match("${line}", "pid: (.*) type"))
+		if ($result.Success)
+		{
+			$ppid = $result.Groups[1].Value
+			taskkill /f /pid $ppid
+		}
+	}
+}
+
+$PROCESSES_TO_KILL = @("dotnet", "Unity", "UnityPackageManager")
+
+ForEach ($Process in $PROCESSES_TO_KILL) 
+{
+	Kill-Dangling-Processes $Process
+}


### PR DESCRIPTION
#### Description
Pre exit hook to kill all dangling processes in Buildkite.

Written in Powershell and uses `handle64` to find processes. I went with a blacklist approach as blindly killing processes touching the directory didn't end too well 😬 

Currently kills all `dotnet`, `Unity`, and `UnityPackageManager` processes 

