### PR TITLE
Remove serialization helpers from code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,6 @@
 - Added constructors for all generated component snapshot types.
 - Added the ability to send arbitrary serialized data in a player creation request.
     - Replaced `Vector3f` position in `CreatePlayerRequestType` with a `bytes` field for sending arbitrary serialized data.
-    - Added `SerializeArguments` and `DeserializeArguments<T>` methods to `PlayerLifecycleHelper`.
 - Added `RequestPlayerCreation` to manually request for player creation in `SendCreatePlayerRequestSystem`.
 - Added a menu item, navigate to **SpatialOS** > **Generate Dev Authentication Token**, to generate a TextAsset containing the [Development Authentication Token](https://docs.improbable.io/reference/latest/shared/auth/development-authentication).
 - Added the ability to mark a build target as `Required` which will cause builds to fail in the Editor if the prerequisite build support is not installed.

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/PlayerLifecycleHelper.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/PlayerLifecycleHelper.cs
@@ -23,27 +23,6 @@ namespace Improbable.Gdk.PlayerLifecycle
             template.AddComponent(owningComponent, serverAccess);
         }
 
-        public static byte[] SerializeArguments(object playerCreationArguments)
-        {
-            using (var memoryStream = new MemoryStream())
-            {
-                var binaryFormatter = new BinaryFormatter();
-                binaryFormatter.Serialize(memoryStream, playerCreationArguments);
-                return memoryStream.ToArray();
-            }
-        }
-
-        public static T DeserializeArguments<T>(byte[] serializedArguments)
-        {
-            using (var memoryStream = new MemoryStream())
-            {
-                var binaryFormatter = new BinaryFormatter();
-                memoryStream.Write(serializedArguments, 0, serializedArguments.Length);
-                memoryStream.Seek(0, SeekOrigin.Begin);
-                return (T) binaryFormatter.Deserialize(memoryStream);
-            }
-        }
-
         public static bool IsOwningWorker(SpatialEntityId entityId, World workerWorld)
         {
             var entityManager = workerWorld.GetOrCreateManager<EntityManager>();


### PR DESCRIPTION
#### Description
Removing the serialization helpers in the `PlayerLifecycleHelper` class - to be provided as sample code in the docs instead

#### Tests
playground + CI

#### Documentation
to be doc'd in this PR: https://github.com/spatialos/gdk-for-unity/pull/820/files

**Did you remember a changelog entry?**
yes, updated changelog

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
