### PR TITLE
Add generate api docs script

### DIFF
--- a/ci/generate-docs.sh
+++ b/ci/generate-docs.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -e -u -x -o pipefail
+
+if [ ! "$#" -eq 1 ]; then
+    echo "Expected usage: generate-docs.sh <git_hash>"
+    exit 1
+fi
+
+TAG="${1}"
+
+function cleanUp() {
+    # Ensure we are not in the temp dir before cleaning it
+    cd "${CURRENT_DIR}"
+    if [[ -n "${TMP_DIR-}" ]]; then
+        rm -rf "${TMP_DIR}"
+    fi
+}
+
+trap cleanUp EXIT
+
+cd "$(dirname "$0")/../"
+
+ci/bootstrap.sh
+
+# TODO: Remove when merged or moved to other repo.
+pushd .shared-ci
+    git checkout feature/api-docs-generator
+popd
+
+# Make a copy of this repo and the docs repo.
+CLONE_URL="git@github.com:spatialos/gdk-for-unity.git"
+
+CURRENT_DIR=$(pwd)
+TMP_DIR=$(mktemp -d)
+CODE_DIR="${TMP_DIR}/code"
+DOCS_DIR="${TMP_DIR}/docs"
+
+# Clone and checkout correct code tag.
+git clone "${CLONE_URL}" "${CODE_DIR}"
+pushd "${CODE_DIR}"
+    git checkout "${TAG}"
+popd
+
+# Clone and create branch for docs
+DOCS_BRANCH="docs/api-docs-${TAG}"
+git clone "${CLONE_URL}" "${DOCS_DIR}"
+pushd "${DOCS_DIR}"
+    git checkout docs/improbadoc-conversion
+    git checkout -b "${DOCS_BRANCH}"
+popd
+
+# Generate API docs
+dotnet run -p .shared-ci/tools/Docgen/Docgen.csproj -- \
+    --target-directory="${CODE_DIR}/workers/unity/Packages/" \
+    --target-namespace="Improbable.Gdk" \
+    --output-directory="${DOCS_DIR}/docs/api" \
+    --namespace-filter=".*EditmodeTests" \
+    --namespace-filter=".*PlaymodeTests" \
+    --api-path="api" \
+    --git-tag="${TAG}"
+
+# Commit and push
+pushd "${DOCS_DIR}"
+    git add --all
+    git commit -m 'api docs'
+    git push origin "${DOCS_BRANCH}"
+popd
+
+# If the hub CLI is on the command line, open a PR automatically.
+if [ -x "$(command -v hub)" ]; then
+    hub pull-request -b spatialos/gdk-for-unity:docs/improbadoc-conversion -h "spatialos/gdk-for-unity:${DOCS_BRANCH}" -o -m "API docs update for ${TAG}"
+fi

--- a/ci/generate-docs.sh
+++ b/ci/generate-docs.sh
@@ -47,6 +47,10 @@ DOCS_BRANCH="docs/api-docs-${TAG}"
 git clone "${CLONE_URL}" "${DOCS_DIR}"
 pushd "${DOCS_DIR}"
     git checkout docs/improbadoc-conversion
+    if [ -n $(git show-ref origin/${DOCS_BRANCH}) ]; then
+        echo "Docs branch ${DOCS_BRANCH} already exists"
+        exit 1
+    fi
     git checkout -b "${DOCS_BRANCH}"
 popd
 

--- a/ci/generate-docs.sh
+++ b/ci/generate-docs.sh
@@ -21,20 +21,18 @@ trap cleanUp EXIT
 
 cd "$(dirname "$0")/../"
 
-ci/bootstrap.sh
-
-# TODO: Remove when merged or moved to other repo.
-pushd .shared-ci
-    git checkout feature/api-docs-generator
-popd
-
 # Make a copy of this repo and the docs repo.
 CLONE_URL="git@github.com:spatialos/gdk-for-unity.git"
+DOCGEN_CLONE_URL="git@github.com:improbable/gdk-for-unity-docgen.git"
 
 CURRENT_DIR=$(pwd)
 TMP_DIR=$(mktemp -d)
+DOCGEN_DIR="${TMP_DIR}/docgen"
 CODE_DIR="${TMP_DIR}/code"
 DOCS_DIR="${TMP_DIR}/docs"
+
+# Clone docgen repo.
+git clone "${DOCGEN_CLONE_URL}" "${DOCGEN_DIR}"
 
 # Clone and checkout correct code tag.
 git clone "${CLONE_URL}" "${CODE_DIR}"
@@ -47,7 +45,7 @@ DOCS_BRANCH="docs/api-docs-${TAG}"
 git clone "${CLONE_URL}" "${DOCS_DIR}"
 pushd "${DOCS_DIR}"
     git checkout docs/improbadoc-conversion
-    if [ -n $(git show-ref origin/${DOCS_BRANCH}) ]; then
+    if [ -n "$(git show-ref origin/${DOCS_BRANCH})" ]; then
         echo "Docs branch ${DOCS_BRANCH} already exists"
         exit 1
     fi
@@ -55,7 +53,7 @@ pushd "${DOCS_DIR}"
 popd
 
 # Generate API docs
-dotnet run -p .shared-ci/tools/Docgen/Docgen.csproj -- \
+dotnet run -p "${DOCGEN_DIR}/Docgen/Docgen.csproj" -- \
     --target-directory="${CODE_DIR}/workers/unity/Packages/" \
     --target-namespace="Improbable.Gdk" \
     --output-directory="${DOCS_DIR}/docs/api" \


### PR DESCRIPTION
#### Description
Adds a script to:

1. Generate API docs from a git tag/branch/commit-hash
2. Make a branch, commit, and push the docs changes.
3. If `hub` is on your path, it will automatically create the PR and open it in your browser.

#### Tests
Tested - gave me #825 🎉 

#### Documentation
N/A - internal docs only

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
