### PR TITLE
Removed use of the EntityManager from updating ecs components

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityEcsViewManagerGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityEcsViewManagerGenerator.tt
@@ -50,9 +50,10 @@ namespace <#= qualifiedNamespace #>
                 }
 
                 var updates = diffStorage.GetUpdates();
+                var dataFromEntity = workerSystem.GetComponentDataFromEntity<Component>();
                 for (int i = 0; i < updates.Count; ++i)
                 {
-                    ApplyUpdate(in updates[i]);
+                    ApplyUpdate(in updates[i], dataFromEntity);
                 }
 
                 var authChanges = diffStorage.GetAuthorityChanges();
@@ -123,15 +124,15 @@ namespace <#= qualifiedNamespace #>
                 entityManager.RemoveComponent<<#= componentNamespace #>.Component>(entity);
             }
 
-            private void ApplyUpdate(in ComponentUpdateReceived<Update> update)
+            private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)
             {
                 workerSystem.TryGetEntity(update.EntityId, out var entity);
-                if (!entityManager.HasComponent<<#= componentNamespace #>.Component>(entity))
+                if (!dataFromEntity.Exists(entity))
                 {
                     return;
                 }
 
-                var data = entityManager.GetComponentData<<#= componentNamespace #>.Component>(entity);
+                var data = dataFromEntity[entity];
 <# foreach(var fieldDetails in fieldDetailsList) { #>
 
                 if (update.Update.<#= fieldDetails.PascalCaseName #>.HasValue)
@@ -141,7 +142,7 @@ namespace <#= qualifiedNamespace #>
 <# } #>
 
                 data.MarkDataClean();
-                entityManager.SetComponentData(entity, data);
+                dataFromEntity[entity] = data;
             }
 
             private void SetAuthority(EntityId entityId, Authority authority)


### PR DESCRIPTION
#### Description
We used to use the entity manager. Not the best API as it creates an expensive barrier. This is a fair bit more efficient, although it could be broken by a job running at the same time as it.