### PR TITLE
Tooling PackageManager refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+- Tools package now uses PackageManager API instead of parsing manifest.json
+
 ## `0.2.0` - 2019-03-18
 
 ### Breaking Changes

--- a/workers/unity/Packages/com.improbable.gdk.tools/Common.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/Common.cs
@@ -67,20 +67,21 @@ namespace Improbable.Gdk.Tools
         public static string GetPackagePath(string packageName)
         {
             // Get package info
-            var request = Client.Search(packageName);
+            var request = Client.List(true);
             while (!request.IsCompleted)
             {
                 // Wait for the request to complete
             }
 
             var result = request.Result;
+            var package = result.FirstOrDefault(info => info.name.Equals(packageName));
 
-            if (request.Status != StatusCode.Success || result.Length <= 0)
+            if (package == null)
             {
-                throw new Exception($"Count not find '{packageName}', is it in your projects' manifest?");
+                throw new Exception($"Count not find '{packageName}', is it in your projects' manifest?\n{request.Error.message}");
             }
 
-            return result[0].resolvedPath;
+            return package.resolvedPath;
         }
 
         /// <summary>

--- a/workers/unity/Packages/com.improbable.gdk.tools/Common.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/Common.cs
@@ -67,18 +67,17 @@ namespace Improbable.Gdk.Tools
         public static string GetPackagePath(string packageName)
         {
             // Get package info
-            var request = Client.List(true);
+            var request = Client.List(offlineMode: true);
             while (!request.IsCompleted)
             {
                 // Wait for the request to complete
             }
 
-            var result = request.Result;
-            var package = result.FirstOrDefault(info => info.name.Equals(packageName));
+            var package = request.Result.FirstOrDefault(info => info.name.Equals(packageName));
 
             if (package == null)
             {
-                throw new Exception($"Count not find '{packageName}', is it in your project's manifest?\n{request.Error.message}");
+                throw new Exception($"Could not find '{packageName}', is it in your project's manifest?\n{request.Error.message}");
             }
 
             return package.resolvedPath;

--- a/workers/unity/Packages/com.improbable.gdk.tools/Common.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/Common.cs
@@ -78,36 +78,10 @@ namespace Improbable.Gdk.Tools
 
             if (package == null)
             {
-                throw new Exception($"Count not find '{packageName}', is it in your projects' manifest?\n{request.Error.message}");
+                throw new Exception($"Count not find '{packageName}', is it in your project's manifest?\n{request.Error.message}");
             }
 
             return package.resolvedPath;
-        }
-
-        /// <summary>
-        ///     Parses a json file and returns the dependencies found in it.
-        /// </summary>
-        /// <param name="filePath">Path to the json file to be parsed.</param>
-        /// <returns>The dependencies in the given json file.</returns>
-        internal static Dictionary<string, string> ParseDependencies(string filePath)
-        {
-            try
-            {
-                var package = Json.Deserialize(File.ReadAllText(filePath, Encoding.UTF8));
-                if (!package.TryGetValue("dependencies", out var dependenciesJson))
-                {
-                    return new Dictionary<string, string>();
-                }
-
-                return ((Dictionary<string, object>) dependenciesJson).ToDictionary(kv => kv.Key,
-                    kv => (string) kv.Value);
-            }
-            catch (Exception e)
-            {
-                var errorMessage = $"Failed to parse dependencies: {e.Message}";
-                Debug.LogError(errorMessage);
-                throw new ArgumentException(errorMessage);
-            }
         }
 
         /// <summary>
@@ -115,9 +89,9 @@ namespace Improbable.Gdk.Tools
         ///     On MacOS, also looks in `/usr/local/bin` because applications launched from the Finder
         ///     don't always have that in the PATH provided to them.
         /// </summary>
-        /// <param name="binarybaseName">The base name of the binary to find (without an extension).</param>
+        /// <param name="binaryBaseName">The base name of the binary to find (without an extension).</param>
         /// <returns></returns>
-        private static string DiscoverLocation(string binarybaseName)
+        private static string DiscoverLocation(string binaryBaseName)
         {
             var pathValue = Environment.GetEnvironmentVariable("PATH");
             if (pathValue == null)
@@ -128,9 +102,9 @@ namespace Improbable.Gdk.Tools
 
             if (Application.platform == RuntimePlatform.WindowsEditor)
             {
-                binarybaseName = Path.ChangeExtension(binarybaseName, ".exe");
+                binaryBaseName = Path.ChangeExtension(binaryBaseName, ".exe");
 
-                if (binarybaseName == null)
+                if (binaryBaseName == null)
                 {
                     return string.Empty;
                 }
@@ -144,18 +118,18 @@ namespace Improbable.Gdk.Tools
                 {
                     if (!splitPath.Contains(macPath))
                     {
-                        splitPath = splitPath.Union(new[] { macPath, Path.Combine(macPath, binarybaseName) }).ToArray();
+                        splitPath = splitPath.Union(new[] { macPath, Path.Combine(macPath, binaryBaseName) }).ToArray();
                     }
                 }
             }
 
-            var location = splitPath.Select(p => Path.Combine(p, binarybaseName)).FirstOrDefault(File.Exists);
+            var location = splitPath.Select(p => Path.Combine(p, binaryBaseName)).FirstOrDefault(File.Exists);
             if (location != null)
             {
                 return location;
             }
 
-            Debug.LogError($"Could not discover location for {binarybaseName}");
+            Debug.LogError($"Could not discover location for {binaryBaseName}");
             return string.Empty;
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
@@ -229,14 +229,13 @@ namespace Improbable.Gdk.Tools
                 CleanDestination(schemaRoot);
 
                 // Get all packages we depend on
-                var request = Client.List(true);
+                var request = Client.List(offlineMode: true);
                 while (!request.IsCompleted)
                 {
                     // Wait for the request to complete
                 }
 
-                var packages = request.Result;
-                var schemaSources = packages.ToDictionary(package => package.name,
+                var schemaSources = request.Result.ToDictionary(package => package.name,
                         package => Path.Combine(package.resolvedPath, "Schema"))
                     .Where(kv => Directory.Exists(kv.Value));
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
@@ -257,7 +257,8 @@ namespace Improbable.Gdk.Tools
             var files = Directory.GetFiles(packageSchemaPath, "*.schema", SearchOption.AllDirectories);
             foreach (var file in files)
             {
-                var relativeFilePath = file.Replace(packageSchemaPath, string.Empty).TrimStart(Path.DirectorySeparatorChar);
+                var relativeFilePath =
+                    file.Replace(packageSchemaPath, string.Empty).TrimStart(Path.DirectorySeparatorChar);
                 var fileCopy = Path.Combine(schemaRoot, FromGdkPackagesDir, packageName, relativeFilePath);
 
                 var directoryName = Path.GetDirectoryName(fileCopy);
@@ -269,7 +270,15 @@ namespace Improbable.Gdk.Tools
                     }
                 }
 
-                File.WriteAllText(fileCopy, SchemaWarningMessage + File.ReadAllText(file));
+                using (var output = File.OpenWrite(fileCopy))
+                using (var outputText = new StreamWriter(output))
+                {
+                    outputText.Write(SchemaWarningMessage);
+                    using (var inputText = File.OpenRead(file))
+                    {
+                        inputText.CopyTo(outputText.BaseStream);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
#### Description
Refactored the Tooling package to no longer have a hardcoded dependency on `file:` paths in the manifest.
This allows support for published unity packages in the future.

#### Tests
New approach works with playground, test project, and fps

#### Documentation
No - Internal tooling change
