### PR TITLE
Get commands received by index

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Collections/ReceivedMessagesSpan.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Collections/ReceivedMessagesSpan.cs
@@ -29,7 +29,7 @@ namespace Improbable.Gdk.Core
         {
             get
             {
-                if (index < 0 || index >= Count)
+                if (index >= Count)
                 {
                     throw new IndexOutOfRangeException();
                 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Collections/ReceivedMessagesSpan.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Collections/ReceivedMessagesSpan.cs
@@ -8,7 +8,12 @@ namespace Improbable.Gdk.Core
 
         private readonly int firstIndex;
 
-        public int Count { get; }
+        public readonly int Count;
+
+        static internal ReceivedMessagesSpan<T> Empty()
+        {
+            return new ReceivedMessagesSpan<T>(null, 0, 0);
+        }
 
         internal ReceivedMessagesSpan(MessageList<T> updates)
         {

--- a/workers/unity/Packages/com.improbable.gdk.core/Commands/CommandComponents.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Commands/CommandComponents.cs
@@ -4,19 +4,13 @@ namespace Improbable.Gdk.Core.Commands
     {
     }
 
-    public interface IReceivedCommandRequest : IReceivedMessage
+    public interface IReceivedCommandRequest : IReceivedEntityMessage
     {
         /// <summary>
         ///     Gets the request ID from the request. For use in generic methods.
         /// </summary>
         /// <returns> The request ID associated with the request </returns>
         long GetRequestId();
-
-        /// <summary>
-        ///     Gets the target entity ID from the request. For use in generic methods.
-        /// </summary>
-        /// <returns> The target entity ID associated with the request </returns>
-        EntityId GetTargetEntityId();
     }
 
     public interface ICommandResponse

--- a/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/CalllbackManagers/CommandRequestCallbackManager.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/CalllbackManagers/CommandRequestCallbackManager.cs
@@ -23,7 +23,7 @@ namespace Improbable.Gdk.Subscriptions
             for (int i = 0; i < requests.Count; ++i)
             {
                 ref readonly var request = ref requests[i];
-                callbacks.InvokeAll(request.GetTargetEntityId().Id, request);
+                callbacks.InvokeAll(request.GetEntityId().Id, request);
             }
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs
@@ -33,10 +33,22 @@ namespace Improbable.Gdk.Core
             return manager.GetRequests();
         }
 
+        public ReceivedMessagesSpan<T> GetRequests<T>(EntityId targetEntityId) where T : struct, IReceivedCommandRequest
+        {
+            var manager = (IDiffCommandRequestStorage<T>) worker.Diff.GetCommandDiffStorage(typeof(T));
+            return manager.GetRequests(targetEntityId);
+        }
+
         public ReceivedMessagesSpan<T> GetResponses<T>() where T : struct, IReceivedCommandResponse
         {
             var manager = (IDiffCommandResponseStorage<T>) worker.Diff.GetCommandDiffStorage(typeof(T));
             return manager.GetResponses();
+        }
+
+        public ReceivedMessagesSpan<T> GetResponse<T>(long requestId) where T : struct, IReceivedCommandResponse
+        {
+            var manager = (IDiffCommandResponseStorage<T>) worker.Diff.GetCommandDiffStorage(typeof(T));
+            return manager.GetResponse(requestId);
         }
 
         protected override void OnCreateManager()

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs
@@ -66,6 +66,7 @@ namespace Improbable.Gdk.Core
     {
         void AddRequest(T request);
         ReceivedMessagesSpan<T> GetRequests();
+        ReceivedMessagesSpan<T> GetRequests(EntityId targetEntityId);
     }
 
     public interface IDiffCommandResponseStorage<T> : ICommandDiffStorage
@@ -73,5 +74,6 @@ namespace Improbable.Gdk.Core
     {
         void AddResponse(T response);
         ReceivedMessagesSpan<T> GetResponses();
+        ReceivedMessagesSpan<T> GetResponse(long requestId);
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsReceivedStorage.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsReceivedStorage.cs
@@ -96,8 +96,7 @@ namespace Improbable.Gdk.Core
             var responseIndex = createEntityResponses.GetResponseIndex(requestId);
             if (responseIndex < 0)
             {
-                return new ReceivedMessagesSpan<WorldCommands.CreateEntity.ReceivedResponse>(createEntityResponses, 0,
-                    0);
+                return ReceivedMessagesSpan<WorldCommands.CreateEntity.ReceivedResponse>.Empty();
             }
 
             return new ReceivedMessagesSpan<WorldCommands.CreateEntity.ReceivedResponse>(createEntityResponses,
@@ -116,8 +115,7 @@ namespace Improbable.Gdk.Core
             var responseIndex = deleteEntityResponses.GetResponseIndex(requestId);
             if (responseIndex < 0)
             {
-                return new ReceivedMessagesSpan<WorldCommands.DeleteEntity.ReceivedResponse>(deleteEntityResponses, 0,
-                    0);
+                return ReceivedMessagesSpan<WorldCommands.DeleteEntity.ReceivedResponse>.Empty();
             }
 
             return new ReceivedMessagesSpan<WorldCommands.DeleteEntity.ReceivedResponse>(deleteEntityResponses,
@@ -136,8 +134,7 @@ namespace Improbable.Gdk.Core
             var responseIndex = reserveEntityIdsResponses.GetResponseIndex(requestId);
             if (responseIndex < 0)
             {
-                return new ReceivedMessagesSpan<WorldCommands.ReserveEntityIds.ReceivedResponse>(
-                    reserveEntityIdsResponses, 0, 0);
+                return ReceivedMessagesSpan<WorldCommands.ReserveEntityIds.ReceivedResponse>.Empty();
             }
 
             return new ReceivedMessagesSpan<WorldCommands.ReserveEntityIds.ReceivedResponse>(reserveEntityIdsResponses,
@@ -156,7 +153,7 @@ namespace Improbable.Gdk.Core
             var responseIndex = entityQueryResponses.GetResponseIndex(requestId);
             if (responseIndex < 0)
             {
-                return new ReceivedMessagesSpan<WorldCommands.EntityQuery.ReceivedResponse>(entityQueryResponses, 0, 0);
+                return ReceivedMessagesSpan<WorldCommands.EntityQuery.ReceivedResponse>.Empty();
             }
 
             return new ReceivedMessagesSpan<WorldCommands.EntityQuery.ReceivedResponse>(entityQueryResponses,

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsReceivedStorage.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsReceivedStorage.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Improbable.Gdk.Core.Commands;
 
 namespace Improbable.Gdk.Core
@@ -20,12 +21,23 @@ namespace Improbable.Gdk.Core
         private readonly MessageList<WorldCommands.EntityQuery.ReceivedResponse> entityQueryResponses =
             new MessageList<WorldCommands.EntityQuery.ReceivedResponse>();
 
+        private readonly Comparer comparer = new Comparer();
+
+        private bool createEntitySorted;
+        private bool deleteEntitySorted;
+        private bool reserveEntityIdsSorted;
+        private bool entityQueriesSorted;
+
         public void Clear()
         {
             createEntityResponses.Clear();
             deleteEntityResponses.Clear();
             reserveEntityIdsResponses.Clear();
             entityQueryResponses.Clear();
+            createEntitySorted = false;
+            deleteEntitySorted = false;
+            reserveEntityIdsSorted = false;
+            entityQueriesSorted = false;
         }
 
         public void AddResponse(WorldCommands.CreateEntity.ReceivedResponse response)
@@ -70,6 +82,115 @@ namespace Improbable.Gdk.Core
             IDiffCommandResponseStorage<WorldCommands.EntityQuery.ReceivedResponse>.GetResponses()
         {
             return new ReceivedMessagesSpan<WorldCommands.EntityQuery.ReceivedResponse>(entityQueryResponses);
+        }
+
+        ReceivedMessagesSpan<WorldCommands.CreateEntity.ReceivedResponse>
+            IDiffCommandResponseStorage<WorldCommands.CreateEntity.ReceivedResponse>.GetResponse(long requestId)
+        {
+            if (!createEntitySorted)
+            {
+                createEntityResponses.Sort(comparer);
+                createEntitySorted = true;
+            }
+
+            var responseIndex = createEntityResponses.GetResponseIndex(requestId);
+            if (responseIndex < 0)
+            {
+                return new ReceivedMessagesSpan<WorldCommands.CreateEntity.ReceivedResponse>(createEntityResponses, 0,
+                    0);
+            }
+
+            return new ReceivedMessagesSpan<WorldCommands.CreateEntity.ReceivedResponse>(createEntityResponses,
+                responseIndex, 1);
+        }
+
+        ReceivedMessagesSpan<WorldCommands.DeleteEntity.ReceivedResponse>
+            IDiffCommandResponseStorage<WorldCommands.DeleteEntity.ReceivedResponse>.GetResponse(long requestId)
+        {
+            if (!deleteEntitySorted)
+            {
+                deleteEntityResponses.Sort(comparer);
+                deleteEntitySorted = true;
+            }
+
+            var responseIndex = deleteEntityResponses.GetResponseIndex(requestId);
+            if (responseIndex < 0)
+            {
+                return new ReceivedMessagesSpan<WorldCommands.DeleteEntity.ReceivedResponse>(deleteEntityResponses, 0,
+                    0);
+            }
+
+            return new ReceivedMessagesSpan<WorldCommands.DeleteEntity.ReceivedResponse>(deleteEntityResponses,
+                responseIndex, 1);
+        }
+
+        ReceivedMessagesSpan<WorldCommands.ReserveEntityIds.ReceivedResponse>
+            IDiffCommandResponseStorage<WorldCommands.ReserveEntityIds.ReceivedResponse>.GetResponse(long requestId)
+        {
+            if (!reserveEntityIdsSorted)
+            {
+                reserveEntityIdsResponses.Sort(comparer);
+                reserveEntityIdsSorted = true;
+            }
+
+            var responseIndex = reserveEntityIdsResponses.GetResponseIndex(requestId);
+            if (responseIndex < 0)
+            {
+                return new ReceivedMessagesSpan<WorldCommands.ReserveEntityIds.ReceivedResponse>(
+                    reserveEntityIdsResponses, 0, 0);
+            }
+
+            return new ReceivedMessagesSpan<WorldCommands.ReserveEntityIds.ReceivedResponse>(reserveEntityIdsResponses,
+                responseIndex, 1);
+        }
+
+        ReceivedMessagesSpan<WorldCommands.EntityQuery.ReceivedResponse>
+            IDiffCommandResponseStorage<WorldCommands.EntityQuery.ReceivedResponse>.GetResponse(long requestId)
+        {
+            if (!entityQueriesSorted)
+            {
+                entityQueryResponses.Sort(comparer);
+                entityQueriesSorted = true;
+            }
+
+            var responseIndex = entityQueryResponses.GetResponseIndex(requestId);
+            if (responseIndex < 0)
+            {
+                return new ReceivedMessagesSpan<WorldCommands.EntityQuery.ReceivedResponse>(entityQueryResponses, 0, 0);
+            }
+
+            return new ReceivedMessagesSpan<WorldCommands.EntityQuery.ReceivedResponse>(entityQueryResponses,
+                responseIndex, 1);
+        }
+
+        private class Comparer : IComparer<WorldCommands.CreateEntity.ReceivedResponse>,
+            IComparer<WorldCommands.DeleteEntity.ReceivedResponse>,
+            IComparer<WorldCommands.ReserveEntityIds.ReceivedResponse>,
+            IComparer<WorldCommands.EntityQuery.ReceivedResponse>
+        {
+            public int Compare(WorldCommands.CreateEntity.ReceivedResponse x,
+                WorldCommands.CreateEntity.ReceivedResponse y)
+            {
+                return x.RequestId.CompareTo(y.RequestId);
+            }
+
+            public int Compare(WorldCommands.DeleteEntity.ReceivedResponse x,
+                WorldCommands.DeleteEntity.ReceivedResponse y)
+            {
+                return x.RequestId.CompareTo(y.RequestId);
+            }
+
+            public int Compare(WorldCommands.ReserveEntityIds.ReceivedResponse x,
+                WorldCommands.ReserveEntityIds.ReceivedResponse y)
+            {
+                return x.RequestId.CompareTo(y.RequestId);
+            }
+
+            public int Compare(WorldCommands.EntityQuery.ReceivedResponse x,
+                WorldCommands.EntityQuery.ReceivedResponse y)
+            {
+                return x.RequestId.CompareTo(y.RequestId);
+            }
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/CommandDiffStorageGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/CommandDiffStorageGenerator.tt
@@ -113,7 +113,7 @@ namespace <#= qualifiedNamespace #>
                 var responseIndex = responseStorage.GetResponseIndex(requestId);
                 if (responseIndex < 0)
                 {
-                    return new ReceivedMessagesSpan<<#= receivedResponseType #>>(responseStorage, 0, 0);
+                    return ReceivedMessagesSpan<<#= receivedResponseType #>>.Empty();
                 }
 
                 return new ReceivedMessagesSpan<<#= receivedResponseType #>>(responseStorage, responseIndex, 1);

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/CommandDiffStorageGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/CommandDiffStorageGenerator.tt
@@ -8,6 +8,7 @@
 <#= generatedHeader #>
 
 using System;
+using System.Collections.Generic;
 using Improbable.Gdk.Core;
 using Unity.Entities;
 
@@ -28,6 +29,12 @@ namespace <#= qualifiedNamespace #>
 
             private MessageList<<#= receivedResponseType #>> responseStorage =
                 new MessageList<<#= receivedResponseType #>>();
+
+            private readonly RequestComparer requestComparer = new RequestComparer();
+            private readonly ResponseComparer responseComparer = new ResponseComparer();
+
+            private bool requestsSorted;
+            private bool responsesSorted;
 
             public uint GetComponentId()
             {
@@ -53,6 +60,8 @@ namespace <#= qualifiedNamespace #>
             {
                 requestStorage.Clear();
                 responseStorage.Clear();
+                requestsSorted = false;
+                responsesSorted = false;
             }
 
             public void RemoveRequests(long entityId)
@@ -75,38 +84,55 @@ namespace <#= qualifiedNamespace #>
                 return new ReceivedMessagesSpan<<#= receivedRequestType #>>(requestStorage);
             }
 
+            public ReceivedMessagesSpan<<#= receivedRequestType #>> GetRequests(EntityId targetEntityId)
+            {
+                if (!requestsSorted)
+                {
+                    requestStorage.Sort(requestComparer);
+                    requestsSorted = true;
+                }
+
+                var (firstIndex, count) = requestStorage.GetEntityRange(targetEntityId);
+
+                return new ReceivedMessagesSpan<<#= receivedRequestType #>>(requestStorage, firstIndex, count);
+            }
+
             public ReceivedMessagesSpan<<#= receivedResponseType #>> GetResponses()
             {
                 return new ReceivedMessagesSpan<<#= receivedResponseType #>>(responseStorage);
             }
 
-            internal bool TryGetResponseReceivedForRequestId(long requestId, out <#= receivedResponseType #> response)
+            public ReceivedMessagesSpan<<#= receivedResponseType #>> GetResponse(long requestId)
             {
+                if (!responsesSorted)
+                {
+                    responseStorage.Sort(responseComparer);
+                    responsesSorted = true;
+                }
+
                 var responseIndex = responseStorage.GetResponseIndex(requestId);
                 if (responseIndex < 0)
                 {
-                    response = default(<#= receivedResponseType #>);
-                    return false;
+                    return new ReceivedMessagesSpan<<#= receivedResponseType #>>(responseStorage, 0, 0);
                 }
 
-                response = responseStorage[responseIndex];
-                return true;
+                return new ReceivedMessagesSpan<<#= receivedResponseType #>>(responseStorage, responseIndex, 1);
             }
 
-            internal void SwapAndClearMessageLists(ref MessageList<<#= receivedRequestType #>> messageList)
+            private class RequestComparer : IComparer<<#= receivedRequestType #>>
             {
-                MessageList<<#= receivedRequestType #>> temp = messageList;
-                messageList = requestStorage;
-                requestStorage = temp;
-                requestStorage.Clear();
+                public int Compare(<#= receivedRequestType #> x, <#= receivedRequestType #> y)
+                {
+                    return x.EntityId.Id.CompareTo(y.EntityId.Id);
+                }
             }
 
-            internal void SwapAndClearMessageLists(ref MessageList<<#= receivedResponseType #>> messageList)
+            private class ResponseComparer : IComparer<<#= receivedResponseType #>>
             {
-                MessageList<<#= receivedResponseType #>> temp = messageList;
-                messageList = responseStorage;
-                responseStorage = temp;
-                responseStorage.Clear();
+                public int Compare(<#= receivedResponseType #> x, <#= receivedResponseType #> y)
+                {
+                    return x.RequestId.CompareTo(y.RequestId);
+                }
             }
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityCommandPayloadGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityCommandPayloadGenerator.tt
@@ -70,7 +70,7 @@ namespace <#= qualifiedNamespace #>
                     return RequestId;
                 }
 
-                EntityId IReceivedCommandRequest.GetTargetEntityId()
+                EntityId IReceivedEntityMessage.GetEntityId()
                 {
                     return EntityId;
                 }


### PR DESCRIPTION
#### Description
Command requests can now be queried by entity ID and responses by request ID. This is to match the component update API that allows searching updates by entity ID.