### PR TITLE
Fix nested types edge case

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/Generation/Model/Details/DetailsStore.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/Generation/Model/Details/DetailsStore.cs
@@ -75,7 +75,7 @@ namespace Improbable.Gdk.CodeGenerator
 
         private bool IsIdentifierChild(Identifier parent, Identifier potentialChild)
         {
-            return potentialChild.QualifiedName.StartsWith(parent.QualifiedName)
+            return potentialChild.QualifiedName.StartsWith($"{parent.QualifiedName}.")
                 && potentialChild.Path.Count == parent.Path.Count + 1;
         }
 


### PR DESCRIPTION
#### Description
There was a small bug in how nested types were found where calling `GetNestedTypes` on `Foo.Bar` could potentially return `Foo.BarBaz.Foo` as a child. Fixed this by appending a trailing period to the parent qualified name for the name matching such that we check potential children against `Foo.Bar.` instead of `Foo.Bar`.

#### Tests
I can add an explicit test to cover this - would require adding additional test schema however. Thoughts? 

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?
N/A

**Did you remember a changelog entry?**
N/A

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
