### PR TITLE
Remove the transitional template from Playground, as the new runtime is now the default runtime.

### DIFF
--- a/cloud_launch.json
+++ b/cloud_launch.json
@@ -1,5 +1,5 @@
 {
-  "template": "small_entity_db_v2",
+  "template": "small",
   "world": {
     "chunkEdgeLengthMeters": 50,
     "snapshots": {

--- a/default_launch.json
+++ b/default_launch.json
@@ -1,5 +1,5 @@
 {
-  "template": "small_entity_db_v2",
+  "template": "small",
   "world": {
     "chunkEdgeLengthMeters": 50,
     "snapshots": {

--- a/mobile_launch.json
+++ b/mobile_launch.json
@@ -1,5 +1,5 @@
 {
-  "template": "small_entity_db_v2",
+  "template": "small",
   "world": {
     "chunkEdgeLengthMeters": 50,
     "snapshots": {


### PR DESCRIPTION
#### Description
Remove the transitional template from Playground, as the new runtime is now the default runtime.

#### Tests
`spatial local launch`

#### Documentation
None

#### Primary reviewers
@zeroZshadow
