### PR TITLE
Add a callout that iOS Simulator is incombatible with the FPS Starter Project

### DIFF
--- a/docs/content/mobile/ios/cloud-deploy.md
+++ b/docs/content/mobile/ios/cloud-deploy.md
@@ -13,6 +13,8 @@ Alternatively, if you want to create your own authentication server, follow [thi
 
 ## iOS Simulator{#ios-simulator}
 
+<%(Callout type="alert" message="The [**First Person Shooter (FPS) Starter Project**]({{urlRoot}}/projects/fps/overview) cannot currently run on the iOS Simulator. This is due to an incompatibility between the [Metal Graphics API](https://developer.apple.com/metal/) used by the project, and the Simulator.")%>
+
 1. Open your project in your Unity Editor.
 1. In your Unity Editor, select **File** > **Build Settings**, and ensure that **iOS** is selected. (The Unity logo next to a platform name indicates it's selected.)<br>
 If **iOS** is not selected, select it and then select **Switch Platform**.

--- a/docs/content/mobile/ios/cloud-deploy.md
+++ b/docs/content/mobile/ios/cloud-deploy.md
@@ -13,7 +13,7 @@ Alternatively, if you want to create your own authentication server, follow [thi
 
 ## iOS Simulator{#ios-simulator}
 
-<%(Callout type="alert" message="The [**First Person Shooter (FPS) Starter Project**]({{urlRoot}}/projects/fps/overview) cannot currently run on the iOS Simulator. This is due to an incompatibility between the [Metal Graphics API](https://developer.apple.com/metal/) used by the project, and the Simulator.")%>
+**Note:** You cannot run the [First Person Shooter (FPS) Starter Project]({{urlRoot}}/projects/fps/overview) on the iOS Simulator. This is due to an incompatibility between the [Metal Graphics API](https://developer.apple.com/metal/) used by the project and the iOS simulator.
 
 1. Open your project in your Unity Editor.
 1. In your Unity Editor, select **File** > **Build Settings**, and ensure that **iOS** is selected. (The Unity logo next to a platform name indicates it's selected.)<br>

--- a/docs/content/mobile/ios/local-deploy.md
+++ b/docs/content/mobile/ios/local-deploy.md
@@ -35,7 +35,7 @@ It’s done when you see the following message in the terminal: `SpatialOS ready
 
 ## iOS Simulator{#ios-simulator}
 
-<%(Callout type="alert" message="The [**First Person Shooter (FPS) Starter Project**]({{urlRoot}}/projects/fps/overview) cannot currently run on the iOS Simulator. This is due to an incompatibility between the [Metal Graphics API](https://developer.apple.com/metal/) used by the project, and the Simulator.")%>
+**Note:** You cannot run the [First Person Shooter (FPS) Starter Project]({{urlRoot}}/projects/fps/overview) on the iOS Simulator. This is due to an incompatibility between the [Metal Graphics API](https://developer.apple.com/metal/) used by the project and the iOS simulator.
 
 1. Open your project in your Unity Editor.
 1. In your Unity Editor, select **File** > **Build Settings**, and ensure that **iOS** is selected. (The Unity logo next to a platform name indicates it's selected.)<br>

--- a/docs/content/mobile/ios/local-deploy.md
+++ b/docs/content/mobile/ios/local-deploy.md
@@ -35,6 +35,8 @@ It’s done when you see the following message in the terminal: `SpatialOS ready
 
 ## iOS Simulator{#ios-simulator}
 
+<%(Callout type="alert" message="The [**First Person Shooter (FPS) Starter Project**]({{urlRoot}}/projects/fps/overview) cannot currently run on the iOS Simulator. This is due to an incompatibility between the [Metal Graphics API](https://developer.apple.com/metal/) used by the project, and the Simulator.")%>
+
 1. Open your project in your Unity Editor.
 1. In your Unity Editor, select **File** > **Build Settings**, and ensure that **iOS** is selected. (The Unity logo next to a platform name indicates it's selected.)<br>
 If **iOS** is not selected, select it and then select **Switch Platform**.


### PR DESCRIPTION
#### Description
Due to this error:

<img width="645" alt="1" src="https://user-images.githubusercontent.com/19690292/53340869-f7673f00-3901-11e9-8963-7fe9868bf3d7.png">

I've added this alert:

![capture](https://user-images.githubusercontent.com/19690292/53340885-02ba6a80-3902-11e9-825b-693c0a40fbb2.PNG)

to both local and cloud workflow docs.

#### Tests
I encountered the error.
I rendered the changes in improbadoc.

#### Documentation
This is documentation.
