### PR TITLE
Add Application.isPlaying check to WorkerConnector

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
@@ -117,10 +117,12 @@ namespace Improbable.Gdk.Core
 
                 Worker.OnDisconnect += OnDisconnected;
 
-                HandleWorkerConnectionEstablished();
-
-                World.Active = World.Active ?? Worker.World;
-                ScriptBehaviourUpdateOrder.UpdatePlayerLoop(World.AllWorlds.ToArray());
+                if (Application.isPlaying)
+                {
+                    HandleWorkerConnectionEstablished();
+                    World.Active = World.Active ?? Worker.World;
+                    ScriptBehaviourUpdateOrder.UpdatePlayerLoop(World.AllWorlds.ToArray());
+                }
             }
             catch (Exception e)
             {

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
@@ -54,12 +54,12 @@ namespace Improbable.Gdk.Core
         private static readonly SemaphoreSlim WorkerConnectionSemaphore = new SemaphoreSlim(1, 1);
 
         // Important run in this step as otherwise it can interfere with the the domain unloading logic.
-        private void OnApplicationQuit()
+        protected void OnApplicationQuit()
         {
             Dispose();
         }
 
-        private void OnDestroy()
+        protected void OnDestroy()
         {
             Dispose();
         }
@@ -117,12 +117,14 @@ namespace Improbable.Gdk.Core
 
                 Worker.OnDisconnect += OnDisconnected;
 
-                if (Application.isPlaying)
+                if (!Application.isPlaying)
                 {
-                    HandleWorkerConnectionEstablished();
-                    World.Active = World.Active ?? Worker.World;
-                    ScriptBehaviourUpdateOrder.UpdatePlayerLoop(World.AllWorlds.ToArray());
+                    Dispose();
                 }
+
+                HandleWorkerConnectionEstablished();
+                World.Active = World.Active ?? Worker.World;
+                ScriptBehaviourUpdateOrder.UpdatePlayerLoop(World.AllWorlds.ToArray());
             }
             catch (Exception e)
             {


### PR DESCRIPTION
#### Description
Adding an `Application.isPlaying`check before calling `HandleWorkerConnectionEstablished` as this can result in spawning countless error messages, if the Editor play mode is exited at the wrong time. 
this occured in the `SimualtedPlayerWorkerConnector` which tried to access its transform component after already being destroyed. 
A second PR in the FPS starter project will be opened to add additional checks as that behaviour occured in multiple places. (though all related to the `HandleWorkerConnectionEstablished`)
