### PR TITLE
Docs: Use `id` not `tokenSecret`.

### DIFF
--- a/docs/content/mobile/android/cloud-deploy.md
+++ b/docs/content/mobile/android/cloud-deploy.md
@@ -41,10 +41,14 @@ Altenatively, if you want to create your own authentication server, follow [this
 To do this:
   *  From the [SpatialOS Console](https://console.improbable.io/projects), select your deployment name to display the project **OVERVIEW** screen.
   * In the **OVERVIEW** screen, there’s a **Tag** field, add `dev_login` to the field.
-1. [Create a Development Authentication Token (SpatialOS documentation)](https://docs.improbable.io/reference/latest/shared/auth/development-authentication#developmentauthenticationtoken-maintenance).
-1. In your Unity Editor, select the prefab containing the MonoBehaviour script which inherits from the [`MobileWorkerConnector`](https://github.com/spatialos/gdk-for-unity/blob/master/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs).<br>
-In the FPS Starter Project this is located at: **Assets** > **Fps** > **Prefabs** > **AndroidClientWorker**.
-1. Still in your Unity Editor, in the Inspector window, enter the Development Authentication Token you created in the `DevelopmentAuthToken` field.
+1. [Create a Development Authentication Token (SpatialOS documentation)](https://docs.improbable.io/reference/latest/shared/auth/development-authentication#developmentauthenticationtoken-maintenance).<br>
+Be sure to note down the `id` that is output when you create this, you will need it in a moment.
+1. In your Unity editor, locate the mobile connector script which inherits from the [`MobileWorkerConnector`](https://github.com/spatialos/gdk-for-unity/blob/master/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs).<br>
+If you're using the FPS Starter Project, you can locate this script in `Assets/FPS/Prefabs/AndroidClientWorker`.<br>
+If you added the GDK to an existing project, then you created this script in the **Create a mobile connector script** section [above](#prepare).<br>
+1. Still in your Unity Editor, in the Inspector, in the `Android Worker Connector` section, there is a **Development Auth Token** field.<br>
+Add the `id` that you noted down earlier.
+1. In the same drop-down window, ensure that the checkbox `ShouldConnectLocally` is not checked.
 1. In your Unity Editor, navigate to **SpatialOS** > **Build for cloud**. Select your Android client-worker, and wait for the build to complete. <br/>
 You know it’s complete when it says `Completed build for Cloud target` in your Unity Editor’s Console window.
 1. Select **SpatialOS** > **Launch mobile client** > **Android Device**.

--- a/docs/content/mobile/android/cloud-deploy.md
+++ b/docs/content/mobile/android/cloud-deploy.md
@@ -47,7 +47,7 @@ Be sure to note down the `id` that is output when you create this, you will need
 If you're using the FPS Starter Project, you can locate this script in `Assets/FPS/Prefabs/AndroidClientWorker`.<br>
 If you added the GDK to an existing project, then you created this script in the **Create a mobile connector script** section [above](#prepare).<br>
 1. Still in your Unity Editor, in the Inspector, in the `Android Worker Connector` section, there is a **Development Auth Token** field.<br>
-Add the `id` that you noted down earlier.
+Enter the `id` that you noted down earlier.
 1. In the same drop-down window, ensure that the checkbox `ShouldConnectLocally` is not checked.
 1. In your Unity Editor, navigate to **SpatialOS** > **Build for cloud**. Select your Android client-worker, and wait for the build to complete. <br/>
 You know it’s complete when it says `Completed build for Cloud target` in your Unity Editor’s Console window.

--- a/docs/content/mobile/android/cloud-deploy.md
+++ b/docs/content/mobile/android/cloud-deploy.md
@@ -43,7 +43,7 @@ To do this:
   * In the **OVERVIEW** screen, there’s a **Tag** field, add `dev_login` to the field.
 1. [Create a Development Authentication Token (SpatialOS documentation)](https://docs.improbable.io/reference/latest/shared/auth/development-authentication#developmentauthenticationtoken-maintenance).<br>
 Be sure to note down the `id` that is output when you create this, you will need it in a moment.
-1. In your Unity editor, locate the mobile connector script which inherits from the [`MobileWorkerConnector`](https://github.com/spatialos/gdk-for-unity/blob/master/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs).<br>
+1. In your Unity Editor, locate the mobile connector script which inherits from the [`MobileWorkerConnector`](https://github.com/spatialos/gdk-for-unity/blob/master/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs).<br>
 If you're using the FPS Starter Project, you can locate this script in `Assets/FPS/Prefabs/AndroidClientWorker`.<br>
 If you added the GDK to an existing project, then you created this script in the **Create a mobile connector script** section [above](#prepare).<br>
 1. Still in your Unity Editor, in the Inspector, in the `Android Worker Connector` section, there is a **Development Auth Token** field.<br>

--- a/docs/content/mobile/ios/cloud-deploy.md
+++ b/docs/content/mobile/ios/cloud-deploy.md
@@ -46,10 +46,13 @@ If **iOS** is not selected, select it and then select **Switch Platform**.
 To do this:
   *  In your SpatialOS Console, select your deployment name to display the project **OVERVIEW** screen.
   * In the **OVERVIEW** screen, there’s a **Tag** field, add `dev_login` to the field.
-1. [Create a Development Authentication Token (SpatialOS documentation).](https://docs.improbable.io/reference/latest/shared/auth/development-authentication#developmentauthenticationtoken-maintenance)
-1. Create a MonoBehaviour script which inherits from the [`MobileWorkerConnector`](https://github.com/spatialos/gdk-for-unity/blob/master/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs) and includes the functionality you want. In your Unity Editor, add this script it to your iOS client-worker GameObject.
-1. The `MobileWorkerConnector` provides a `DevelopmentAuthToken` field. Still in your Unity Editor, make sure your iOS client-worker GameObject is selected and in the Inspector, locate the script you just added to it. 
-1. In the Inspector, in the script’s drop-down window, there is a field to add the authentication token that you created. 
+1. [Create a Development Authentication Token (SpatialOS documentation)](https://docs.improbable.io/reference/latest/shared/auth/development-authentication#developmentauthenticationtoken-maintenance).<br>
+Be sure to note down the `id` that is output when you create this, you will need it in a moment.
+1. In your Unity editor, locate the mobile connector script which inherits from the [`MobileWorkerConnector`](https://github.com/spatialos/gdk-for-unity/blob/master/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs).<br>
+If you're using the FPS Starter Project, you can locate this script in `Assets/FPS/Prefabs/iOSClientWorker`.<br>
+If you added the GDK to an existing project, then you created this script in the **Create a mobile connector script** section [above](#prepare).<br>
+1. Still in your Unity Editor, in the Inspector, in the `iOS Worker Connector` section, there is a **Development Auth Token** field.<br>
+Add the `id` that you noted down.
 1. In the same drop-down window, ensure that the checkbox `ShouldConnectLocally` is not checked.
 1. In your Unity Editor, navigate to **SpatialOS** > **Build for cloud**. Select your iOS client-worker, and wait for the build to complete. <br/>
 You know it’s complete when it says `Completed build for Cloud target` in your Unity Editor’s Console window.
@@ -87,10 +90,13 @@ If **iOS** is not selected, select it and then select **Switch Platform**.
 To do this:
   *  In your SpatialOS Console, select your deployment name to display the project **OVERVIEW** screen.
   * In the **OVERVIEW** screen, there’s a **Tag** field, add `dev_login` to the field.
-1. [Create a Development Authentication Token (SpatialOS documentation).](https://docs.improbable.io/reference/latest/shared/auth/development-authentication#developmentauthenticationtoken-maintenance)
-1. Create a MonoBehaviour script which inherits from the [`MobileWorkerConnector`](https://github.com/spatialos/gdk-for-unity/blob/master/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs) and includes the functionality you want. In your Unity Editor, add this script it to your iOS client-worker GameObject.
-1. The `MobileWorkerConnector` provides a `DevelopmentAuthToken` field. Still in your Unity Editor, make sure your iOS client-worker GameObject is selected and in the Inspector, locate the script you just added to it. 
-1. In the Inspector, in the script’s drop-down window, there is a field to add the authentication token that you created. 
+1. [Create a Development Authentication Token (SpatialOS documentation)](https://docs.improbable.io/reference/latest/shared/auth/development-authentication#developmentauthenticationtoken-maintenance).<br>
+Be sure to note down the `id` that is output when you create this, you will need it in a moment.
+1. In your Unity editor, locate the mobile connector script which inherits from the [`MobileWorkerConnector`](https://github.com/spatialos/gdk-for-unity/blob/master/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs).<br>
+If you're using the FPS Starter Project, you can locate this script in `Assets/FPS/Prefabs/iOSClientWorker`.<br>
+If you added the GDK to an existing project, then you created this script in the **Create a mobile connector script** section [above](#prepare).<br>
+1. Still in your Unity Editor, in the Inspector, in the `iOS Worker Connector` section, there is a **Development Auth Token** field.<br>
+Add the `id` that you noted down.
 1. In the same drop-down window, ensure that the checkbox `ShouldConnectLocally` is not checked.
 1. In your Unity Editor, navigate to **SpatialOS** > **Build for cloud**. Select your iOS client-worker, and wait for the build to complete. <br/>
 You know it’s complete when it says `Completed build for Cloud target` in your Unity Editor’s Console window.

--- a/docs/content/mobile/ios/cloud-deploy.md
+++ b/docs/content/mobile/ios/cloud-deploy.md
@@ -92,7 +92,7 @@ To do this:
   * In the **OVERVIEW** screen, there’s a **Tag** field, add `dev_login` to the field.
 1. [Create a Development Authentication Token (SpatialOS documentation)](https://docs.improbable.io/reference/latest/shared/auth/development-authentication#developmentauthenticationtoken-maintenance).<br>
 Be sure to note down the `id` that is output when you create this, you will need it in a moment.
-1. In your Unity editor, locate the mobile connector script which inherits from the [`MobileWorkerConnector`](https://github.com/spatialos/gdk-for-unity/blob/master/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs).<br>
+1. In your Unity Editor, locate the mobile connector script which inherits from the [`MobileWorkerConnector`](https://github.com/spatialos/gdk-for-unity/blob/master/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs).<br>
 If you're using the FPS Starter Project, you can locate this script in `Assets/FPS/Prefabs/iOSClientWorker`.<br>
 If you added the GDK to an existing project, then you created this script in the **Create a mobile connector script** section [above](#prepare).<br>
 1. Still in your Unity Editor, in the Inspector, in the `iOS Worker Connector` section, there is a **Development Auth Token** field.<br>

--- a/docs/content/mobile/ios/cloud-deploy.md
+++ b/docs/content/mobile/ios/cloud-deploy.md
@@ -52,7 +52,7 @@ Be sure to note down the `id` that is output when you create this, you will need
 If you're using the FPS Starter Project, you can locate this script in `Assets/FPS/Prefabs/iOSClientWorker`.<br>
 If you added the GDK to an existing project, then you created this script in the **Create a mobile connector script** section [above](#prepare).<br>
 1. Still in your Unity Editor, in the Inspector, in the `iOS Worker Connector` section, there is a **Development Auth Token** field.<br>
-Add the `id` that you noted down earlier.
+Enter the `id` that you noted down earlier.
 1. In the same drop-down window, ensure that the checkbox `ShouldConnectLocally` is not checked.
 1. In your Unity Editor, navigate to **SpatialOS** > **Build for cloud**. Select your iOS client-worker, and wait for the build to complete. <br/>
 You know it’s complete when it says `Completed build for Cloud target` in your Unity Editor’s Console window.

--- a/docs/content/mobile/ios/cloud-deploy.md
+++ b/docs/content/mobile/ios/cloud-deploy.md
@@ -48,7 +48,7 @@ To do this:
   * In the **OVERVIEW** screen, there’s a **Tag** field, add `dev_login` to the field.
 1. [Create a Development Authentication Token (SpatialOS documentation)](https://docs.improbable.io/reference/latest/shared/auth/development-authentication#developmentauthenticationtoken-maintenance).<br>
 Be sure to note down the `id` that is output when you create this, you will need it in a moment.
-1. In your Unity editor, locate the mobile connector script which inherits from the [`MobileWorkerConnector`](https://github.com/spatialos/gdk-for-unity/blob/master/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs).<br>
+1. In your Unity Editor, locate the mobile connector script which inherits from the [`MobileWorkerConnector`](https://github.com/spatialos/gdk-for-unity/blob/master/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs).<br>
 If you're using the FPS Starter Project, you can locate this script in `Assets/FPS/Prefabs/iOSClientWorker`.<br>
 If you added the GDK to an existing project, then you created this script in the **Create a mobile connector script** section [above](#prepare).<br>
 1. Still in your Unity Editor, in the Inspector, in the `iOS Worker Connector` section, there is a **Development Auth Token** field.<br>

--- a/docs/content/mobile/ios/cloud-deploy.md
+++ b/docs/content/mobile/ios/cloud-deploy.md
@@ -96,7 +96,7 @@ Be sure to note down the `id` that is output when you create this, you will need
 If you're using the FPS Starter Project, you can locate this script in `Assets/FPS/Prefabs/iOSClientWorker`.<br>
 If you added the GDK to an existing project, then you created this script in the **Create a mobile connector script** section [above](#prepare).<br>
 1. Still in your Unity Editor, in the Inspector, in the `iOS Worker Connector` section, there is a **Development Auth Token** field.<br>
-Add the `id` that you noted down earlier.
+Enter the `id` that you noted down earlier.
 1. In the same drop-down window, ensure that the checkbox `ShouldConnectLocally` is not checked.
 1. In your Unity Editor, navigate to **SpatialOS** > **Build for cloud**. Select your iOS client-worker, and wait for the build to complete. <br/>
 You know it’s complete when it says `Completed build for Cloud target` in your Unity Editor’s Console window.

--- a/docs/content/mobile/ios/cloud-deploy.md
+++ b/docs/content/mobile/ios/cloud-deploy.md
@@ -52,7 +52,7 @@ Be sure to note down the `id` that is output when you create this, you will need
 If you're using the FPS Starter Project, you can locate this script in `Assets/FPS/Prefabs/iOSClientWorker`.<br>
 If you added the GDK to an existing project, then you created this script in the **Create a mobile connector script** section [above](#prepare).<br>
 1. Still in your Unity Editor, in the Inspector, in the `iOS Worker Connector` section, there is a **Development Auth Token** field.<br>
-Add the `id` that you noted down.
+Add the `id` that you noted down earlier.
 1. In the same drop-down window, ensure that the checkbox `ShouldConnectLocally` is not checked.
 1. In your Unity Editor, navigate to **SpatialOS** > **Build for cloud**. Select your iOS client-worker, and wait for the build to complete. <br/>
 You know it’s complete when it says `Completed build for Cloud target` in your Unity Editor’s Console window.
@@ -96,7 +96,7 @@ Be sure to note down the `id` that is output when you create this, you will need
 If you're using the FPS Starter Project, you can locate this script in `Assets/FPS/Prefabs/iOSClientWorker`.<br>
 If you added the GDK to an existing project, then you created this script in the **Create a mobile connector script** section [above](#prepare).<br>
 1. Still in your Unity Editor, in the Inspector, in the `iOS Worker Connector` section, there is a **Development Auth Token** field.<br>
-Add the `id` that you noted down.
+Add the `id` that you noted down earlier.
 1. In the same drop-down window, ensure that the checkbox `ShouldConnectLocally` is not checked.
 1. In your Unity Editor, navigate to **SpatialOS** > **Build for cloud**. Select your iOS client-worker, and wait for the build to complete. <br/>
 You know it’s complete when it says `Completed build for Cloud target` in your Unity Editor’s Console window.


### PR DESCRIPTION
#### Description
* Explicitly specifies that users must input their `id` into the **Development Auth Token** field.
* Cuts duplicated steps on creating the script.

#### Tests
Rendered in improbadoc.

#### Documentation
This is documentation.