### PR TITLE
Update the view when sending an update. Disable loopback

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs
@@ -10,9 +10,10 @@ namespace Improbable.Gdk.Core
     {
         private WorkerSystem worker;
 
-        public void SendUpdate<T>(T update, EntityId entityId) where T : ISpatialComponentUpdate
+        public void SendUpdate<T>(in T update, EntityId entityId) where T : struct, ISpatialComponentUpdate
         {
-            worker.MessagesToSend.AddComponentUpdate(update, entityId.Id);
+            worker.View.UpdateComponent(entityId, in update);
+            worker.MessagesToSend.AddComponentUpdate(in update, entityId.Id);
         }
 
         public void SendEvent<T>(T eventToSend, EntityId entityId) where T : IEvent

--- a/workers/unity/Packages/com.improbable.gdk.core/View/View.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/View/View.cs
@@ -24,6 +24,7 @@ namespace Improbable.Gdk.Core
                         var instance = (IViewStorage) Activator.CreateInstance(type);
 
                         typeToViewStorage.Add(instance.GetSnapshotType(), instance);
+                        typeToViewStorage.Add(instance.GetUpdateType(), instance);
                         componentIdToViewStorage.Add(instance.GetComponentId(), instance);
 
                         viewStorages.Add(instance);
@@ -32,7 +33,7 @@ namespace Improbable.Gdk.Core
             }
         }
 
-        public void ApplyDiff(ViewDiff diff)
+        internal void ApplyDiff(ViewDiff diff)
         {
             var entitiesAdded = diff.GetEntitiesAdded();
             foreach (var entity in entitiesAdded)
@@ -51,6 +52,12 @@ namespace Improbable.Gdk.Core
                 // Resolve this with an actual diff!
                 storage.ApplyDiff(diff);
             }
+        }
+
+        internal void UpdateComponent<T>(EntityId entityId, in T update) where T : struct, ISpatialComponentUpdate
+        {
+            var storage = (IViewComponentUpdater<T>) typeToViewStorage[typeof(T)];
+            storage.ApplyUpdate(entityId.Id, in update);
         }
 
         public HashSet<EntityId> GetEntityIds()

--- a/workers/unity/Packages/com.improbable.gdk.core/View/View.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/View/View.cs
@@ -139,7 +139,6 @@ namespace Improbable.Gdk.Core
 
             foreach (var storage in viewStorages)
             {
-                // Resolve this with an actual diff!
                 storage.ApplyDiff(diff);
             }
         }

--- a/workers/unity/Packages/com.improbable.gdk.core/View/View.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/View/View.cs
@@ -33,28 +33,7 @@ namespace Improbable.Gdk.Core
             }
         }
 
-        internal void ApplyDiff(ViewDiff diff)
-        {
-            var entitiesAdded = diff.GetEntitiesAdded();
-            foreach (var entity in entitiesAdded)
-            {
-                entities.Add(entity);
-            }
-
-            var entitiesRemoved = diff.GetEntitiesRemoved();
-            foreach (var entity in entitiesRemoved)
-            {
-                entities.Remove(entity);
-            }
-
-            foreach (var storage in viewStorages)
-            {
-                // Resolve this with an actual diff!
-                storage.ApplyDiff(diff);
-            }
-        }
-
-        internal void UpdateComponent<T>(EntityId entityId, in T update) where T : struct, ISpatialComponentUpdate
+        public void UpdateComponent<T>(EntityId entityId, in T update) where T : struct, ISpatialComponentUpdate
         {
             var storage = (IViewComponentUpdater<T>) typeToViewStorage[typeof(T)];
             storage.ApplyUpdate(entityId.Id, in update);
@@ -142,6 +121,27 @@ namespace Improbable.Gdk.Core
             }
 
             return componentIdToViewStorage[componentId].GetAuthority(entityId.Id) == Authority.Authoritative;
+        }
+
+        internal void ApplyDiff(ViewDiff diff)
+        {
+            var entitiesAdded = diff.GetEntitiesAdded();
+            foreach (var entity in entitiesAdded)
+            {
+                entities.Add(entity);
+            }
+
+            var entitiesRemoved = diff.GetEntitiesRemoved();
+            foreach (var entity in entitiesRemoved)
+            {
+                entities.Remove(entity);
+            }
+
+            foreach (var storage in viewStorages)
+            {
+                // Resolve this with an actual diff!
+                storage.ApplyDiff(diff);
+            }
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs
@@ -6,6 +6,7 @@ namespace Improbable.Gdk.Core
     public interface IViewStorage
     {
         Type GetSnapshotType();
+        Type GetUpdateType();
         uint GetComponentId();
 
         bool HasComponent(long entityId);
@@ -17,5 +18,10 @@ namespace Improbable.Gdk.Core
     public interface IViewComponentStorage<T> where T : struct, ISpatialComponentSnapshot
     {
         T GetComponent(long entityId);
+    }
+
+    public interface IViewComponentUpdater<T> where T : struct, ISpatialComponentUpdate
+    {
+        void ApplyUpdate(long entityId, in T update);
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/MessagesToSend.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/MessagesToSend.cs
@@ -100,7 +100,7 @@ namespace Improbable.Gdk.Core
             authorityLossAcks.Add(new EntityComponent(entityId, componentId));
         }
 
-        public void AddComponentUpdate<T>(T update, long entityId)
+        public void AddComponentUpdate<T>(in T update, long entityId)
             where T : ISpatialComponentUpdate
         {
             var storage = GetComponentDiffStorage(typeof(T));

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs
@@ -37,8 +37,11 @@ namespace Improbable.Gdk.Core
         private readonly List<IComponentSerializer> componentSerializers = new List<IComponentSerializer>();
         private readonly List<ICommandSerializer> commandSerializers = new List<ICommandSerializer>();
 
+        private readonly UpdateParameters updateParams = new UpdateParameters();
+
         public SerializedMessagesToSend()
         {
+            updateParams.Loopback = ComponentUpdateLoopback.None;
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
                 foreach (var type in assembly.GetTypes())
@@ -112,7 +115,7 @@ namespace Improbable.Gdk.Core
             for (int i = 0; i < updates.Count; ++i)
             {
                 ref readonly var update = ref updates[i];
-                connection.SendComponentUpdate(update.EntityId, update.Update);
+                connection.SendComponentUpdate(update.EntityId, update.Update, updateParams);
             }
 
             for (int i = 0; i < requests.Count; ++i)

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs
@@ -41,7 +41,7 @@ namespace Improbable.Gdk.Core
 
         public SerializedMessagesToSend()
         {
-            updateParams.Loopback = ComponentUpdateLoopback.None;
+            updateParams.Loopback = ComponentUpdateLoopback.ShortCircuited;
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
                 foreach (var type in assembly.GetTypes())

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs
@@ -20,7 +20,7 @@ namespace Improbable.Gdk.Core
         private readonly Dictionary<uint, IComponentDiffStorage> componentIdToComponentStorage =
             new Dictionary<uint, IComponentDiffStorage>();
 
-        private Dictionary<Type, IComponentDiffStorage> typeToComponentStorage =
+        private readonly Dictionary<Type, IComponentDiffStorage> typeToComponentStorage =
             new Dictionary<Type, IComponentDiffStorage>();
 
         private readonly List<IComponentDiffStorage> componentStorageList = new List<IComponentDiffStorage>();
@@ -28,7 +28,7 @@ namespace Improbable.Gdk.Core
         private readonly Dictionary<uint, Dictionary<uint, IComponentCommandDiffStorage>> componentIdToCommandIdToStorage =
             new Dictionary<uint, Dictionary<uint, IComponentCommandDiffStorage>>();
 
-        private Dictionary<Type, ICommandDiffStorage> typeToCommandStorage =
+        private readonly Dictionary<Type, ICommandDiffStorage> typeToCommandStorage =
             new Dictionary<Type, ICommandDiffStorage>();
 
         private readonly List<ICommandDiffStorage> commandStorageList = new List<ICommandDiffStorage>();

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentSenderGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentSenderGenerator.tt
@@ -81,7 +81,7 @@ var fieldDetails = fieldDetailsList[i]; #>
                             }
 <# } #>
 
-                            componentUpdateSystem.SendUpdate(update, entityIdArray[i].EntityId);
+                            componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
                             data.MarkDataClean();
                             componentArray[i] = data;
                         }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ViewStorageGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ViewStorageGenerator.tt
@@ -16,7 +16,8 @@ namespace <#= qualifiedNamespace #>
 {
     public partial class <#= componentDetails.ComponentName #>
     {
-        public class <#= componentDetails.ComponentName #>ViewStorage : IViewStorage, IViewComponentStorage<Snapshot>
+        public class <#= componentDetails.ComponentName #>ViewStorage : IViewStorage, IViewComponentStorage<Snapshot>,
+            IViewComponentUpdater<Update>
         {
             private readonly Dictionary<long, Authority> authorityStates = new Dictionary<long, Authority>();
             private readonly Dictionary<long, Snapshot> componentData = new Dictionary<long, Snapshot>();
@@ -24,6 +25,11 @@ namespace <#= qualifiedNamespace #>
             public Type GetSnapshotType()
             {
                 return typeof(Snapshot);
+            }
+
+            public Type GetUpdateType()
+            {
+                return typeof(Update);
             }
 
             public uint GetComponentId()
@@ -87,7 +93,7 @@ namespace <#= qualifiedNamespace #>
                 }
             }
 
-            private void ApplyUpdate(long entityId, in Update update)
+            public void ApplyUpdate(long entityId, in Update update)
             {
                 var data = componentData[entityId];
 <# foreach (var field in fields) {


### PR DESCRIPTION
#### Description
Sending an update will update the view. This does not make the more intrusive changes, like separating the writer send api from the ecs one. Also does not deal with the potential `in` copy issue. 
