### PR TITLE
Add Some Subscription Tests

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Subscriptions.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Subscriptions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6e84ada826ee0c84492b7073f7c15da3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Subscriptions/AggregateSubscriptionTests.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Subscriptions/AggregateSubscriptionTests.cs
@@ -1,0 +1,51 @@
+using System;
+using Improbable.Gdk.Subscriptions;
+using NUnit.Framework;
+using Unity.Entities;
+
+namespace Improbable.Gdk.Core.EditmodeTests.Subscriptions
+{
+    [TestFixture]
+    public class AggregateSubscriptionTests : SubscriptionTestBase
+    {
+        private EntityId entityId = new EntityId(100);
+
+        [Test]
+        public void AggregateSubscription_should_be_available_if_all_constraints_satisfied()
+        {
+            var handler = new AvailabilityHandler();
+            var aggSub = new SubscriptionAggregate(SubscriptionSystem, entityId, typeof(EntityId), typeof(World));
+            aggSub.SetAvailabilityHandler(handler);
+
+            Assert.IsTrue(handler.IsAvailable);
+            Assert.AreEqual(entityId, aggSub.GetValue<EntityId>());
+            Assert.AreEqual(World, aggSub.GetValue<World>());
+        }
+
+        [Test]
+        public void AggregateSubscription_should_not_be_available_if_not_all_constraints_satisfied()
+        {
+            var handler = new AvailabilityHandler();
+            var aggSub = new SubscriptionAggregate(SubscriptionSystem, entityId, typeof(Entity), typeof(World));
+            aggSub.SetAvailabilityHandler(handler);
+
+            Assert.IsFalse(handler.IsAvailable);
+            Assert.Throws<InvalidOperationException>(() => aggSub.GetValue<Entity>());
+        }
+
+        private class AvailabilityHandler : ISubscriptionAvailabilityHandler
+        {
+            public bool IsAvailable { get; private set; }
+
+            public void OnAvailable()
+            {
+                IsAvailable = true;
+            }
+
+            public void OnUnavailable()
+            {
+                IsAvailable = false;
+            }
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Subscriptions/AggregateSubscriptionTests.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Subscriptions/AggregateSubscriptionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 25c6dd60c16ed49408c133cbc596dd66
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Subscriptions/RequiredSubscriptionsInfoTests.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Subscriptions/RequiredSubscriptionsInfoTests.cs
@@ -1,0 +1,46 @@
+using Improbable.Gdk.Subscriptions;
+using NUnit.Framework;
+using Unity.Entities;
+
+namespace Improbable.Gdk.Core.EditmodeTests.Subscriptions
+{
+    /// <summary>
+    ///     This tests the correctness of the reflection code that grabs information about Required fields on a class.
+    /// </summary>
+    [TestFixture]
+    public class RequiredSubscriptionsInfoTests
+    {
+        private class RequiredFields
+        {
+            [Require] public World World;
+            [Require] protected EntityId EntityId;
+            [Require] internal ILogDispatcher LogDispatcher;
+            [Require] private Entity entity;
+        }
+
+        [Test]
+        public void RequiredSubscriptionsInfo_finds_all_public_and_private_fields()
+        {
+            var info = new RequiredSubscriptionsInfo(typeof(RequiredFields));
+            Assert.AreEqual(4, info.RequiredTypes.Length);
+
+            Assert.Contains(typeof(World), info.RequiredTypes);
+            Assert.Contains(typeof(EntityId), info.RequiredTypes);
+            Assert.Contains(typeof(ILogDispatcher), info.RequiredTypes);
+            Assert.Contains(typeof(Entity), info.RequiredTypes);
+        }
+
+        private class RequiredStaticFields
+        {
+            [Require] public static World World;
+            [Require] private static Entity entity;
+        }
+
+        [Test]
+        public void RequiredSubscriptionsInfo_ignores_static_fields()
+        {
+            var info = new RequiredSubscriptionsInfo(typeof(RequiredStaticFields));
+            Assert.AreEqual(0, info.RequiredTypes.Length);
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Subscriptions/RequiredSubscriptionsInfoTests.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Subscriptions/RequiredSubscriptionsInfoTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a63b169f4ccd1274a98d464ddab4e30f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Subscriptions/StandardSubscriptionTests.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Subscriptions/StandardSubscriptionTests.cs
@@ -1,0 +1,109 @@
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Subscriptions;
+using Improbable.Gdk.TestUtils;
+using NUnit.Framework;
+using Unity.Entities;
+using UnityEngine;
+
+namespace Improbable.Gdk.Core.EditmodeTests.Subscriptions
+{
+    /// <summary>
+    ///     This class tests the following subscriptions:
+    ///         - EntityId
+    ///         - ECS Entity
+    ///         - Log Dispatcher
+    ///         - World Commands
+    ///         - ECS World
+    /// </summary>
+    [TestFixture]
+    public class StandardSubscriptionTests
+    {
+        private World world;
+        private WorkerSystem worker;
+        private SubscriptionSystem subscriptionSystem;
+        private ILogDispatcher logDispatcher;
+
+        private EntityId entityId = new EntityId(100);
+
+        [SetUp]
+        public void Setup()
+        {
+            // This is the minimal set required for subscriptions to work.
+            // TODO: Look into untangling these!
+            world = new World("test-world");
+            worker = world.CreateManager<WorkerSystem>(null, new TestLogDispatcher(), "TestWorkerType", Vector3.zero);
+            world.CreateManager<SpatialOSReceiveSystem>();
+            world.GetOrCreateManager<ComponentConstraintsCallbackSystem>();
+            subscriptionSystem = world.CreateManager<SubscriptionSystem>();
+
+            logDispatcher = worker.LogDispatcher;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            world.Dispose();
+        }
+
+        [Test]
+        public void Subscribe_to_entity_id_should_always_be_available()
+        {
+            var entitySubscription = subscriptionSystem.Subscribe<EntityId>(entityId);
+            Assert.True(entitySubscription.HasValue);
+            Assert.AreEqual(entityId, entitySubscription.Value);
+        }
+
+        [Test]
+        public void Subscribe_to_ecs_entity_should_not_be_available_if_the_entity_does_not_exist()
+        {
+            var ecsEntitySubscription = subscriptionSystem.Subscribe<Entity>(entityId);
+            Assert.IsFalse(ecsEntitySubscription.HasValue);
+        }
+
+        [Test]
+        public void Subscribe_to_ecs_entity_should_be_available_if_the_entity_exists()
+        {
+            var entity = world.GetExistingManager<EntityManager>().CreateEntity();
+            worker.EntityIdToEntity.Add(entityId, entity);
+
+            var ecsEntitySubscription = subscriptionSystem.Subscribe<Entity>(entityId);
+            Assert.IsTrue(ecsEntitySubscription.HasValue);
+            Assert.AreEqual(entity, ecsEntitySubscription.Value);
+        }
+
+        [Test]
+        public void Subscribe_to_log_dispatcher_should_always_be_available()
+        {
+            var logSubscription = subscriptionSystem.Subscribe<ILogDispatcher>(entityId);
+            Assert.IsTrue(logSubscription.HasValue);
+            Assert.AreEqual(logDispatcher, logSubscription.Value);
+        }
+
+        [Test]
+        public void Subscribe_to_world_commands_should_not_be_available_if_the_entity_does_not_exist()
+        {
+            var worldCommandSub = subscriptionSystem.Subscribe<WorldCommandSender>(entityId);
+            Assert.IsFalse(worldCommandSub.HasValue);
+        }
+
+        [Test]
+        public void Subscribe_to_world_commands_should_be_available_if_the_entity_exists()
+        {
+            var entity = world.GetExistingManager<EntityManager>().CreateEntity();
+            worker.EntityIdToEntity.Add(entityId, entity);
+
+            var worldCommandSub = subscriptionSystem.Subscribe<WorldCommandSender>(entityId);
+            Assert.IsTrue(worldCommandSub.HasValue);
+            Assert.IsNotNull(worldCommandSub.Value);
+            Assert.IsTrue(worldCommandSub.Value.IsValid);
+        }
+
+        [Test]
+        public void Subscribe_to_world_should_always_be_available()
+        {
+            var worldSubscription = subscriptionSystem.Subscribe<World>(entityId);
+            Assert.IsTrue(worldSubscription.HasValue);
+            Assert.AreEqual(world, worldSubscription.Value);
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Subscriptions/StandardSubscriptionTests.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Subscriptions/StandardSubscriptionTests.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 namespace Improbable.Gdk.Core.EditmodeTests.Subscriptions
 {
     /// <summary>
-    ///     This class tests the following subscriptions:
+    ///     This tests the availability constraints for the following subscriptions :
     ///         - EntityId
     ///         - ECS Entity
     ///         - Log Dispatcher
@@ -16,39 +16,14 @@ namespace Improbable.Gdk.Core.EditmodeTests.Subscriptions
     ///         - ECS World
     /// </summary>
     [TestFixture]
-    public class StandardSubscriptionTests
+    public class StandardSubscriptionTests : SubscriptionTestBase
     {
-        private World world;
-        private WorkerSystem worker;
-        private SubscriptionSystem subscriptionSystem;
-        private ILogDispatcher logDispatcher;
-
         private EntityId entityId = new EntityId(100);
-
-        [SetUp]
-        public void Setup()
-        {
-            // This is the minimal set required for subscriptions to work.
-            // TODO: Look into untangling these!
-            world = new World("test-world");
-            worker = world.CreateManager<WorkerSystem>(null, new TestLogDispatcher(), "TestWorkerType", Vector3.zero);
-            world.CreateManager<SpatialOSReceiveSystem>();
-            world.GetOrCreateManager<ComponentConstraintsCallbackSystem>();
-            subscriptionSystem = world.CreateManager<SubscriptionSystem>();
-
-            logDispatcher = worker.LogDispatcher;
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            world.Dispose();
-        }
 
         [Test]
         public void Subscribe_to_entity_id_should_always_be_available()
         {
-            var entitySubscription = subscriptionSystem.Subscribe<EntityId>(entityId);
+            var entitySubscription = SubscriptionSystem.Subscribe<EntityId>(entityId);
             Assert.True(entitySubscription.HasValue);
             Assert.AreEqual(entityId, entitySubscription.Value);
         }
@@ -56,17 +31,17 @@ namespace Improbable.Gdk.Core.EditmodeTests.Subscriptions
         [Test]
         public void Subscribe_to_ecs_entity_should_not_be_available_if_the_entity_does_not_exist()
         {
-            var ecsEntitySubscription = subscriptionSystem.Subscribe<Entity>(entityId);
+            var ecsEntitySubscription = SubscriptionSystem.Subscribe<Entity>(entityId);
             Assert.IsFalse(ecsEntitySubscription.HasValue);
         }
 
         [Test]
         public void Subscribe_to_ecs_entity_should_be_available_if_the_entity_exists()
         {
-            var entity = world.GetExistingManager<EntityManager>().CreateEntity();
-            worker.EntityIdToEntity.Add(entityId, entity);
+            var entity = World.GetExistingManager<EntityManager>().CreateEntity();
+            Worker.EntityIdToEntity.Add(entityId, entity);
 
-            var ecsEntitySubscription = subscriptionSystem.Subscribe<Entity>(entityId);
+            var ecsEntitySubscription = SubscriptionSystem.Subscribe<Entity>(entityId);
             Assert.IsTrue(ecsEntitySubscription.HasValue);
             Assert.AreEqual(entity, ecsEntitySubscription.Value);
         }
@@ -74,25 +49,25 @@ namespace Improbable.Gdk.Core.EditmodeTests.Subscriptions
         [Test]
         public void Subscribe_to_log_dispatcher_should_always_be_available()
         {
-            var logSubscription = subscriptionSystem.Subscribe<ILogDispatcher>(entityId);
+            var logSubscription = SubscriptionSystem.Subscribe<ILogDispatcher>(entityId);
             Assert.IsTrue(logSubscription.HasValue);
-            Assert.AreEqual(logDispatcher, logSubscription.Value);
+            Assert.AreEqual(LogDispatcher, logSubscription.Value);
         }
 
         [Test]
         public void Subscribe_to_world_commands_should_not_be_available_if_the_entity_does_not_exist()
         {
-            var worldCommandSub = subscriptionSystem.Subscribe<WorldCommandSender>(entityId);
+            var worldCommandSub = SubscriptionSystem.Subscribe<WorldCommandSender>(entityId);
             Assert.IsFalse(worldCommandSub.HasValue);
         }
 
         [Test]
         public void Subscribe_to_world_commands_should_be_available_if_the_entity_exists()
         {
-            var entity = world.GetExistingManager<EntityManager>().CreateEntity();
-            worker.EntityIdToEntity.Add(entityId, entity);
+            var entity = World.GetExistingManager<EntityManager>().CreateEntity();
+            Worker.EntityIdToEntity.Add(entityId, entity);
 
-            var worldCommandSub = subscriptionSystem.Subscribe<WorldCommandSender>(entityId);
+            var worldCommandSub = SubscriptionSystem.Subscribe<WorldCommandSender>(entityId);
             Assert.IsTrue(worldCommandSub.HasValue);
             Assert.IsNotNull(worldCommandSub.Value);
             Assert.IsTrue(worldCommandSub.Value.IsValid);
@@ -101,9 +76,9 @@ namespace Improbable.Gdk.Core.EditmodeTests.Subscriptions
         [Test]
         public void Subscribe_to_world_should_always_be_available()
         {
-            var worldSubscription = subscriptionSystem.Subscribe<World>(entityId);
+            var worldSubscription = SubscriptionSystem.Subscribe<World>(entityId);
             Assert.IsTrue(worldSubscription.HasValue);
-            Assert.AreEqual(world, worldSubscription.Value);
+            Assert.AreEqual(World, worldSubscription.Value);
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Subscriptions/StandardSubscriptionTests.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Subscriptions/StandardSubscriptionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 160d01b8c1ffb1942807409fb125741a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Subscriptions/SubscriptionTestBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Subscriptions/SubscriptionTestBase.cs
@@ -1,0 +1,36 @@
+using Improbable.Gdk.Subscriptions;
+using Improbable.Gdk.TestUtils;
+using NUnit.Framework;
+using Unity.Entities;
+using UnityEngine;
+
+namespace Improbable.Gdk.Core.EditmodeTests.Subscriptions
+{
+    public class SubscriptionTestBase
+    {
+        protected World World;
+        protected WorkerSystem Worker;
+        protected SubscriptionSystem SubscriptionSystem;
+        protected ILogDispatcher LogDispatcher;
+
+        [SetUp]
+        public void Setup()
+        {
+            // This is the minimal set required for subscriptions to work.
+            // TODO: Look into untangling these!
+            World = new World("test-world");
+            Worker = World.CreateManager<WorkerSystem>(null, new TestLogDispatcher(), "TestWorkerType", Vector3.zero);
+            World.CreateManager<SpatialOSReceiveSystem>();
+            World.GetOrCreateManager<ComponentConstraintsCallbackSystem>();
+            SubscriptionSystem = World.CreateManager<SubscriptionSystem>();
+
+            LogDispatcher = Worker.LogDispatcher;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            World.Dispose();
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Subscriptions/SubscriptionTestBase.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Subscriptions/SubscriptionTestBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1cdf6173078bce04d87aaa037939e631
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#### Description
Some tests for: 
- the standard `SubscriptionManager` implementations.
- `AggregateSubscription` behaviour
- `RequiredSubscriptionFieldInfo` behaviour

More tests will come in the form of integration tests with Reader/Writer injection. 

#### Tests
Yes we are tests.

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

**Did you remember a changelog entry?**
N/A

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
