### PR TITLE
Add Schema Annotations Support

### DIFF
--- a/test-project/Assets/.Schema/improbable/gdk/tests/exhaustive_test.schema
+++ b/test-project/Assets/.Schema/improbable/gdk/tests/exhaustive_test.schema
@@ -7,8 +7,12 @@ enum SomeEnum {
   SECOND_VALUE = 1;
 }
 
-component ExhaustiveSingular {
-  id = 197715;
+[ExhaustiveSingularData(
+    field1 = true, field2 = 10.5, field3 = "foo", field4 = -2, field5 = 3,
+    field6 = -15.5, field7 = "bar", field8 = 0, field9 = 1, field10 = 4,
+    field11 = 5, field12 = 6, field13 = 7, field14 = -8, field15 = -9,
+    field16 = 10, field17 = SomeType, field18 = SomeEnum.FIRST_VALUE)]
+type ExhaustiveSingularData {
   bool field1 = 1;
   float field2 = 2;
   bytes field3 = 3;
@@ -29,8 +33,17 @@ component ExhaustiveSingular {
   SomeEnum field18 = 18;
 }
 
-component ExhaustiveOptional {
-  id = 197716;
+component ExhaustiveSingular {
+  id = 197715;
+  data ExhaustiveSingularData;
+}
+
+[ExhaustiveOptionalData(
+    field1 = true, field2 = 10.5, field3 = "foo", field4 = -2, field5 = 3,
+    field6 = -15.5, field7 = "bar", field8 = 0, field9 = 1, field10 = 4,
+    field11 = 5, field12 = 6, field13 = 7, field14 = -8, field15 = -9,
+    field16 = 10, field17 = SomeType, field18 = SomeEnum.FIRST_VALUE)]
+type ExhaustiveOptionalData {
   option<bool> field1 = 1;
   option<float> field2 = 2;
   option<bytes> field3 = 3;
@@ -51,8 +64,17 @@ component ExhaustiveOptional {
   option<SomeEnum> field18 = 18;
 }
 
-component ExhaustiveRepeated {
-  id = 197717;
+component ExhaustiveOptional {
+  id = 197716;
+  data ExhaustiveOptionalData;
+}
+
+[ExhaustiveRepeatedData(
+    field1 = [true], field2 = [10.5], field3 = ["foo"], field4 = [-2], field5 = [3],
+    field6 = [-15.5], field7 = ["bar"], field8 = [0], field9 = [1], field10 = [4],
+    field11 = [5], field12 = [6], field13 = [7], field14 = [-8], field15 = [-9],
+    field16 = [10], field17 = [SomeType], field18 = [SomeEnum.FIRST_VALUE])]
+type ExhaustiveRepeatedData {
   list<bool> field1 = 1;
   list<float> field2 = 2;
   list<bytes> field3 = 3;
@@ -73,8 +95,17 @@ component ExhaustiveRepeated {
   list<SomeEnum> field18 = 18;
 }
 
-component ExhaustiveMapValue {
-  id = 197718;
+component ExhaustiveRepeated {
+  id = 197717;
+  data ExhaustiveRepeatedData;
+}
+
+[ExhaustiveMapValueData(
+    {"field1" : true}, {"field2" : 10.5}, {"field3" : "foo"}, {"field4" : -2}, {"field5" : 3},
+    {"field6" : -15.5}, {"field7" : "bar"}, {"field8" : 0}, {"field9" : 1}, {"field10" : 4},
+    {"field11" : 5}, {"field12" : 6}, {"field13" : 7}, {"field14" : -8}, {"field15" : -9},
+    {"field16" : 10}, {"field17" : SomeType}, {"field18" : SomeEnum.FIRST_VALUE})]
+type ExhaustiveMapValueData {
   map<string, bool> field1 = 1;
   map<string, float> field2 = 2;
   map<string, bytes> field3 = 3;
@@ -95,11 +126,20 @@ component ExhaustiveMapValue {
   map<string, SomeEnum> field18 = 18;
 }
 
-component ExhaustiveMapKey {
-  id = 197719;
+component ExhaustiveMapValue {
+  id = 197718;
+  data ExhaustiveMapValueData;
+}
+
+[ExhaustiveMapKeyData(
+    {true : "field1"}, {10.5 : "field2"}, {"foo" : "field3"}, {-2 : "field4"}, {3 : "field5"},
+    {-15.5 : "field6"}, {"bar" : "field7"}, {0 : "field8"}, {1 : "field9"}, {4 : "field10"},
+    {5 : "field11"}, {6 : "field12"}, {7 : "field13"}, {-8 : "field14"}, {-9 : "field15"},
+    {10 : "field16"}, {SomeType : "field17"}, {SomeEnum.FIRST_VALUE : "field18"})]
+type ExhaustiveMapKeyData {
   map<bool, string> field1 = 1;
   map<float, string> field2 = 2;
-  map<bytes, string> field3 = 3; 
+  map<bytes, string> field3 = 3;
   map<int32, string> field4 = 4;
   map<int64, string> field5 = 5;
   map<double, string> field6 = 6;
@@ -117,23 +157,7 @@ component ExhaustiveMapKey {
   map<SomeEnum, string> field18 = 18;
 }
 
-// Blittable subset
-component ExhaustiveBlittableSingular {
-  id = 197720;
-  bool field1 = 1;
-  float field2 = 2;
-  int32 field4 = 4;
-  int64 field5 = 5;
-  double field6 = 6;
-  uint32 field8 = 8;
-  uint64 field9 = 9;
-  sint32 field10 = 10;
-  sint64 field11 = 11;
-  fixed32 field12 = 12;
-  fixed64 field13 = 13;
-  sfixed32 field14 = 14;
-  sfixed64 field15 = 15;
-  EntityId field16 = 16;
-  SomeType field17 = 17;
-  SomeEnum field18 = 18;
+component ExhaustiveMapKey {
+  id = 197719;
+  data ExhaustiveMapKeyData;
 }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyData.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyData.cs
@@ -1,0 +1,464 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Linq;
+using Improbable.Gdk.Core;
+using UnityEngine;
+
+namespace Improbable.Gdk.Tests
+{
+    
+    public struct ExhaustiveMapKeyData
+    {
+        public global::System.Collections.Generic.Dictionary<BlittableBool,string> Field1;
+        public global::System.Collections.Generic.Dictionary<float,string> Field2;
+        public global::System.Collections.Generic.Dictionary<byte[],string> Field3;
+        public global::System.Collections.Generic.Dictionary<int,string> Field4;
+        public global::System.Collections.Generic.Dictionary<long,string> Field5;
+        public global::System.Collections.Generic.Dictionary<double,string> Field6;
+        public global::System.Collections.Generic.Dictionary<string,string> Field7;
+        public global::System.Collections.Generic.Dictionary<uint,string> Field8;
+        public global::System.Collections.Generic.Dictionary<ulong,string> Field9;
+        public global::System.Collections.Generic.Dictionary<int,string> Field10;
+        public global::System.Collections.Generic.Dictionary<long,string> Field11;
+        public global::System.Collections.Generic.Dictionary<uint,string> Field12;
+        public global::System.Collections.Generic.Dictionary<ulong,string> Field13;
+        public global::System.Collections.Generic.Dictionary<int,string> Field14;
+        public global::System.Collections.Generic.Dictionary<long,string> Field15;
+        public global::System.Collections.Generic.Dictionary<global::Improbable.Gdk.Core.EntityId,string> Field16;
+        public global::System.Collections.Generic.Dictionary<global::Improbable.Gdk.Tests.SomeType,string> Field17;
+        public global::System.Collections.Generic.Dictionary<global::Improbable.Gdk.Tests.SomeEnum,string> Field18;
+    
+        public ExhaustiveMapKeyData(global::System.Collections.Generic.Dictionary<BlittableBool,string> field1, global::System.Collections.Generic.Dictionary<float,string> field2, global::System.Collections.Generic.Dictionary<byte[],string> field3, global::System.Collections.Generic.Dictionary<int,string> field4, global::System.Collections.Generic.Dictionary<long,string> field5, global::System.Collections.Generic.Dictionary<double,string> field6, global::System.Collections.Generic.Dictionary<string,string> field7, global::System.Collections.Generic.Dictionary<uint,string> field8, global::System.Collections.Generic.Dictionary<ulong,string> field9, global::System.Collections.Generic.Dictionary<int,string> field10, global::System.Collections.Generic.Dictionary<long,string> field11, global::System.Collections.Generic.Dictionary<uint,string> field12, global::System.Collections.Generic.Dictionary<ulong,string> field13, global::System.Collections.Generic.Dictionary<int,string> field14, global::System.Collections.Generic.Dictionary<long,string> field15, global::System.Collections.Generic.Dictionary<global::Improbable.Gdk.Core.EntityId,string> field16, global::System.Collections.Generic.Dictionary<global::Improbable.Gdk.Tests.SomeType,string> field17, global::System.Collections.Generic.Dictionary<global::Improbable.Gdk.Tests.SomeEnum,string> field18)
+        {
+            Field1 = field1;
+            Field2 = field2;
+            Field3 = field3;
+            Field4 = field4;
+            Field5 = field5;
+            Field6 = field6;
+            Field7 = field7;
+            Field8 = field8;
+            Field9 = field9;
+            Field10 = field10;
+            Field11 = field11;
+            Field12 = field12;
+            Field13 = field13;
+            Field14 = field14;
+            Field15 = field15;
+            Field16 = field16;
+            Field17 = field17;
+            Field18 = field18;
+        }
+        public static class Serialization
+        {
+            public static void Serialize(ExhaustiveMapKeyData instance, global::Improbable.Worker.CInterop.SchemaObject obj)
+            {
+                {
+                    foreach (var keyValuePair in instance.Field1)
+                    {
+                        var mapObj = obj.AddObject(1);
+                        mapObj.AddBool(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field2)
+                    {
+                        var mapObj = obj.AddObject(2);
+                        mapObj.AddFloat(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field3)
+                    {
+                        var mapObj = obj.AddObject(3);
+                        mapObj.AddBytes(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field4)
+                    {
+                        var mapObj = obj.AddObject(4);
+                        mapObj.AddInt32(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field5)
+                    {
+                        var mapObj = obj.AddObject(5);
+                        mapObj.AddInt64(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field6)
+                    {
+                        var mapObj = obj.AddObject(6);
+                        mapObj.AddDouble(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field7)
+                    {
+                        var mapObj = obj.AddObject(7);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field8)
+                    {
+                        var mapObj = obj.AddObject(8);
+                        mapObj.AddUint32(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field9)
+                    {
+                        var mapObj = obj.AddObject(9);
+                        mapObj.AddUint64(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field10)
+                    {
+                        var mapObj = obj.AddObject(10);
+                        mapObj.AddSint32(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field11)
+                    {
+                        var mapObj = obj.AddObject(11);
+                        mapObj.AddSint64(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field12)
+                    {
+                        var mapObj = obj.AddObject(12);
+                        mapObj.AddFixed32(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field13)
+                    {
+                        var mapObj = obj.AddObject(13);
+                        mapObj.AddFixed64(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field14)
+                    {
+                        var mapObj = obj.AddObject(14);
+                        mapObj.AddSfixed32(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field15)
+                    {
+                        var mapObj = obj.AddObject(15);
+                        mapObj.AddSfixed64(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field16)
+                    {
+                        var mapObj = obj.AddObject(16);
+                        mapObj.AddEntityId(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field17)
+                    {
+                        var mapObj = obj.AddObject(17);
+                        global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(keyValuePair.Key, mapObj.AddObject(1));
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field18)
+                    {
+                        var mapObj = obj.AddObject(18);
+                        mapObj.AddEnum(1, (uint) keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
+                }
+            }
+    
+            public static ExhaustiveMapKeyData Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj)
+            {
+                var instance = new ExhaustiveMapKeyData();
+                {
+                    instance.Field1 = new global::System.Collections.Generic.Dictionary<BlittableBool,string>();
+                    var map = instance.Field1;
+                    var mapSize = obj.GetObjectCount(1);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(1, (uint) i);
+                        var key = mapObj.GetBool(1);
+                        var value = mapObj.GetString(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field2 = new global::System.Collections.Generic.Dictionary<float,string>();
+                    var map = instance.Field2;
+                    var mapSize = obj.GetObjectCount(2);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(2, (uint) i);
+                        var key = mapObj.GetFloat(1);
+                        var value = mapObj.GetString(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field3 = new global::System.Collections.Generic.Dictionary<byte[],string>();
+                    var map = instance.Field3;
+                    var mapSize = obj.GetObjectCount(3);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(3, (uint) i);
+                        var key = mapObj.GetBytes(1);
+                        var value = mapObj.GetString(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field4 = new global::System.Collections.Generic.Dictionary<int,string>();
+                    var map = instance.Field4;
+                    var mapSize = obj.GetObjectCount(4);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(4, (uint) i);
+                        var key = mapObj.GetInt32(1);
+                        var value = mapObj.GetString(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field5 = new global::System.Collections.Generic.Dictionary<long,string>();
+                    var map = instance.Field5;
+                    var mapSize = obj.GetObjectCount(5);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(5, (uint) i);
+                        var key = mapObj.GetInt64(1);
+                        var value = mapObj.GetString(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field6 = new global::System.Collections.Generic.Dictionary<double,string>();
+                    var map = instance.Field6;
+                    var mapSize = obj.GetObjectCount(6);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(6, (uint) i);
+                        var key = mapObj.GetDouble(1);
+                        var value = mapObj.GetString(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field7 = new global::System.Collections.Generic.Dictionary<string,string>();
+                    var map = instance.Field7;
+                    var mapSize = obj.GetObjectCount(7);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(7, (uint) i);
+                        var key = mapObj.GetString(1);
+                        var value = mapObj.GetString(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field8 = new global::System.Collections.Generic.Dictionary<uint,string>();
+                    var map = instance.Field8;
+                    var mapSize = obj.GetObjectCount(8);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(8, (uint) i);
+                        var key = mapObj.GetUint32(1);
+                        var value = mapObj.GetString(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field9 = new global::System.Collections.Generic.Dictionary<ulong,string>();
+                    var map = instance.Field9;
+                    var mapSize = obj.GetObjectCount(9);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(9, (uint) i);
+                        var key = mapObj.GetUint64(1);
+                        var value = mapObj.GetString(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field10 = new global::System.Collections.Generic.Dictionary<int,string>();
+                    var map = instance.Field10;
+                    var mapSize = obj.GetObjectCount(10);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(10, (uint) i);
+                        var key = mapObj.GetSint32(1);
+                        var value = mapObj.GetString(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field11 = new global::System.Collections.Generic.Dictionary<long,string>();
+                    var map = instance.Field11;
+                    var mapSize = obj.GetObjectCount(11);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(11, (uint) i);
+                        var key = mapObj.GetSint64(1);
+                        var value = mapObj.GetString(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field12 = new global::System.Collections.Generic.Dictionary<uint,string>();
+                    var map = instance.Field12;
+                    var mapSize = obj.GetObjectCount(12);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(12, (uint) i);
+                        var key = mapObj.GetFixed32(1);
+                        var value = mapObj.GetString(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field13 = new global::System.Collections.Generic.Dictionary<ulong,string>();
+                    var map = instance.Field13;
+                    var mapSize = obj.GetObjectCount(13);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(13, (uint) i);
+                        var key = mapObj.GetFixed64(1);
+                        var value = mapObj.GetString(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field14 = new global::System.Collections.Generic.Dictionary<int,string>();
+                    var map = instance.Field14;
+                    var mapSize = obj.GetObjectCount(14);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(14, (uint) i);
+                        var key = mapObj.GetSfixed32(1);
+                        var value = mapObj.GetString(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field15 = new global::System.Collections.Generic.Dictionary<long,string>();
+                    var map = instance.Field15;
+                    var mapSize = obj.GetObjectCount(15);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(15, (uint) i);
+                        var key = mapObj.GetSfixed64(1);
+                        var value = mapObj.GetString(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field16 = new global::System.Collections.Generic.Dictionary<global::Improbable.Gdk.Core.EntityId,string>();
+                    var map = instance.Field16;
+                    var mapSize = obj.GetObjectCount(16);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(16, (uint) i);
+                        var key = mapObj.GetEntityIdStruct(1);
+                        var value = mapObj.GetString(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field17 = new global::System.Collections.Generic.Dictionary<global::Improbable.Gdk.Tests.SomeType,string>();
+                    var map = instance.Field17;
+                    var mapSize = obj.GetObjectCount(17);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(17, (uint) i);
+                        var key = global::Improbable.Gdk.Tests.SomeType.Serialization.Deserialize(mapObj.GetObject(1));
+                        var value = mapObj.GetString(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field18 = new global::System.Collections.Generic.Dictionary<global::Improbable.Gdk.Tests.SomeEnum,string>();
+                    var map = instance.Field18;
+                    var mapSize = obj.GetObjectCount(18);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(18, (uint) i);
+                        var key = (global::Improbable.Gdk.Tests.SomeEnum) mapObj.GetEnum(1);
+                        var value = mapObj.GetString(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                return instance;
+            }
+        }
+    }
+    
+}

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueData.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueData.cs
@@ -1,0 +1,464 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Linq;
+using Improbable.Gdk.Core;
+using UnityEngine;
+
+namespace Improbable.Gdk.Tests
+{
+    
+    public struct ExhaustiveMapValueData
+    {
+        public global::System.Collections.Generic.Dictionary<string,BlittableBool> Field1;
+        public global::System.Collections.Generic.Dictionary<string,float> Field2;
+        public global::System.Collections.Generic.Dictionary<string,byte[]> Field3;
+        public global::System.Collections.Generic.Dictionary<string,int> Field4;
+        public global::System.Collections.Generic.Dictionary<string,long> Field5;
+        public global::System.Collections.Generic.Dictionary<string,double> Field6;
+        public global::System.Collections.Generic.Dictionary<string,string> Field7;
+        public global::System.Collections.Generic.Dictionary<string,uint> Field8;
+        public global::System.Collections.Generic.Dictionary<string,ulong> Field9;
+        public global::System.Collections.Generic.Dictionary<string,int> Field10;
+        public global::System.Collections.Generic.Dictionary<string,long> Field11;
+        public global::System.Collections.Generic.Dictionary<string,uint> Field12;
+        public global::System.Collections.Generic.Dictionary<string,ulong> Field13;
+        public global::System.Collections.Generic.Dictionary<string,int> Field14;
+        public global::System.Collections.Generic.Dictionary<string,long> Field15;
+        public global::System.Collections.Generic.Dictionary<string,global::Improbable.Gdk.Core.EntityId> Field16;
+        public global::System.Collections.Generic.Dictionary<string,global::Improbable.Gdk.Tests.SomeType> Field17;
+        public global::System.Collections.Generic.Dictionary<string,global::Improbable.Gdk.Tests.SomeEnum> Field18;
+    
+        public ExhaustiveMapValueData(global::System.Collections.Generic.Dictionary<string,BlittableBool> field1, global::System.Collections.Generic.Dictionary<string,float> field2, global::System.Collections.Generic.Dictionary<string,byte[]> field3, global::System.Collections.Generic.Dictionary<string,int> field4, global::System.Collections.Generic.Dictionary<string,long> field5, global::System.Collections.Generic.Dictionary<string,double> field6, global::System.Collections.Generic.Dictionary<string,string> field7, global::System.Collections.Generic.Dictionary<string,uint> field8, global::System.Collections.Generic.Dictionary<string,ulong> field9, global::System.Collections.Generic.Dictionary<string,int> field10, global::System.Collections.Generic.Dictionary<string,long> field11, global::System.Collections.Generic.Dictionary<string,uint> field12, global::System.Collections.Generic.Dictionary<string,ulong> field13, global::System.Collections.Generic.Dictionary<string,int> field14, global::System.Collections.Generic.Dictionary<string,long> field15, global::System.Collections.Generic.Dictionary<string,global::Improbable.Gdk.Core.EntityId> field16, global::System.Collections.Generic.Dictionary<string,global::Improbable.Gdk.Tests.SomeType> field17, global::System.Collections.Generic.Dictionary<string,global::Improbable.Gdk.Tests.SomeEnum> field18)
+        {
+            Field1 = field1;
+            Field2 = field2;
+            Field3 = field3;
+            Field4 = field4;
+            Field5 = field5;
+            Field6 = field6;
+            Field7 = field7;
+            Field8 = field8;
+            Field9 = field9;
+            Field10 = field10;
+            Field11 = field11;
+            Field12 = field12;
+            Field13 = field13;
+            Field14 = field14;
+            Field15 = field15;
+            Field16 = field16;
+            Field17 = field17;
+            Field18 = field18;
+        }
+        public static class Serialization
+        {
+            public static void Serialize(ExhaustiveMapValueData instance, global::Improbable.Worker.CInterop.SchemaObject obj)
+            {
+                {
+                    foreach (var keyValuePair in instance.Field1)
+                    {
+                        var mapObj = obj.AddObject(1);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddBool(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field2)
+                    {
+                        var mapObj = obj.AddObject(2);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddFloat(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field3)
+                    {
+                        var mapObj = obj.AddObject(3);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddBytes(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field4)
+                    {
+                        var mapObj = obj.AddObject(4);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddInt32(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field5)
+                    {
+                        var mapObj = obj.AddObject(5);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddInt64(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field6)
+                    {
+                        var mapObj = obj.AddObject(6);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddDouble(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field7)
+                    {
+                        var mapObj = obj.AddObject(7);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddString(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field8)
+                    {
+                        var mapObj = obj.AddObject(8);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddUint32(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field9)
+                    {
+                        var mapObj = obj.AddObject(9);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddUint64(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field10)
+                    {
+                        var mapObj = obj.AddObject(10);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddSint32(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field11)
+                    {
+                        var mapObj = obj.AddObject(11);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddSint64(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field12)
+                    {
+                        var mapObj = obj.AddObject(12);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddFixed32(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field13)
+                    {
+                        var mapObj = obj.AddObject(13);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddFixed64(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field14)
+                    {
+                        var mapObj = obj.AddObject(14);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddSfixed32(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field15)
+                    {
+                        var mapObj = obj.AddObject(15);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddSfixed64(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field16)
+                    {
+                        var mapObj = obj.AddObject(16);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddEntityId(2, keyValuePair.Value);
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field17)
+                    {
+                        var mapObj = obj.AddObject(17);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(keyValuePair.Value, mapObj.AddObject(2));
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.Field18)
+                    {
+                        var mapObj = obj.AddObject(18);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        mapObj.AddEnum(2, (uint) keyValuePair.Value);
+                    }
+                    
+                }
+            }
+    
+            public static ExhaustiveMapValueData Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj)
+            {
+                var instance = new ExhaustiveMapValueData();
+                {
+                    instance.Field1 = new global::System.Collections.Generic.Dictionary<string,BlittableBool>();
+                    var map = instance.Field1;
+                    var mapSize = obj.GetObjectCount(1);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(1, (uint) i);
+                        var key = mapObj.GetString(1);
+                        var value = mapObj.GetBool(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field2 = new global::System.Collections.Generic.Dictionary<string,float>();
+                    var map = instance.Field2;
+                    var mapSize = obj.GetObjectCount(2);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(2, (uint) i);
+                        var key = mapObj.GetString(1);
+                        var value = mapObj.GetFloat(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field3 = new global::System.Collections.Generic.Dictionary<string,byte[]>();
+                    var map = instance.Field3;
+                    var mapSize = obj.GetObjectCount(3);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(3, (uint) i);
+                        var key = mapObj.GetString(1);
+                        var value = mapObj.GetBytes(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field4 = new global::System.Collections.Generic.Dictionary<string,int>();
+                    var map = instance.Field4;
+                    var mapSize = obj.GetObjectCount(4);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(4, (uint) i);
+                        var key = mapObj.GetString(1);
+                        var value = mapObj.GetInt32(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field5 = new global::System.Collections.Generic.Dictionary<string,long>();
+                    var map = instance.Field5;
+                    var mapSize = obj.GetObjectCount(5);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(5, (uint) i);
+                        var key = mapObj.GetString(1);
+                        var value = mapObj.GetInt64(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field6 = new global::System.Collections.Generic.Dictionary<string,double>();
+                    var map = instance.Field6;
+                    var mapSize = obj.GetObjectCount(6);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(6, (uint) i);
+                        var key = mapObj.GetString(1);
+                        var value = mapObj.GetDouble(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field7 = new global::System.Collections.Generic.Dictionary<string,string>();
+                    var map = instance.Field7;
+                    var mapSize = obj.GetObjectCount(7);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(7, (uint) i);
+                        var key = mapObj.GetString(1);
+                        var value = mapObj.GetString(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field8 = new global::System.Collections.Generic.Dictionary<string,uint>();
+                    var map = instance.Field8;
+                    var mapSize = obj.GetObjectCount(8);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(8, (uint) i);
+                        var key = mapObj.GetString(1);
+                        var value = mapObj.GetUint32(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field9 = new global::System.Collections.Generic.Dictionary<string,ulong>();
+                    var map = instance.Field9;
+                    var mapSize = obj.GetObjectCount(9);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(9, (uint) i);
+                        var key = mapObj.GetString(1);
+                        var value = mapObj.GetUint64(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field10 = new global::System.Collections.Generic.Dictionary<string,int>();
+                    var map = instance.Field10;
+                    var mapSize = obj.GetObjectCount(10);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(10, (uint) i);
+                        var key = mapObj.GetString(1);
+                        var value = mapObj.GetSint32(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field11 = new global::System.Collections.Generic.Dictionary<string,long>();
+                    var map = instance.Field11;
+                    var mapSize = obj.GetObjectCount(11);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(11, (uint) i);
+                        var key = mapObj.GetString(1);
+                        var value = mapObj.GetSint64(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field12 = new global::System.Collections.Generic.Dictionary<string,uint>();
+                    var map = instance.Field12;
+                    var mapSize = obj.GetObjectCount(12);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(12, (uint) i);
+                        var key = mapObj.GetString(1);
+                        var value = mapObj.GetFixed32(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field13 = new global::System.Collections.Generic.Dictionary<string,ulong>();
+                    var map = instance.Field13;
+                    var mapSize = obj.GetObjectCount(13);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(13, (uint) i);
+                        var key = mapObj.GetString(1);
+                        var value = mapObj.GetFixed64(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field14 = new global::System.Collections.Generic.Dictionary<string,int>();
+                    var map = instance.Field14;
+                    var mapSize = obj.GetObjectCount(14);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(14, (uint) i);
+                        var key = mapObj.GetString(1);
+                        var value = mapObj.GetSfixed32(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field15 = new global::System.Collections.Generic.Dictionary<string,long>();
+                    var map = instance.Field15;
+                    var mapSize = obj.GetObjectCount(15);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(15, (uint) i);
+                        var key = mapObj.GetString(1);
+                        var value = mapObj.GetSfixed64(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field16 = new global::System.Collections.Generic.Dictionary<string,global::Improbable.Gdk.Core.EntityId>();
+                    var map = instance.Field16;
+                    var mapSize = obj.GetObjectCount(16);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(16, (uint) i);
+                        var key = mapObj.GetString(1);
+                        var value = mapObj.GetEntityIdStruct(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field17 = new global::System.Collections.Generic.Dictionary<string,global::Improbable.Gdk.Tests.SomeType>();
+                    var map = instance.Field17;
+                    var mapSize = obj.GetObjectCount(17);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(17, (uint) i);
+                        var key = mapObj.GetString(1);
+                        var value = global::Improbable.Gdk.Tests.SomeType.Serialization.Deserialize(mapObj.GetObject(2));
+                        map.Add(key, value);
+                    }
+                    
+                }
+                {
+                    instance.Field18 = new global::System.Collections.Generic.Dictionary<string,global::Improbable.Gdk.Tests.SomeEnum>();
+                    var map = instance.Field18;
+                    var mapSize = obj.GetObjectCount(18);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(18, (uint) i);
+                        var key = mapObj.GetString(1);
+                        var value = (global::Improbable.Gdk.Tests.SomeEnum) mapObj.GetEnum(2);
+                        map.Add(key, value);
+                    }
+                    
+                }
+                return instance;
+            }
+        }
+    }
+    
+}

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalData.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalData.cs
@@ -1,0 +1,320 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Linq;
+using Improbable.Gdk.Core;
+using UnityEngine;
+
+namespace Improbable.Gdk.Tests
+{
+    
+    public struct ExhaustiveOptionalData
+    {
+        public BlittableBool? Field1;
+        public float? Field2;
+        public global::Improbable.Gdk.Core.Option<byte[]> Field3;
+        public int? Field4;
+        public long? Field5;
+        public double? Field6;
+        public global::Improbable.Gdk.Core.Option<string> Field7;
+        public uint? Field8;
+        public ulong? Field9;
+        public int? Field10;
+        public long? Field11;
+        public uint? Field12;
+        public ulong? Field13;
+        public int? Field14;
+        public long? Field15;
+        public global::Improbable.Gdk.Core.EntityId? Field16;
+        public global::Improbable.Gdk.Tests.SomeType? Field17;
+        public global::Improbable.Gdk.Tests.SomeEnum? Field18;
+    
+        public ExhaustiveOptionalData(BlittableBool? field1, float? field2, global::Improbable.Gdk.Core.Option<byte[]> field3, int? field4, long? field5, double? field6, global::Improbable.Gdk.Core.Option<string> field7, uint? field8, ulong? field9, int? field10, long? field11, uint? field12, ulong? field13, int? field14, long? field15, global::Improbable.Gdk.Core.EntityId? field16, global::Improbable.Gdk.Tests.SomeType? field17, global::Improbable.Gdk.Tests.SomeEnum? field18)
+        {
+            Field1 = field1;
+            Field2 = field2;
+            Field3 = field3;
+            Field4 = field4;
+            Field5 = field5;
+            Field6 = field6;
+            Field7 = field7;
+            Field8 = field8;
+            Field9 = field9;
+            Field10 = field10;
+            Field11 = field11;
+            Field12 = field12;
+            Field13 = field13;
+            Field14 = field14;
+            Field15 = field15;
+            Field16 = field16;
+            Field17 = field17;
+            Field18 = field18;
+        }
+        public static class Serialization
+        {
+            public static void Serialize(ExhaustiveOptionalData instance, global::Improbable.Worker.CInterop.SchemaObject obj)
+            {
+                {
+                    if (instance.Field1.HasValue)
+                    {
+                        obj.AddBool(1, instance.Field1.Value);
+                    }
+                    
+                }
+                {
+                    if (instance.Field2.HasValue)
+                    {
+                        obj.AddFloat(2, instance.Field2.Value);
+                    }
+                    
+                }
+                {
+                    if (instance.Field3.HasValue)
+                    {
+                        obj.AddBytes(3, instance.Field3.Value);
+                    }
+                    
+                }
+                {
+                    if (instance.Field4.HasValue)
+                    {
+                        obj.AddInt32(4, instance.Field4.Value);
+                    }
+                    
+                }
+                {
+                    if (instance.Field5.HasValue)
+                    {
+                        obj.AddInt64(5, instance.Field5.Value);
+                    }
+                    
+                }
+                {
+                    if (instance.Field6.HasValue)
+                    {
+                        obj.AddDouble(6, instance.Field6.Value);
+                    }
+                    
+                }
+                {
+                    if (instance.Field7.HasValue)
+                    {
+                        obj.AddString(7, instance.Field7.Value);
+                    }
+                    
+                }
+                {
+                    if (instance.Field8.HasValue)
+                    {
+                        obj.AddUint32(8, instance.Field8.Value);
+                    }
+                    
+                }
+                {
+                    if (instance.Field9.HasValue)
+                    {
+                        obj.AddUint64(9, instance.Field9.Value);
+                    }
+                    
+                }
+                {
+                    if (instance.Field10.HasValue)
+                    {
+                        obj.AddSint32(10, instance.Field10.Value);
+                    }
+                    
+                }
+                {
+                    if (instance.Field11.HasValue)
+                    {
+                        obj.AddSint64(11, instance.Field11.Value);
+                    }
+                    
+                }
+                {
+                    if (instance.Field12.HasValue)
+                    {
+                        obj.AddFixed32(12, instance.Field12.Value);
+                    }
+                    
+                }
+                {
+                    if (instance.Field13.HasValue)
+                    {
+                        obj.AddFixed64(13, instance.Field13.Value);
+                    }
+                    
+                }
+                {
+                    if (instance.Field14.HasValue)
+                    {
+                        obj.AddSfixed32(14, instance.Field14.Value);
+                    }
+                    
+                }
+                {
+                    if (instance.Field15.HasValue)
+                    {
+                        obj.AddSfixed64(15, instance.Field15.Value);
+                    }
+                    
+                }
+                {
+                    if (instance.Field16.HasValue)
+                    {
+                        obj.AddEntityId(16, instance.Field16.Value);
+                    }
+                    
+                }
+                {
+                    if (instance.Field17.HasValue)
+                    {
+                        global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(instance.Field17.Value, obj.AddObject(17));
+                    }
+                    
+                }
+                {
+                    if (instance.Field18.HasValue)
+                    {
+                        obj.AddEnum(18, (uint) instance.Field18.Value);
+                    }
+                    
+                }
+            }
+    
+            public static ExhaustiveOptionalData Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj)
+            {
+                var instance = new ExhaustiveOptionalData();
+                {
+                    if (obj.GetBoolCount(1) == 1)
+                    {
+                        instance.Field1 = new BlittableBool?(obj.GetBool(1));
+                    }
+                    
+                }
+                {
+                    if (obj.GetFloatCount(2) == 1)
+                    {
+                        instance.Field2 = new float?(obj.GetFloat(2));
+                    }
+                    
+                }
+                {
+                    if (obj.GetBytesCount(3) == 1)
+                    {
+                        instance.Field3 = new global::Improbable.Gdk.Core.Option<byte[]>(obj.GetBytes(3));
+                    }
+                    
+                }
+                {
+                    if (obj.GetInt32Count(4) == 1)
+                    {
+                        instance.Field4 = new int?(obj.GetInt32(4));
+                    }
+                    
+                }
+                {
+                    if (obj.GetInt64Count(5) == 1)
+                    {
+                        instance.Field5 = new long?(obj.GetInt64(5));
+                    }
+                    
+                }
+                {
+                    if (obj.GetDoubleCount(6) == 1)
+                    {
+                        instance.Field6 = new double?(obj.GetDouble(6));
+                    }
+                    
+                }
+                {
+                    if (obj.GetStringCount(7) == 1)
+                    {
+                        instance.Field7 = new global::Improbable.Gdk.Core.Option<string>(obj.GetString(7));
+                    }
+                    
+                }
+                {
+                    if (obj.GetUint32Count(8) == 1)
+                    {
+                        instance.Field8 = new uint?(obj.GetUint32(8));
+                    }
+                    
+                }
+                {
+                    if (obj.GetUint64Count(9) == 1)
+                    {
+                        instance.Field9 = new ulong?(obj.GetUint64(9));
+                    }
+                    
+                }
+                {
+                    if (obj.GetSint32Count(10) == 1)
+                    {
+                        instance.Field10 = new int?(obj.GetSint32(10));
+                    }
+                    
+                }
+                {
+                    if (obj.GetSint64Count(11) == 1)
+                    {
+                        instance.Field11 = new long?(obj.GetSint64(11));
+                    }
+                    
+                }
+                {
+                    if (obj.GetFixed32Count(12) == 1)
+                    {
+                        instance.Field12 = new uint?(obj.GetFixed32(12));
+                    }
+                    
+                }
+                {
+                    if (obj.GetFixed64Count(13) == 1)
+                    {
+                        instance.Field13 = new ulong?(obj.GetFixed64(13));
+                    }
+                    
+                }
+                {
+                    if (obj.GetSfixed32Count(14) == 1)
+                    {
+                        instance.Field14 = new int?(obj.GetSfixed32(14));
+                    }
+                    
+                }
+                {
+                    if (obj.GetSfixed64Count(15) == 1)
+                    {
+                        instance.Field15 = new long?(obj.GetSfixed64(15));
+                    }
+                    
+                }
+                {
+                    if (obj.GetEntityIdCount(16) == 1)
+                    {
+                        instance.Field16 = new global::Improbable.Gdk.Core.EntityId?(obj.GetEntityIdStruct(16));
+                    }
+                    
+                }
+                {
+                    if (obj.GetObjectCount(17) == 1)
+                    {
+                        instance.Field17 = new global::Improbable.Gdk.Tests.SomeType?(global::Improbable.Gdk.Tests.SomeType.Serialization.Deserialize(obj.GetObject(17)));
+                    }
+                    
+                }
+                {
+                    if (obj.GetEnumCount(18) == 1)
+                    {
+                        instance.Field18 = new global::Improbable.Gdk.Tests.SomeEnum?((global::Improbable.Gdk.Tests.SomeEnum) obj.GetEnum(18));
+                    }
+                    
+                }
+                return instance;
+            }
+        }
+    }
+    
+}

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedData.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedData.cs
@@ -1,0 +1,374 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Linq;
+using Improbable.Gdk.Core;
+using UnityEngine;
+
+namespace Improbable.Gdk.Tests
+{
+    
+    public struct ExhaustiveRepeatedData
+    {
+        public global::System.Collections.Generic.List<BlittableBool> Field1;
+        public global::System.Collections.Generic.List<float> Field2;
+        public global::System.Collections.Generic.List<byte[]> Field3;
+        public global::System.Collections.Generic.List<int> Field4;
+        public global::System.Collections.Generic.List<long> Field5;
+        public global::System.Collections.Generic.List<double> Field6;
+        public global::System.Collections.Generic.List<string> Field7;
+        public global::System.Collections.Generic.List<uint> Field8;
+        public global::System.Collections.Generic.List<ulong> Field9;
+        public global::System.Collections.Generic.List<int> Field10;
+        public global::System.Collections.Generic.List<long> Field11;
+        public global::System.Collections.Generic.List<uint> Field12;
+        public global::System.Collections.Generic.List<ulong> Field13;
+        public global::System.Collections.Generic.List<int> Field14;
+        public global::System.Collections.Generic.List<long> Field15;
+        public global::System.Collections.Generic.List<global::Improbable.Gdk.Core.EntityId> Field16;
+        public global::System.Collections.Generic.List<global::Improbable.Gdk.Tests.SomeType> Field17;
+        public global::System.Collections.Generic.List<global::Improbable.Gdk.Tests.SomeEnum> Field18;
+    
+        public ExhaustiveRepeatedData(global::System.Collections.Generic.List<BlittableBool> field1, global::System.Collections.Generic.List<float> field2, global::System.Collections.Generic.List<byte[]> field3, global::System.Collections.Generic.List<int> field4, global::System.Collections.Generic.List<long> field5, global::System.Collections.Generic.List<double> field6, global::System.Collections.Generic.List<string> field7, global::System.Collections.Generic.List<uint> field8, global::System.Collections.Generic.List<ulong> field9, global::System.Collections.Generic.List<int> field10, global::System.Collections.Generic.List<long> field11, global::System.Collections.Generic.List<uint> field12, global::System.Collections.Generic.List<ulong> field13, global::System.Collections.Generic.List<int> field14, global::System.Collections.Generic.List<long> field15, global::System.Collections.Generic.List<global::Improbable.Gdk.Core.EntityId> field16, global::System.Collections.Generic.List<global::Improbable.Gdk.Tests.SomeType> field17, global::System.Collections.Generic.List<global::Improbable.Gdk.Tests.SomeEnum> field18)
+        {
+            Field1 = field1;
+            Field2 = field2;
+            Field3 = field3;
+            Field4 = field4;
+            Field5 = field5;
+            Field6 = field6;
+            Field7 = field7;
+            Field8 = field8;
+            Field9 = field9;
+            Field10 = field10;
+            Field11 = field11;
+            Field12 = field12;
+            Field13 = field13;
+            Field14 = field14;
+            Field15 = field15;
+            Field16 = field16;
+            Field17 = field17;
+            Field18 = field18;
+        }
+        public static class Serialization
+        {
+            public static void Serialize(ExhaustiveRepeatedData instance, global::Improbable.Worker.CInterop.SchemaObject obj)
+            {
+                {
+                    foreach (var value in instance.Field1)
+                    {
+                        obj.AddBool(1, value);
+                    }
+                    
+                }
+                {
+                    foreach (var value in instance.Field2)
+                    {
+                        obj.AddFloat(2, value);
+                    }
+                    
+                }
+                {
+                    foreach (var value in instance.Field3)
+                    {
+                        obj.AddBytes(3, value);
+                    }
+                    
+                }
+                {
+                    foreach (var value in instance.Field4)
+                    {
+                        obj.AddInt32(4, value);
+                    }
+                    
+                }
+                {
+                    foreach (var value in instance.Field5)
+                    {
+                        obj.AddInt64(5, value);
+                    }
+                    
+                }
+                {
+                    foreach (var value in instance.Field6)
+                    {
+                        obj.AddDouble(6, value);
+                    }
+                    
+                }
+                {
+                    foreach (var value in instance.Field7)
+                    {
+                        obj.AddString(7, value);
+                    }
+                    
+                }
+                {
+                    foreach (var value in instance.Field8)
+                    {
+                        obj.AddUint32(8, value);
+                    }
+                    
+                }
+                {
+                    foreach (var value in instance.Field9)
+                    {
+                        obj.AddUint64(9, value);
+                    }
+                    
+                }
+                {
+                    foreach (var value in instance.Field10)
+                    {
+                        obj.AddSint32(10, value);
+                    }
+                    
+                }
+                {
+                    foreach (var value in instance.Field11)
+                    {
+                        obj.AddSint64(11, value);
+                    }
+                    
+                }
+                {
+                    foreach (var value in instance.Field12)
+                    {
+                        obj.AddFixed32(12, value);
+                    }
+                    
+                }
+                {
+                    foreach (var value in instance.Field13)
+                    {
+                        obj.AddFixed64(13, value);
+                    }
+                    
+                }
+                {
+                    foreach (var value in instance.Field14)
+                    {
+                        obj.AddSfixed32(14, value);
+                    }
+                    
+                }
+                {
+                    foreach (var value in instance.Field15)
+                    {
+                        obj.AddSfixed64(15, value);
+                    }
+                    
+                }
+                {
+                    foreach (var value in instance.Field16)
+                    {
+                        obj.AddEntityId(16, value);
+                    }
+                    
+                }
+                {
+                    foreach (var value in instance.Field17)
+                    {
+                        global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(value, obj.AddObject(17));
+                    }
+                    
+                }
+                {
+                    foreach (var value in instance.Field18)
+                    {
+                        obj.AddEnum(18, (uint) value);
+                    }
+                    
+                }
+            }
+    
+            public static ExhaustiveRepeatedData Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj)
+            {
+                var instance = new ExhaustiveRepeatedData();
+                {
+                    instance.Field1 = new global::System.Collections.Generic.List<BlittableBool>();
+                    var list = instance.Field1;
+                    var listLength = obj.GetBoolCount(1);
+                    for (var i = 0; i < listLength; i++)
+                    {
+                        list.Add(obj.IndexBool(1, (uint) i));
+                    }
+                    
+                }
+                {
+                    instance.Field2 = new global::System.Collections.Generic.List<float>();
+                    var list = instance.Field2;
+                    var listLength = obj.GetFloatCount(2);
+                    for (var i = 0; i < listLength; i++)
+                    {
+                        list.Add(obj.IndexFloat(2, (uint) i));
+                    }
+                    
+                }
+                {
+                    instance.Field3 = new global::System.Collections.Generic.List<byte[]>();
+                    var list = instance.Field3;
+                    var listLength = obj.GetBytesCount(3);
+                    for (var i = 0; i < listLength; i++)
+                    {
+                        list.Add(obj.IndexBytes(3, (uint) i));
+                    }
+                    
+                }
+                {
+                    instance.Field4 = new global::System.Collections.Generic.List<int>();
+                    var list = instance.Field4;
+                    var listLength = obj.GetInt32Count(4);
+                    for (var i = 0; i < listLength; i++)
+                    {
+                        list.Add(obj.IndexInt32(4, (uint) i));
+                    }
+                    
+                }
+                {
+                    instance.Field5 = new global::System.Collections.Generic.List<long>();
+                    var list = instance.Field5;
+                    var listLength = obj.GetInt64Count(5);
+                    for (var i = 0; i < listLength; i++)
+                    {
+                        list.Add(obj.IndexInt64(5, (uint) i));
+                    }
+                    
+                }
+                {
+                    instance.Field6 = new global::System.Collections.Generic.List<double>();
+                    var list = instance.Field6;
+                    var listLength = obj.GetDoubleCount(6);
+                    for (var i = 0; i < listLength; i++)
+                    {
+                        list.Add(obj.IndexDouble(6, (uint) i));
+                    }
+                    
+                }
+                {
+                    instance.Field7 = new global::System.Collections.Generic.List<string>();
+                    var list = instance.Field7;
+                    var listLength = obj.GetStringCount(7);
+                    for (var i = 0; i < listLength; i++)
+                    {
+                        list.Add(obj.IndexString(7, (uint) i));
+                    }
+                    
+                }
+                {
+                    instance.Field8 = new global::System.Collections.Generic.List<uint>();
+                    var list = instance.Field8;
+                    var listLength = obj.GetUint32Count(8);
+                    for (var i = 0; i < listLength; i++)
+                    {
+                        list.Add(obj.IndexUint32(8, (uint) i));
+                    }
+                    
+                }
+                {
+                    instance.Field9 = new global::System.Collections.Generic.List<ulong>();
+                    var list = instance.Field9;
+                    var listLength = obj.GetUint64Count(9);
+                    for (var i = 0; i < listLength; i++)
+                    {
+                        list.Add(obj.IndexUint64(9, (uint) i));
+                    }
+                    
+                }
+                {
+                    instance.Field10 = new global::System.Collections.Generic.List<int>();
+                    var list = instance.Field10;
+                    var listLength = obj.GetSint32Count(10);
+                    for (var i = 0; i < listLength; i++)
+                    {
+                        list.Add(obj.IndexSint32(10, (uint) i));
+                    }
+                    
+                }
+                {
+                    instance.Field11 = new global::System.Collections.Generic.List<long>();
+                    var list = instance.Field11;
+                    var listLength = obj.GetSint64Count(11);
+                    for (var i = 0; i < listLength; i++)
+                    {
+                        list.Add(obj.IndexSint64(11, (uint) i));
+                    }
+                    
+                }
+                {
+                    instance.Field12 = new global::System.Collections.Generic.List<uint>();
+                    var list = instance.Field12;
+                    var listLength = obj.GetFixed32Count(12);
+                    for (var i = 0; i < listLength; i++)
+                    {
+                        list.Add(obj.IndexFixed32(12, (uint) i));
+                    }
+                    
+                }
+                {
+                    instance.Field13 = new global::System.Collections.Generic.List<ulong>();
+                    var list = instance.Field13;
+                    var listLength = obj.GetFixed64Count(13);
+                    for (var i = 0; i < listLength; i++)
+                    {
+                        list.Add(obj.IndexFixed64(13, (uint) i));
+                    }
+                    
+                }
+                {
+                    instance.Field14 = new global::System.Collections.Generic.List<int>();
+                    var list = instance.Field14;
+                    var listLength = obj.GetSfixed32Count(14);
+                    for (var i = 0; i < listLength; i++)
+                    {
+                        list.Add(obj.IndexSfixed32(14, (uint) i));
+                    }
+                    
+                }
+                {
+                    instance.Field15 = new global::System.Collections.Generic.List<long>();
+                    var list = instance.Field15;
+                    var listLength = obj.GetSfixed64Count(15);
+                    for (var i = 0; i < listLength; i++)
+                    {
+                        list.Add(obj.IndexSfixed64(15, (uint) i));
+                    }
+                    
+                }
+                {
+                    instance.Field16 = new global::System.Collections.Generic.List<global::Improbable.Gdk.Core.EntityId>();
+                    var list = instance.Field16;
+                    var listLength = obj.GetEntityIdCount(16);
+                    for (var i = 0; i < listLength; i++)
+                    {
+                        list.Add(obj.IndexEntityIdStruct(16, (uint) i));
+                    }
+                    
+                }
+                {
+                    instance.Field17 = new global::System.Collections.Generic.List<global::Improbable.Gdk.Tests.SomeType>();
+                    var list = instance.Field17;
+                    var listLength = obj.GetObjectCount(17);
+                    for (var i = 0; i < listLength; i++)
+                    {
+                        list.Add(global::Improbable.Gdk.Tests.SomeType.Serialization.Deserialize(obj.IndexObject(17, (uint) i)));
+                    }
+                    
+                }
+                {
+                    instance.Field18 = new global::System.Collections.Generic.List<global::Improbable.Gdk.Tests.SomeEnum>();
+                    var list = instance.Field18;
+                    var listLength = obj.GetEnumCount(18);
+                    for (var i = 0; i < listLength; i++)
+                    {
+                        list.Add((global::Improbable.Gdk.Tests.SomeEnum) obj.IndexEnum(18, (uint) i));
+                    }
+                    
+                }
+                return instance;
+            }
+        }
+    }
+    
+}

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularData.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularData.cs
@@ -1,0 +1,176 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Linq;
+using Improbable.Gdk.Core;
+using UnityEngine;
+
+namespace Improbable.Gdk.Tests
+{
+    
+    public struct ExhaustiveSingularData
+    {
+        public BlittableBool Field1;
+        public float Field2;
+        public byte[] Field3;
+        public int Field4;
+        public long Field5;
+        public double Field6;
+        public string Field7;
+        public uint Field8;
+        public ulong Field9;
+        public int Field10;
+        public long Field11;
+        public uint Field12;
+        public ulong Field13;
+        public int Field14;
+        public long Field15;
+        public global::Improbable.Gdk.Core.EntityId Field16;
+        public global::Improbable.Gdk.Tests.SomeType Field17;
+        public global::Improbable.Gdk.Tests.SomeEnum Field18;
+    
+        public ExhaustiveSingularData(BlittableBool field1, float field2, byte[] field3, int field4, long field5, double field6, string field7, uint field8, ulong field9, int field10, long field11, uint field12, ulong field13, int field14, long field15, global::Improbable.Gdk.Core.EntityId field16, global::Improbable.Gdk.Tests.SomeType field17, global::Improbable.Gdk.Tests.SomeEnum field18)
+        {
+            Field1 = field1;
+            Field2 = field2;
+            Field3 = field3;
+            Field4 = field4;
+            Field5 = field5;
+            Field6 = field6;
+            Field7 = field7;
+            Field8 = field8;
+            Field9 = field9;
+            Field10 = field10;
+            Field11 = field11;
+            Field12 = field12;
+            Field13 = field13;
+            Field14 = field14;
+            Field15 = field15;
+            Field16 = field16;
+            Field17 = field17;
+            Field18 = field18;
+        }
+        public static class Serialization
+        {
+            public static void Serialize(ExhaustiveSingularData instance, global::Improbable.Worker.CInterop.SchemaObject obj)
+            {
+                {
+                    obj.AddBool(1, instance.Field1);
+                }
+                {
+                    obj.AddFloat(2, instance.Field2);
+                }
+                {
+                    obj.AddBytes(3, instance.Field3);
+                }
+                {
+                    obj.AddInt32(4, instance.Field4);
+                }
+                {
+                    obj.AddInt64(5, instance.Field5);
+                }
+                {
+                    obj.AddDouble(6, instance.Field6);
+                }
+                {
+                    obj.AddString(7, instance.Field7);
+                }
+                {
+                    obj.AddUint32(8, instance.Field8);
+                }
+                {
+                    obj.AddUint64(9, instance.Field9);
+                }
+                {
+                    obj.AddSint32(10, instance.Field10);
+                }
+                {
+                    obj.AddSint64(11, instance.Field11);
+                }
+                {
+                    obj.AddFixed32(12, instance.Field12);
+                }
+                {
+                    obj.AddFixed64(13, instance.Field13);
+                }
+                {
+                    obj.AddSfixed32(14, instance.Field14);
+                }
+                {
+                    obj.AddSfixed64(15, instance.Field15);
+                }
+                {
+                    obj.AddEntityId(16, instance.Field16);
+                }
+                {
+                    global::Improbable.Gdk.Tests.SomeType.Serialization.Serialize(instance.Field17, obj.AddObject(17));
+                }
+                {
+                    obj.AddEnum(18, (uint) instance.Field18);
+                }
+            }
+    
+            public static ExhaustiveSingularData Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj)
+            {
+                var instance = new ExhaustiveSingularData();
+                {
+                    instance.Field1 = obj.GetBool(1);
+                }
+                {
+                    instance.Field2 = obj.GetFloat(2);
+                }
+                {
+                    instance.Field3 = obj.GetBytes(3);
+                }
+                {
+                    instance.Field4 = obj.GetInt32(4);
+                }
+                {
+                    instance.Field5 = obj.GetInt64(5);
+                }
+                {
+                    instance.Field6 = obj.GetDouble(6);
+                }
+                {
+                    instance.Field7 = obj.GetString(7);
+                }
+                {
+                    instance.Field8 = obj.GetUint32(8);
+                }
+                {
+                    instance.Field9 = obj.GetUint64(9);
+                }
+                {
+                    instance.Field10 = obj.GetSint32(10);
+                }
+                {
+                    instance.Field11 = obj.GetSint64(11);
+                }
+                {
+                    instance.Field12 = obj.GetFixed32(12);
+                }
+                {
+                    instance.Field13 = obj.GetFixed64(13);
+                }
+                {
+                    instance.Field14 = obj.GetSfixed32(14);
+                }
+                {
+                    instance.Field15 = obj.GetSfixed64(15);
+                }
+                {
+                    instance.Field16 = obj.GetEntityIdStruct(16);
+                }
+                {
+                    instance.Field17 = global::Improbable.Gdk.Tests.SomeType.Serialization.Deserialize(obj.GetObject(17));
+                }
+                {
+                    instance.Field18 = (global::Improbable.Gdk.Tests.SomeEnum) obj.GetEnum(18);
+                }
+                return instance;
+            }
+        }
+    }
+    
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/AnnotationRaw.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/AnnotationRaw.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1
+{
+    public class AnnotationRaw
+    {
+        [JsonProperty("value")] public TypeValueData Value;
+    }
+
+    public class TypeValueData
+    {
+        [JsonProperty("type")] public FullyQualifiedReference Type;
+        [JsonProperty("fields")] public List<FieldValue> Fields;
+
+        public class FieldValue
+        {
+            [JsonProperty("field")] public FullyQualifiedReference Field;
+            [JsonProperty("name")] public string Name;
+            [JsonProperty("number")] public uint Number;
+            [JsonProperty("value")] public Value Value;
+        }
+    }
+
+    public class OptionValueData
+    {
+        [JsonProperty("value")] public Value Value;
+    }
+
+    public class ListValueData
+    {
+        [JsonProperty("values")] public List<Value> Values;
+    }
+
+    public class MapValueData
+    {
+        [JsonProperty("values")] public List<MapPair> Values;
+
+        public class MapPair
+        {
+            [JsonProperty("value")] public Value Value;
+            [JsonProperty("key ")] public Value Key;
+        }
+    }
+
+    public class EnumDataValue
+    {
+        [JsonProperty("enum")] public FullyQualifiedReference EnumReference;
+        [JsonProperty("enum_value")] public FullyQualifiedReference EnumValueReference;
+        [JsonProperty("name")] public string Name;
+        [JsonProperty("value")] public uint Value;
+    }
+
+    public class Value
+    {
+        [JsonProperty("option_value")] public OptionValueData OptionValue;
+        [JsonProperty("list_value")] public ListValueData ListValue;
+        [JsonProperty("map_value")] public MapValueData MapValue;
+
+        [JsonProperty("enum_value")] public EnumDataValue EnumValue;
+        [JsonProperty("type_value")] public TypeValueData TypeValue;
+
+        [JsonProperty("bool_value")] public bool BoolValue;
+        [JsonProperty("uint32_value")] public uint Uint32Value;
+        [JsonProperty("uint64_value")] public ulong Uint64Value;
+        [JsonProperty("int32_value")] public int Int32Value;
+        [JsonProperty("int64_value")] public long Int64Value;
+        [JsonProperty("float_value")] public float FloatValue;
+        [JsonProperty("double_value")] public double DoubleValue;
+        [JsonProperty("string_value")] public string StringValue;
+        [JsonProperty("bytes_value")] public byte[] BytesValue;
+        [JsonProperty("entity_id_value")] public long EntityIdValue;
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/Common.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/Common.cs
@@ -68,6 +68,7 @@ namespace Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1
         [JsonProperty("mapType")] public MapType Map;
         [JsonProperty("optionType")] public OptionType Option;
         [JsonProperty("singularType")] public SingularType Singular;
+        [JsonProperty("annotations")] public List<AnnotationRaw> Annotations;
 
         public class ListType
         {

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/Common.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/Common.cs
@@ -54,7 +54,7 @@ namespace Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1
         }
     }
 
-    public class UserType
+    public class FullyQualifiedReference
     {
         [JsonProperty("qualifiedName")] public string QualifiedName;
     }
@@ -94,9 +94,9 @@ namespace Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1
         // The type is either a primitive or its a user defined type.
         public class InnerType
         {
-            [JsonProperty("type")] public UserType UserType;
+            [JsonProperty("type")] public FullyQualifiedReference UserType;
             [JsonProperty("primitive")] public string Primitive;
-            [JsonProperty("enum")] public UserType EnumType;
+            [JsonProperty("enum")] public FullyQualifiedReference EnumType;
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/ComponentDefinitionRaw.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/ComponentDefinitionRaw.cs
@@ -13,6 +13,8 @@ namespace Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1
         [JsonProperty("eventDefinitions")] public List<EventDefinitionRaw> Events;
         [JsonProperty("commandDefinitions")] public List<CommandDefinitionRaw> Commands;
 
+        [JsonProperty("annotations")] public List<AnnotationRaw> Annotations;
+
         public class WrappedType
         {
             [JsonProperty("type")] public FullyQualifiedReference Type;
@@ -23,6 +25,8 @@ namespace Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1
             [JsonProperty("identifier")] public Identifier Identifier;
             [JsonProperty("eventIndex")] public uint EventIndex;
             [JsonProperty("type")] public WrappedType Type;
+
+            [JsonProperty("annotations")] public List<AnnotationRaw> Annotations;
         }
 
         public class CommandDefinitionRaw
@@ -31,6 +35,8 @@ namespace Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1
             [JsonProperty("commandIndex")] public uint CommandIndex;
             [JsonProperty("requestType")] public WrappedType RequestType;
             [JsonProperty("responseType")] public WrappedType ResponseType;
+
+            [JsonProperty("annotations")] public List<AnnotationRaw> Annotations;
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/ComponentDefinitionRaw.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/ComponentDefinitionRaw.cs
@@ -8,14 +8,14 @@ namespace Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1
         [JsonProperty("identifier")] public Identifier Identifier;
         [JsonProperty("componentId")] public uint ComponentId;
         [JsonProperty("fieldDefinitions")] public List<Field> Fields;
-        [JsonProperty("dataDefinition")] public UserType Data;
+        [JsonProperty("dataDefinition")] public FullyQualifiedReference Data;
 
         [JsonProperty("eventDefinitions")] public List<EventDefinitionRaw> Events;
         [JsonProperty("commandDefinitions")] public List<CommandDefinitionRaw> Commands;
 
         public class WrappedType
         {
-            [JsonProperty("type")] public UserType Type;
+            [JsonProperty("type")] public FullyQualifiedReference Type;
         }
 
         public class EventDefinitionRaw

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/EnumDefinitionRaw.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/EnumDefinitionRaw.cs
@@ -7,11 +7,13 @@ namespace Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1
     {
         [JsonProperty("identifier")] public Identifier EnumIdentifier;
         [JsonProperty("valueDefinitions")] public List<Value> Values;
+        [JsonProperty("annotations")] public List<AnnotationRaw> Annotations;
 
         public class Value
         {
             [JsonProperty("identifier")] public Identifier Identifier;
             [JsonProperty("value")] public uint EnumValue;
+            [JsonProperty("annotations")] public List<AnnotationRaw> Annotations;
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/TypeDefinitionRaw.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Model/SchemaBundleV1/TypeDefinitionRaw.cs
@@ -7,5 +7,6 @@ namespace Improbable.Gdk.CodeGeneration.Model.SchemaBundleV1
     {
         [JsonProperty("identifier")] public Identifier Identifier;
         [JsonProperty("fieldDefinitions")] public List<Field> Fields;
+        [JsonProperty("annotations")] public List<AnnotationRaw> Annotations;
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Tests/Model/SchemaBundleV1/Resources/exhaustive_bundle.json
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Tests/Model/SchemaBundleV1/Resources/exhaustive_bundle.json
@@ -438,6 +438,3695 @@
       },
       {
         "identifier": {
+          "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData",
+          "name": "ExhaustiveSingularData",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "ExhaustiveSingularData"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field1",
+              "name": "field1",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field1"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Bool"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field2",
+              "name": "field2",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field2"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Float"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field3",
+              "name": "field3",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field3"
+              ]
+            },
+            "fieldId": 3,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Bytes"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field4",
+              "name": "field4",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field4"
+              ]
+            },
+            "fieldId": 4,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Int32"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field5",
+              "name": "field5",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field5"
+              ]
+            },
+            "fieldId": 5,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Int64"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field6",
+              "name": "field6",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field6"
+              ]
+            },
+            "fieldId": 6,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Double"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field7",
+              "name": "field7",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field7"
+              ]
+            },
+            "fieldId": 7,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "String"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field8",
+              "name": "field8",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field8"
+              ]
+            },
+            "fieldId": 8,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Uint32"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field9",
+              "name": "field9",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field9"
+              ]
+            },
+            "fieldId": 9,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Uint64"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field10",
+              "name": "field10",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field10"
+              ]
+            },
+            "fieldId": 10,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Sint32"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field11",
+              "name": "field11",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field11"
+              ]
+            },
+            "fieldId": 11,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Sint64"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field12",
+              "name": "field12",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field12"
+              ]
+            },
+            "fieldId": 12,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Fixed32"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field13",
+              "name": "field13",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field13"
+              ]
+            },
+            "fieldId": 13,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Fixed64"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field14",
+              "name": "field14",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field14"
+              ]
+            },
+            "fieldId": 14,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Sfixed32"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field15",
+              "name": "field15",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field15"
+              ]
+            },
+            "fieldId": 15,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "Sfixed64"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field16",
+              "name": "field16",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field16"
+              ]
+            },
+            "fieldId": 16,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "primitive": "EntityId"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field17",
+              "name": "field17",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field17"
+              ]
+            },
+            "fieldId": 17,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "type": {
+                  "qualifiedName": "improbable.gdk.tests.SomeType"
+                }
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field18",
+              "name": "field18",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveSingularData",
+                "field18"
+              ]
+            },
+            "fieldId": 18,
+            "transient": false,
+            "singularType": {
+              "type": {
+                "enum": {
+                  "qualifiedName": "improbable.gdk.tests.SomeEnum"
+                }
+              }
+            },
+            "annotations": []
+          }
+        ],
+        "annotations": [
+          {
+            "typeValue": {
+              "type": {
+                "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData"
+              },
+              "fields": [
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field1"
+                  },
+                  "name": "field1",
+                  "number": 1,
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field2"
+                  },
+                  "name": "field2",
+                  "number": 2,
+                  "value": {
+                    "floatValue": 10.5
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field3"
+                  },
+                  "name": "field3",
+                  "number": 3,
+                  "value": {
+                    "bytesValue": "foo"
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field4"
+                  },
+                  "name": "field4",
+                  "number": 4,
+                  "value": {
+                    "int32Value": -2
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field5"
+                  },
+                  "name": "field5",
+                  "number": 5,
+                  "value": {
+                    "int64Value": "3"
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field6"
+                  },
+                  "name": "field6",
+                  "number": 6,
+                  "value": {
+                    "doubleValue": -15.5
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field7"
+                  },
+                  "name": "field7",
+                  "number": 7,
+                  "value": {
+                    "stringValue": "bar"
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field8"
+                  },
+                  "name": "field8",
+                  "number": 8,
+                  "value": {
+                    "uint32Value": 0
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field9"
+                  },
+                  "name": "field9",
+                  "number": 9,
+                  "value": {
+                    "uint64Value": "1"
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field10"
+                  },
+                  "name": "field10",
+                  "number": 10,
+                  "value": {
+                    "int32Value": 4
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field11"
+                  },
+                  "name": "field11",
+                  "number": 11,
+                  "value": {
+                    "int64Value": "5"
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field12"
+                  },
+                  "name": "field12",
+                  "number": 12,
+                  "value": {
+                    "uint32Value": 6
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field13"
+                  },
+                  "name": "field13",
+                  "number": 13,
+                  "value": {
+                    "uint64Value": "7"
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field14"
+                  },
+                  "name": "field14",
+                  "number": 14,
+                  "value": {
+                    "int32Value": -8
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field15"
+                  },
+                  "name": "field15",
+                  "number": 15,
+                  "value": {
+                    "int64Value": "-9"
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field16"
+                  },
+                  "name": "field16",
+                  "number": 16,
+                  "value": {
+                    "entityIdValue": "10"
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field17"
+                  },
+                  "name": "field17",
+                  "number": 17,
+                  "value": {
+                    "typeValue": {
+                      "type": {
+                        "qualifiedName": "improbable.gdk.tests.SomeType"
+                      },
+                      "fields": []
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData.field18"
+                  },
+                  "name": "field18",
+                  "number": 18,
+                  "value": {
+                    "enumValue": {
+                      "enumValue": {
+                        "qualifiedName": "improbable.gdk.tests.SomeEnum.FIRST_VALUE"
+                      },
+                      "enum": {
+                        "qualifiedName": "improbable.gdk.tests.SomeEnum"
+                      },
+                      "name": "FIRST_VALUE",
+                      "value": 0
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData",
+          "name": "ExhaustiveOptionalData",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "ExhaustiveOptionalData"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field1",
+              "name": "field1",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field1"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Bool"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field2",
+              "name": "field2",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field2"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Float"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field3",
+              "name": "field3",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field3"
+              ]
+            },
+            "fieldId": 3,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Bytes"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field4",
+              "name": "field4",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field4"
+              ]
+            },
+            "fieldId": 4,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Int32"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field5",
+              "name": "field5",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field5"
+              ]
+            },
+            "fieldId": 5,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Int64"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field6",
+              "name": "field6",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field6"
+              ]
+            },
+            "fieldId": 6,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Double"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field7",
+              "name": "field7",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field7"
+              ]
+            },
+            "fieldId": 7,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "String"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field8",
+              "name": "field8",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field8"
+              ]
+            },
+            "fieldId": 8,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Uint32"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field9",
+              "name": "field9",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field9"
+              ]
+            },
+            "fieldId": 9,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Uint64"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field10",
+              "name": "field10",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field10"
+              ]
+            },
+            "fieldId": 10,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Sint32"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field11",
+              "name": "field11",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field11"
+              ]
+            },
+            "fieldId": 11,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Sint64"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field12",
+              "name": "field12",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field12"
+              ]
+            },
+            "fieldId": 12,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Fixed32"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field13",
+              "name": "field13",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field13"
+              ]
+            },
+            "fieldId": 13,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Fixed64"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field14",
+              "name": "field14",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field14"
+              ]
+            },
+            "fieldId": 14,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Sfixed32"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field15",
+              "name": "field15",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field15"
+              ]
+            },
+            "fieldId": 15,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "Sfixed64"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field16",
+              "name": "field16",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field16"
+              ]
+            },
+            "fieldId": 16,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "primitive": "EntityId"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field17",
+              "name": "field17",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field17"
+              ]
+            },
+            "fieldId": 17,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "type": {
+                  "qualifiedName": "improbable.gdk.tests.SomeType"
+                }
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field18",
+              "name": "field18",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveOptionalData",
+                "field18"
+              ]
+            },
+            "fieldId": 18,
+            "transient": false,
+            "optionType": {
+              "innerType": {
+                "enum": {
+                  "qualifiedName": "improbable.gdk.tests.SomeEnum"
+                }
+              }
+            },
+            "annotations": []
+          }
+        ],
+        "annotations": [
+          {
+            "typeValue": {
+              "type": {
+                "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData"
+              },
+              "fields": [
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field1"
+                  },
+                  "name": "field1",
+                  "number": 1,
+                  "value": {
+                    "optionValue": {
+                      "value": {
+                        "boolValue": true
+                      }
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field2"
+                  },
+                  "name": "field2",
+                  "number": 2,
+                  "value": {
+                    "optionValue": {
+                      "value": {
+                        "floatValue": 10.5
+                      }
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field3"
+                  },
+                  "name": "field3",
+                  "number": 3,
+                  "value": {
+                    "optionValue": {
+                      "value": {
+                        "bytesValue": "foo"
+                      }
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field4"
+                  },
+                  "name": "field4",
+                  "number": 4,
+                  "value": {
+                    "optionValue": {
+                      "value": {
+                        "int32Value": -2
+                      }
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field5"
+                  },
+                  "name": "field5",
+                  "number": 5,
+                  "value": {
+                    "optionValue": {
+                      "value": {
+                        "int64Value": "3"
+                      }
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field6"
+                  },
+                  "name": "field6",
+                  "number": 6,
+                  "value": {
+                    "optionValue": {
+                      "value": {
+                        "doubleValue": -15.5
+                      }
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field7"
+                  },
+                  "name": "field7",
+                  "number": 7,
+                  "value": {
+                    "optionValue": {
+                      "value": {
+                        "stringValue": "bar"
+                      }
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field8"
+                  },
+                  "name": "field8",
+                  "number": 8,
+                  "value": {
+                    "optionValue": {
+                      "value": {
+                        "uint32Value": 0
+                      }
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field9"
+                  },
+                  "name": "field9",
+                  "number": 9,
+                  "value": {
+                    "optionValue": {
+                      "value": {
+                        "uint64Value": "1"
+                      }
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field10"
+                  },
+                  "name": "field10",
+                  "number": 10,
+                  "value": {
+                    "optionValue": {
+                      "value": {
+                        "int32Value": 4
+                      }
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field11"
+                  },
+                  "name": "field11",
+                  "number": 11,
+                  "value": {
+                    "optionValue": {
+                      "value": {
+                        "int64Value": "5"
+                      }
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field12"
+                  },
+                  "name": "field12",
+                  "number": 12,
+                  "value": {
+                    "optionValue": {
+                      "value": {
+                        "uint32Value": 6
+                      }
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field13"
+                  },
+                  "name": "field13",
+                  "number": 13,
+                  "value": {
+                    "optionValue": {
+                      "value": {
+                        "uint64Value": "7"
+                      }
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field14"
+                  },
+                  "name": "field14",
+                  "number": 14,
+                  "value": {
+                    "optionValue": {
+                      "value": {
+                        "int32Value": -8
+                      }
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field15"
+                  },
+                  "name": "field15",
+                  "number": 15,
+                  "value": {
+                    "optionValue": {
+                      "value": {
+                        "int64Value": "-9"
+                      }
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field16"
+                  },
+                  "name": "field16",
+                  "number": 16,
+                  "value": {
+                    "optionValue": {
+                      "value": {
+                        "entityIdValue": "10"
+                      }
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field17"
+                  },
+                  "name": "field17",
+                  "number": 17,
+                  "value": {
+                    "optionValue": {
+                      "value": {
+                        "typeValue": {
+                          "type": {
+                            "qualifiedName": "improbable.gdk.tests.SomeType"
+                          },
+                          "fields": []
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData.field18"
+                  },
+                  "name": "field18",
+                  "number": 18,
+                  "value": {
+                    "optionValue": {
+                      "value": {
+                        "enumValue": {
+                          "enumValue": {
+                            "qualifiedName": "improbable.gdk.tests.SomeEnum.FIRST_VALUE"
+                          },
+                          "enum": {
+                            "qualifiedName": "improbable.gdk.tests.SomeEnum"
+                          },
+                          "name": "FIRST_VALUE",
+                          "value": 0
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData",
+          "name": "ExhaustiveRepeatedData",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "ExhaustiveRepeatedData"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field1",
+              "name": "field1",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field1"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Bool"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field2",
+              "name": "field2",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field2"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Float"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field3",
+              "name": "field3",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field3"
+              ]
+            },
+            "fieldId": 3,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Bytes"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field4",
+              "name": "field4",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field4"
+              ]
+            },
+            "fieldId": 4,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Int32"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field5",
+              "name": "field5",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field5"
+              ]
+            },
+            "fieldId": 5,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Int64"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field6",
+              "name": "field6",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field6"
+              ]
+            },
+            "fieldId": 6,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Double"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field7",
+              "name": "field7",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field7"
+              ]
+            },
+            "fieldId": 7,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "String"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field8",
+              "name": "field8",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field8"
+              ]
+            },
+            "fieldId": 8,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Uint32"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field9",
+              "name": "field9",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field9"
+              ]
+            },
+            "fieldId": 9,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Uint64"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field10",
+              "name": "field10",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field10"
+              ]
+            },
+            "fieldId": 10,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Sint32"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field11",
+              "name": "field11",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field11"
+              ]
+            },
+            "fieldId": 11,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Sint64"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field12",
+              "name": "field12",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field12"
+              ]
+            },
+            "fieldId": 12,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Fixed32"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field13",
+              "name": "field13",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field13"
+              ]
+            },
+            "fieldId": 13,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Fixed64"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field14",
+              "name": "field14",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field14"
+              ]
+            },
+            "fieldId": 14,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Sfixed32"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field15",
+              "name": "field15",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field15"
+              ]
+            },
+            "fieldId": 15,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "Sfixed64"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field16",
+              "name": "field16",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field16"
+              ]
+            },
+            "fieldId": 16,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "primitive": "EntityId"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field17",
+              "name": "field17",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field17"
+              ]
+            },
+            "fieldId": 17,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "type": {
+                  "qualifiedName": "improbable.gdk.tests.SomeType"
+                }
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field18",
+              "name": "field18",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveRepeatedData",
+                "field18"
+              ]
+            },
+            "fieldId": 18,
+            "transient": false,
+            "listType": {
+              "innerType": {
+                "enum": {
+                  "qualifiedName": "improbable.gdk.tests.SomeEnum"
+                }
+              }
+            },
+            "annotations": []
+          }
+        ],
+        "annotations": [
+          {
+            "typeValue": {
+              "type": {
+                "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData"
+              },
+              "fields": [
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field1"
+                  },
+                  "name": "field1",
+                  "number": 1,
+                  "value": {
+                    "listValue": {
+                      "values": [
+                        {
+                          "boolValue": true
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field2"
+                  },
+                  "name": "field2",
+                  "number": 2,
+                  "value": {
+                    "listValue": {
+                      "values": [
+                        {
+                          "floatValue": 10.5
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field3"
+                  },
+                  "name": "field3",
+                  "number": 3,
+                  "value": {
+                    "listValue": {
+                      "values": [
+                        {
+                          "bytesValue": "foo"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field4"
+                  },
+                  "name": "field4",
+                  "number": 4,
+                  "value": {
+                    "listValue": {
+                      "values": [
+                        {
+                          "int32Value": -2
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field5"
+                  },
+                  "name": "field5",
+                  "number": 5,
+                  "value": {
+                    "listValue": {
+                      "values": [
+                        {
+                          "int64Value": "3"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field6"
+                  },
+                  "name": "field6",
+                  "number": 6,
+                  "value": {
+                    "listValue": {
+                      "values": [
+                        {
+                          "doubleValue": -15.5
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field7"
+                  },
+                  "name": "field7",
+                  "number": 7,
+                  "value": {
+                    "listValue": {
+                      "values": [
+                        {
+                          "stringValue": "bar"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field8"
+                  },
+                  "name": "field8",
+                  "number": 8,
+                  "value": {
+                    "listValue": {
+                      "values": [
+                        {
+                          "uint32Value": 0
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field9"
+                  },
+                  "name": "field9",
+                  "number": 9,
+                  "value": {
+                    "listValue": {
+                      "values": [
+                        {
+                          "uint64Value": "1"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field10"
+                  },
+                  "name": "field10",
+                  "number": 10,
+                  "value": {
+                    "listValue": {
+                      "values": [
+                        {
+                          "int32Value": 4
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field11"
+                  },
+                  "name": "field11",
+                  "number": 11,
+                  "value": {
+                    "listValue": {
+                      "values": [
+                        {
+                          "int64Value": "5"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field12"
+                  },
+                  "name": "field12",
+                  "number": 12,
+                  "value": {
+                    "listValue": {
+                      "values": [
+                        {
+                          "uint32Value": 6
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field13"
+                  },
+                  "name": "field13",
+                  "number": 13,
+                  "value": {
+                    "listValue": {
+                      "values": [
+                        {
+                          "uint64Value": "7"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field14"
+                  },
+                  "name": "field14",
+                  "number": 14,
+                  "value": {
+                    "listValue": {
+                      "values": [
+                        {
+                          "int32Value": -8
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field15"
+                  },
+                  "name": "field15",
+                  "number": 15,
+                  "value": {
+                    "listValue": {
+                      "values": [
+                        {
+                          "int64Value": "-9"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field16"
+                  },
+                  "name": "field16",
+                  "number": 16,
+                  "value": {
+                    "listValue": {
+                      "values": [
+                        {
+                          "entityIdValue": "10"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field17"
+                  },
+                  "name": "field17",
+                  "number": 17,
+                  "value": {
+                    "listValue": {
+                      "values": [
+                        {
+                          "typeValue": {
+                            "type": {
+                              "qualifiedName": "improbable.gdk.tests.SomeType"
+                            },
+                            "fields": []
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData.field18"
+                  },
+                  "name": "field18",
+                  "number": 18,
+                  "value": {
+                    "listValue": {
+                      "values": [
+                        {
+                          "enumValue": {
+                            "enumValue": {
+                              "qualifiedName": "improbable.gdk.tests.SomeEnum.FIRST_VALUE"
+                            },
+                            "enum": {
+                              "qualifiedName": "improbable.gdk.tests.SomeEnum"
+                            },
+                            "name": "FIRST_VALUE",
+                            "value": 0
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData",
+          "name": "ExhaustiveMapValueData",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "ExhaustiveMapValueData"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field1",
+              "name": "field1",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field1"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Bool"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field2",
+              "name": "field2",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field2"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Float"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field3",
+              "name": "field3",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field3"
+              ]
+            },
+            "fieldId": 3,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Bytes"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field4",
+              "name": "field4",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field4"
+              ]
+            },
+            "fieldId": 4,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Int32"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field5",
+              "name": "field5",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field5"
+              ]
+            },
+            "fieldId": 5,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Int64"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field6",
+              "name": "field6",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field6"
+              ]
+            },
+            "fieldId": 6,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Double"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field7",
+              "name": "field7",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field7"
+              ]
+            },
+            "fieldId": 7,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field8",
+              "name": "field8",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field8"
+              ]
+            },
+            "fieldId": 8,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Uint32"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field9",
+              "name": "field9",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field9"
+              ]
+            },
+            "fieldId": 9,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Uint64"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field10",
+              "name": "field10",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field10"
+              ]
+            },
+            "fieldId": 10,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Sint32"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field11",
+              "name": "field11",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field11"
+              ]
+            },
+            "fieldId": 11,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Sint64"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field12",
+              "name": "field12",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field12"
+              ]
+            },
+            "fieldId": 12,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Fixed32"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field13",
+              "name": "field13",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field13"
+              ]
+            },
+            "fieldId": 13,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Fixed64"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field14",
+              "name": "field14",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field14"
+              ]
+            },
+            "fieldId": 14,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Sfixed32"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field15",
+              "name": "field15",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field15"
+              ]
+            },
+            "fieldId": 15,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "Sfixed64"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field16",
+              "name": "field16",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field16"
+              ]
+            },
+            "fieldId": 16,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "EntityId"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field17",
+              "name": "field17",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field17"
+              ]
+            },
+            "fieldId": 17,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "type": {
+                  "qualifiedName": "improbable.gdk.tests.SomeType"
+                }
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field18",
+              "name": "field18",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapValueData",
+                "field18"
+              ]
+            },
+            "fieldId": 18,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "enum": {
+                  "qualifiedName": "improbable.gdk.tests.SomeEnum"
+                }
+              }
+            },
+            "annotations": []
+          }
+        ],
+        "annotations": [
+          {
+            "typeValue": {
+              "type": {
+                "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData"
+              },
+              "fields": [
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field1"
+                  },
+                  "name": "field1",
+                  "number": 1,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "stringValue": "field1"
+                          },
+                          "value": {
+                            "boolValue": true
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field2"
+                  },
+                  "name": "field2",
+                  "number": 2,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "stringValue": "field2"
+                          },
+                          "value": {
+                            "floatValue": 10.5
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field3"
+                  },
+                  "name": "field3",
+                  "number": 3,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "stringValue": "field3"
+                          },
+                          "value": {
+                            "bytesValue": "foo"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field4"
+                  },
+                  "name": "field4",
+                  "number": 4,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "stringValue": "field4"
+                          },
+                          "value": {
+                            "int32Value": -2
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field5"
+                  },
+                  "name": "field5",
+                  "number": 5,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "stringValue": "field5"
+                          },
+                          "value": {
+                            "int64Value": "3"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field6"
+                  },
+                  "name": "field6",
+                  "number": 6,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "stringValue": "field6"
+                          },
+                          "value": {
+                            "doubleValue": -15.5
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field7"
+                  },
+                  "name": "field7",
+                  "number": 7,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "stringValue": "field7"
+                          },
+                          "value": {
+                            "stringValue": "bar"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field8"
+                  },
+                  "name": "field8",
+                  "number": 8,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "stringValue": "field8"
+                          },
+                          "value": {
+                            "uint32Value": 0
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field9"
+                  },
+                  "name": "field9",
+                  "number": 9,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "stringValue": "field9"
+                          },
+                          "value": {
+                            "uint64Value": "1"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field10"
+                  },
+                  "name": "field10",
+                  "number": 10,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "stringValue": "field10"
+                          },
+                          "value": {
+                            "int32Value": 4
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field11"
+                  },
+                  "name": "field11",
+                  "number": 11,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "stringValue": "field11"
+                          },
+                          "value": {
+                            "int64Value": "5"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field12"
+                  },
+                  "name": "field12",
+                  "number": 12,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "stringValue": "field12"
+                          },
+                          "value": {
+                            "uint32Value": 6
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field13"
+                  },
+                  "name": "field13",
+                  "number": 13,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "stringValue": "field13"
+                          },
+                          "value": {
+                            "uint64Value": "7"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field14"
+                  },
+                  "name": "field14",
+                  "number": 14,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "stringValue": "field14"
+                          },
+                          "value": {
+                            "int32Value": -8
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field15"
+                  },
+                  "name": "field15",
+                  "number": 15,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "stringValue": "field15"
+                          },
+                          "value": {
+                            "int64Value": "-9"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field16"
+                  },
+                  "name": "field16",
+                  "number": 16,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "stringValue": "field16"
+                          },
+                          "value": {
+                            "entityIdValue": "10"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field17"
+                  },
+                  "name": "field17",
+                  "number": 17,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "stringValue": "field17"
+                          },
+                          "value": {
+                            "typeValue": {
+                              "type": {
+                                "qualifiedName": "improbable.gdk.tests.SomeType"
+                              },
+                              "fields": []
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData.field18"
+                  },
+                  "name": "field18",
+                  "number": 18,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "stringValue": "field18"
+                          },
+                          "value": {
+                            "enumValue": {
+                              "enumValue": {
+                                "qualifiedName": "improbable.gdk.tests.SomeEnum.FIRST_VALUE"
+                              },
+                              "enum": {
+                                "qualifiedName": "improbable.gdk.tests.SomeEnum"
+                              },
+                              "name": "FIRST_VALUE",
+                              "value": 0
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
+          "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData",
+          "name": "ExhaustiveMapKeyData",
+          "path": [
+            "improbable",
+            "gdk",
+            "tests",
+            "ExhaustiveMapKeyData"
+          ]
+        },
+        "fieldDefinitions": [
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field1",
+              "name": "field1",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field1"
+              ]
+            },
+            "fieldId": 1,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Bool"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field2",
+              "name": "field2",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field2"
+              ]
+            },
+            "fieldId": 2,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Float"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field3",
+              "name": "field3",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field3"
+              ]
+            },
+            "fieldId": 3,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Bytes"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field4",
+              "name": "field4",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field4"
+              ]
+            },
+            "fieldId": 4,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Int32"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field5",
+              "name": "field5",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field5"
+              ]
+            },
+            "fieldId": 5,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Int64"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field6",
+              "name": "field6",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field6"
+              ]
+            },
+            "fieldId": 6,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Double"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field7",
+              "name": "field7",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field7"
+              ]
+            },
+            "fieldId": 7,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "String"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field8",
+              "name": "field8",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field8"
+              ]
+            },
+            "fieldId": 8,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Uint32"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field9",
+              "name": "field9",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field9"
+              ]
+            },
+            "fieldId": 9,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Uint64"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field10",
+              "name": "field10",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field10"
+              ]
+            },
+            "fieldId": 10,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Sint32"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field11",
+              "name": "field11",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field11"
+              ]
+            },
+            "fieldId": 11,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Sint64"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field12",
+              "name": "field12",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field12"
+              ]
+            },
+            "fieldId": 12,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Fixed32"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field13",
+              "name": "field13",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field13"
+              ]
+            },
+            "fieldId": 13,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Fixed64"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field14",
+              "name": "field14",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field14"
+              ]
+            },
+            "fieldId": 14,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Sfixed32"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field15",
+              "name": "field15",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field15"
+              ]
+            },
+            "fieldId": 15,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "Sfixed64"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field16",
+              "name": "field16",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field16"
+              ]
+            },
+            "fieldId": 16,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "primitive": "EntityId"
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field17",
+              "name": "field17",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field17"
+              ]
+            },
+            "fieldId": 17,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "type": {
+                  "qualifiedName": "improbable.gdk.tests.SomeType"
+                }
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            },
+            "annotations": []
+          },
+          {
+            "identifier": {
+              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field18",
+              "name": "field18",
+              "path": [
+                "improbable",
+                "gdk",
+                "tests",
+                "ExhaustiveMapKeyData",
+                "field18"
+              ]
+            },
+            "fieldId": 18,
+            "transient": false,
+            "mapType": {
+              "keyType": {
+                "enum": {
+                  "qualifiedName": "improbable.gdk.tests.SomeEnum"
+                }
+              },
+              "valueType": {
+                "primitive": "String"
+              }
+            },
+            "annotations": []
+          }
+        ],
+        "annotations": [
+          {
+            "typeValue": {
+              "type": {
+                "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData"
+              },
+              "fields": [
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field1"
+                  },
+                  "name": "field1",
+                  "number": 1,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "boolValue": true
+                          },
+                          "value": {
+                            "stringValue": "field1"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field2"
+                  },
+                  "name": "field2",
+                  "number": 2,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "floatValue": 10.5
+                          },
+                          "value": {
+                            "stringValue": "field2"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field3"
+                  },
+                  "name": "field3",
+                  "number": 3,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "bytesValue": "foo"
+                          },
+                          "value": {
+                            "stringValue": "field3"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field4"
+                  },
+                  "name": "field4",
+                  "number": 4,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "int32Value": -2
+                          },
+                          "value": {
+                            "stringValue": "field4"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field5"
+                  },
+                  "name": "field5",
+                  "number": 5,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "int64Value": "3"
+                          },
+                          "value": {
+                            "stringValue": "field5"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field6"
+                  },
+                  "name": "field6",
+                  "number": 6,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "doubleValue": -15.5
+                          },
+                          "value": {
+                            "stringValue": "field6"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field7"
+                  },
+                  "name": "field7",
+                  "number": 7,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "stringValue": "bar"
+                          },
+                          "value": {
+                            "stringValue": "field7"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field8"
+                  },
+                  "name": "field8",
+                  "number": 8,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "uint32Value": 0
+                          },
+                          "value": {
+                            "stringValue": "field8"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field9"
+                  },
+                  "name": "field9",
+                  "number": 9,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "uint64Value": "1"
+                          },
+                          "value": {
+                            "stringValue": "field9"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field10"
+                  },
+                  "name": "field10",
+                  "number": 10,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "int32Value": 4
+                          },
+                          "value": {
+                            "stringValue": "field10"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field11"
+                  },
+                  "name": "field11",
+                  "number": 11,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "int64Value": "5"
+                          },
+                          "value": {
+                            "stringValue": "field11"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field12"
+                  },
+                  "name": "field12",
+                  "number": 12,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "uint32Value": 6
+                          },
+                          "value": {
+                            "stringValue": "field12"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field13"
+                  },
+                  "name": "field13",
+                  "number": 13,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "uint64Value": "7"
+                          },
+                          "value": {
+                            "stringValue": "field13"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field14"
+                  },
+                  "name": "field14",
+                  "number": 14,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "int32Value": -8
+                          },
+                          "value": {
+                            "stringValue": "field14"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field15"
+                  },
+                  "name": "field15",
+                  "number": 15,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "int64Value": "-9"
+                          },
+                          "value": {
+                            "stringValue": "field15"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field16"
+                  },
+                  "name": "field16",
+                  "number": 16,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "entityIdValue": "10"
+                          },
+                          "value": {
+                            "stringValue": "field16"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field17"
+                  },
+                  "name": "field17",
+                  "number": 17,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "typeValue": {
+                              "type": {
+                                "qualifiedName": "improbable.gdk.tests.SomeType"
+                              },
+                              "fields": []
+                            }
+                          },
+                          "value": {
+                            "stringValue": "field17"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData.field18"
+                  },
+                  "name": "field18",
+                  "number": 18,
+                  "value": {
+                    "mapValue": {
+                      "values": [
+                        {
+                          "key": {
+                            "enumValue": {
+                              "enumValue": {
+                                "qualifiedName": "improbable.gdk.tests.SomeEnum.FIRST_VALUE"
+                              },
+                              "enum": {
+                                "qualifiedName": "improbable.gdk.tests.SomeEnum"
+                              },
+                              "name": "FIRST_VALUE",
+                              "value": 0
+                            }
+                          },
+                          "value": {
+                            "stringValue": "field18"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "identifier": {
           "qualifiedName": "improbable.gdk.tests.TypeName",
           "name": "TypeName",
           "path": [
@@ -2371,390 +6060,10 @@
           ]
         },
         "componentId": 197715,
-        "fieldDefinitions": [
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingular.field1",
-              "name": "field1",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveSingular",
-                "field1"
-              ]
-            },
-            "fieldId": 1,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Bool"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingular.field2",
-              "name": "field2",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveSingular",
-                "field2"
-              ]
-            },
-            "fieldId": 2,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Float"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingular.field3",
-              "name": "field3",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveSingular",
-                "field3"
-              ]
-            },
-            "fieldId": 3,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Bytes"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingular.field4",
-              "name": "field4",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveSingular",
-                "field4"
-              ]
-            },
-            "fieldId": 4,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Int32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingular.field5",
-              "name": "field5",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveSingular",
-                "field5"
-              ]
-            },
-            "fieldId": 5,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Int64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingular.field6",
-              "name": "field6",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveSingular",
-                "field6"
-              ]
-            },
-            "fieldId": 6,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Double"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingular.field7",
-              "name": "field7",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveSingular",
-                "field7"
-              ]
-            },
-            "fieldId": 7,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "String"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingular.field8",
-              "name": "field8",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveSingular",
-                "field8"
-              ]
-            },
-            "fieldId": 8,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Uint32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingular.field9",
-              "name": "field9",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveSingular",
-                "field9"
-              ]
-            },
-            "fieldId": 9,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Uint64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingular.field10",
-              "name": "field10",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveSingular",
-                "field10"
-              ]
-            },
-            "fieldId": 10,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Sint32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingular.field11",
-              "name": "field11",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveSingular",
-                "field11"
-              ]
-            },
-            "fieldId": 11,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Sint64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingular.field12",
-              "name": "field12",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveSingular",
-                "field12"
-              ]
-            },
-            "fieldId": 12,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Fixed32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingular.field13",
-              "name": "field13",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveSingular",
-                "field13"
-              ]
-            },
-            "fieldId": 13,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Fixed64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingular.field14",
-              "name": "field14",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveSingular",
-                "field14"
-              ]
-            },
-            "fieldId": 14,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Sfixed32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingular.field15",
-              "name": "field15",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveSingular",
-                "field15"
-              ]
-            },
-            "fieldId": 15,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Sfixed64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingular.field16",
-              "name": "field16",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveSingular",
-                "field16"
-              ]
-            },
-            "fieldId": 16,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "EntityId"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingular.field17",
-              "name": "field17",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveSingular",
-                "field17"
-              ]
-            },
-            "fieldId": 17,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "type": {
-                  "qualifiedName": "improbable.gdk.tests.SomeType"
-                }
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveSingular.field18",
-              "name": "field18",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveSingular",
-                "field18"
-              ]
-            },
-            "fieldId": 18,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "enum": {
-                  "qualifiedName": "improbable.gdk.tests.SomeEnum"
-                }
-              }
-            },
-            "annotations": []
-          }
-        ],
+        "dataDefinition": {
+          "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData"
+        },
+        "fieldDefinitions": [],
         "eventDefinitions": [],
         "commandDefinitions": [],
         "annotations": []
@@ -2771,390 +6080,10 @@
           ]
         },
         "componentId": 197716,
-        "fieldDefinitions": [
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptional.field1",
-              "name": "field1",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveOptional",
-                "field1"
-              ]
-            },
-            "fieldId": 1,
-            "transient": false,
-            "optionType": {
-              "innerType": {
-                "primitive": "Bool"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptional.field2",
-              "name": "field2",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveOptional",
-                "field2"
-              ]
-            },
-            "fieldId": 2,
-            "transient": false,
-            "optionType": {
-              "innerType": {
-                "primitive": "Float"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptional.field3",
-              "name": "field3",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveOptional",
-                "field3"
-              ]
-            },
-            "fieldId": 3,
-            "transient": false,
-            "optionType": {
-              "innerType": {
-                "primitive": "Bytes"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptional.field4",
-              "name": "field4",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveOptional",
-                "field4"
-              ]
-            },
-            "fieldId": 4,
-            "transient": false,
-            "optionType": {
-              "innerType": {
-                "primitive": "Int32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptional.field5",
-              "name": "field5",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveOptional",
-                "field5"
-              ]
-            },
-            "fieldId": 5,
-            "transient": false,
-            "optionType": {
-              "innerType": {
-                "primitive": "Int64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptional.field6",
-              "name": "field6",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveOptional",
-                "field6"
-              ]
-            },
-            "fieldId": 6,
-            "transient": false,
-            "optionType": {
-              "innerType": {
-                "primitive": "Double"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptional.field7",
-              "name": "field7",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveOptional",
-                "field7"
-              ]
-            },
-            "fieldId": 7,
-            "transient": false,
-            "optionType": {
-              "innerType": {
-                "primitive": "String"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptional.field8",
-              "name": "field8",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveOptional",
-                "field8"
-              ]
-            },
-            "fieldId": 8,
-            "transient": false,
-            "optionType": {
-              "innerType": {
-                "primitive": "Uint32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptional.field9",
-              "name": "field9",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveOptional",
-                "field9"
-              ]
-            },
-            "fieldId": 9,
-            "transient": false,
-            "optionType": {
-              "innerType": {
-                "primitive": "Uint64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptional.field10",
-              "name": "field10",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveOptional",
-                "field10"
-              ]
-            },
-            "fieldId": 10,
-            "transient": false,
-            "optionType": {
-              "innerType": {
-                "primitive": "Sint32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptional.field11",
-              "name": "field11",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveOptional",
-                "field11"
-              ]
-            },
-            "fieldId": 11,
-            "transient": false,
-            "optionType": {
-              "innerType": {
-                "primitive": "Sint64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptional.field12",
-              "name": "field12",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveOptional",
-                "field12"
-              ]
-            },
-            "fieldId": 12,
-            "transient": false,
-            "optionType": {
-              "innerType": {
-                "primitive": "Fixed32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptional.field13",
-              "name": "field13",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveOptional",
-                "field13"
-              ]
-            },
-            "fieldId": 13,
-            "transient": false,
-            "optionType": {
-              "innerType": {
-                "primitive": "Fixed64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptional.field14",
-              "name": "field14",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveOptional",
-                "field14"
-              ]
-            },
-            "fieldId": 14,
-            "transient": false,
-            "optionType": {
-              "innerType": {
-                "primitive": "Sfixed32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptional.field15",
-              "name": "field15",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveOptional",
-                "field15"
-              ]
-            },
-            "fieldId": 15,
-            "transient": false,
-            "optionType": {
-              "innerType": {
-                "primitive": "Sfixed64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptional.field16",
-              "name": "field16",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveOptional",
-                "field16"
-              ]
-            },
-            "fieldId": 16,
-            "transient": false,
-            "optionType": {
-              "innerType": {
-                "primitive": "EntityId"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptional.field17",
-              "name": "field17",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveOptional",
-                "field17"
-              ]
-            },
-            "fieldId": 17,
-            "transient": false,
-            "optionType": {
-              "innerType": {
-                "type": {
-                  "qualifiedName": "improbable.gdk.tests.SomeType"
-                }
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveOptional.field18",
-              "name": "field18",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveOptional",
-                "field18"
-              ]
-            },
-            "fieldId": 18,
-            "transient": false,
-            "optionType": {
-              "innerType": {
-                "enum": {
-                  "qualifiedName": "improbable.gdk.tests.SomeEnum"
-                }
-              }
-            },
-            "annotations": []
-          }
-        ],
+        "dataDefinition": {
+          "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData"
+        },
+        "fieldDefinitions": [],
         "eventDefinitions": [],
         "commandDefinitions": [],
         "annotations": []
@@ -3171,390 +6100,10 @@
           ]
         },
         "componentId": 197717,
-        "fieldDefinitions": [
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeated.field1",
-              "name": "field1",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveRepeated",
-                "field1"
-              ]
-            },
-            "fieldId": 1,
-            "transient": false,
-            "listType": {
-              "innerType": {
-                "primitive": "Bool"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeated.field2",
-              "name": "field2",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveRepeated",
-                "field2"
-              ]
-            },
-            "fieldId": 2,
-            "transient": false,
-            "listType": {
-              "innerType": {
-                "primitive": "Float"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeated.field3",
-              "name": "field3",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveRepeated",
-                "field3"
-              ]
-            },
-            "fieldId": 3,
-            "transient": false,
-            "listType": {
-              "innerType": {
-                "primitive": "Bytes"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeated.field4",
-              "name": "field4",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveRepeated",
-                "field4"
-              ]
-            },
-            "fieldId": 4,
-            "transient": false,
-            "listType": {
-              "innerType": {
-                "primitive": "Int32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeated.field5",
-              "name": "field5",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveRepeated",
-                "field5"
-              ]
-            },
-            "fieldId": 5,
-            "transient": false,
-            "listType": {
-              "innerType": {
-                "primitive": "Int64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeated.field6",
-              "name": "field6",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveRepeated",
-                "field6"
-              ]
-            },
-            "fieldId": 6,
-            "transient": false,
-            "listType": {
-              "innerType": {
-                "primitive": "Double"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeated.field7",
-              "name": "field7",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveRepeated",
-                "field7"
-              ]
-            },
-            "fieldId": 7,
-            "transient": false,
-            "listType": {
-              "innerType": {
-                "primitive": "String"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeated.field8",
-              "name": "field8",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveRepeated",
-                "field8"
-              ]
-            },
-            "fieldId": 8,
-            "transient": false,
-            "listType": {
-              "innerType": {
-                "primitive": "Uint32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeated.field9",
-              "name": "field9",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveRepeated",
-                "field9"
-              ]
-            },
-            "fieldId": 9,
-            "transient": false,
-            "listType": {
-              "innerType": {
-                "primitive": "Uint64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeated.field10",
-              "name": "field10",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveRepeated",
-                "field10"
-              ]
-            },
-            "fieldId": 10,
-            "transient": false,
-            "listType": {
-              "innerType": {
-                "primitive": "Sint32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeated.field11",
-              "name": "field11",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveRepeated",
-                "field11"
-              ]
-            },
-            "fieldId": 11,
-            "transient": false,
-            "listType": {
-              "innerType": {
-                "primitive": "Sint64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeated.field12",
-              "name": "field12",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveRepeated",
-                "field12"
-              ]
-            },
-            "fieldId": 12,
-            "transient": false,
-            "listType": {
-              "innerType": {
-                "primitive": "Fixed32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeated.field13",
-              "name": "field13",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveRepeated",
-                "field13"
-              ]
-            },
-            "fieldId": 13,
-            "transient": false,
-            "listType": {
-              "innerType": {
-                "primitive": "Fixed64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeated.field14",
-              "name": "field14",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveRepeated",
-                "field14"
-              ]
-            },
-            "fieldId": 14,
-            "transient": false,
-            "listType": {
-              "innerType": {
-                "primitive": "Sfixed32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeated.field15",
-              "name": "field15",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveRepeated",
-                "field15"
-              ]
-            },
-            "fieldId": 15,
-            "transient": false,
-            "listType": {
-              "innerType": {
-                "primitive": "Sfixed64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeated.field16",
-              "name": "field16",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveRepeated",
-                "field16"
-              ]
-            },
-            "fieldId": 16,
-            "transient": false,
-            "listType": {
-              "innerType": {
-                "primitive": "EntityId"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeated.field17",
-              "name": "field17",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveRepeated",
-                "field17"
-              ]
-            },
-            "fieldId": 17,
-            "transient": false,
-            "listType": {
-              "innerType": {
-                "type": {
-                  "qualifiedName": "improbable.gdk.tests.SomeType"
-                }
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeated.field18",
-              "name": "field18",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveRepeated",
-                "field18"
-              ]
-            },
-            "fieldId": 18,
-            "transient": false,
-            "listType": {
-              "innerType": {
-                "enum": {
-                  "qualifiedName": "improbable.gdk.tests.SomeEnum"
-                }
-              }
-            },
-            "annotations": []
-          }
-        ],
+        "dataDefinition": {
+          "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData"
+        },
+        "fieldDefinitions": [],
         "eventDefinitions": [],
         "commandDefinitions": [],
         "annotations": []
@@ -3571,444 +6120,10 @@
           ]
         },
         "componentId": 197718,
-        "fieldDefinitions": [
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValue.field1",
-              "name": "field1",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapValue",
-                "field1"
-              ]
-            },
-            "fieldId": 1,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "String"
-              },
-              "valueType": {
-                "primitive": "Bool"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValue.field2",
-              "name": "field2",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapValue",
-                "field2"
-              ]
-            },
-            "fieldId": 2,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "String"
-              },
-              "valueType": {
-                "primitive": "Float"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValue.field3",
-              "name": "field3",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapValue",
-                "field3"
-              ]
-            },
-            "fieldId": 3,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "String"
-              },
-              "valueType": {
-                "primitive": "Bytes"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValue.field4",
-              "name": "field4",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapValue",
-                "field4"
-              ]
-            },
-            "fieldId": 4,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "String"
-              },
-              "valueType": {
-                "primitive": "Int32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValue.field5",
-              "name": "field5",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapValue",
-                "field5"
-              ]
-            },
-            "fieldId": 5,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "String"
-              },
-              "valueType": {
-                "primitive": "Int64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValue.field6",
-              "name": "field6",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapValue",
-                "field6"
-              ]
-            },
-            "fieldId": 6,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "String"
-              },
-              "valueType": {
-                "primitive": "Double"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValue.field7",
-              "name": "field7",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapValue",
-                "field7"
-              ]
-            },
-            "fieldId": 7,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "String"
-              },
-              "valueType": {
-                "primitive": "String"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValue.field8",
-              "name": "field8",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapValue",
-                "field8"
-              ]
-            },
-            "fieldId": 8,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "String"
-              },
-              "valueType": {
-                "primitive": "Uint32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValue.field9",
-              "name": "field9",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapValue",
-                "field9"
-              ]
-            },
-            "fieldId": 9,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "String"
-              },
-              "valueType": {
-                "primitive": "Uint64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValue.field10",
-              "name": "field10",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapValue",
-                "field10"
-              ]
-            },
-            "fieldId": 10,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "String"
-              },
-              "valueType": {
-                "primitive": "Sint32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValue.field11",
-              "name": "field11",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapValue",
-                "field11"
-              ]
-            },
-            "fieldId": 11,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "String"
-              },
-              "valueType": {
-                "primitive": "Sint64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValue.field12",
-              "name": "field12",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapValue",
-                "field12"
-              ]
-            },
-            "fieldId": 12,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "String"
-              },
-              "valueType": {
-                "primitive": "Fixed32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValue.field13",
-              "name": "field13",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapValue",
-                "field13"
-              ]
-            },
-            "fieldId": 13,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "String"
-              },
-              "valueType": {
-                "primitive": "Fixed64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValue.field14",
-              "name": "field14",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapValue",
-                "field14"
-              ]
-            },
-            "fieldId": 14,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "String"
-              },
-              "valueType": {
-                "primitive": "Sfixed32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValue.field15",
-              "name": "field15",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapValue",
-                "field15"
-              ]
-            },
-            "fieldId": 15,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "String"
-              },
-              "valueType": {
-                "primitive": "Sfixed64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValue.field16",
-              "name": "field16",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapValue",
-                "field16"
-              ]
-            },
-            "fieldId": 16,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "String"
-              },
-              "valueType": {
-                "primitive": "EntityId"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValue.field17",
-              "name": "field17",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapValue",
-                "field17"
-              ]
-            },
-            "fieldId": 17,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "String"
-              },
-              "valueType": {
-                "type": {
-                  "qualifiedName": "improbable.gdk.tests.SomeType"
-                }
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValue.field18",
-              "name": "field18",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapValue",
-                "field18"
-              ]
-            },
-            "fieldId": 18,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "String"
-              },
-              "valueType": {
-                "enum": {
-                  "qualifiedName": "improbable.gdk.tests.SomeEnum"
-                }
-              }
-            },
-            "annotations": []
-          }
-        ],
+        "dataDefinition": {
+          "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData"
+        },
+        "fieldDefinitions": [],
         "eventDefinitions": [],
         "commandDefinitions": [],
         "annotations": []
@@ -4025,802 +6140,10 @@
           ]
         },
         "componentId": 197719,
-        "fieldDefinitions": [
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKey.field1",
-              "name": "field1",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapKey",
-                "field1"
-              ]
-            },
-            "fieldId": 1,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "Bool"
-              },
-              "valueType": {
-                "primitive": "String"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKey.field2",
-              "name": "field2",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapKey",
-                "field2"
-              ]
-            },
-            "fieldId": 2,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "Float"
-              },
-              "valueType": {
-                "primitive": "String"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKey.field3",
-              "name": "field3",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapKey",
-                "field3"
-              ]
-            },
-            "fieldId": 3,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "Bytes"
-              },
-              "valueType": {
-                "primitive": "String"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKey.field4",
-              "name": "field4",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapKey",
-                "field4"
-              ]
-            },
-            "fieldId": 4,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "Int32"
-              },
-              "valueType": {
-                "primitive": "String"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKey.field5",
-              "name": "field5",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapKey",
-                "field5"
-              ]
-            },
-            "fieldId": 5,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "Int64"
-              },
-              "valueType": {
-                "primitive": "String"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKey.field6",
-              "name": "field6",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapKey",
-                "field6"
-              ]
-            },
-            "fieldId": 6,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "Double"
-              },
-              "valueType": {
-                "primitive": "String"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKey.field7",
-              "name": "field7",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapKey",
-                "field7"
-              ]
-            },
-            "fieldId": 7,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "String"
-              },
-              "valueType": {
-                "primitive": "String"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKey.field8",
-              "name": "field8",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapKey",
-                "field8"
-              ]
-            },
-            "fieldId": 8,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "Uint32"
-              },
-              "valueType": {
-                "primitive": "String"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKey.field9",
-              "name": "field9",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapKey",
-                "field9"
-              ]
-            },
-            "fieldId": 9,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "Uint64"
-              },
-              "valueType": {
-                "primitive": "String"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKey.field10",
-              "name": "field10",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapKey",
-                "field10"
-              ]
-            },
-            "fieldId": 10,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "Sint32"
-              },
-              "valueType": {
-                "primitive": "String"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKey.field11",
-              "name": "field11",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapKey",
-                "field11"
-              ]
-            },
-            "fieldId": 11,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "Sint64"
-              },
-              "valueType": {
-                "primitive": "String"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKey.field12",
-              "name": "field12",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapKey",
-                "field12"
-              ]
-            },
-            "fieldId": 12,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "Fixed32"
-              },
-              "valueType": {
-                "primitive": "String"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKey.field13",
-              "name": "field13",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapKey",
-                "field13"
-              ]
-            },
-            "fieldId": 13,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "Fixed64"
-              },
-              "valueType": {
-                "primitive": "String"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKey.field14",
-              "name": "field14",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapKey",
-                "field14"
-              ]
-            },
-            "fieldId": 14,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "Sfixed32"
-              },
-              "valueType": {
-                "primitive": "String"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKey.field15",
-              "name": "field15",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapKey",
-                "field15"
-              ]
-            },
-            "fieldId": 15,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "Sfixed64"
-              },
-              "valueType": {
-                "primitive": "String"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKey.field16",
-              "name": "field16",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapKey",
-                "field16"
-              ]
-            },
-            "fieldId": 16,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "primitive": "EntityId"
-              },
-              "valueType": {
-                "primitive": "String"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKey.field17",
-              "name": "field17",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapKey",
-                "field17"
-              ]
-            },
-            "fieldId": 17,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "type": {
-                  "qualifiedName": "improbable.gdk.tests.SomeType"
-                }
-              },
-              "valueType": {
-                "primitive": "String"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKey.field18",
-              "name": "field18",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveMapKey",
-                "field18"
-              ]
-            },
-            "fieldId": 18,
-            "transient": false,
-            "mapType": {
-              "keyType": {
-                "enum": {
-                  "qualifiedName": "improbable.gdk.tests.SomeEnum"
-                }
-              },
-              "valueType": {
-                "primitive": "String"
-              }
-            },
-            "annotations": []
-          }
-        ],
-        "eventDefinitions": [],
-        "commandDefinitions": [],
-        "annotations": []
-      },
-      {
-        "identifier": {
-          "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingular",
-          "name": "ExhaustiveBlittableSingular",
-          "path": [
-            "improbable",
-            "gdk",
-            "tests",
-            "ExhaustiveBlittableSingular"
-          ]
+        "dataDefinition": {
+          "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData"
         },
-        "componentId": 197720,
-        "fieldDefinitions": [
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingular.field1",
-              "name": "field1",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveBlittableSingular",
-                "field1"
-              ]
-            },
-            "fieldId": 1,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Bool"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingular.field2",
-              "name": "field2",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveBlittableSingular",
-                "field2"
-              ]
-            },
-            "fieldId": 2,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Float"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingular.field4",
-              "name": "field4",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveBlittableSingular",
-                "field4"
-              ]
-            },
-            "fieldId": 4,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Int32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingular.field5",
-              "name": "field5",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveBlittableSingular",
-                "field5"
-              ]
-            },
-            "fieldId": 5,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Int64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingular.field6",
-              "name": "field6",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveBlittableSingular",
-                "field6"
-              ]
-            },
-            "fieldId": 6,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Double"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingular.field8",
-              "name": "field8",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveBlittableSingular",
-                "field8"
-              ]
-            },
-            "fieldId": 8,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Uint32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingular.field9",
-              "name": "field9",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveBlittableSingular",
-                "field9"
-              ]
-            },
-            "fieldId": 9,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Uint64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingular.field10",
-              "name": "field10",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveBlittableSingular",
-                "field10"
-              ]
-            },
-            "fieldId": 10,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Sint32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingular.field11",
-              "name": "field11",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveBlittableSingular",
-                "field11"
-              ]
-            },
-            "fieldId": 11,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Sint64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingular.field12",
-              "name": "field12",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveBlittableSingular",
-                "field12"
-              ]
-            },
-            "fieldId": 12,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Fixed32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingular.field13",
-              "name": "field13",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveBlittableSingular",
-                "field13"
-              ]
-            },
-            "fieldId": 13,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Fixed64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingular.field14",
-              "name": "field14",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveBlittableSingular",
-                "field14"
-              ]
-            },
-            "fieldId": 14,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Sfixed32"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingular.field15",
-              "name": "field15",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveBlittableSingular",
-                "field15"
-              ]
-            },
-            "fieldId": 15,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "Sfixed64"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingular.field16",
-              "name": "field16",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveBlittableSingular",
-                "field16"
-              ]
-            },
-            "fieldId": 16,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "primitive": "EntityId"
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingular.field17",
-              "name": "field17",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveBlittableSingular",
-                "field17"
-              ]
-            },
-            "fieldId": 17,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "type": {
-                  "qualifiedName": "improbable.gdk.tests.SomeType"
-                }
-              }
-            },
-            "annotations": []
-          },
-          {
-            "identifier": {
-              "qualifiedName": "improbable.gdk.tests.ExhaustiveBlittableSingular.field18",
-              "name": "field18",
-              "path": [
-                "improbable",
-                "gdk",
-                "tests",
-                "ExhaustiveBlittableSingular",
-                "field18"
-              ]
-            },
-            "fieldId": 18,
-            "transient": false,
-            "singularType": {
-              "type": {
-                "enum": {
-                  "qualifiedName": "improbable.gdk.tests.SomeEnum"
-                }
-              }
-            },
-            "annotations": []
-          }
-        ],
+        "fieldDefinitions": [],
         "eventDefinitions": [],
         "commandDefinitions": [],
         "annotations": []
@@ -5374,24 +6697,19 @@
   },
   "sourceMapV1": {
     "sourceReferences": {
-      "improbable.gdk.tests.ExhaustiveOptional.field12": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 45,
-        "column": 3
-      },
       "improbable.gdk.tests.SomeEnum.FIRST_VALUE": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
         "line": 6,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveRepeated.field10": {
+      "improbable.gdk.tests.ExhaustiveOptionalData.field16": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 65,
+        "line": 62,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveMapValue.field3": {
+      "improbable.gdk.tests.ExhaustiveSingularData.field8": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 80,
+        "line": 23,
         "column": 3
       },
       "improbable.gdk.tests.components_with_no_fields.ComponentWithNoFieldsWithCommands.cmd": {
@@ -5399,19 +6717,24 @@
         "line": 18,
         "column": 3
       },
+      "improbable.gdk.tests.ExhaustiveRepeatedData.field15": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 92,
+        "column": 3
+      },
       "improbable.ComponentInterest.BoxConstraint": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\standard_library.schema",
         "line": 154,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveMapValue.field18": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 95,
-        "column": 3
-      },
       "improbable.Metadata.entity_type": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\standard_library.schema",
         "line": 57,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveMapKeyData.field3": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 142,
         "column": 3
       },
       "improbable.gdk.tests.TypeName.Other.NestedTypeName": {
@@ -5421,22 +6744,12 @@
       },
       "improbable.gdk.tests.ExhaustiveMapValue": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 76,
+        "line": 129,
         "column": 1
       },
       "improbable.Position.coords": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\standard_library.schema",
         "line": 83,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveMapKey.field4": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 103,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveBlittableSingular.field12": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 132,
         "column": 3
       },
       "improbable.ComponentInterest.BoxConstraint.center": {
@@ -5466,12 +6779,22 @@
       },
       "improbable.gdk.tests.ExhaustiveSingular": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 10,
+        "line": 36,
         "column": 1
       },
-      "improbable.gdk.tests.ExhaustiveRepeated.field5": {
+      "improbable.gdk.tests.ExhaustiveOptionalData.field9": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 60,
+        "line": 55,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveSingularData.field10": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 25,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveMapKeyData.field12": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 151,
         "column": 3
       },
       "improbable.ComponentInterest.RelativeSphereConstraint": {
@@ -5479,9 +6802,19 @@
         "line": 159,
         "column": 3
       },
+      "improbable.gdk.tests.ExhaustiveRepeatedData.field9": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 86,
+        "column": 3
+      },
       "improbable.Coordinates.y": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\standard_library.schema",
         "line": 64,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveMapValueData.field13": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 121,
         "column": 3
       },
       "improbable.gdk.tests.nonblittable_types.FirstCommandResponse": {
@@ -5504,11 +6837,6 @@
         "line": 25,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveMapValue.field6": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 83,
-        "column": 3
-      },
       "improbable.Vector3f.x": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\vector3.schema",
         "line": 4,
@@ -5519,29 +6847,24 @@
         "line": 28,
         "column": 3
       },
+      "improbable.gdk.tests.ExhaustiveRepeatedData.field10": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 87,
+        "column": 3
+      },
       "improbable.EntityAcl.component_write_acl": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\standard_library.schema",
         "line": 46,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveMapValue.field10": {
+      "improbable.gdk.tests.ExhaustiveMapKeyData.field6": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 87,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveSingular.field2": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 13,
+        "line": 145,
         "column": 3
       },
       "improbable.gdk.tests.blittable_types.BlittableComponent.bool_field": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\blittable_types.schema",
         "line": 31,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveBlittableSingular.field15": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 135,
         "column": 3
       },
       "improbable.gdk.tests.blittable_types.SecondEventPayload": {
@@ -5554,11 +6877,6 @@
         "line": 3,
         "column": 1
       },
-      "improbable.gdk.tests.ExhaustiveMapKey.field16": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 115,
-        "column": 3
-      },
       "improbable.gdk.tests.TypeName.other_type": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\nested_typenames.schema",
         "line": 17,
@@ -5569,14 +6887,24 @@
         "line": 33,
         "column": 5
       },
-      "improbable.gdk.tests.ExhaustiveOptional.field3": {
+      "improbable.gdk.tests.ExhaustiveMapValueData.field8": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 36,
+        "line": 116,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveSingular.field11": {
+      "improbable.gdk.tests.ExhaustiveSingularData.field15": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 22,
+        "line": 30,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveMapKeyData.field17": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 156,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveOptionalData.field1": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 47,
         "column": 3
       },
       "improbable.Coordinates": {
@@ -5584,14 +6912,19 @@
         "line": 62,
         "column": 1
       },
+      "improbable.gdk.tests.ExhaustiveRepeatedData.field2": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 79,
+        "column": 3
+      },
       "improbable.gdk.tests.nonblittable_types.FirstCommandResponse.response": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\nonblittable_types.schema",
         "line": 8,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveOptional.field11": {
+      "improbable.gdk.tests.ExhaustiveMapValueData.field18": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 44,
+        "line": 126,
         "column": 3
       },
       "improbable.gdk.tests.blittable_types.BlittableComponent.first_event": {
@@ -5604,9 +6937,19 @@
         "line": 98,
         "column": 1
       },
-      "improbable.gdk.tests.ExhaustiveRepeated.field13": {
+      "improbable.gdk.tests.ExhaustiveOptionalData.field18": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 68,
+        "line": 64,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveOptionalData.field15": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 61,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveSingularData.field7": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 22,
         "column": 3
       },
       "improbable.gdk.tests.nonblittable_types.NonBlittableComponent.string_field": {
@@ -5614,40 +6957,20 @@
         "line": 36,
         "column": 5
       },
+      "improbable.gdk.tests.ExhaustiveRepeatedData.field18": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 95,
+        "column": 3
+      },
       "improbable.gdk.tests.nonblittable_types.NonBlittableComponent.first_event": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\nonblittable_types.schema",
         "line": 44,
         "column": 5
       },
-      "improbable.gdk.tests.ExhaustiveBlittableSingular.field5": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 126,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveMapValue.field15": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 92,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveBlittableSingular.field8": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 128,
-        "column": 3
-      },
       "improbable.gdk.tests.nonblittable_types.SecondCommandResponse": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\nonblittable_types.schema",
         "line": 15,
         "column": 1
-      },
-      "improbable.gdk.tests.ExhaustiveMapKey.field3": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 102,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveBlittableSingular.field18": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 138,
-        "column": 3
       },
       "improbable.gdk.tests.components_with_no_fields.ComponentWithNoFieldsWithCommands": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\empty_component.schema",
@@ -5657,6 +6980,11 @@
       "improbable.gdk.tests.SomeEnum.SECOND_VALUE": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
         "line": 7,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveMapValueData.field3": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 111,
         "column": 3
       },
       "improbable.gdk.tests.nonblittable_types.NonBlittableComponent": {
@@ -5674,19 +7002,14 @@
         "line": 5,
         "column": 1
       },
-      "improbable.gdk.tests.ExhaustiveOptional.field8": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 41,
-        "column": 3
-      },
       "improbable.gdk.tests.blittable_types.BlittableComponent.int_field": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\blittable_types.schema",
         "line": 32,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveRepeated.field6": {
+      "improbable.gdk.tests.ExhaustiveOptionalData.field6": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 61,
+        "line": 52,
         "column": 3
       },
       "improbable.Coordinates.z": {
@@ -5694,20 +7017,30 @@
         "line": 65,
         "column": 3
       },
+      "improbable.gdk.tests.ExhaustiveMapValueData.field10": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 118,
+        "column": 3
+      },
       "improbable.Position": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\standard_library.schema",
         "line": 81,
         "column": 1
       },
-      "improbable.gdk.tests.ExhaustiveMapValue.field1": {
+      "improbable.gdk.tests.ExhaustiveOptionalData.field10": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 78,
+        "line": 56,
         "column": 3
       },
       "improbable.gdk.tests.blittable_types.SecondEventPayload.field2": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\blittable_types.schema",
         "line": 26,
         "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveRepeatedData": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 77,
+        "column": 1
       },
       "improbable.gdk.tests.blittable_types.BlittableComponent.float_field": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\blittable_types.schema",
@@ -5719,39 +7052,29 @@
         "line": 38,
         "column": 3
       },
+      "improbable.gdk.tests.ExhaustiveRepeatedData.field13": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 90,
+        "column": 3
+      },
       "improbable.gdk.tests.blittable_types.FirstEventPayload": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\blittable_types.schema",
         "line": 19,
         "column": 1
       },
-      "improbable.gdk.tests.ExhaustiveSingular.field1": {
+      "improbable.gdk.tests.ExhaustiveMapKeyData.field5": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 12,
+        "line": 144,
         "column": 3
       },
       "improbable.gdk.tests.ExhaustiveMapKey": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 98,
+        "line": 160,
         "column": 1
-      },
-      "improbable.gdk.tests.ExhaustiveMapKey.field6": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 105,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveBlittableSingular.field10": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 130,
-        "column": 3
       },
       "improbable.gdk.tests.blittable_types.FirstEventPayload.field2": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\blittable_types.schema",
         "line": 21,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveMapKey.field13": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 112,
         "column": 3
       },
       "improbable.Metadata": {
@@ -5759,24 +7082,29 @@
         "line": 51,
         "column": 1
       },
-      "improbable.gdk.tests.ExhaustiveSingular.field12": {
+      "improbable.gdk.tests.ExhaustiveMapValueData.field6": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 23,
+        "line": 114,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveRepeated.field3": {
+      "improbable.gdk.tests.ExhaustiveSingularData.field16": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 58,
+        "line": 31,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveOptional.field14": {
+      "improbable.gdk.tests.ExhaustiveMapKeyData.field10": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 47,
+        "line": 149,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveMapValue.field4": {
+      "improbable.gdk.tests.ExhaustiveRepeatedData.field7": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 81,
+        "line": 84,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveMapValueData.field15": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 123,
         "column": 3
       },
       "improbable.Vector3f.z": {
@@ -5784,20 +7112,15 @@
         "line": 6,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveRepeated.field16": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 71,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveMapValue.field9": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 86,
-        "column": 3
-      },
       "improbable.ComponentInterest.QueryConstraint.sphere_constraint": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\standard_library.schema",
         "line": 132,
         "column": 5
+      },
+      "improbable.gdk.tests.ExhaustiveSingularData.field2": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 17,
+        "column": 3
       },
       "improbable.Vector3d.y": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\vector3.schema",
@@ -5819,35 +7142,10 @@
         "line": 20,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveBlittableSingular.field6": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 127,
-        "column": 3
-      },
       "improbable.ComponentInterest.RelativeCylinderConstraint.radius": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\standard_library.schema",
         "line": 164,
         "column": 5
-      },
-      "improbable.gdk.tests.ExhaustiveMapValue.field12": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 89,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveSingular.field4": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 15,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveSingular.field9": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 20,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveMapKey.field14": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 113,
-        "column": 3
       },
       "improbable.Vector3d": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\vector3.schema",
@@ -5859,30 +7157,35 @@
         "line": 9,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveOptional.field5": {
+      "improbable.gdk.tests.ExhaustiveMapKeyData.field15": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 38,
+        "line": 154,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveSingular.field17": {
+      "improbable.gdk.tests.ExhaustiveOptionalData.field3": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 28,
+        "line": 49,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveOptional.field13": {
+      "improbable.gdk.tests.ExhaustiveMapKeyData.field18": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 46,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveRepeated.field11": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 66,
+        "line": 157,
         "column": 3
       },
       "improbable.ComponentInterest.Query.result_component_id": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\standard_library.schema",
         "line": 109,
         "column": 5
+      },
+      "improbable.gdk.tests.ExhaustiveOptionalData.field17": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 63,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveSingularData.field9": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 24,
+        "column": 3
       },
       "improbable.gdk.tests.blittable_types.SecondEventPayload.field1": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\blittable_types.schema",
@@ -5899,30 +7202,25 @@
         "line": 108,
         "column": 5
       },
+      "improbable.gdk.tests.ExhaustiveRepeatedData.field16": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 93,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveSingularData": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 15,
+        "column": 1
+      },
       "improbable.gdk.tests.blittable_types.FirstCommandResponse.response": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\blittable_types.schema",
         "line": 8,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveMapValue.field17": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 94,
         "column": 3
       },
       "improbable.ComponentInterest.CylinderConstraint.radius": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\standard_library.schema",
         "line": 151,
         "column": 5
-      },
-      "improbable.gdk.tests.ExhaustiveMapKey.field5": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 104,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveBlittableSingular.field13": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 133,
-        "column": 3
       },
       "improbable.gdk.tests.TypeName": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\nested_typenames.schema",
@@ -5939,24 +7237,39 @@
         "line": 29,
         "column": 1
       },
+      "improbable.gdk.tests.ExhaustiveMapValueData.field1": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 109,
+        "column": 3
+      },
       "improbable.EdgeLength.y": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\standard_library.schema",
         "line": 71,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveRepeated.field9": {
+      "improbable.gdk.tests.ExhaustiveOptionalData.field8": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 64,
+        "line": 54,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveRepeated.field4": {
+      "improbable.gdk.tests.ExhaustiveSingularData.field13": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 59,
+        "line": 28,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveRepeatedData.field8": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 85,
         "column": 3
       },
       "improbable.Coordinates.x": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\standard_library.schema",
         "line": 63,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveMapValueData.field12": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 120,
         "column": 3
       },
       "improbable.ComponentInterest.QueryConstraint.relative_box_constraint": {
@@ -5969,14 +7282,19 @@
         "line": 3,
         "column": 1
       },
-      "improbable.gdk.tests.ExhaustiveMapValue.field7": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 84,
-        "column": 3
-      },
       "improbable.Vector3f.y": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\vector3.schema",
         "line": 5,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveOptionalData.field12": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 58,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveSingularData.field1": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 16,
         "column": 3
       },
       "improbable.ComponentInterest": {
@@ -5989,30 +7307,35 @@
         "line": 145,
         "column": 5
       },
+      "improbable.gdk.tests.ExhaustiveRepeatedData.field11": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 88,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveOptionalData": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 46,
+        "column": 1
+      },
+      "improbable.gdk.tests.ExhaustiveMapKeyData.field7": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 146,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveMapKeyData.field8": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 147,
+        "column": 3
+      },
       "improbable.gdk.tests.nonblittable_types.FirstCommandRequest.field": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\nonblittable_types.schema",
         "line": 4,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveSingular.field3": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 14,
         "column": 3
       },
       "improbable.gdk.tests.components_with_no_fields.ComponentWithNoFieldsWithEvents": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\empty_component.schema",
         "line": 9,
         "column": 1
-      },
-      "improbable.gdk.tests.ExhaustiveMapKey.field8": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 107,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveBlittableSingular.field16": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 136,
-        "column": 3
       },
       "improbable.gdk.tests.nonblittable_types.NonBlittableComponent.second_command": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\nonblittable_types.schema",
@@ -6034,14 +7357,14 @@
         "line": 16,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveMapKey.field11": {
+      "improbable.gdk.tests.ExhaustiveMapValueData.field4": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 110,
+        "line": 112,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveOptional.field2": {
+      "improbable.gdk.tests.ExhaustiveMapValueData.field9": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 35,
+        "line": 117,
         "column": 3
       },
       "improbable.gdk.tests.blittable_types.SecondCommandResponse": {
@@ -6049,14 +7372,14 @@
         "line": 15,
         "column": 1
       },
-      "improbable.gdk.tests.ExhaustiveSingular.field10": {
+      "improbable.gdk.tests.ExhaustiveSingularData.field14": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 21,
+        "line": 29,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveRepeated.field1": {
+      "improbable.gdk.tests.ExhaustiveMapKeyData.field16": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 56,
+        "line": 155,
         "column": 3
       },
       "improbable.ComponentInterest.QueryConstraint.and_constraint": {
@@ -6064,35 +7387,25 @@
         "line": 140,
         "column": 5
       },
-      "improbable.gdk.tests.ExhaustiveOptional.field16": {
+      "improbable.gdk.tests.ExhaustiveRepeatedData.field5": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 49,
+        "line": 82,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveRepeated.field14": {
+      "improbable.gdk.tests.ExhaustiveMapValueData.field17": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 69,
+        "line": 125,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveSingularData.field4": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 19,
         "column": 3
       },
       "improbable.gdk.tests.TypeName.Other.NestedTypeName.NestedEnum.enum_value": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\nested_typenames.schema",
         "line": 10,
         "column": 17
-      },
-      "improbable.gdk.tests.ExhaustiveBlittableSingular.field4": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 125,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveMapValue.field14": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 91,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveSingular.field6": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 17,
-        "column": 3
       },
       "improbable.gdk.tests.components_with_no_fields.ComponentWithNoFieldsWithEvents.evt": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\empty_component.schema",
@@ -6129,19 +7442,9 @@
         "line": 9,
         "column": 13
       },
-      "improbable.gdk.tests.ExhaustiveOptional.field7": {
+      "improbable.gdk.tests.ExhaustiveOptionalData.field5": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 40,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveSingular.field15": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 26,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveSingular.field18": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 29,
+        "line": 51,
         "column": 3
       },
       "improbable.gdk.tests.blittable_types.BlittableComponent.first_command": {
@@ -6149,15 +7452,25 @@
         "line": 37,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveMapValue.field2": {
+      "improbable.gdk.tests.ExhaustiveOptionalData.field11": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 79,
+        "line": 57,
         "column": 3
       },
       "improbable.gdk.tests.ExhaustiveRepeated": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 54,
+        "line": 98,
         "column": 1
+      },
+      "improbable.gdk.tests.ExhaustiveRepeatedData.field14": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 91,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveMapKeyData.field2": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 141,
+        "column": 3
       },
       "improbable.EntityAcl.read_acl": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\standard_library.schema",
@@ -6166,18 +7479,8 @@
       },
       "improbable.gdk.tests.ExhaustiveOptional": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 32,
+        "line": 67,
         "column": 1
-      },
-      "improbable.gdk.tests.ExhaustiveMapKey.field7": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 106,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveBlittableSingular.field11": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 131,
-        "column": 3
       },
       "improbable.common.Empty": {
         "filePath": "Assets/.Schema\\from_gdk_packages\\com.improbable.gdk.core\\common.schema",
@@ -6194,19 +7497,24 @@
         "line": 35,
         "column": 5
       },
-      "improbable.gdk.tests.ExhaustiveMapKey.field12": {
+      "improbable.gdk.tests.ExhaustiveMapValueData.field7": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 111,
+        "line": 115,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveBlittableSingular": {
+      "improbable.gdk.tests.ExhaustiveSingularData.field11": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 121,
-        "column": 1
+        "line": 26,
+        "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveRepeated.field2": {
+      "improbable.gdk.tests.ExhaustiveMapKeyData.field13": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 57,
+        "line": 152,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveRepeatedData.field6": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 83,
         "column": 3
       },
       "improbable.gdk.tests.blittable_types.FirstCommandResponse": {
@@ -6214,19 +7522,14 @@
         "line": 7,
         "column": 1
       },
+      "improbable.gdk.tests.ExhaustiveMapValueData.field14": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 122,
+        "column": 3
+      },
       "improbable.gdk.tests.blittable_types.BlittableComponent.second_event": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\blittable_types.schema",
         "line": 41,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveOptional.field18": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 51,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveOptional.field15": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 48,
         "column": 3
       },
       "improbable.gdk.tests.nonblittable_types.SecondEventPayload.field2": {
@@ -6234,14 +7537,9 @@
         "line": 26,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveMapValue.field5": {
+      "improbable.gdk.tests.ExhaustiveSingularData.field3": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 82,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveRepeated.field17": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 72,
+        "line": 18,
         "column": 3
       },
       "improbable.gdk.tests.nonblittable_types.SecondCommandRequest.field": {
@@ -6274,49 +7572,29 @@
         "line": 24,
         "column": 1
       },
-      "improbable.gdk.tests.ExhaustiveBlittableSingular.field1": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 123,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveMapValue.field11": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 88,
-        "column": 3
-      },
       "improbable.ComponentInterest.Query.constraint": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\standard_library.schema",
         "line": 105,
         "column": 5
-      },
-      "improbable.gdk.tests.ExhaustiveSingular.field5": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 16,
-        "column": 3
       },
       "improbable.ComponentInterest.CylinderConstraint.center": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\standard_library.schema",
         "line": 150,
         "column": 5
       },
-      "improbable.gdk.tests.ExhaustiveBlittableSingular.field14": {
+      "improbable.gdk.tests.ExhaustiveMapValueData": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 134,
+        "line": 108,
+        "column": 1
+      },
+      "improbable.gdk.tests.ExhaustiveMapKeyData.field14": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 153,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveMapKey.field17": {
+      "improbable.gdk.tests.ExhaustiveOptionalData.field2": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 116,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveOptional.field4": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 37,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveSingular.field16": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 27,
+        "line": 48,
         "column": 3
       },
       "improbable.gdk.tests.alternate_schema_syntax.Connection.my_event": {
@@ -6324,25 +7602,35 @@
         "line": 11,
         "column": 5
       },
+      "improbable.gdk.tests.ExhaustiveRepeatedData.field3": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 80,
+        "column": 3
+      },
       "improbable.gdk.tests.alternate_schema_syntax.Connection": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\alternate_schema_syntax.schema",
         "line": 7,
         "column": 1
       },
-      "improbable.gdk.tests.ExhaustiveOptional.field10": {
+      "improbable.gdk.tests.ExhaustiveOptionalData.field14": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 43,
+        "line": 60,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveRepeated.field12": {
+      "improbable.gdk.tests.ExhaustiveSingularData.field6": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 67,
+        "line": 21,
         "column": 3
       },
       "improbable.Persistence": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\standard_library.schema",
         "line": 89,
         "column": 1
+      },
+      "improbable.gdk.tests.ExhaustiveRepeatedData.field17": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 94,
+        "column": 3
       },
       "improbable.ComponentInterest.QueryConstraint": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\standard_library.schema",
@@ -6354,14 +7642,9 @@
         "line": 6,
         "column": 1
       },
-      "improbable.gdk.tests.ExhaustiveMapValue.field16": {
+      "improbable.gdk.tests.ExhaustiveMapKeyData.field1": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 93,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveBlittableSingular.field9": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 129,
+        "line": 140,
         "column": 3
       },
       "improbable.gdk.tests.nonblittable_types.NonBlittableComponent.float_field": {
@@ -6373,11 +7656,6 @@
         "filePath": "build/dependencies/schema/standard_library\\improbable\\standard_library.schema",
         "line": 160,
         "column": 5
-      },
-      "improbable.gdk.tests.ExhaustiveMapKey.field2": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 101,
-        "column": 3
       },
       "improbable.gdk.tests.TypeName.Other.NestedTypeName.Other0": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\nested_typenames.schema",
@@ -6394,15 +7672,15 @@
         "line": 19,
         "column": 1
       },
-      "improbable.gdk.tests.ExhaustiveMapKey.field18": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 117,
-        "column": 3
-      },
       "improbable.gdk.tests.TypeName.Other.NestedTypeName.enum_field": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\nested_typenames.schema",
         "line": 13,
         "column": 13
+      },
+      "improbable.gdk.tests.ExhaustiveMapValueData.field2": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 110,
+        "column": 3
       },
       "improbable.gdk.tests.blittable_types.BlittableComponent.double_field": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\blittable_types.schema",
@@ -6419,24 +7697,19 @@
         "line": 70,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveOptional.field9": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 42,
-        "column": 3
-      },
       "improbable.gdk.tests.alternate_schema_syntax.RandomDataType": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\alternate_schema_syntax.schema",
         "line": 3,
         "column": 1
       },
-      "improbable.gdk.tests.ExhaustiveRepeated.field8": {
+      "improbable.gdk.tests.ExhaustiveOptionalData.field7": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 63,
+        "line": 53,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveRepeated.field7": {
+      "improbable.gdk.tests.ExhaustiveSingularData.field12": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 62,
+        "line": 27,
         "column": 3
       },
       "improbable.gdk.tests.TypeName.Other.NestedTypeName.Other0.foo": {
@@ -6454,10 +7727,20 @@
         "line": 104,
         "column": 3
       },
+      "improbable.gdk.tests.ExhaustiveMapValueData.field11": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 119,
+        "column": 3
+      },
       "improbable.gdk.tests.nonblittable_types.NonBlittableComponent.optional_field": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\nonblittable_types.schema",
         "line": 37,
         "column": 5
+      },
+      "improbable.gdk.tests.ExhaustiveOptionalData.field13": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 59,
+        "column": 3
       },
       "improbable.gdk.tests.nonblittable_types.NonBlittableComponent.int_field": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\nonblittable_types.schema",
@@ -6474,19 +7757,29 @@
         "line": 144,
         "column": 3
       },
-      "improbable.gdk.tests.nonblittable_types.NonBlittableComponent.list_field": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\nonblittable_types.schema",
-        "line": 38,
-        "column": 5
-      },
       "improbable.gdk.tests.SomeType": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
         "line": 3,
         "column": 1
       },
-      "improbable.gdk.tests.ExhaustiveBlittableSingular.field2": {
+      "improbable.gdk.tests.nonblittable_types.NonBlittableComponent.list_field": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\nonblittable_types.schema",
+        "line": 38,
+        "column": 5
+      },
+      "improbable.gdk.tests.ExhaustiveRepeatedData.field12": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 124,
+        "line": 89,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveMapKeyData.field4": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 143,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveMapKeyData.field9": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 148,
         "column": 3
       },
       "improbable.EntityAcl": {
@@ -6499,54 +7792,49 @@
         "line": 156,
         "column": 5
       },
-      "improbable.gdk.tests.ExhaustiveMapKey.field9": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 108,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveBlittableSingular.field17": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 137,
-        "column": 3
-      },
       "improbable.gdk.tests.blittable_types.FirstEventPayload.field1": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\blittable_types.schema",
         "line": 20,
         "column": 3
-      },
-      "improbable.gdk.tests.nonblittable_types.NonBlittableComponent.second_event": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\nonblittable_types.schema",
-        "line": 45,
-        "column": 5
       },
       "improbable.tests.DependencyTest": {
         "filePath": "Assets/.Schema\\from_gdk_packages\\com.improbable.gdk.dependencytest\\dependency_test.schema",
         "line": 8,
         "column": 1
       },
-      "improbable.gdk.tests.ExhaustiveMapKey.field10": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 109,
-        "column": 3
+      "improbable.gdk.tests.nonblittable_types.NonBlittableComponent.second_event": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\nonblittable_types.schema",
+        "line": 45,
+        "column": 5
       },
       "improbable.ComponentInterest.RelativeBoxConstraint": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\standard_library.schema",
         "line": 167,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveOptional.field1": {
+      "improbable.gdk.tests.ExhaustiveMapValueData.field5": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 34,
+        "line": 113,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveSingular.field13": {
+      "improbable.gdk.tests.ExhaustiveSingularData.field17": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 24,
+        "line": 32,
         "column": 3
       },
-      "improbable.gdk.tests.ExhaustiveOptional.field17": {
+      "improbable.gdk.tests.ExhaustiveMapKeyData.field11": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 50,
+        "line": 150,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveRepeatedData.field4": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 81,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveMapValueData.field16": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 124,
         "column": 3
       },
       "improbable.EdgeLength": {
@@ -6554,19 +7842,9 @@
         "line": 69,
         "column": 1
       },
-      "improbable.gdk.tests.ExhaustiveRepeated.field18": {
+      "improbable.gdk.tests.ExhaustiveSingularData.field5": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 73,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveRepeated.field15": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 70,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveMapValue.field8": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 85,
+        "line": 20,
         "column": 3
       },
       "improbable.ComponentInterest.QueryConstraint.relative_sphere_constraint": {
@@ -6599,11 +7877,6 @@
         "line": 139,
         "column": 5
       },
-      "improbable.gdk.tests.ExhaustiveMapValue.field13": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 90,
-        "column": 3
-      },
       "improbable.tests.DependencyTestGrandchild": {
         "filePath": "Assets/.Schema\\from_gdk_packages\\com.improbable.gdk.dependencytestgrandchild\\dependency_test_grandchild.schema",
         "line": 8,
@@ -6619,16 +7892,6 @@
         "line": 146,
         "column": 5
       },
-      "improbable.gdk.tests.ExhaustiveSingular.field7": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 18,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveSingular.field8": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 19,
-        "column": 3
-      },
       "improbable.tests.DependencyTestChild": {
         "filePath": "Assets/.Schema\\from_gdk_packages\\com.improbable.gdk.dependencytestchild\\dependency_test_child.schema",
         "line": 8,
@@ -6639,40 +7902,40 @@
         "line": 12,
         "column": 13
       },
-      "improbable.gdk.tests.ExhaustiveMapKey.field1": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 100,
-        "column": 3
-      },
       "improbable.gdk.tests.nonblittable_types.SecondCommandRequest": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\nonblittable_types.schema",
         "line": 11,
         "column": 1
       },
-      "improbable.gdk.tests.ExhaustiveMapKey.field15": {
+      "improbable.gdk.tests.ExhaustiveMapKeyData": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 114,
-        "column": 3
-      },
-      "improbable.gdk.tests.ExhaustiveOptional.field6": {
-        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 39,
-        "column": 3
+        "line": 139,
+        "column": 1
       },
       "improbable.ComponentInterest.QueryConstraint.relative_cylinder_constraint": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\standard_library.schema",
         "line": 136,
         "column": 5
       },
-      "improbable.gdk.tests.ExhaustiveSingular.field14": {
+      "improbable.gdk.tests.ExhaustiveSingularData.field18": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
-        "line": 25,
+        "line": 33,
+        "column": 3
+      },
+      "improbable.gdk.tests.ExhaustiveOptionalData.field4": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 50,
         "column": 3
       },
       "improbable.ComponentInterest.RelativeBoxConstraint.edge_length": {
         "filePath": "build/dependencies/schema/standard_library\\improbable\\standard_library.schema",
         "line": 168,
         "column": 5
+      },
+      "improbable.gdk.tests.ExhaustiveRepeatedData.field1": {
+        "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\exhaustive_test.schema",
+        "line": 78,
+        "column": 3
       },
       "improbable.gdk.tests.TypeName.Other": {
         "filePath": "Assets/.Schema\\improbable\\gdk\\tests\\nested_typenames.schema",

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Tests/Model/SchemaBundleV1/Resources/exhaustive_bundle.json
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Tests/Model/SchemaBundleV1/Resources/exhaustive_bundle.json
@@ -25,7 +25,8 @@
                 "FIRST_VALUE"
               ]
             },
-            "value": 0
+            "value": 0,
+            "annotations": []
           },
           {
             "identifier": {
@@ -39,9 +40,11 @@
                 "SECOND_VALUE"
               ]
             },
-            "value": 1
+            "value": 1,
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -73,9 +76,11 @@
                 "enum_value"
               ]
             },
-            "value": 1
+            "value": 1,
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       }
     ],
     "typeDefinitions": [
@@ -89,7 +94,8 @@
             "Empty"
           ]
         },
-        "fieldDefinitions": []
+        "fieldDefinitions": [],
+        "annotations": []
       },
       {
         "identifier": {
@@ -123,9 +129,11 @@
               "type": {
                 "primitive": "Int32"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -159,9 +167,11 @@
               "type": {
                 "primitive": "Int32"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -195,9 +205,11 @@
               "type": {
                 "primitive": "Bool"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -231,9 +243,11 @@
               "type": {
                 "primitive": "Int64"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -267,9 +281,11 @@
               "type": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -303,7 +319,8 @@
               "type": {
                 "primitive": "Bool"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -324,9 +341,11 @@
               "type": {
                 "primitive": "Int32"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -360,7 +379,8 @@
               "type": {
                 "primitive": "Float"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -381,9 +401,11 @@
               "type": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -397,7 +419,8 @@
             "Empty"
           ]
         },
-        "fieldDefinitions": []
+        "fieldDefinitions": [],
+        "annotations": []
       },
       {
         "identifier": {
@@ -410,7 +433,8 @@
             "SomeType"
           ]
         },
-        "fieldDefinitions": []
+        "fieldDefinitions": [],
+        "annotations": []
       },
       {
         "identifier": {
@@ -444,9 +468,11 @@
                   "qualifiedName": "improbable.gdk.tests.TypeName.Other"
                 }
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -482,9 +508,11 @@
                   "qualifiedName": "improbable.gdk.tests.TypeName.Other.NestedTypeName"
                 }
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -522,7 +550,8 @@
                   "qualifiedName": "improbable.gdk.tests.TypeName.Other.NestedTypeName.Other0"
                 }
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -546,9 +575,11 @@
                   "qualifiedName": "improbable.gdk.tests.TypeName.Other.NestedTypeName.NestedEnum"
                 }
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -586,9 +617,11 @@
               "type": {
                 "primitive": "Int32"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -622,9 +655,11 @@
               "type": {
                 "primitive": "Int32"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -658,9 +693,11 @@
               "type": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -694,9 +731,11 @@
               "type": {
                 "primitive": "Int64"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -730,9 +769,11 @@
               "type": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -766,7 +807,8 @@
               "type": {
                 "primitive": "Bool"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -787,9 +829,11 @@
               "type": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -823,7 +867,8 @@
               "type": {
                 "primitive": "Float"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -844,9 +889,11 @@
               "innerType": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -874,9 +921,11 @@
               "innerType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -906,9 +955,11 @@
                   "qualifiedName": "improbable.WorkerAttributeSet"
                 }
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -936,7 +987,8 @@
               "type": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -954,7 +1006,8 @@
               "type": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -972,9 +1025,11 @@
               "type": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -1002,7 +1057,8 @@
               "type": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1020,7 +1076,8 @@
               "type": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1038,9 +1095,11 @@
               "type": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -1070,9 +1129,11 @@
                   "qualifiedName": "improbable.ComponentInterest.Query"
                 }
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -1104,7 +1165,8 @@
                   "qualifiedName": "improbable.ComponentInterest.QueryConstraint"
                 }
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1123,7 +1185,8 @@
               "innerType": {
                 "primitive": "Bool"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1142,7 +1205,8 @@
               "innerType": {
                 "primitive": "Uint32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1161,9 +1225,11 @@
               "innerType": {
                 "primitive": "Float"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -1195,7 +1261,8 @@
                   "qualifiedName": "improbable.ComponentInterest.SphereConstraint"
                 }
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1216,7 +1283,8 @@
                   "qualifiedName": "improbable.ComponentInterest.CylinderConstraint"
                 }
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1237,7 +1305,8 @@
                   "qualifiedName": "improbable.ComponentInterest.BoxConstraint"
                 }
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1258,7 +1327,8 @@
                   "qualifiedName": "improbable.ComponentInterest.RelativeSphereConstraint"
                 }
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1279,7 +1349,8 @@
                   "qualifiedName": "improbable.ComponentInterest.RelativeCylinderConstraint"
                 }
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1300,7 +1371,8 @@
                   "qualifiedName": "improbable.ComponentInterest.RelativeBoxConstraint"
                 }
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1319,7 +1391,8 @@
               "innerType": {
                 "primitive": "Int64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1338,7 +1411,8 @@
               "innerType": {
                 "primitive": "Uint32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1359,7 +1433,8 @@
                   "qualifiedName": "improbable.ComponentInterest.QueryConstraint"
                 }
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1380,9 +1455,11 @@
                   "qualifiedName": "improbable.ComponentInterest.QueryConstraint"
                 }
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -1414,7 +1491,8 @@
                   "qualifiedName": "improbable.Coordinates"
                 }
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1433,9 +1511,11 @@
               "type": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -1467,7 +1547,8 @@
                   "qualifiedName": "improbable.Coordinates"
                 }
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1486,9 +1567,11 @@
               "type": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -1520,7 +1603,8 @@
                   "qualifiedName": "improbable.Coordinates"
                 }
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1541,9 +1625,11 @@
                   "qualifiedName": "improbable.EdgeLength"
                 }
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -1573,9 +1659,11 @@
               "type": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -1605,9 +1693,11 @@
               "type": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -1639,9 +1729,11 @@
                   "qualifiedName": "improbable.EdgeLength"
                 }
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -1669,7 +1761,8 @@
               "type": {
                 "primitive": "Float"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1687,7 +1780,8 @@
               "type": {
                 "primitive": "Float"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1705,9 +1799,11 @@
               "type": {
                 "primitive": "Float"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -1735,7 +1831,8 @@
               "type": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1753,7 +1850,8 @@
               "type": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1771,9 +1869,11 @@
               "type": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       }
     ],
     "componentDefinitions": [
@@ -1806,11 +1906,13 @@
               "type": {
                 "primitive": "Uint32"
               }
-            }
+            },
+            "annotations": []
           }
         ],
         "eventDefinitions": [],
-        "commandDefinitions": []
+        "commandDefinitions": [],
+        "annotations": []
       },
       {
         "identifier": {
@@ -1841,11 +1943,13 @@
               "type": {
                 "primitive": "Uint32"
               }
-            }
+            },
+            "annotations": []
           }
         ],
         "eventDefinitions": [],
-        "commandDefinitions": []
+        "commandDefinitions": [],
+        "annotations": []
       },
       {
         "identifier": {
@@ -1876,11 +1980,13 @@
               "type": {
                 "primitive": "Uint32"
               }
-            }
+            },
+            "annotations": []
           }
         ],
         "eventDefinitions": [],
-        "commandDefinitions": []
+        "commandDefinitions": [],
+        "annotations": []
       },
       {
         "identifier": {
@@ -1918,10 +2024,12 @@
               "type": {
                 "qualifiedName": "improbable.gdk.tests.alternate_schema_syntax.RandomDataType"
               }
-            }
+            },
+            "annotations": []
           }
         ],
-        "commandDefinitions": []
+        "commandDefinitions": [],
+        "annotations": []
       },
       {
         "identifier": {
@@ -1956,7 +2064,8 @@
               "type": {
                 "primitive": "Bool"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1977,7 +2086,8 @@
               "type": {
                 "primitive": "Int32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -1998,7 +2108,8 @@
               "type": {
                 "primitive": "Int64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2019,7 +2130,8 @@
               "type": {
                 "primitive": "Float"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2040,7 +2152,8 @@
               "type": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           }
         ],
         "eventDefinitions": [
@@ -2062,7 +2175,8 @@
               "type": {
                 "qualifiedName": "improbable.gdk.tests.blittable_types.FirstEventPayload"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2082,7 +2196,8 @@
               "type": {
                 "qualifiedName": "improbable.gdk.tests.blittable_types.SecondEventPayload"
               }
-            }
+            },
+            "annotations": []
           }
         ],
         "commandDefinitions": [
@@ -2109,7 +2224,8 @@
               "type": {
                 "qualifiedName": "improbable.gdk.tests.blittable_types.FirstCommandResponse"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2134,9 +2250,11 @@
               "type": {
                 "qualifiedName": "improbable.gdk.tests.blittable_types.SecondCommandResponse"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -2153,7 +2271,8 @@
         "componentId": 1003,
         "fieldDefinitions": [],
         "eventDefinitions": [],
-        "commandDefinitions": []
+        "commandDefinitions": [],
+        "annotations": []
       },
       {
         "identifier": {
@@ -2188,10 +2307,12 @@
               "type": {
                 "qualifiedName": "improbable.gdk.tests.components_with_no_fields.Empty"
               }
-            }
+            },
+            "annotations": []
           }
         ],
-        "commandDefinitions": []
+        "commandDefinitions": [],
+        "annotations": []
       },
       {
         "identifier": {
@@ -2232,9 +2353,11 @@
               "type": {
                 "qualifiedName": "improbable.gdk.tests.components_with_no_fields.Empty"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -2267,7 +2390,8 @@
               "type": {
                 "primitive": "Bool"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2287,7 +2411,8 @@
               "type": {
                 "primitive": "Float"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2307,7 +2432,8 @@
               "type": {
                 "primitive": "Bytes"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2327,7 +2453,8 @@
               "type": {
                 "primitive": "Int32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2347,7 +2474,8 @@
               "type": {
                 "primitive": "Int64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2367,7 +2495,8 @@
               "type": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2387,7 +2516,8 @@
               "type": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2407,7 +2537,8 @@
               "type": {
                 "primitive": "Uint32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2427,7 +2558,8 @@
               "type": {
                 "primitive": "Uint64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2447,7 +2579,8 @@
               "type": {
                 "primitive": "Sint32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2467,7 +2600,8 @@
               "type": {
                 "primitive": "Sint64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2487,7 +2621,8 @@
               "type": {
                 "primitive": "Fixed32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2507,7 +2642,8 @@
               "type": {
                 "primitive": "Fixed64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2527,7 +2663,8 @@
               "type": {
                 "primitive": "Sfixed32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2547,7 +2684,8 @@
               "type": {
                 "primitive": "Sfixed64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2567,7 +2705,8 @@
               "type": {
                 "primitive": "EntityId"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2589,7 +2728,8 @@
                   "qualifiedName": "improbable.gdk.tests.SomeType"
                 }
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2611,11 +2751,13 @@
                   "qualifiedName": "improbable.gdk.tests.SomeEnum"
                 }
               }
-            }
+            },
+            "annotations": []
           }
         ],
         "eventDefinitions": [],
-        "commandDefinitions": []
+        "commandDefinitions": [],
+        "annotations": []
       },
       {
         "identifier": {
@@ -2648,7 +2790,8 @@
               "innerType": {
                 "primitive": "Bool"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2668,7 +2811,8 @@
               "innerType": {
                 "primitive": "Float"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2688,7 +2832,8 @@
               "innerType": {
                 "primitive": "Bytes"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2708,7 +2853,8 @@
               "innerType": {
                 "primitive": "Int32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2728,7 +2874,8 @@
               "innerType": {
                 "primitive": "Int64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2748,7 +2895,8 @@
               "innerType": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2768,7 +2916,8 @@
               "innerType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2788,7 +2937,8 @@
               "innerType": {
                 "primitive": "Uint32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2808,7 +2958,8 @@
               "innerType": {
                 "primitive": "Uint64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2828,7 +2979,8 @@
               "innerType": {
                 "primitive": "Sint32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2848,7 +3000,8 @@
               "innerType": {
                 "primitive": "Sint64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2868,7 +3021,8 @@
               "innerType": {
                 "primitive": "Fixed32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2888,7 +3042,8 @@
               "innerType": {
                 "primitive": "Fixed64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2908,7 +3063,8 @@
               "innerType": {
                 "primitive": "Sfixed32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2928,7 +3084,8 @@
               "innerType": {
                 "primitive": "Sfixed64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2948,7 +3105,8 @@
               "innerType": {
                 "primitive": "EntityId"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2970,7 +3128,8 @@
                   "qualifiedName": "improbable.gdk.tests.SomeType"
                 }
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -2992,11 +3151,13 @@
                   "qualifiedName": "improbable.gdk.tests.SomeEnum"
                 }
               }
-            }
+            },
+            "annotations": []
           }
         ],
         "eventDefinitions": [],
-        "commandDefinitions": []
+        "commandDefinitions": [],
+        "annotations": []
       },
       {
         "identifier": {
@@ -3029,7 +3190,8 @@
               "innerType": {
                 "primitive": "Bool"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3049,7 +3211,8 @@
               "innerType": {
                 "primitive": "Float"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3069,7 +3232,8 @@
               "innerType": {
                 "primitive": "Bytes"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3089,7 +3253,8 @@
               "innerType": {
                 "primitive": "Int32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3109,7 +3274,8 @@
               "innerType": {
                 "primitive": "Int64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3129,7 +3295,8 @@
               "innerType": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3149,7 +3316,8 @@
               "innerType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3169,7 +3337,8 @@
               "innerType": {
                 "primitive": "Uint32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3189,7 +3358,8 @@
               "innerType": {
                 "primitive": "Uint64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3209,7 +3379,8 @@
               "innerType": {
                 "primitive": "Sint32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3229,7 +3400,8 @@
               "innerType": {
                 "primitive": "Sint64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3249,7 +3421,8 @@
               "innerType": {
                 "primitive": "Fixed32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3269,7 +3442,8 @@
               "innerType": {
                 "primitive": "Fixed64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3289,7 +3463,8 @@
               "innerType": {
                 "primitive": "Sfixed32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3309,7 +3484,8 @@
               "innerType": {
                 "primitive": "Sfixed64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3329,7 +3505,8 @@
               "innerType": {
                 "primitive": "EntityId"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3351,7 +3528,8 @@
                   "qualifiedName": "improbable.gdk.tests.SomeType"
                 }
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3373,11 +3551,13 @@
                   "qualifiedName": "improbable.gdk.tests.SomeEnum"
                 }
               }
-            }
+            },
+            "annotations": []
           }
         ],
         "eventDefinitions": [],
-        "commandDefinitions": []
+        "commandDefinitions": [],
+        "annotations": []
       },
       {
         "identifier": {
@@ -3413,7 +3593,8 @@
               "valueType": {
                 "primitive": "Bool"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3436,7 +3617,8 @@
               "valueType": {
                 "primitive": "Float"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3459,7 +3641,8 @@
               "valueType": {
                 "primitive": "Bytes"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3482,7 +3665,8 @@
               "valueType": {
                 "primitive": "Int32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3505,7 +3689,8 @@
               "valueType": {
                 "primitive": "Int64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3528,7 +3713,8 @@
               "valueType": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3551,7 +3737,8 @@
               "valueType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3574,7 +3761,8 @@
               "valueType": {
                 "primitive": "Uint32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3597,7 +3785,8 @@
               "valueType": {
                 "primitive": "Uint64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3620,7 +3809,8 @@
               "valueType": {
                 "primitive": "Sint32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3643,7 +3833,8 @@
               "valueType": {
                 "primitive": "Sint64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3666,7 +3857,8 @@
               "valueType": {
                 "primitive": "Fixed32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3689,7 +3881,8 @@
               "valueType": {
                 "primitive": "Fixed64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3712,7 +3905,8 @@
               "valueType": {
                 "primitive": "Sfixed32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3735,7 +3929,8 @@
               "valueType": {
                 "primitive": "Sfixed64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3758,7 +3953,8 @@
               "valueType": {
                 "primitive": "EntityId"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3783,7 +3979,8 @@
                   "qualifiedName": "improbable.gdk.tests.SomeType"
                 }
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3808,11 +4005,13 @@
                   "qualifiedName": "improbable.gdk.tests.SomeEnum"
                 }
               }
-            }
+            },
+            "annotations": []
           }
         ],
         "eventDefinitions": [],
-        "commandDefinitions": []
+        "commandDefinitions": [],
+        "annotations": []
       },
       {
         "identifier": {
@@ -3848,7 +4047,8 @@
               "valueType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3871,7 +4071,8 @@
               "valueType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3894,7 +4095,8 @@
               "valueType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3917,7 +4119,8 @@
               "valueType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3940,7 +4143,8 @@
               "valueType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3963,7 +4167,8 @@
               "valueType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -3986,7 +4191,8 @@
               "valueType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4009,7 +4215,8 @@
               "valueType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4032,7 +4239,8 @@
               "valueType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4055,7 +4263,8 @@
               "valueType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4078,7 +4287,8 @@
               "valueType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4101,7 +4311,8 @@
               "valueType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4124,7 +4335,8 @@
               "valueType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4147,7 +4359,8 @@
               "valueType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4170,7 +4383,8 @@
               "valueType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4193,7 +4407,8 @@
               "valueType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4218,7 +4433,8 @@
               "valueType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4243,11 +4459,13 @@
               "valueType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           }
         ],
         "eventDefinitions": [],
-        "commandDefinitions": []
+        "commandDefinitions": [],
+        "annotations": []
       },
       {
         "identifier": {
@@ -4280,7 +4498,8 @@
               "type": {
                 "primitive": "Bool"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4300,7 +4519,8 @@
               "type": {
                 "primitive": "Float"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4320,7 +4540,8 @@
               "type": {
                 "primitive": "Int32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4340,7 +4561,8 @@
               "type": {
                 "primitive": "Int64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4360,7 +4582,8 @@
               "type": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4380,7 +4603,8 @@
               "type": {
                 "primitive": "Uint32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4400,7 +4624,8 @@
               "type": {
                 "primitive": "Uint64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4420,7 +4645,8 @@
               "type": {
                 "primitive": "Sint32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4440,7 +4666,8 @@
               "type": {
                 "primitive": "Sint64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4460,7 +4687,8 @@
               "type": {
                 "primitive": "Fixed32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4480,7 +4708,8 @@
               "type": {
                 "primitive": "Fixed64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4500,7 +4729,8 @@
               "type": {
                 "primitive": "Sfixed32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4520,7 +4750,8 @@
               "type": {
                 "primitive": "Sfixed64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4540,7 +4771,8 @@
               "type": {
                 "primitive": "EntityId"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4562,7 +4794,8 @@
                   "qualifiedName": "improbable.gdk.tests.SomeType"
                 }
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4584,11 +4817,13 @@
                   "qualifiedName": "improbable.gdk.tests.SomeEnum"
                 }
               }
-            }
+            },
+            "annotations": []
           }
         ],
         "eventDefinitions": [],
-        "commandDefinitions": []
+        "commandDefinitions": [],
+        "annotations": []
       },
       {
         "identifier": {
@@ -4623,11 +4858,13 @@
                   "qualifiedName": "improbable.gdk.tests.TypeName"
                 }
               }
-            }
+            },
+            "annotations": []
           }
         ],
         "eventDefinitions": [],
-        "commandDefinitions": []
+        "commandDefinitions": [],
+        "annotations": []
       },
       {
         "identifier": {
@@ -4662,7 +4899,8 @@
               "type": {
                 "primitive": "Bool"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4683,7 +4921,8 @@
               "type": {
                 "primitive": "Int32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4704,7 +4943,8 @@
               "type": {
                 "primitive": "Int64"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4725,7 +4965,8 @@
               "type": {
                 "primitive": "Float"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4746,7 +4987,8 @@
               "type": {
                 "primitive": "Double"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4767,7 +5009,8 @@
               "type": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4788,7 +5031,8 @@
               "innerType": {
                 "primitive": "Int32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4809,7 +5053,8 @@
               "innerType": {
                 "primitive": "Int32"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4833,7 +5078,8 @@
               "valueType": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           }
         ],
         "eventDefinitions": [
@@ -4855,7 +5101,8 @@
               "type": {
                 "qualifiedName": "improbable.gdk.tests.nonblittable_types.FirstEventPayload"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4875,7 +5122,8 @@
               "type": {
                 "qualifiedName": "improbable.gdk.tests.nonblittable_types.SecondEventPayload"
               }
-            }
+            },
+            "annotations": []
           }
         ],
         "commandDefinitions": [
@@ -4902,7 +5150,8 @@
               "type": {
                 "qualifiedName": "improbable.gdk.tests.nonblittable_types.FirstCommandResponse"
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4927,9 +5176,11 @@
               "type": {
                 "qualifiedName": "improbable.gdk.tests.nonblittable_types.SecondCommandResponse"
               }
-            }
+            },
+            "annotations": []
           }
-        ]
+        ],
+        "annotations": []
       },
       {
         "identifier": {
@@ -4960,7 +5211,8 @@
                   "qualifiedName": "improbable.WorkerRequirementSet"
                 }
               }
-            }
+            },
+            "annotations": []
           },
           {
             "identifier": {
@@ -4983,11 +5235,13 @@
                   "qualifiedName": "improbable.WorkerRequirementSet"
                 }
               }
-            }
+            },
+            "annotations": []
           }
         ],
         "eventDefinitions": [],
-        "commandDefinitions": []
+        "commandDefinitions": [],
+        "annotations": []
       },
       {
         "identifier": {
@@ -5016,11 +5270,13 @@
               "type": {
                 "primitive": "String"
               }
-            }
+            },
+            "annotations": []
           }
         ],
         "eventDefinitions": [],
-        "commandDefinitions": []
+        "commandDefinitions": [],
+        "annotations": []
       },
       {
         "identifier": {
@@ -5051,11 +5307,13 @@
                   "qualifiedName": "improbable.Coordinates"
                 }
               }
-            }
+            },
+            "annotations": []
           }
         ],
         "eventDefinitions": [],
-        "commandDefinitions": []
+        "commandDefinitions": [],
+        "annotations": []
       },
       {
         "identifier": {
@@ -5069,7 +5327,8 @@
         "componentId": 55,
         "fieldDefinitions": [],
         "eventDefinitions": [],
-        "commandDefinitions": []
+        "commandDefinitions": [],
+        "annotations": []
       },
       {
         "identifier": {
@@ -5103,11 +5362,13 @@
                   "qualifiedName": "improbable.ComponentInterest"
                 }
               }
-            }
+            },
+            "annotations": []
           }
         ],
         "eventDefinitions": [],
-        "commandDefinitions": []
+        "commandDefinitions": [],
+        "annotations": []
       }
     ]
   },

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/Generation/Model/Details/DetailsStore.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/Generation/Model/Details/DetailsStore.cs
@@ -105,9 +105,24 @@ namespace Improbable.Gdk.CodeGenerator
 
             foreach (var component in bundle.BundleContents.ComponentDefinitions)
             {
-                var fields = component.Data != null
-                    ? bundle.BundleContents.TypeDefinitions.First(type => type.Identifier.QualifiedName == component.Data.QualifiedName).Fields
-                    : component.Fields;
+                List<Field> fields;
+
+                if (component.Data != null)
+                {
+                    var dataType = bundle.BundleContents.TypeDefinitions.FirstOrDefault(type =>
+                        type.Identifier.QualifiedName == component.Data.QualifiedName);
+
+                    if (dataType == null)
+                    {
+                        throw new Exception($"Invalid bundle JSON. Could not find type reference: {component.Data.QualifiedName}");
+                    }
+
+                    fields = dataType.Fields;
+                }
+                else
+                {
+                    fields = component.Fields;
+                }
 
                 var blittableCheckResult = CheckBlittable(fields);
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/Generation/Model/Details/DetailsStore.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/Generation/Model/Details/DetailsStore.cs
@@ -105,7 +105,11 @@ namespace Improbable.Gdk.CodeGenerator
 
             foreach (var component in bundle.BundleContents.ComponentDefinitions)
             {
-                var blittableCheckResult = CheckBlittable(component.Fields);
+                var fields = component.Data != null
+                    ? bundle.BundleContents.TypeDefinitions.First(type => type.Identifier.QualifiedName == component.Data.QualifiedName).Fields
+                    : component.Fields;
+
+                var blittableCheckResult = CheckBlittable(fields);
 
                 if (!blittableCheckResult.HasValue)
                 {


### PR DESCRIPTION
#### Description
Add annotations support for schema. 

- Regenerated example JSON
- Added `AnnotationRaw` class
- Renamed `UserType` -> `FullyQualifiedReference` as it was a more appropriate name.
- Applied a bugfix where blittable checks would be incorrect for components defined with the `data` schema syntax

PR is in commit order.

Will update exhaustive test schema in another PR to not pollute this one. See #746 

#### Tests
Ran the one and only unit test 💯 

#### Documentation
N/A

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
