### PR TITLE
Remove UTY-1578 workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Fixed a bug where launching on Android from the Unity Editor would break if you have spaces in your project path.
 - Fixed a bug where a Unity package with no dependencies field in its `package.json` would cause code generation to throw exceptions.
+- Fixed protocol logging crashing on linux workers.
 
 ## `0.1.4` - 2019-01-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - Fixed a bug where launching on Android from the Unity Editor would break if you have spaces in your project path.
 - Fixed a bug where a Unity package with no dependencies field in its `package.json` would cause code generation to throw exceptions.
-- Fixed protocol logging crashing on linux workers.
+- Fixed a bug where protocol logging would crash Linux workers.
 
 ## `0.1.4` - 2019-01-28
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs
@@ -135,11 +135,6 @@ namespace Improbable.Gdk.Core
             ConnectionParameters connectionParameters,
             ILogDispatcher logger, Vector3 origin)
         {
-            // TODO: Remove when UTY-1578 is fixed.
-#if UNITY_STANDALONE_LINUX
-            connectionParameters.EnableProtocolLoggingAtStartup = false;
-            Debug.LogWarning("Automatically disabling protocol logging on Linux workers to prevent crashes.");
-#endif
             using (var connectionFuture =
                 Connection.ConnectAsync(config.ReceptionistHost, config.ReceptionistPort, config.WorkerId,
                     connectionParameters))
@@ -168,11 +163,6 @@ namespace Improbable.Gdk.Core
             ConnectionParameters connectionParameters,
             ILogDispatcher logger, Vector3 origin)
         {
-            // TODO: Remove when UTY-1578 is fixed.
-#if UNITY_STANDALONE_LINUX
-            connectionParameters.EnableProtocolLoggingAtStartup = false;
-            Debug.LogWarning("Automatically disabling protocol logging on Linux workers to prevent crashes.");
-#endif
             using (var locator = new Locator(parameters.LocatorHost, parameters.LocatorParameters))
             {
                 var deploymentList = await GetDeploymentList(locator);
@@ -211,11 +201,6 @@ namespace Improbable.Gdk.Core
             ConnectionParameters connectionParameters,
             ILogDispatcher logger, Vector3 origin)
         {
-            // TODO: Remove when UTY-1578 is fixed.
-#if UNITY_STANDALONE_LINUX
-            connectionParameters.EnableProtocolLoggingAtStartup = false;
-            Debug.LogWarning("Automatically disabling protocol logging on Linux workers to prevent crashes.");
-#endif
             using (var locator = new AlphaLocator(parameters.LocatorHost, parameters.LocatorParameters))
             {
                 using (var connectionFuture = locator.ConnectAsync(connectionParameters))


### PR DESCRIPTION
#### Description
Now with 2018.3.5f1, we no longer need to force disable the protocolLogging.

#### Tests
Created a cloud deployment with logging enabled on GameLogic workers.
Didn't crash, saw nice protocol logs appear.

#### Documentation
Added changelog
