### PR TITLE
Docs/cite correct snapshot

### DIFF
--- a/docs/content/mobile/android/cloud-deploy.md
+++ b/docs/content/mobile/android/cloud-deploy.md
@@ -36,7 +36,7 @@ Altenatively, if you want to create your own authentication server, follow [this
 
 1. [Build your server-workers.]({{urlRoot}}/content/build)
 1. Upload your server-workers. To do this, open a terminal window and from the root directory of your SpatialOS project, enter `spatial cloud upload <assembly name>`.
-1. In the same directory, start your cloud deployment using `spatial cloud launch --snapshot=snapshots/default.snapshot my_assembly <launch configuration>.json <deployment name>`.
+1. In the same directory, start your cloud deployment using `spatial cloud launch --snapshot=snapshots/cloud.snapshot my_assembly <launch configuration>.json <deployment name>`.
 1. In the SpatialOS Console, tag your cloud deployment with the tag `dev_login`. <BR/>
 To do this:
   *  From the [SpatialOS Console](https://console.improbable.io/projects), select your deployment name to display the project **OVERVIEW** screen.

--- a/docs/content/mobile/android/cloud-deploy.md
+++ b/docs/content/mobile/android/cloud-deploy.md
@@ -36,7 +36,7 @@ Altenatively, if you want to create your own authentication server, follow [this
 
 1. [Build your server-workers.]({{urlRoot}}/content/build)
 1. Upload your server-workers. To do this, open a terminal window and from the root directory of your SpatialOS project, enter `spatial cloud upload <assembly name>`.
-1. In the same directory, start your cloud deployment using `spatial cloud launch --snapshot=snapshots/cloud.snapshot my_assembly <launch configuration>.json <deployment name>`.
+1. In the same directory, start your cloud deployment using `spatial cloud launch --snapshot=snapshots/<your snapshot> <assembly name> <launch configuration>.json <deployment name>`.
 1. In the SpatialOS Console, tag your cloud deployment with the tag `dev_login`. <BR/>
 To do this:
   *  From the [SpatialOS Console](https://console.improbable.io/projects), select your deployment name to display the project **OVERVIEW** screen.

--- a/docs/content/mobile/ios/cloud-deploy.md
+++ b/docs/content/mobile/ios/cloud-deploy.md
@@ -41,7 +41,7 @@ If **iOS** is not selected, select it and then select **Switch Platform**.
 1. Build your workers from the SpatialOS menu by selecting **Build for cloud** > **All workers**.
 1. Upload your server-workers.<br>
 	To do this, open a terminal window and from the root directory of your SpatialOS project, enter `spatial cloud upload <assembly name>`.
-1. In the same directory, start your cloud deployment using `spatial cloud launch --snapshot=snapshots/default.snapshot <assembly name> <launch configuration>.json <deployment name>`.
+1. In the same directory, start your cloud deployment using `spatial cloud launch --snapshot=snapshots/cloud.snapshot <assembly name> <launch configuration>.json <deployment name>`.
 1. In your [SpatialOS Console](https://console.improbable.io), tag your cloud deployment with the tag `dev_login`. <br/>
 To do this:
   *  In your SpatialOS Console, select your deployment name to display the project **OVERVIEW** screen.
@@ -82,7 +82,7 @@ If **iOS** is not selected, select it and then select **Switch Platform**.
 1. Build your workers from the SpatialOS menu by selecting **Build for cloud** > **All workers**.
 1. Upload your server-workers.<br>
 	To do this, open a terminal window and from the root directory of your SpatialOS project, enter `spatial cloud upload <assembly name>`.
-1. In the same directory, start your cloud deployment using `spatial cloud launch --snapshot=snapshots/default.snapshot <assembly name> <launch configuration>.json <deployment name>`.
+1. In the same directory, start your cloud deployment using `spatial cloud launch --snapshot=snapshots/cloud.snapshot <assembly name> <launch configuration>.json <deployment name>`.
 1. In your [SpatialOS Console](https://console.improbable.io), tag your cloud deployment with the tag `dev_login`. <br/>
 To do this:
   *  In your SpatialOS Console, select your deployment name to display the project **OVERVIEW** screen.

--- a/docs/content/mobile/ios/cloud-deploy.md
+++ b/docs/content/mobile/ios/cloud-deploy.md
@@ -41,7 +41,7 @@ If **iOS** is not selected, select it and then select **Switch Platform**.
 1. Build your workers from the SpatialOS menu by selecting **Build for cloud** > **All workers**.
 1. Upload your server-workers.<br>
 	To do this, open a terminal window and from the root directory of your SpatialOS project, enter `spatial cloud upload <assembly name>`.
-1. In the same directory, start your cloud deployment using `spatial cloud launch --snapshot=snapshots/cloud.snapshot <assembly name> <launch configuration>.json <deployment name>`.
+1. In the same directory, start your cloud deployment using `spatial cloud launch --snapshot=snapshots/<your snapshot> <assembly name> <launch configuration>.json <deployment name>`.
 1. In your [SpatialOS Console](https://console.improbable.io), tag your cloud deployment with the tag `dev_login`. <br/>
 To do this:
   *  In your SpatialOS Console, select your deployment name to display the project **OVERVIEW** screen.
@@ -82,7 +82,7 @@ If **iOS** is not selected, select it and then select **Switch Platform**.
 1. Build your workers from the SpatialOS menu by selecting **Build for cloud** > **All workers**.
 1. Upload your server-workers.<br>
 	To do this, open a terminal window and from the root directory of your SpatialOS project, enter `spatial cloud upload <assembly name>`.
-1. In the same directory, start your cloud deployment using `spatial cloud launch --snapshot=snapshots/cloud.snapshot <assembly name> <launch configuration>.json <deployment name>`.
+1. In the same directory, start your cloud deployment using `spatial cloud launch --snapshot=snapshots/<your snapshot> <assembly name> <launch configuration>.json <deployment name>`.
 1. In your [SpatialOS Console](https://console.improbable.io), tag your cloud deployment with the tag `dev_login`. <br/>
 To do this:
   *  In your SpatialOS Console, select your deployment name to display the project **OVERVIEW** screen.


### PR DESCRIPTION
#### Description
Mobile cloud docs incorrectly cited `default.snapshot` instead of `cloud.snapshot`. I fixed that.

#### Tests
None

#### Documentation
This is documentation.