### PR TITLE
Quick fix of a wrong query type

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/PlayerHeartbeatInitializationSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/PlayerHeartbeatInitializationSystem.cs
@@ -26,7 +26,7 @@ namespace Improbable.Gdk.PlayerLifecycle
                 Any = Array.Empty<ComponentType>(),
                 None = new[]
                 {
-                    ComponentType.Subtractive<HeartbeatData>(),
+                    ComponentType.Create<HeartbeatData>(),
                 },
             };
 


### PR DESCRIPTION
Unblocks upgrade path to entities.24

#### Description
Quick fix of a wrong ComponentType used in a query. Doesn't change anything functionally, but stops Entities .24 packages from throwing as this has an added check.