### PR TITLE
Make Types, Enums, and Snapshots Serializable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- All generated schema types, enums, and types which implement `ISpatialComponentSnapshot` are now marked as `Serializable`.
+    - Note that generated types that implement `ISpatialComponentData` are not marked as `Serializable`. 
+
 ### Internal
 
 - Changed the code generator to use the schema bundle JSON rather than AST JSON.

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
@@ -194,6 +194,7 @@ var fieldDetails = fieldDetailsList[i]; #>
             }
         }
 
+        [System.Serializable]
         public struct Snapshot : ISpatialComponentSnapshot
         {
             public uint ComponentId => <#= componentDetails.ComponentId #>;

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityEnumContent.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityEnumContent.tt
@@ -4,6 +4,7 @@
     var enumDetails = GetEnumDetails();
 #>
 
+[System.Serializable]
 public enum <#=  enumDetails.TypeName #> : uint
 {
 <# foreach (var valueDefinition in enumDetails.Values) { #>

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityTypeContent.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityTypeContent.tt
@@ -6,6 +6,7 @@
     var hasPartial = PartialDatabase.TryGetPartial(typeDetails.GetPartialResourceTypeName(), out var partial);
 #>
 
+[System.Serializable]
 public struct <#= typeDetails.CapitalisedName #>
 {
 <# foreach (var fieldDetails in fieldDetailsList) { #>


### PR DESCRIPTION
#### Description
Added the `[Serializable]` tag to all Types, Enums, and Snapshots.
Fixes #677 

#### Tests
Created a temporary `ScriptableObject` with public fields of the now serializable types, and confirmed that they indeed shop up in the editor.

Small caveat, the Nullable/Option types do NOT show up, as Unity does not render them by default.
This could possible be worked around using generated inspectors, but will not be trivial.

#### Documentation
**Did you remember a changelog entry?**
NOT YET, post release to avoid conflics.
