### PR TITLE
Redirected process changes required for deployment launcher fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     - `InterestTemplate` provides functionality to ergonomically add, replace and clear queries from an Interest component.
     - `InterestQuery` reduces boilerplate code required to construct interest queries.
     - `Constraint` contains static methods to easily create constraints for an interest query.
+- Added a `WithTimeout(TimeSpan timeout)` method to the `RedirectedProcess` class. This allows you to set a timeout for the underlying process execution.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
     - `InterestQuery` reduces boilerplate code required to construct interest queries.
     - `Constraint` contains static methods to easily create constraints for an interest query.
 - Added a `WithTimeout(TimeSpan timeout)` method to the `RedirectedProcess` class. This allows you to set a timeout for the underlying process execution.
+- Added a `Improbable.Gdk.Core.Collections.Result<T, E>` struct to represent a result which can either contain a value `T` or an error `E`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,12 @@
 
 - The player lifecycle module now dynamically queries for PlayerCreator entities, and sends requests to a random one each time. This removes the reliance on a hardcoded PlayerCreator Entity ID.
 - Removed the `Type` suffix from player lifecycle schema types.
+- `RedirectedProcess.RunAsync()` now takes a `CancellationToken?` as a parameter. This token can be used to cancel the underlying process.
 
 ### Fixed
 
 - Fixed an issue where player creation requests could retry infinitely without logging failure.
+- Fixed an issue where if you called `RedirectedProcess.Command(...)` in a non-main thread, it would throw an exception.
 
 ### Internal
 

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
@@ -274,6 +274,7 @@ namespace Improbable.Gdk.BuildSystem
             using (new ShowProgressBarScope($"Package {basePath}"))
             {
                 RedirectedProcess.Command(Common.SpatialBinary)
+                    .InDirectory(Path.GetFullPath(Path.Combine(Application.dataPath, "..")))
                     .WithArgs("file", "zip", $"--output=\"{Path.GetFullPath(zipAbsolutePath)}\"",
                         $"--basePath=\"{Path.GetFullPath(basePath)}\"", "\"**\"",
                         $"--compression={useCompression}")

--- a/workers/unity/Packages/com.improbable.gdk.core/Collections/Result.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Collections/Result.cs
@@ -1,0 +1,85 @@
+using System;
+
+namespace Improbable.Gdk.Core.Collections
+{
+    /// <summary>
+    ///     A type to represent a result. Can either have a success value or an error, but not both.
+    /// </summary>
+    /// <typeparam name="T">The type of the success value.</typeparam>
+    /// <typeparam name="E">The type of the error.</typeparam>
+    public struct Result<T, E>
+    {
+        private T okValue;
+        private E errorValue;
+
+        private bool isOkay;
+
+        /// <summary>
+        ///     True if the result contains a success, false otherwise.
+        /// </summary>
+        public bool IsOkay => isOkay;
+
+        /// <summary>
+        ///     True if the result contains an error, false otherwise.
+        /// </summary>
+        public bool IsError => !isOkay;
+
+        /// <summary>
+        ///     Creates a result which contains a success value.
+        /// </summary>
+        /// <param name="value">The value of the result.</param>
+        /// <returns>The result object.</returns>
+        public static Result<T, E> Ok(T value)
+        {
+            return new Result<T, E>
+            {
+                okValue = value,
+                isOkay = true
+            };
+        }
+
+        /// <summary>
+        ///     Creates a result which contains an error.
+        /// </summary>
+        /// <param name="error">The value of the error.</param>
+        /// <returns>The result object.</returns>
+        public static Result<T, E> Error(E error)
+        {
+            return new Result<T, E>
+            {
+                errorValue = error,
+                isOkay = false
+            };
+        }
+
+        /// <summary>
+        ///     Attempts to get the success value from the result.
+        /// </summary>
+        /// <returns>The success value of the result.</returns>
+        /// <exception cref="InvalidOperationException">Thrown if the result contains an error.</exception>
+        public T Unwrap()
+        {
+            if (!isOkay)
+            {
+                throw new InvalidOperationException("Cannot unwrap a result value which has an error.");
+            }
+
+            return okValue;
+        }
+
+        /// <summary>
+        ///     Attempts to get the error from the result.
+        /// </summary>
+        /// <returns>The error from the result.</returns>
+        /// <exception cref="InvalidOperationException">Thrown if result contains a success value.</exception>
+        public E UnwrapError()
+        {
+            if (isOkay)
+            {
+                throw new InvalidOperationException("Cannot unwrap a result error which has a value.");
+            }
+
+            return errorValue;
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Collections/Result.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Collections/Result.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 926889da477d7644284bf39c8a363ce0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
@@ -39,14 +39,18 @@ namespace Improbable.Gdk.Mobile
                 }
 
                 // Ensure an android device/emulator is present
-                if (RedirectedProcess.Command(adbPath).WithArgs("get-state").Run() != 0)
+                if (RedirectedProcess.Command(adbPath)
+                    .InDirectory(Path.GetFullPath(Path.Combine(Application.dataPath, "..")))
+                    .WithArgs("get-state").Run() != 0)
                 {
                     Debug.LogError("No Android device/emulator detected.");
                     return;
                 }
 
                 // Install apk on connected phone / emulator
-                if (RedirectedProcess.Command(adbPath).WithArgs("install", "-r", $"\"{apkPath}\"").Run() != 0)
+                if (RedirectedProcess.Command(adbPath)
+                    .InDirectory(Path.GetFullPath(Path.Combine(Application.dataPath, "..")))
+                    .WithArgs("install", "-r", $"\"{apkPath}\"").Run() != 0)
                 {
                     Debug.LogError("Failed to install the apk on the device/emulator. If the application is already installed on your device/emulator, " +
                         "try uninstalling it before launching the mobile client.");
@@ -69,6 +73,7 @@ namespace Improbable.Gdk.Mobile
                 RedirectedProcess.Command(adbPath)
                     .WithArgs("shell", "am", "start", "-S", "-n", $"{bundleId}/com.unity3d.player.UnityPlayerActivity",
                         "-e", "\"arguments\"", $"\\\"{arguments.ToString()}\\\"")
+                    .InDirectory(Path.GetFullPath(Path.Combine(Application.dataPath, "..")))
                     .Run();
 
                 EditorUtility.DisplayProgressBar("Launching Mobile Client", "Done", 1.0f);

--- a/workers/unity/Packages/com.improbable.gdk.tools/DownloadCoreSdk.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/DownloadCoreSdk.cs
@@ -130,7 +130,10 @@ namespace Improbable.Gdk.Tools
 
                 using (new ShowProgressBarScope($"Installing SpatialOS libraries, version {Common.CoreSdkVersion}..."))
                 {
-                    exitCode = RedirectedProcess.Command(Common.DotNetBinary).WithArgs(ConstructArguments()).Run();
+                    exitCode = RedirectedProcess.Command(Common.DotNetBinary)
+                        .InDirectory(Path.GetFullPath(Path.Combine(Application.dataPath, "..")))
+                        .WithArgs(ConstructArguments())
+                        .Run();
                     if (exitCode != 0)
                     {
                         Debug.LogError($"Failed to download SpatialOS Core Sdk version {Common.CoreSdkVersion}. You can use SpatialOS -> Download CoreSDK (force) to retry this.");

--- a/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
@@ -105,7 +105,10 @@ namespace Improbable.Gdk.Tools
                     case RuntimePlatform.LinuxEditor:
                     case RuntimePlatform.OSXEditor:
                         // Ensure the schema compiler is executable.
-                        var _ = RedirectedProcess.Command("chmod").WithArgs("+x", $"\"{schemaCompilerPath}\"").Run();
+                        var _ = RedirectedProcess.Command("chmod")
+                            .WithArgs("+x", $"\"{schemaCompilerPath}\"")
+                            .InDirectory(Path.GetFullPath(Path.Combine(Application.dataPath, "..")))
+                            .Run();
                         break;
                     default:
                         throw new PlatformNotSupportedException(

--- a/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
@@ -104,8 +104,7 @@ namespace Improbable.Gdk.Tools
                         break;
                     case RuntimePlatform.LinuxEditor:
                     case RuntimePlatform.OSXEditor:
-                        // Ensure the schema compiler is executable.
-                        var _ = RedirectedProcess.Command("chmod")
+                        RedirectedProcess.Command("chmod")
                             .WithArgs("+x", $"\"{schemaCompilerPath}\"")
                             .InDirectory(Path.GetFullPath(Path.Combine(Application.dataPath, "..")))
                             .Run();

--- a/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs
@@ -93,6 +93,10 @@ namespace Improbable.Gdk.Tools
         /// <summary>
         ///     Adds custom processing for regular output of process.
         /// </summary>
+        /// <remarks>
+        ///     The <see cref="outputProcessor"/> callback will be ran on a different thread to the one which
+        ///     registered it.
+        /// </remarks>
         /// <param name="outputProcessor">Processing action for regular output.</param>
         public RedirectedProcess AddOutputProcessing(Action<string> outputProcessor)
         {
@@ -103,6 +107,10 @@ namespace Improbable.Gdk.Tools
         /// <summary>
         ///     Adds custom processing for error output of process.
         /// </summary>
+        /// <remarks>
+        ///     The <see cref="errorProcessor"/> callback will be ran on a different thread to the one which
+        ///     registered it.
+        /// </remarks>
         /// <param name="errorProcessor">Processing action for error output.</param>
         public RedirectedProcess AddErrorProcessing(Action<string> errorProcessor)
         {

--- a/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs
@@ -132,7 +132,7 @@ namespace Improbable.Gdk.Tools
         /// <summary>
         ///     Adds a timeout to the process execution. The process will be killed if the timeout expires.
         /// </summary>
-        /// <param name="timeoutSecs">The timeout in seconds.</param>
+        /// <param name="timeout">The timeout for the process execution.</param>
         public RedirectedProcess WithTimeout(TimeSpan timeout)
         {
             this.timeout = timeout;

--- a/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs
@@ -162,6 +162,7 @@ namespace Improbable.Gdk.Tools
         /// <summary>
         ///     Runs the redirected process and returns a task which can be waited on.
         /// </summary>
+        /// <param name="token">A cancellation token which can be used for cancelling the underlying process. Default is null.</param>
         /// <returns>A task which would return the exit code and output.</returns>
         public Task<RedirectedProcessResult> RunAsync(CancellationToken? token = null)
         {
@@ -225,7 +226,7 @@ namespace Improbable.Gdk.Tools
                             return;
                         }
 
-                        Task.Delay(1, token);
+                        Task.Delay(500, token);
                     }
                 }, token);
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs
@@ -137,6 +137,7 @@ namespace Improbable.Gdk.Tools
 
             using (process)
             {
+                Start(process);
                 process.WaitForExit();
 
                 var trimmedOutput = outputLog?.ToString().TrimStart();


### PR DESCRIPTION
#### Description
* Refactor `RedirectedProcess` to support running async with a cancellation token.
* Also fixed a bug where if you invoked `RedirectedProcess.Command()` on a non-main thread Unity would throw an exception.

#### Tests
Ran things. It seemed to work just fine.

#### Documentation
Needs release note.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
