### PR TITLE
Build system: Android SDK check & active target switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,10 +46,13 @@
 - Improved the UX of the BuildConfiguration inspector.
 - Improved the UX of the GDK Tools Configuration window.
 - Deleting a `GameObject` now automatically unlinks it from its ECS entity. Note that the ECS entity and the SpatialOS entity are _not_ also deleted.
+- Changed the format of the BuildConfiguration asset. Please recreate, or copy it from `workers/unity/Playground/Assets/Config/BuildConfiguration.asset`.
+- Building workers will not change the active build target anymore. The build target will be set back to whatever was set before starting the build process.
 
 ### Fixed
 
 - Fixed a bug where running `SpatialOS -> Generate code` would always regenerate code, even if no files had changed.
+- Fixed a bug where building all workers in our sample projects would fail, if you have Android build support installed, but didn't set the path to the Android SDK.
 
 ### Internal
 

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/Configuration/BuildConfigEditor.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/Configuration/BuildConfigEditor.cs
@@ -169,7 +169,7 @@ namespace Improbable.Gdk.BuildSystem.Configuration
                     {
                         foldoutState.Icon =
                             new GUIContent(EditorGUIUtility.IconContent(BuildConfigEditorStyle.BuiltInErrorIcon))
-                                { tooltip = "Ensure you have the Android SDK installed. Inside the Unity Editor, go to Preferences > External Tools to set it up." };
+                                { tooltip = "Missing Android SDK installation. Go to Preferences > External Tools to set it up." };
                     }
                     else
                     {

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/Configuration/BuildConfigEditor.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/Configuration/BuildConfigEditor.cs
@@ -164,6 +164,13 @@ namespace Improbable.Gdk.BuildSystem.Configuration
                             new GUIContent(EditorGUIUtility.IconContent(BuildConfigEditorStyle.BuiltInErrorIcon))
                                 { tooltip = "Missing build support for one or more build targets." };
                     }
+                    else if (configurationForWorker.CloudBuildConfig.BuildTargets.Any(NeedsAndroidSdk) ||
+                        configurationForWorker.LocalBuildConfig.BuildTargets.Any(NeedsAndroidSdk))
+                    {
+                        foldoutState.Icon =
+                            new GUIContent(EditorGUIUtility.IconContent(BuildConfigEditorStyle.BuiltInErrorIcon))
+                                { tooltip = "Ensure you have the Android SDK installed. Inside the Unity Editor, go to Preferences > External Tools to set it up." };
+                    }
                     else
                     {
                         foldoutState.Icon = null;
@@ -829,6 +836,11 @@ namespace Improbable.Gdk.BuildSystem.Configuration
         private static bool IsBuildTargetError(BuildTargetConfig t)
         {
             return !WorkerBuildData.BuildTargetsThatCanBeBuilt[t.Target] && t.Enabled;
+        }
+
+        private static bool NeedsAndroidSdk(BuildTargetConfig t)
+        {
+            return t.Enabled && t.Target == BuildTarget.Android && string.IsNullOrEmpty(EditorPrefs.GetString("AndroidSdkRoot"));
         }
 
         /// <summary>

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
@@ -67,7 +67,12 @@ namespace Improbable.Gdk.BuildSystem
                         throw new BuildFailedException("Unknown scripting backend value: " + wantedScriptingBackend);
                 }
 
-                BuildWorkers(wantedWorkerTypes, buildEnvironment, scriptingBackend);
+                var buildsSucceeded = BuildWorkers(wantedWorkerTypes, buildEnvironment, scriptingBackend);
+
+                if (!buildsSucceeded)
+                {
+                    throw new BuildFailedException("Not all builds were completed successfully. See the log for more information.");
+                }
             }
             catch (Exception e)
             {
@@ -101,7 +106,7 @@ namespace Improbable.Gdk.BuildSystem
             };
         }
 
-        private static void BuildWorkers(string[] workerTypes, BuildEnvironment buildEnvironment, ScriptingImplementation? scriptingBackend = null)
+        private static bool BuildWorkers(string[] workerTypes, BuildEnvironment buildEnvironment, ScriptingImplementation? scriptingBackend = null)
         {
             var activeBuildTarget = EditorUserBuildSettings.activeBuildTarget;
             var activeBuildTargetGroup = BuildPipeline.GetBuildTargetGroup(activeBuildTarget);
@@ -126,10 +131,12 @@ namespace Improbable.Gdk.BuildSystem
                         $"Completed build for {buildEnvironment} target.\n"
                         + $"Completed builds for: {completedWorkerTypes}\n"
                         + $"Skipped builds for: {missingWorkerTypes}. See above for more information.");
+                    return false;
                 }
                 else
                 {
                     Debug.Log($"Completed build for {buildEnvironment} target.");
+                    return true;
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
#### Description

- Added a check on whether Android SDK path is set or not. Note this is done only, if the build fails because Unity does give the user a prompt to set the path before deciding to continue or fail the build.
- When building for all workers, the platform of the last worker built would be the active one (usually Android in our sample prjects). Added an extra step to switch back to whichever build target was set before starting to build the workers.
- Moved a part of the `Build` out into its own method, so that it can be used for both: building from command line or via the menu items.
- Fixed the message where it reports completed & skipped worker types. The list was switched (i.e. we reported skipped worker types as those that succeeded and vice versa)
