### PR TITLE
Sort while deserialising

### DIFF
--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyComponentDiffStorage.cs
@@ -18,9 +18,6 @@ namespace Improbable.Gdk.Tests
             private List<EntityId> componentsAdded = new List<EntityId>();
             private List<EntityId> componentsRemoved = new List<EntityId>();
 
-            private bool authoritySorted;
-            private bool updatesSorted;
-
             private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
             private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
 
@@ -63,9 +60,6 @@ namespace Improbable.Gdk.Tests
                 authorityChanges.Clear();
                 componentsAdded.Clear();
                 componentsRemoved.Clear();
-
-                authoritySorted = false;
-                updatesSorted = false;
             }
 
             public void RemoveEntityComponent(long entityId)
@@ -99,7 +93,7 @@ namespace Improbable.Gdk.Tests
             public void AddUpdate(ComponentUpdateReceived<Update> update)
             {
                 entitiesUpdated.Add(update.EntityId);
-                updateStorage.Add(update);
+                updateStorage.InsertSorted(update, updateComparer);
             }
 
             public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
@@ -123,7 +117,7 @@ namespace Improbable.Gdk.Tests
                     }
                 }
 
-                authorityChanges.Add(authorityChange);
+                authorityChanges.InsertSorted(authorityChange, authorityComparer);
             }
 
             public List<EntityId> GetComponentsAdded()
@@ -138,26 +132,11 @@ namespace Improbable.Gdk.Tests
 
             public ReceivedMessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
             {
-                // todo consider if this needs to be sorted
-                // possible offer two functions
-                // probably just sort it
-                if (!updatesSorted)
-                {
-                    updatesSorted = true;
-                    updateStorage.Sort(updateComparer);
-                }
-
                 return new ReceivedMessagesSpan<ComponentUpdateReceived<Update>>(updateStorage);
             }
 
             public ReceivedMessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
             {
-                if (!updatesSorted)
-                {
-                    updatesSorted = true;
-                    updateStorage.Sort(updateComparer);
-                }
-
                 var range = updateStorage.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<ComponentUpdateReceived<Update>>(updateStorage, range.FirstIndex,
                     range.Count);
@@ -165,23 +144,11 @@ namespace Improbable.Gdk.Tests
 
             public ReceivedMessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
             {
-                if (!authoritySorted)
-                {
-                    authoritySorted = true;
-                    authorityChanges.Sort(authorityComparer);
-                }
-
                 return new ReceivedMessagesSpan<AuthorityChangeReceived>(authorityChanges);
             }
 
             public ReceivedMessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
             {
-                if (!authoritySorted)
-                {
-                    authoritySorted = true;
-                    authorityChanges.Sort(authorityComparer);
-                }
-
                 var range = authorityChanges.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<AuthorityChangeReceived>(authorityChanges, range.FirstIndex, range.Count);
             }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyUpdateSender.cs
@@ -33,14 +33,13 @@ namespace Improbable.Gdk.Tests
             };
 
             public void SendUpdates(
-                ComponentGroup replicationGroup,
+                NativeArray<ArchetypeChunk> chunkArray,
                 ComponentSystemBase system,
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
                 Profiler.BeginSample("ExhaustiveMapKey");
 
-                var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
                 var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>();
 
@@ -162,7 +161,6 @@ namespace Improbable.Gdk.Tests
                     }
                 }
 
-                chunkArray.Dispose();
                 Profiler.EndSample();
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueComponentDiffStorage.cs
@@ -18,9 +18,6 @@ namespace Improbable.Gdk.Tests
             private List<EntityId> componentsAdded = new List<EntityId>();
             private List<EntityId> componentsRemoved = new List<EntityId>();
 
-            private bool authoritySorted;
-            private bool updatesSorted;
-
             private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
             private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
 
@@ -63,9 +60,6 @@ namespace Improbable.Gdk.Tests
                 authorityChanges.Clear();
                 componentsAdded.Clear();
                 componentsRemoved.Clear();
-
-                authoritySorted = false;
-                updatesSorted = false;
             }
 
             public void RemoveEntityComponent(long entityId)
@@ -99,7 +93,7 @@ namespace Improbable.Gdk.Tests
             public void AddUpdate(ComponentUpdateReceived<Update> update)
             {
                 entitiesUpdated.Add(update.EntityId);
-                updateStorage.Add(update);
+                updateStorage.InsertSorted(update, updateComparer);
             }
 
             public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
@@ -123,7 +117,7 @@ namespace Improbable.Gdk.Tests
                     }
                 }
 
-                authorityChanges.Add(authorityChange);
+                authorityChanges.InsertSorted(authorityChange, authorityComparer);
             }
 
             public List<EntityId> GetComponentsAdded()
@@ -138,26 +132,11 @@ namespace Improbable.Gdk.Tests
 
             public ReceivedMessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
             {
-                // todo consider if this needs to be sorted
-                // possible offer two functions
-                // probably just sort it
-                if (!updatesSorted)
-                {
-                    updatesSorted = true;
-                    updateStorage.Sort(updateComparer);
-                }
-
                 return new ReceivedMessagesSpan<ComponentUpdateReceived<Update>>(updateStorage);
             }
 
             public ReceivedMessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
             {
-                if (!updatesSorted)
-                {
-                    updatesSorted = true;
-                    updateStorage.Sort(updateComparer);
-                }
-
                 var range = updateStorage.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<ComponentUpdateReceived<Update>>(updateStorage, range.FirstIndex,
                     range.Count);
@@ -165,23 +144,11 @@ namespace Improbable.Gdk.Tests
 
             public ReceivedMessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
             {
-                if (!authoritySorted)
-                {
-                    authoritySorted = true;
-                    authorityChanges.Sort(authorityComparer);
-                }
-
                 return new ReceivedMessagesSpan<AuthorityChangeReceived>(authorityChanges);
             }
 
             public ReceivedMessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
             {
-                if (!authoritySorted)
-                {
-                    authoritySorted = true;
-                    authorityChanges.Sort(authorityComparer);
-                }
-
                 var range = authorityChanges.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<AuthorityChangeReceived>(authorityChanges, range.FirstIndex, range.Count);
             }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueUpdateSender.cs
@@ -33,14 +33,13 @@ namespace Improbable.Gdk.Tests
             };
 
             public void SendUpdates(
-                ComponentGroup replicationGroup,
+                NativeArray<ArchetypeChunk> chunkArray,
                 ComponentSystemBase system,
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
                 Profiler.BeginSample("ExhaustiveMapValue");
 
-                var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
                 var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>();
 
@@ -162,7 +161,6 @@ namespace Improbable.Gdk.Tests
                     }
                 }
 
-                chunkArray.Dispose();
                 Profiler.EndSample();
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalComponentDiffStorage.cs
@@ -18,9 +18,6 @@ namespace Improbable.Gdk.Tests
             private List<EntityId> componentsAdded = new List<EntityId>();
             private List<EntityId> componentsRemoved = new List<EntityId>();
 
-            private bool authoritySorted;
-            private bool updatesSorted;
-
             private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
             private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
 
@@ -63,9 +60,6 @@ namespace Improbable.Gdk.Tests
                 authorityChanges.Clear();
                 componentsAdded.Clear();
                 componentsRemoved.Clear();
-
-                authoritySorted = false;
-                updatesSorted = false;
             }
 
             public void RemoveEntityComponent(long entityId)
@@ -99,7 +93,7 @@ namespace Improbable.Gdk.Tests
             public void AddUpdate(ComponentUpdateReceived<Update> update)
             {
                 entitiesUpdated.Add(update.EntityId);
-                updateStorage.Add(update);
+                updateStorage.InsertSorted(update, updateComparer);
             }
 
             public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
@@ -123,7 +117,7 @@ namespace Improbable.Gdk.Tests
                     }
                 }
 
-                authorityChanges.Add(authorityChange);
+                authorityChanges.InsertSorted(authorityChange, authorityComparer);
             }
 
             public List<EntityId> GetComponentsAdded()
@@ -138,26 +132,11 @@ namespace Improbable.Gdk.Tests
 
             public ReceivedMessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
             {
-                // todo consider if this needs to be sorted
-                // possible offer two functions
-                // probably just sort it
-                if (!updatesSorted)
-                {
-                    updatesSorted = true;
-                    updateStorage.Sort(updateComparer);
-                }
-
                 return new ReceivedMessagesSpan<ComponentUpdateReceived<Update>>(updateStorage);
             }
 
             public ReceivedMessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
             {
-                if (!updatesSorted)
-                {
-                    updatesSorted = true;
-                    updateStorage.Sort(updateComparer);
-                }
-
                 var range = updateStorage.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<ComponentUpdateReceived<Update>>(updateStorage, range.FirstIndex,
                     range.Count);
@@ -165,23 +144,11 @@ namespace Improbable.Gdk.Tests
 
             public ReceivedMessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
             {
-                if (!authoritySorted)
-                {
-                    authoritySorted = true;
-                    authorityChanges.Sort(authorityComparer);
-                }
-
                 return new ReceivedMessagesSpan<AuthorityChangeReceived>(authorityChanges);
             }
 
             public ReceivedMessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
             {
-                if (!authoritySorted)
-                {
-                    authoritySorted = true;
-                    authorityChanges.Sort(authorityComparer);
-                }
-
                 var range = authorityChanges.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<AuthorityChangeReceived>(authorityChanges, range.FirstIndex, range.Count);
             }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalUpdateSender.cs
@@ -33,14 +33,13 @@ namespace Improbable.Gdk.Tests
             };
 
             public void SendUpdates(
-                ComponentGroup replicationGroup,
+                NativeArray<ArchetypeChunk> chunkArray,
                 ComponentSystemBase system,
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
                 Profiler.BeginSample("ExhaustiveOptional");
 
-                var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
                 var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ExhaustiveOptional.Component>();
 
@@ -162,7 +161,6 @@ namespace Improbable.Gdk.Tests
                     }
                 }
 
-                chunkArray.Dispose();
                 Profiler.EndSample();
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedComponentDiffStorage.cs
@@ -18,9 +18,6 @@ namespace Improbable.Gdk.Tests
             private List<EntityId> componentsAdded = new List<EntityId>();
             private List<EntityId> componentsRemoved = new List<EntityId>();
 
-            private bool authoritySorted;
-            private bool updatesSorted;
-
             private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
             private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
 
@@ -63,9 +60,6 @@ namespace Improbable.Gdk.Tests
                 authorityChanges.Clear();
                 componentsAdded.Clear();
                 componentsRemoved.Clear();
-
-                authoritySorted = false;
-                updatesSorted = false;
             }
 
             public void RemoveEntityComponent(long entityId)
@@ -99,7 +93,7 @@ namespace Improbable.Gdk.Tests
             public void AddUpdate(ComponentUpdateReceived<Update> update)
             {
                 entitiesUpdated.Add(update.EntityId);
-                updateStorage.Add(update);
+                updateStorage.InsertSorted(update, updateComparer);
             }
 
             public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
@@ -123,7 +117,7 @@ namespace Improbable.Gdk.Tests
                     }
                 }
 
-                authorityChanges.Add(authorityChange);
+                authorityChanges.InsertSorted(authorityChange, authorityComparer);
             }
 
             public List<EntityId> GetComponentsAdded()
@@ -138,26 +132,11 @@ namespace Improbable.Gdk.Tests
 
             public ReceivedMessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
             {
-                // todo consider if this needs to be sorted
-                // possible offer two functions
-                // probably just sort it
-                if (!updatesSorted)
-                {
-                    updatesSorted = true;
-                    updateStorage.Sort(updateComparer);
-                }
-
                 return new ReceivedMessagesSpan<ComponentUpdateReceived<Update>>(updateStorage);
             }
 
             public ReceivedMessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
             {
-                if (!updatesSorted)
-                {
-                    updatesSorted = true;
-                    updateStorage.Sort(updateComparer);
-                }
-
                 var range = updateStorage.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<ComponentUpdateReceived<Update>>(updateStorage, range.FirstIndex,
                     range.Count);
@@ -165,23 +144,11 @@ namespace Improbable.Gdk.Tests
 
             public ReceivedMessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
             {
-                if (!authoritySorted)
-                {
-                    authoritySorted = true;
-                    authorityChanges.Sort(authorityComparer);
-                }
-
                 return new ReceivedMessagesSpan<AuthorityChangeReceived>(authorityChanges);
             }
 
             public ReceivedMessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
             {
-                if (!authoritySorted)
-                {
-                    authoritySorted = true;
-                    authorityChanges.Sort(authorityComparer);
-                }
-
                 var range = authorityChanges.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<AuthorityChangeReceived>(authorityChanges, range.FirstIndex, range.Count);
             }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedUpdateSender.cs
@@ -33,14 +33,13 @@ namespace Improbable.Gdk.Tests
             };
 
             public void SendUpdates(
-                ComponentGroup replicationGroup,
+                NativeArray<ArchetypeChunk> chunkArray,
                 ComponentSystemBase system,
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
                 Profiler.BeginSample("ExhaustiveRepeated");
 
-                var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
                 var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>();
 
@@ -162,7 +161,6 @@ namespace Improbable.Gdk.Tests
                     }
                 }
 
-                chunkArray.Dispose();
                 Profiler.EndSample();
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularComponentDiffStorage.cs
@@ -18,9 +18,6 @@ namespace Improbable.Gdk.Tests
             private List<EntityId> componentsAdded = new List<EntityId>();
             private List<EntityId> componentsRemoved = new List<EntityId>();
 
-            private bool authoritySorted;
-            private bool updatesSorted;
-
             private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
             private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
 
@@ -63,9 +60,6 @@ namespace Improbable.Gdk.Tests
                 authorityChanges.Clear();
                 componentsAdded.Clear();
                 componentsRemoved.Clear();
-
-                authoritySorted = false;
-                updatesSorted = false;
             }
 
             public void RemoveEntityComponent(long entityId)
@@ -99,7 +93,7 @@ namespace Improbable.Gdk.Tests
             public void AddUpdate(ComponentUpdateReceived<Update> update)
             {
                 entitiesUpdated.Add(update.EntityId);
-                updateStorage.Add(update);
+                updateStorage.InsertSorted(update, updateComparer);
             }
 
             public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
@@ -123,7 +117,7 @@ namespace Improbable.Gdk.Tests
                     }
                 }
 
-                authorityChanges.Add(authorityChange);
+                authorityChanges.InsertSorted(authorityChange, authorityComparer);
             }
 
             public List<EntityId> GetComponentsAdded()
@@ -138,26 +132,11 @@ namespace Improbable.Gdk.Tests
 
             public ReceivedMessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
             {
-                // todo consider if this needs to be sorted
-                // possible offer two functions
-                // probably just sort it
-                if (!updatesSorted)
-                {
-                    updatesSorted = true;
-                    updateStorage.Sort(updateComparer);
-                }
-
                 return new ReceivedMessagesSpan<ComponentUpdateReceived<Update>>(updateStorage);
             }
 
             public ReceivedMessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
             {
-                if (!updatesSorted)
-                {
-                    updatesSorted = true;
-                    updateStorage.Sort(updateComparer);
-                }
-
                 var range = updateStorage.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<ComponentUpdateReceived<Update>>(updateStorage, range.FirstIndex,
                     range.Count);
@@ -165,23 +144,11 @@ namespace Improbable.Gdk.Tests
 
             public ReceivedMessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
             {
-                if (!authoritySorted)
-                {
-                    authoritySorted = true;
-                    authorityChanges.Sort(authorityComparer);
-                }
-
                 return new ReceivedMessagesSpan<AuthorityChangeReceived>(authorityChanges);
             }
 
             public ReceivedMessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
             {
-                if (!authoritySorted)
-                {
-                    authoritySorted = true;
-                    authorityChanges.Sort(authorityComparer);
-                }
-
                 var range = authorityChanges.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<AuthorityChangeReceived>(authorityChanges, range.FirstIndex, range.Count);
             }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularUpdateSender.cs
@@ -33,14 +33,13 @@ namespace Improbable.Gdk.Tests
             };
 
             public void SendUpdates(
-                ComponentGroup replicationGroup,
+                NativeArray<ArchetypeChunk> chunkArray,
                 ComponentSystemBase system,
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
                 Profiler.BeginSample("ExhaustiveSingular");
 
-                var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
                 var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ExhaustiveSingular.Component>();
 
@@ -162,7 +161,6 @@ namespace Improbable.Gdk.Tests
                     }
                 }
 
-                chunkArray.Dispose();
                 Profiler.EndSample();
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentComponentDiffStorage.cs
@@ -18,9 +18,6 @@ namespace Improbable.Gdk.Tests
             private List<EntityId> componentsAdded = new List<EntityId>();
             private List<EntityId> componentsRemoved = new List<EntityId>();
 
-            private bool authoritySorted;
-            private bool updatesSorted;
-
             private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
             private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
 
@@ -63,9 +60,6 @@ namespace Improbable.Gdk.Tests
                 authorityChanges.Clear();
                 componentsAdded.Clear();
                 componentsRemoved.Clear();
-
-                authoritySorted = false;
-                updatesSorted = false;
             }
 
             public void RemoveEntityComponent(long entityId)
@@ -99,7 +93,7 @@ namespace Improbable.Gdk.Tests
             public void AddUpdate(ComponentUpdateReceived<Update> update)
             {
                 entitiesUpdated.Add(update.EntityId);
-                updateStorage.Add(update);
+                updateStorage.InsertSorted(update, updateComparer);
             }
 
             public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
@@ -123,7 +117,7 @@ namespace Improbable.Gdk.Tests
                     }
                 }
 
-                authorityChanges.Add(authorityChange);
+                authorityChanges.InsertSorted(authorityChange, authorityComparer);
             }
 
             public List<EntityId> GetComponentsAdded()
@@ -138,26 +132,11 @@ namespace Improbable.Gdk.Tests
 
             public ReceivedMessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
             {
-                // todo consider if this needs to be sorted
-                // possible offer two functions
-                // probably just sort it
-                if (!updatesSorted)
-                {
-                    updatesSorted = true;
-                    updateStorage.Sort(updateComparer);
-                }
-
                 return new ReceivedMessagesSpan<ComponentUpdateReceived<Update>>(updateStorage);
             }
 
             public ReceivedMessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
             {
-                if (!updatesSorted)
-                {
-                    updatesSorted = true;
-                    updateStorage.Sort(updateComparer);
-                }
-
                 var range = updateStorage.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<ComponentUpdateReceived<Update>>(updateStorage, range.FirstIndex,
                     range.Count);
@@ -165,23 +144,11 @@ namespace Improbable.Gdk.Tests
 
             public ReceivedMessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
             {
-                if (!authoritySorted)
-                {
-                    authoritySorted = true;
-                    authorityChanges.Sort(authorityComparer);
-                }
-
                 return new ReceivedMessagesSpan<AuthorityChangeReceived>(authorityChanges);
             }
 
             public ReceivedMessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
             {
-                if (!authoritySorted)
-                {
-                    authoritySorted = true;
-                    authorityChanges.Sort(authorityComparer);
-                }
-
                 var range = authorityChanges.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<AuthorityChangeReceived>(authorityChanges, range.FirstIndex, range.Count);
             }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentUpdateSender.cs
@@ -33,14 +33,13 @@ namespace Improbable.Gdk.Tests
             };
 
             public void SendUpdates(
-                ComponentGroup replicationGroup,
+                NativeArray<ArchetypeChunk> chunkArray,
                 ComponentSystemBase system,
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
                 Profiler.BeginSample("NestedComponent");
 
-                var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
                 var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.NestedComponent.Component>();
 
@@ -77,7 +76,6 @@ namespace Improbable.Gdk.Tests
                     }
                 }
 
-                chunkArray.Dispose();
                 Profiler.EndSample();
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionUpdateSender.cs
@@ -33,14 +33,13 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
             };
 
             public void SendUpdates(
-                ComponentGroup replicationGroup,
+                NativeArray<ArchetypeChunk> chunkArray,
                 ComponentSystemBase system,
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
                 Profiler.BeginSample("Connection");
 
-                var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
                 var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>();
 
@@ -77,7 +76,6 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                     }
                 }
 
-                chunkArray.Dispose();
                 Profiler.EndSample();
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentComponentDiffStorage.cs
@@ -20,9 +20,6 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             private List<EntityId> componentsAdded = new List<EntityId>();
             private List<EntityId> componentsRemoved = new List<EntityId>();
 
-            private bool authoritySorted;
-            private bool updatesSorted;
-
             private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
             private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
 
@@ -44,17 +41,11 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             private MessageList<ComponentEventReceived<FirstEvent.Event>> firstEventEventStorage =
                 new MessageList<ComponentEventReceived<FirstEvent.Event>>();
 
-            // todo consider putting this in the list type
-            private bool firstEventSorted;
-
             private readonly EventComparer<FirstEvent.Event> firstEventComparer =
                 new EventComparer<FirstEvent.Event>();
 
             private MessageList<ComponentEventReceived<SecondEvent.Event>> secondEventEventStorage =
                 new MessageList<ComponentEventReceived<SecondEvent.Event>>();
-
-            // todo consider putting this in the list type
-            private bool secondEventSorted;
 
             private readonly EventComparer<SecondEvent.Event> secondEventComparer =
                 new EventComparer<SecondEvent.Event>();
@@ -86,14 +77,9 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 componentsAdded.Clear();
                 componentsRemoved.Clear();
 
-                authoritySorted = false;
-                updatesSorted = false;
-
                 firstEventEventStorage.Clear();
-                firstEventSorted = false;
 
                 secondEventEventStorage.Clear();
-                secondEventSorted = false;
             }
 
             public void RemoveEntityComponent(long entityId)
@@ -127,7 +113,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             public void AddUpdate(ComponentUpdateReceived<Update> update)
             {
                 entitiesUpdated.Add(update.EntityId);
-                updateStorage.Add(update);
+                updateStorage.InsertSorted(update, updateComparer);
             }
 
             public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
@@ -151,7 +137,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     }
                 }
 
-                authorityChanges.Add(authorityChange);
+                authorityChanges.InsertSorted(authorityChange, authorityComparer);
             }
 
             public List<EntityId> GetComponentsAdded()
@@ -166,26 +152,11 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
             public ReceivedMessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
             {
-                // todo consider if this needs to be sorted
-                // possible offer two functions
-                // probably just sort it
-                if (!updatesSorted)
-                {
-                    updatesSorted = true;
-                    updateStorage.Sort(updateComparer);
-                }
-
                 return new ReceivedMessagesSpan<ComponentUpdateReceived<Update>>(updateStorage);
             }
 
             public ReceivedMessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
             {
-                if (!updatesSorted)
-                {
-                    updatesSorted = true;
-                    updateStorage.Sort(updateComparer);
-                }
-
                 var range = updateStorage.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<ComponentUpdateReceived<Update>>(updateStorage, range.FirstIndex,
                     range.Count);
@@ -193,35 +164,17 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
             public ReceivedMessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
             {
-                if (!authoritySorted)
-                {
-                    authoritySorted = true;
-                    authorityChanges.Sort(authorityComparer);
-                }
-
                 return new ReceivedMessagesSpan<AuthorityChangeReceived>(authorityChanges);
             }
 
             public ReceivedMessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
             {
-                if (!authoritySorted)
-                {
-                    authoritySorted = true;
-                    authorityChanges.Sort(authorityComparer);
-                }
-
                 var range = authorityChanges.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<AuthorityChangeReceived>(authorityChanges, range.FirstIndex, range.Count);
             }
 
             ReceivedMessagesSpan<ComponentEventReceived<FirstEvent.Event>> IDiffEventStorage<FirstEvent.Event>.GetEvents(EntityId entityId)
             {
-                if (!firstEventSorted)
-                {
-                    firstEventEventStorage.Sort(firstEventComparer);
-                    firstEventSorted = true;
-                }
-
                 var range = firstEventEventStorage.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<ComponentEventReceived<FirstEvent.Event>>(
                     firstEventEventStorage, range.FirstIndex, range.Count);
@@ -229,28 +182,16 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
             ReceivedMessagesSpan<ComponentEventReceived<FirstEvent.Event>> IDiffEventStorage<FirstEvent.Event>.GetEvents()
             {
-                if (!firstEventSorted)
-                {
-                    firstEventEventStorage.Sort(firstEventComparer);
-                    firstEventSorted = true;
-                }
-
                 return new ReceivedMessagesSpan<ComponentEventReceived<FirstEvent.Event>>(firstEventEventStorage);
             }
 
             void IDiffEventStorage<FirstEvent.Event>.AddEvent(ComponentEventReceived<FirstEvent.Event> ev)
             {
-                firstEventEventStorage.Add(ev);
+                firstEventEventStorage.InsertSorted(ev, firstEventComparer);
             }
 
             ReceivedMessagesSpan<ComponentEventReceived<SecondEvent.Event>> IDiffEventStorage<SecondEvent.Event>.GetEvents(EntityId entityId)
             {
-                if (!secondEventSorted)
-                {
-                    secondEventEventStorage.Sort(secondEventComparer);
-                    secondEventSorted = true;
-                }
-
                 var range = secondEventEventStorage.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<ComponentEventReceived<SecondEvent.Event>>(
                     secondEventEventStorage, range.FirstIndex, range.Count);
@@ -258,18 +199,12 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
             ReceivedMessagesSpan<ComponentEventReceived<SecondEvent.Event>> IDiffEventStorage<SecondEvent.Event>.GetEvents()
             {
-                if (!secondEventSorted)
-                {
-                    secondEventEventStorage.Sort(secondEventComparer);
-                    secondEventSorted = true;
-                }
-
                 return new ReceivedMessagesSpan<ComponentEventReceived<SecondEvent.Event>>(secondEventEventStorage);
             }
 
             void IDiffEventStorage<SecondEvent.Event>.AddEvent(ComponentEventReceived<SecondEvent.Event> ev)
             {
-                secondEventEventStorage.Add(ev);
+                secondEventEventStorage.InsertSorted(ev, secondEventComparer);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentUpdateSender.cs
@@ -33,14 +33,13 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             };
 
             public void SendUpdates(
-                ComponentGroup replicationGroup,
+                NativeArray<ArchetypeChunk> chunkArray,
                 ComponentSystemBase system,
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
                 Profiler.BeginSample("BlittableComponent");
 
-                var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
                 var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>();
 
@@ -97,7 +96,6 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     }
                 }
 
-                chunkArray.Dispose();
                 Profiler.EndSample();
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsComponentDiffStorage.cs
@@ -18,9 +18,6 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             private List<EntityId> componentsAdded = new List<EntityId>();
             private List<EntityId> componentsRemoved = new List<EntityId>();
 
-            private bool authoritySorted;
-            private bool updatesSorted;
-
             private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
             private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
 
@@ -63,9 +60,6 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 authorityChanges.Clear();
                 componentsAdded.Clear();
                 componentsRemoved.Clear();
-
-                authoritySorted = false;
-                updatesSorted = false;
             }
 
             public void RemoveEntityComponent(long entityId)
@@ -99,7 +93,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             public void AddUpdate(ComponentUpdateReceived<Update> update)
             {
                 entitiesUpdated.Add(update.EntityId);
-                updateStorage.Add(update);
+                updateStorage.InsertSorted(update, updateComparer);
             }
 
             public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
@@ -123,7 +117,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     }
                 }
 
-                authorityChanges.Add(authorityChange);
+                authorityChanges.InsertSorted(authorityChange, authorityComparer);
             }
 
             public List<EntityId> GetComponentsAdded()
@@ -138,26 +132,11 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public ReceivedMessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
             {
-                // todo consider if this needs to be sorted
-                // possible offer two functions
-                // probably just sort it
-                if (!updatesSorted)
-                {
-                    updatesSorted = true;
-                    updateStorage.Sort(updateComparer);
-                }
-
                 return new ReceivedMessagesSpan<ComponentUpdateReceived<Update>>(updateStorage);
             }
 
             public ReceivedMessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
             {
-                if (!updatesSorted)
-                {
-                    updatesSorted = true;
-                    updateStorage.Sort(updateComparer);
-                }
-
                 var range = updateStorage.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<ComponentUpdateReceived<Update>>(updateStorage, range.FirstIndex,
                     range.Count);
@@ -165,23 +144,11 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public ReceivedMessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
             {
-                if (!authoritySorted)
-                {
-                    authoritySorted = true;
-                    authorityChanges.Sort(authorityComparer);
-                }
-
                 return new ReceivedMessagesSpan<AuthorityChangeReceived>(authorityChanges);
             }
 
             public ReceivedMessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
             {
-                if (!authoritySorted)
-                {
-                    authoritySorted = true;
-                    authorityChanges.Sort(authorityComparer);
-                }
-
                 var range = authorityChanges.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<AuthorityChangeReceived>(authorityChanges, range.FirstIndex, range.Count);
             }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsUpdateSender.cs
@@ -33,14 +33,13 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             };
 
             public void SendUpdates(
-                ComponentGroup replicationGroup,
+                NativeArray<ArchetypeChunk> chunkArray,
                 ComponentSystemBase system,
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
                 Profiler.BeginSample("ComponentWithNoFields");
 
-                var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
                 var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>();
 
@@ -72,7 +71,6 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     }
                 }
 
-                chunkArray.Dispose();
                 Profiler.EndSample();
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsComponentDiffStorage.cs
@@ -18,9 +18,6 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             private List<EntityId> componentsAdded = new List<EntityId>();
             private List<EntityId> componentsRemoved = new List<EntityId>();
 
-            private bool authoritySorted;
-            private bool updatesSorted;
-
             private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
             private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
 
@@ -63,9 +60,6 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 authorityChanges.Clear();
                 componentsAdded.Clear();
                 componentsRemoved.Clear();
-
-                authoritySorted = false;
-                updatesSorted = false;
             }
 
             public void RemoveEntityComponent(long entityId)
@@ -99,7 +93,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             public void AddUpdate(ComponentUpdateReceived<Update> update)
             {
                 entitiesUpdated.Add(update.EntityId);
-                updateStorage.Add(update);
+                updateStorage.InsertSorted(update, updateComparer);
             }
 
             public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
@@ -123,7 +117,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     }
                 }
 
-                authorityChanges.Add(authorityChange);
+                authorityChanges.InsertSorted(authorityChange, authorityComparer);
             }
 
             public List<EntityId> GetComponentsAdded()
@@ -138,26 +132,11 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public ReceivedMessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
             {
-                // todo consider if this needs to be sorted
-                // possible offer two functions
-                // probably just sort it
-                if (!updatesSorted)
-                {
-                    updatesSorted = true;
-                    updateStorage.Sort(updateComparer);
-                }
-
                 return new ReceivedMessagesSpan<ComponentUpdateReceived<Update>>(updateStorage);
             }
 
             public ReceivedMessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
             {
-                if (!updatesSorted)
-                {
-                    updatesSorted = true;
-                    updateStorage.Sort(updateComparer);
-                }
-
                 var range = updateStorage.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<ComponentUpdateReceived<Update>>(updateStorage, range.FirstIndex,
                     range.Count);
@@ -165,23 +144,11 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public ReceivedMessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
             {
-                if (!authoritySorted)
-                {
-                    authoritySorted = true;
-                    authorityChanges.Sort(authorityComparer);
-                }
-
                 return new ReceivedMessagesSpan<AuthorityChangeReceived>(authorityChanges);
             }
 
             public ReceivedMessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
             {
-                if (!authoritySorted)
-                {
-                    authoritySorted = true;
-                    authorityChanges.Sort(authorityComparer);
-                }
-
                 var range = authorityChanges.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<AuthorityChangeReceived>(authorityChanges, range.FirstIndex, range.Count);
             }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsUpdateSender.cs
@@ -33,14 +33,13 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             };
 
             public void SendUpdates(
-                ComponentGroup replicationGroup,
+                NativeArray<ArchetypeChunk> chunkArray,
                 ComponentSystemBase system,
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
                 Profiler.BeginSample("ComponentWithNoFieldsWithCommands");
 
-                var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
                 var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>();
 
@@ -72,7 +71,6 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     }
                 }
 
-                chunkArray.Dispose();
                 Profiler.EndSample();
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsUpdateSender.cs
@@ -33,14 +33,13 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             };
 
             public void SendUpdates(
-                ComponentGroup replicationGroup,
+                NativeArray<ArchetypeChunk> chunkArray,
                 ComponentSystemBase system,
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
                 Profiler.BeginSample("ComponentWithNoFieldsWithEvents");
 
-                var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
                 var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>();
 
@@ -72,7 +71,6 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     }
                 }
 
-                chunkArray.Dispose();
                 Profiler.EndSample();
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentComponentDiffStorage.cs
@@ -20,9 +20,6 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             private List<EntityId> componentsAdded = new List<EntityId>();
             private List<EntityId> componentsRemoved = new List<EntityId>();
 
-            private bool authoritySorted;
-            private bool updatesSorted;
-
             private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
             private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
 
@@ -44,17 +41,11 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             private MessageList<ComponentEventReceived<FirstEvent.Event>> firstEventEventStorage =
                 new MessageList<ComponentEventReceived<FirstEvent.Event>>();
 
-            // todo consider putting this in the list type
-            private bool firstEventSorted;
-
             private readonly EventComparer<FirstEvent.Event> firstEventComparer =
                 new EventComparer<FirstEvent.Event>();
 
             private MessageList<ComponentEventReceived<SecondEvent.Event>> secondEventEventStorage =
                 new MessageList<ComponentEventReceived<SecondEvent.Event>>();
-
-            // todo consider putting this in the list type
-            private bool secondEventSorted;
 
             private readonly EventComparer<SecondEvent.Event> secondEventComparer =
                 new EventComparer<SecondEvent.Event>();
@@ -86,14 +77,9 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 componentsAdded.Clear();
                 componentsRemoved.Clear();
 
-                authoritySorted = false;
-                updatesSorted = false;
-
                 firstEventEventStorage.Clear();
-                firstEventSorted = false;
 
                 secondEventEventStorage.Clear();
-                secondEventSorted = false;
             }
 
             public void RemoveEntityComponent(long entityId)
@@ -127,7 +113,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             public void AddUpdate(ComponentUpdateReceived<Update> update)
             {
                 entitiesUpdated.Add(update.EntityId);
-                updateStorage.Add(update);
+                updateStorage.InsertSorted(update, updateComparer);
             }
 
             public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
@@ -151,7 +137,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     }
                 }
 
-                authorityChanges.Add(authorityChange);
+                authorityChanges.InsertSorted(authorityChange, authorityComparer);
             }
 
             public List<EntityId> GetComponentsAdded()
@@ -166,26 +152,11 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
             public ReceivedMessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
             {
-                // todo consider if this needs to be sorted
-                // possible offer two functions
-                // probably just sort it
-                if (!updatesSorted)
-                {
-                    updatesSorted = true;
-                    updateStorage.Sort(updateComparer);
-                }
-
                 return new ReceivedMessagesSpan<ComponentUpdateReceived<Update>>(updateStorage);
             }
 
             public ReceivedMessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
             {
-                if (!updatesSorted)
-                {
-                    updatesSorted = true;
-                    updateStorage.Sort(updateComparer);
-                }
-
                 var range = updateStorage.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<ComponentUpdateReceived<Update>>(updateStorage, range.FirstIndex,
                     range.Count);
@@ -193,35 +164,17 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
             public ReceivedMessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
             {
-                if (!authoritySorted)
-                {
-                    authoritySorted = true;
-                    authorityChanges.Sort(authorityComparer);
-                }
-
                 return new ReceivedMessagesSpan<AuthorityChangeReceived>(authorityChanges);
             }
 
             public ReceivedMessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
             {
-                if (!authoritySorted)
-                {
-                    authoritySorted = true;
-                    authorityChanges.Sort(authorityComparer);
-                }
-
                 var range = authorityChanges.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<AuthorityChangeReceived>(authorityChanges, range.FirstIndex, range.Count);
             }
 
             ReceivedMessagesSpan<ComponentEventReceived<FirstEvent.Event>> IDiffEventStorage<FirstEvent.Event>.GetEvents(EntityId entityId)
             {
-                if (!firstEventSorted)
-                {
-                    firstEventEventStorage.Sort(firstEventComparer);
-                    firstEventSorted = true;
-                }
-
                 var range = firstEventEventStorage.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<ComponentEventReceived<FirstEvent.Event>>(
                     firstEventEventStorage, range.FirstIndex, range.Count);
@@ -229,28 +182,16 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
             ReceivedMessagesSpan<ComponentEventReceived<FirstEvent.Event>> IDiffEventStorage<FirstEvent.Event>.GetEvents()
             {
-                if (!firstEventSorted)
-                {
-                    firstEventEventStorage.Sort(firstEventComparer);
-                    firstEventSorted = true;
-                }
-
                 return new ReceivedMessagesSpan<ComponentEventReceived<FirstEvent.Event>>(firstEventEventStorage);
             }
 
             void IDiffEventStorage<FirstEvent.Event>.AddEvent(ComponentEventReceived<FirstEvent.Event> ev)
             {
-                firstEventEventStorage.Add(ev);
+                firstEventEventStorage.InsertSorted(ev, firstEventComparer);
             }
 
             ReceivedMessagesSpan<ComponentEventReceived<SecondEvent.Event>> IDiffEventStorage<SecondEvent.Event>.GetEvents(EntityId entityId)
             {
-                if (!secondEventSorted)
-                {
-                    secondEventEventStorage.Sort(secondEventComparer);
-                    secondEventSorted = true;
-                }
-
                 var range = secondEventEventStorage.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<ComponentEventReceived<SecondEvent.Event>>(
                     secondEventEventStorage, range.FirstIndex, range.Count);
@@ -258,18 +199,12 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
             ReceivedMessagesSpan<ComponentEventReceived<SecondEvent.Event>> IDiffEventStorage<SecondEvent.Event>.GetEvents()
             {
-                if (!secondEventSorted)
-                {
-                    secondEventEventStorage.Sort(secondEventComparer);
-                    secondEventSorted = true;
-                }
-
                 return new ReceivedMessagesSpan<ComponentEventReceived<SecondEvent.Event>>(secondEventEventStorage);
             }
 
             void IDiffEventStorage<SecondEvent.Event>.AddEvent(ComponentEventReceived<SecondEvent.Event> ev)
             {
-                secondEventEventStorage.Add(ev);
+                secondEventEventStorage.InsertSorted(ev, secondEventComparer);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentUpdateSender.cs
@@ -33,14 +33,13 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             };
 
             public void SendUpdates(
-                ComponentGroup replicationGroup,
+                NativeArray<ArchetypeChunk> chunkArray,
                 ComponentSystemBase system,
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
                 Profiler.BeginSample("NonBlittableComponent");
 
-                var chunkArray = replicationGroup.CreateArchetypeChunkArray(Allocator.TempJob);
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
                 var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>();
 
@@ -117,7 +116,6 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     }
                 }
 
-                chunkArray.Dispose();
                 Profiler.EndSample();
             }
         }

--- a/workers/unity/Packages/com.improbable.gdk.core/Collections/MessageList.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Collections/MessageList.cs
@@ -45,6 +45,40 @@ namespace Improbable.Gdk.Core
             ++Count;
         }
 
+        public void Insert(int index, in T item)
+        {
+            if (items.Length <= Count)
+            {
+                int targetLength = items.Length == 0 ? 4 : items.Length * 2;
+                var temp = new T[targetLength];
+                Array.Copy(items, 0, temp, 0, index);
+                temp[index] = item;
+                Array.Copy(items, index, temp, index + 1, Count - index);
+                items = temp;
+            }
+            else
+            {
+                Array.Copy(items, index, items, index + 1, Count - index);
+                items[index] = item;
+            }
+
+            items[Count] = item;
+            ++Count;
+        }
+
+        public void InsertSorted(in T item, IComparer<T> comparer)
+        {
+            var index = Array.BinarySearch(items, 0, Count, item, comparer);
+            if (index < 0)
+            {
+                Insert(~index, in item);
+            }
+            else
+            {
+                Insert(index, in item);
+            }
+        }
+
         // Similar to the List<> RemoveAll. No return value and the array is not resized down.
         public void RemoveAll(Predicate<T> match)
         {

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ComponentDiffStorageGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ComponentDiffStorageGenerator.tt
@@ -29,9 +29,6 @@ namespace <#= qualifiedNamespace #>
             private List<EntityId> componentsAdded = new List<EntityId>();
             private List<EntityId> componentsRemoved = new List<EntityId>();
 
-            private bool authoritySorted;
-            private bool updatesSorted;
-
             private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
             private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
 
@@ -55,9 +52,6 @@ namespace <#= qualifiedNamespace #>
 
             private MessageList<ComponentEventReceived<<#= eventType #>>> <#= ev.CamelCaseEventName #>EventStorage =
                 new MessageList<ComponentEventReceived<<#= eventType #>>>();
-
-            // todo consider putting this in the list type
-            private bool <#= ev.CamelCaseEventName #>Sorted;
 
             private readonly EventComparer<<#= eventType #>> <#= ev.CamelCaseEventName #>Comparer =
                 new EventComparer<<#= eventType #>>();
@@ -92,13 +86,9 @@ namespace <#= qualifiedNamespace #>
                 authorityChanges.Clear();
                 componentsAdded.Clear();
                 componentsRemoved.Clear();
-
-                authoritySorted = false;
-                updatesSorted = false;
 <# foreach (var ev in eventDetailsList) {#>
 
                 <#= ev.CamelCaseEventName #>EventStorage.Clear();
-                <#= ev.CamelCaseEventName #>Sorted = false;
 <# } #>
             }
 
@@ -133,7 +123,7 @@ namespace <#= qualifiedNamespace #>
             public void AddUpdate(ComponentUpdateReceived<Update> update)
             {
                 entitiesUpdated.Add(update.EntityId);
-                updateStorage.Add(update);
+                updateStorage.InsertSorted(update, updateComparer);
             }
 
             public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
@@ -157,7 +147,7 @@ namespace <#= qualifiedNamespace #>
                     }
                 }
 
-                authorityChanges.Add(authorityChange);
+                authorityChanges.InsertSorted(authorityChange, authorityComparer);
             }
 
             public List<EntityId> GetComponentsAdded()
@@ -172,26 +162,11 @@ namespace <#= qualifiedNamespace #>
 
             public ReceivedMessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
             {
-                // todo consider if this needs to be sorted
-                // possible offer two functions
-                // probably just sort it
-                if (!updatesSorted)
-                {
-                    updatesSorted = true;
-                    updateStorage.Sort(updateComparer);
-                }
-
                 return new ReceivedMessagesSpan<ComponentUpdateReceived<Update>>(updateStorage);
             }
 
             public ReceivedMessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
             {
-                if (!updatesSorted)
-                {
-                    updatesSorted = true;
-                    updateStorage.Sort(updateComparer);
-                }
-
                 var range = updateStorage.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<ComponentUpdateReceived<Update>>(updateStorage, range.FirstIndex,
                     range.Count);
@@ -199,23 +174,11 @@ namespace <#= qualifiedNamespace #>
 
             public ReceivedMessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
             {
-                if (!authoritySorted)
-                {
-                    authoritySorted = true;
-                    authorityChanges.Sort(authorityComparer);
-                }
-
                 return new ReceivedMessagesSpan<AuthorityChangeReceived>(authorityChanges);
             }
 
             public ReceivedMessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
             {
-                if (!authoritySorted)
-                {
-                    authoritySorted = true;
-                    authorityChanges.Sort(authorityComparer);
-                }
-
                 var range = authorityChanges.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<AuthorityChangeReceived>(authorityChanges, range.FirstIndex, range.Count);
             }
@@ -225,12 +188,6 @@ namespace <#= qualifiedNamespace #>
 
             ReceivedMessagesSpan<ComponentEventReceived<<#= eventType #>>> IDiffEventStorage<<#= eventType #>>.GetEvents(EntityId entityId)
             {
-                if (!<#= ev.CamelCaseEventName #>Sorted)
-                {
-                    <#= ev.CamelCaseEventName #>EventStorage.Sort(<#= ev.CamelCaseEventName #>Comparer);
-                    <#= ev.CamelCaseEventName #>Sorted = true;
-                }
-
                 var range = <#= ev.CamelCaseEventName #>EventStorage.GetEntityRange(entityId);
                 return new ReceivedMessagesSpan<ComponentEventReceived<<#= eventType #>>>(
                     <#= ev.CamelCaseEventName #>EventStorage, range.FirstIndex, range.Count);
@@ -238,18 +195,12 @@ namespace <#= qualifiedNamespace #>
 
             ReceivedMessagesSpan<ComponentEventReceived<<#= eventType #>>> IDiffEventStorage<<#= eventType #>>.GetEvents()
             {
-                if (!<#= ev.CamelCaseEventName #>Sorted)
-                {
-                    <#= ev.CamelCaseEventName #>EventStorage.Sort(<#= ev.CamelCaseEventName #>Comparer);
-                    <#= ev.CamelCaseEventName #>Sorted = true;
-                }
-
                 return new ReceivedMessagesSpan<ComponentEventReceived<<#= eventType #>>>(<#= ev.CamelCaseEventName #>EventStorage);
             }
 
             void IDiffEventStorage<<#= eventType #>>.AddEvent(ComponentEventReceived<<#= eventType #>> ev)
             {
-                <#= ev.CamelCaseEventName #>EventStorage.Add(ev);
+                <#= ev.CamelCaseEventName #>EventStorage.InsertSorted(ev, <#= ev.CamelCaseEventName #>Comparer);
             }
 <# } #>
         }


### PR DESCRIPTION
#### Description
Change lists are now created sorted rather than doing this lazily. Configuration should be added to specify what to do on a component basis.

This is not optimised an any way but it can be offloaded onto a deserialisation thread as is.