### PR TITLE
API docs update for f54d7cdc

### DIFF
--- a/docs/api/.toc/toc.md
+++ b/docs/api/.toc/toc.md
@@ -155,6 +155,10 @@
         - <a href="{{urlRoot}}/api/player-lifecycle/player-lifecycle-helper">PlayerLifecycleHelper</a>
         - <a href="{{urlRoot}}/api/player-lifecycle/send-create-player-request-system">SendCreatePlayerRequestSystem</a>
         - <a href="{{urlRoot}}/api/player-lifecycle/send-player-heartbeat-request-system">SendPlayerHeartbeatRequestSystem</a>
+    - [QueryBasedInterest]({{urlRoot}}/api/query-based-interest-index)
+        - <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a>
+        - <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a>
+        - <a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a>
     - [ReactiveComponents]({{urlRoot}}/api/reactive-components-index)
         - <a href="{{urlRoot}}/api/reactive-components/abstract-acknowledge-authority-loss-handler">AbstractAcknowledgeAuthorityLossHandler</a>
         - <a href="{{urlRoot}}/api/reactive-components/acknowledge-authority-loss-system">AcknowledgeAuthorityLossSystem</a>

--- a/docs/api/build-system/configuration/build-environment.md
+++ b/docs/api/build-system/configuration/build-environment.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/build-system-index">BuildSystem</a>.<a href="{{urlRoot}}/api/build-system/configuration-index">Configuration</a><br/>
 GDK package: BuildSystem<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.buildsystem/Configuration/BuildEnvironment.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.buildsystem/Configuration/BuildEnvironment.cs/#L6">Source</a>
 </sup>
 
 </p>

--- a/docs/api/build-system/editor-paths.md
+++ b/docs/api/build-system/editor-paths.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/build-system-index">BuildSystem</a><br/>
 GDK package: BuildSystem<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/EditorPaths.cs/#L12">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/EditorPaths.cs/#L12">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>BuildScratchDirectory</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/EditorPaths.cs/#L14">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/EditorPaths.cs/#L14">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -62,7 +62,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AssetDatabaseDirectory</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/EditorPaths.cs/#L17">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/EditorPaths.cs/#L17">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/build-system/worker-builder.md
+++ b/docs/api/build-system/worker-builder.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/build-system-index">BuildSystem</a><br/>
 GDK package: BuildSystem<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs/#L15">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs/#L15">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Build</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs/#L30">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs/#L30">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -58,7 +58,7 @@ Build method that is invoked by commandline
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Clean</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs/#L199">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs/#L199">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/alpha-locator-config.md
+++ b/docs/api/core/alpha-locator-config.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L60">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L60">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -42,7 +42,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>LocatorHost</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L65">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L65">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -57,7 +57,7 @@ The host used to connect to the Locator.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>LocatorParameters</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L70">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L70">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/authentication-failed-exception.md
+++ b/docs/api/core/authentication-failed-exception.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Exceptions/AuthenticationFailedException.cs/#L9">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Exceptions/AuthenticationFailedException.cs/#L9">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -52,7 +52,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AuthenticationFailedException</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Exceptions/AuthenticationFailedException.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Exceptions/AuthenticationFailedException.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/authority-change-received.md
+++ b/docs/api/core/authority-change-received.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L67">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L67">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -44,7 +44,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Authority</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L69">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L69">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -59,7 +59,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L70">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L70">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -89,7 +89,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AuthorityChangeReceived</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L72">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L72">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -130,7 +130,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetEntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L78">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L78">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/blittable-bool.md
+++ b/docs/api/core/blittable-bool.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/BlittableBool.cs/#L11">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/BlittableBool.cs/#L11">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -61,7 +61,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>BlittableBool</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/BlittableBool.cs/#L15">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/BlittableBool.cs/#L15">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -101,7 +101,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Equals</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/BlittableBool.cs/#L30">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/BlittableBool.cs/#L30">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -141,7 +141,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Equals</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/BlittableBool.cs/#L35">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/BlittableBool.cs/#L35">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -169,7 +169,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetHashCode</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/BlittableBool.cs/#L45">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/BlittableBool.cs/#L45">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -188,7 +188,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ToString</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/BlittableBool.cs/#L60">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/BlittableBool.cs/#L60">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -219,7 +219,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>operator bool</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/BlittableBool.cs/#L20">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/BlittableBool.cs/#L20">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -247,7 +247,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>operator BlittableBool</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/BlittableBool.cs/#L25">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/BlittableBool.cs/#L25">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -275,7 +275,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>operator==</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/BlittableBool.cs/#L50">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/BlittableBool.cs/#L50">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -304,7 +304,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>operator!=</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/BlittableBool.cs/#L55">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/BlittableBool.cs/#L55">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/called-value-on-empty-option-exception.md
+++ b/docs/api/core/called-value-on-empty-option-exception.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L163">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L163">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -52,7 +52,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CalledValueOnEmptyOptionException</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L165">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L165">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/clean-temporary-components-system.md
+++ b/docs/api/core/clean-temporary-components-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanTemporaryComponentsSystem.cs/#L13">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanTemporaryComponentsSystem.cs/#L13">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -54,7 +54,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanTemporaryComponentsSystem.cs/#L18">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanTemporaryComponentsSystem.cs/#L18">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -73,7 +73,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanTemporaryComponentsSystem.cs/#L36">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanTemporaryComponentsSystem.cs/#L36">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/codegen-adapters/i-component-replication-handler.md
+++ b/docs/api/core/codegen-adapters/i-component-replication-handler.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/codegen-adapters-index">CodegenAdapters</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/IComponentReplicationHandler.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/IComponentReplicationHandler.cs/#L6">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ComponentId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/IComponentReplicationHandler.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/IComponentReplicationHandler.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -55,7 +55,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ComponentUpdateQuery</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/IComponentReplicationHandler.cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/IComponentReplicationHandler.cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -85,7 +85,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SendUpdates</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/IComponentReplicationHandler.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/IComponentReplicationHandler.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/command-context.md
+++ b/docs/api/core/command-context.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L7">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L7">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -37,7 +37,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SendingEntity</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -52,7 +52,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Request</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Context</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -82,7 +82,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RequestId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L12">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L12">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -112,7 +112,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CommandContext</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L14">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L14">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/command-line-utility.md
+++ b/docs/api/core/command-line-utility.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandLineUtility.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandLineUtility.cs/#L6">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetArguments</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandLineUtility.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandLineUtility.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -58,7 +58,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetCommandLineValue&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandLineUtility.cs/#L14">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandLineUtility.cs/#L14">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -88,7 +88,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetCommandLineValue&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandLineUtility.cs/#L25">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandLineUtility.cs/#L25">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -118,7 +118,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ParseCommandLineArgs</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandLineUtility.cs/#L58">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandLineUtility.cs/#L58">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/command-meta-data-aggregate.md
+++ b/docs/api/core/command-meta-data-aggregate.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaDataAggregate.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaDataAggregate.cs/#L6">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>MarkIdForRemoval</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaDataAggregate.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaDataAggregate.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -71,7 +71,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>FlushRemovedIds</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaDataAggregate.cs/#L21">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaDataAggregate.cs/#L21">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -90,7 +90,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetContext&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaDataAggregate.cs/#L29">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaDataAggregate.cs/#L29">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/command-meta-data.md
+++ b/docs/api/core/command-meta-data.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L23">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L23">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CommandMetaData</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L35">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L35">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -72,7 +72,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>MarkIdForRemoval</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L57">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L57">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -102,7 +102,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>FlushRemovedIds</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L62">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L62">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -121,7 +121,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddRequest&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L74">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L74">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -151,7 +151,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddInternalRequestId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L80">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L80">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -182,7 +182,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetContext&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L87">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandMetaData.cs/#L87">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/command-request-id-generator.md
+++ b/docs/api/core/command-request-id-generator.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandRequestIdGenerator.cs/#L3">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandRequestIdGenerator.cs/#L3">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetNext</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandRequestIdGenerator.cs/#L7">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandRequestIdGenerator.cs/#L7">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/command-system.md
+++ b/docs/api/core/command-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs/#L7">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs/#L7">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SendCommand&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs/#L13">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs/#L13">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -77,7 +77,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SendCommand&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs/#L19">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs/#L19">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -105,7 +105,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SendResponse&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs/#L25">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs/#L25">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -133,7 +133,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetRequests&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs/#L30">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs/#L30">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -152,7 +152,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetRequests&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs/#L36">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs/#L36">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -180,7 +180,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetResponses&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs/#L42">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs/#L42">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -199,7 +199,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetResponse&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs/#L48">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs/#L48">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -239,7 +239,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs/#L54">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs/#L54">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -258,7 +258,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs/#L61">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs/#L61">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/commands/i-command-request.md
+++ b/docs/api/core/commands/i-command-request.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/CommandComponents.cs/#L3">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/CommandComponents.cs/#L3">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/core/commands/i-command-response.md
+++ b/docs/api/core/commands/i-command-response.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/CommandComponents.cs/#L16">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/CommandComponents.cs/#L16">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/core/commands/i-raw-received-command-response.md
+++ b/docs/api/core/commands/i-raw-received-command-response.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/CommandComponents.cs/#L29">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/CommandComponents.cs/#L29">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/core/commands/i-received-command-request.md
+++ b/docs/api/core/commands/i-received-command-request.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/CommandComponents.cs/#L7">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/CommandComponents.cs/#L7">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetRequestId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/CommandComponents.cs/#L13">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/CommandComponents.cs/#L13">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/commands/i-received-command-response.md
+++ b/docs/api/core/commands/i-received-command-response.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/CommandComponents.cs/#L20">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/CommandComponents.cs/#L20">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetRequestId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/CommandComponents.cs/#L26">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/CommandComponents.cs/#L26">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/commands/world-commands.md
+++ b/docs/api/core/commands/world-commands.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L11">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L11">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/core/commands/world-commands/create-entity.md
+++ b/docs/api/core/commands/world-commands/create-entity.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L13">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L13">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/core/commands/world-commands/create-entity/command-component-manager.md
+++ b/docs/api/core/commands/world-commands/create-entity/command-component-manager.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands/create-entity">CreateEntity</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L277">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L277">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>PopulateReactiveCommandComponents</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L279">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L279">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -78,7 +78,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Clean</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L315">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L315">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/commands/world-commands/create-entity/command-responses.md
+++ b/docs/api/core/commands/world-commands/create-entity/command-responses.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands/create-entity">CreateEntity</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L131">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L131">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -50,7 +50,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Responses</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L138">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L138">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/commands/world-commands/create-entity/command-sender.md
+++ b/docs/api/core/commands/world-commands/create-entity/command-sender.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands/create-entity">CreateEntity</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L113">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L113">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -50,7 +50,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RequestsToSend</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L121">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L121">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/commands/world-commands/create-entity/received-response.md
+++ b/docs/api/core/commands/world-commands/create-entity/received-response.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands/create-entity">CreateEntity</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L55">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L55">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -49,7 +49,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SendingEntity</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L57">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L57">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -64,7 +64,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>StatusCode</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L63">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L63">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -79,7 +79,7 @@ The status code of the command response. If equal to StatusCode.Success then the
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Message</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L68">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L68">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -94,7 +94,7 @@ The failure message of the command. Will only be non-null if the command failed.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L73">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L73">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -109,7 +109,7 @@ The Entity ID of the created entity. Will only be non-null if the command succee
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RequestPayload</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L78">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L78">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -124,7 +124,7 @@ The request payload that was originally sent with this command.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Context</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L83">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L83">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -139,7 +139,7 @@ The context object that was provided when sending the command.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RequestId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L88">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L88">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -170,7 +170,7 @@ The unique request ID of this command. Will match the request ID in the correspo
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetRequestId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L104">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L104">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/commands/world-commands/create-entity/request.md
+++ b/docs/api/core/commands/world-commands/create-entity/request.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands/create-entity">CreateEntity</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L18">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L18">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -49,7 +49,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Entity</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L20">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L20">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -64,7 +64,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L21">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L21">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -79,7 +79,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>TimeoutMillis</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L22">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L22">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -94,7 +94,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Context</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L23">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L23">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -124,7 +124,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Request</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L42">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/CreateEntity.cs/#L42">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/commands/world-commands/delete-entity.md
+++ b/docs/api/core/commands/world-commands/delete-entity.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L13">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L13">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/core/commands/world-commands/delete-entity/command-responses.md
+++ b/docs/api/core/commands/world-commands/delete-entity/command-responses.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands/delete-entity">DeleteEntity</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L119">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L119">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -50,7 +50,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Responses</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L126">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L126">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/commands/world-commands/delete-entity/command-sender.md
+++ b/docs/api/core/commands/world-commands/delete-entity/command-sender.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands/delete-entity">DeleteEntity</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L101">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L101">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -50,7 +50,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RequestsToSend</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L109">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L109">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/commands/world-commands/delete-entity/delete-entity-component-manager.md
+++ b/docs/api/core/commands/world-commands/delete-entity/delete-entity-component-manager.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands/delete-entity">DeleteEntity</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L265">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L265">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>PopulateReactiveCommandComponents</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L267">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L267">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -78,7 +78,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Clean</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L303">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L303">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/commands/world-commands/delete-entity/received-response.md
+++ b/docs/api/core/commands/world-commands/delete-entity/received-response.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands/delete-entity">DeleteEntity</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L46">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L46">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -49,7 +49,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SendingEntity</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L48">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L48">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -64,7 +64,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>StatusCode</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L54">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L54">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -79,7 +79,7 @@ The status code of the command response. If equal to StatusCode.Success then the
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Message</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L59">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L59">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -94,7 +94,7 @@ The failure message of the command. Will only be non-null if the command failed.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L64">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L64">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -109,7 +109,7 @@ The Entity ID that was the target of the DeleteEntity command.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RequestPayload</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L69">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L69">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -124,7 +124,7 @@ The request payload that was originally sent with this command.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Context</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L74">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L74">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -139,7 +139,7 @@ The context object that was provided when sending the command.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RequestId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L79">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L79">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -170,7 +170,7 @@ The unique request ID of this command. Will match the request ID in the correspo
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetRequestId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L92">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L92">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/commands/world-commands/delete-entity/request.md
+++ b/docs/api/core/commands/world-commands/delete-entity/request.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands/delete-entity">DeleteEntity</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L18">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L18">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -49,7 +49,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L20">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L20">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -64,7 +64,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>TimeoutMillis</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L21">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L21">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -79,7 +79,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Context</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L22">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L22">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -109,7 +109,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Request</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L35">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/DeleteEntity.cs/#L35">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/commands/world-commands/entity-query.md
+++ b/docs/api/core/commands/world-commands/entity-query.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L14">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L14">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/core/commands/world-commands/entity-query/command-component-manager.md
+++ b/docs/api/core/commands/world-commands/entity-query/command-component-manager.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands/entity-query">EntityQuery</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L285">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L285">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>PopulateReactiveCommandComponents</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L287">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L287">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -78,7 +78,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Clean</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L323">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L323">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/commands/world-commands/entity-query/command-responses.md
+++ b/docs/api/core/commands/world-commands/entity-query/command-responses.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands/entity-query">EntityQuery</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L139">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L139">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -50,7 +50,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Responses</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L146">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L146">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/commands/world-commands/entity-query/command-sender.md
+++ b/docs/api/core/commands/world-commands/entity-query/command-sender.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands/entity-query">EntityQuery</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L121">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L121">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -50,7 +50,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RequestsToSend</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L129">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L129">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/commands/world-commands/entity-query/received-response.md
+++ b/docs/api/core/commands/world-commands/entity-query/received-response.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands/entity-query">EntityQuery</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L48">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L48">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -49,7 +49,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SendingEntity</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L50">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L50">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -64,7 +64,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>StatusCode</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L56">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L56">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -79,7 +79,7 @@ The status code of the command response. If equal to StatusCode.Success then the
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Message</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L61">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L61">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -94,7 +94,7 @@ The failure message of the command. Will only be non-null if the command failed.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Result</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L67">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L67">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -109,7 +109,7 @@ A dictionary that represents the results of a SnapshotResultType entity query. T
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ResultCount</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L72">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L72">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -124,7 +124,7 @@ The number of entities that matched the entity query constraints.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RequestPayload</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L77">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L77">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -139,7 +139,7 @@ The request payload that was originally sent with this command.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Context</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L82">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L82">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -154,7 +154,7 @@ The context object that was provided when sending the command.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RequestId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L87">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L87">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -185,7 +185,7 @@ The unique request ID of this command. Will match the request ID in the correspo
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetRequestId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L112">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L112">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/commands/world-commands/entity-query/request.md
+++ b/docs/api/core/commands/world-commands/entity-query/request.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands/entity-query">EntityQuery</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L19">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L19">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -49,7 +49,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EntityQuery</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L21">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L21">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -64,7 +64,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>TimeoutMillis</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L22">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L22">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -79,7 +79,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Context</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L23">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L23">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -109,7 +109,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Request</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L36">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/EntityQuery.cs/#L36">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/commands/world-commands/reserve-entity-ids.md
+++ b/docs/api/core/commands/world-commands/reserve-entity-ids.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L13">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L13">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/core/commands/world-commands/reserve-entity-ids/command-component-manager.md
+++ b/docs/api/core/commands/world-commands/reserve-entity-ids/command-component-manager.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands/reserve-entity-ids">ReserveEntityIds</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L276">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L276">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>PopulateReactiveCommandComponents</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L278">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L278">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -78,7 +78,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Clean</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L314">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L314">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/commands/world-commands/reserve-entity-ids/command-responses.md
+++ b/docs/api/core/commands/world-commands/reserve-entity-ids/command-responses.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands/reserve-entity-ids">ReserveEntityIds</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L130">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L130">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -50,7 +50,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Responses</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L137">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L137">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/commands/world-commands/reserve-entity-ids/command-sender.md
+++ b/docs/api/core/commands/world-commands/reserve-entity-ids/command-sender.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands/reserve-entity-ids">ReserveEntityIds</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L112">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L112">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -50,7 +50,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RequestsToSend</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L120">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L120">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/commands/world-commands/reserve-entity-ids/received-response.md
+++ b/docs/api/core/commands/world-commands/reserve-entity-ids/received-response.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands/reserve-entity-ids">ReserveEntityIds</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L47">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L47">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -49,7 +49,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SendingEntity</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L49">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L49">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -64,7 +64,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>StatusCode</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L55">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L55">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -79,7 +79,7 @@ The status code of the command response. If equal to StatusCode.Success then the
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Message</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L60">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L60">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -94,7 +94,7 @@ The failure message of the command. Will only be non-null if the command failed.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>FirstEntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L66">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L66">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -109,7 +109,7 @@ The first entity ID in the range that was reserved. Will only be non-null if the
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>NumberOfEntityIds</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L71">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L71">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -124,7 +124,7 @@ The number of entity IDs that were reserved.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RequestPayload</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L76">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L76">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -139,7 +139,7 @@ The request payload that was originally sent with this command.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Context</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L81">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L81">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -154,7 +154,7 @@ The context object that was provided when sending the command.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RequestId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L86">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L86">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -185,7 +185,7 @@ The unique request ID of this command. Will match the request ID in the correspo
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetRequestId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L103">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L103">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/commands/world-commands/reserve-entity-ids/request.md
+++ b/docs/api/core/commands/world-commands/reserve-entity-ids/request.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/commands-index">Commands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands">WorldCommands</a>.<a href="{{urlRoot}}/api/core/commands/world-commands/reserve-entity-ids">ReserveEntityIds</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L18">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L18">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -49,7 +49,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>NumberOfEntityIds</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L20">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L20">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -64,7 +64,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>TimeoutMillis</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L21">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L21">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -79,7 +79,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Context</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L22">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L22">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -109,7 +109,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Request</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L35">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands/ReserveEntityIds.cs/#L35">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/component-event-received.md
+++ b/docs/api/core/component-event-received.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L48">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L48">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -44,7 +44,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Event</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L50">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L50">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -59,7 +59,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>UpdateId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L51">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L51">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -74,7 +74,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L52">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L52">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -104,7 +104,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ComponentEventReceived</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L54">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L54">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -146,7 +146,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetEntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L61">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L61">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/component-event-to-send.md
+++ b/docs/api/core/component-event-to-send.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L17">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L17">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -37,7 +37,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Event</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L19">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L19">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -52,7 +52,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L20">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L20">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -82,7 +82,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ComponentEventToSend</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L22">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L22">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/component-send-system.md
+++ b/docs/api/core/component-send-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentSendSystem.cs/#L21">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentSendSystem.cs/#L21">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -54,7 +54,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>TryRegisterCustomReplicationSystem</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentSendSystem.cs/#L46">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentSendSystem.cs/#L46">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -94,7 +94,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentSendSystem.cs/#L29">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentSendSystem.cs/#L29">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -113,7 +113,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnDestroyManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentSendSystem.cs/#L40">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentSendSystem.cs/#L40">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -132,7 +132,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentSendSystem.cs/#L58">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentSendSystem.cs/#L58">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/component-update-received.md
+++ b/docs/api/core/component-update-received.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L29">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L29">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -44,7 +44,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Update</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L31">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L31">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -59,7 +59,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>UpdateId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L32">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L32">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -74,7 +74,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L33">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L33">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -104,7 +104,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ComponentUpdateReceived</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L35">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L35">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -146,7 +146,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetEntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L42">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L42">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/component-update-system.md
+++ b/docs/api/core/component-update-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L9">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L9">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SendUpdate&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L13">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L13">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -77,7 +77,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SendEvent&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L19">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L19">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -106,7 +106,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetEventsReceived&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L24">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L24">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -125,7 +125,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetEventsReceived&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L30">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L30">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -153,7 +153,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponentUpdatesReceived&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L36">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L36">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -172,7 +172,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetEntityComponentUpdatesReceived&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L43">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L43">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -200,7 +200,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetAuthorityChangesReceived</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L50">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L50">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -228,7 +228,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetAuthorityChangesReceived</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L56">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L56">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -257,7 +257,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponentsAdded</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L63">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L63">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -285,7 +285,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponentsRemoved</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L69">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L69">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -313,7 +313,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetAuthority</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L75">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L75">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -342,7 +342,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponent&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L80">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L80">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -370,7 +370,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AcknowledgeAuthorityLoss</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L85">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L85">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -399,7 +399,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>HasComponent</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L90">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L90">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -440,7 +440,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L95">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L95">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -459,7 +459,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L104">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs/#L104">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/component-update-to-send.md
+++ b/docs/api/core/component-update-to-send.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -37,7 +37,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Update</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L7">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L7">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -52,7 +52,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -82,7 +82,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ComponentUpdateToSend</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentUpdateToSend.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/concurrent-op-list-converter.md
+++ b/docs/api/core/concurrent-op-list-converter.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/ConcurrentOpListConverter.cs/#L18">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/ConcurrentOpListConverter.cs/#L18">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -53,7 +53,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ParseOpListIntoDiff</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/ConcurrentOpListConverter.cs/#L41">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/ConcurrentOpListConverter.cs/#L41">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -82,7 +82,7 @@ Iterate over the op list and populate a <a href="{{urlRoot}}/api/core/view-diff"
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>TryGetViewDiff</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/ConcurrentOpListConverter.cs/#L139">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/ConcurrentOpListConverter.cs/#L139">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/connection-error-reason.md
+++ b/docs/api/core/connection-error-reason.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Exceptions/ConnectionFailedException.cs/#L8">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Exceptions/ConnectionFailedException.cs/#L8">Source</a>
 </sup>
 
 </p>

--- a/docs/api/core/connection-failed-exception.md
+++ b/docs/api/core/connection-failed-exception.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Exceptions/ConnectionFailedException.cs/#L20">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Exceptions/ConnectionFailedException.cs/#L20">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -49,7 +49,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Reason</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Exceptions/ConnectionFailedException.cs/#L22">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Exceptions/ConnectionFailedException.cs/#L22">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -79,7 +79,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ConnectionFailedException</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Exceptions/ConnectionFailedException.cs/#L24">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Exceptions/ConnectionFailedException.cs/#L24">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/connection-service.md
+++ b/docs/api/core/connection-service.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L97">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L97">Source</a>
 </sup>
 
 </p>

--- a/docs/api/core/created-option-with-null-payload-exception.md
+++ b/docs/api/core/created-option-with-null-payload-exception.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L152">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L152">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -52,7 +52,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CreatedOptionWithNullPayloadException</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L154">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L154">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/custom-spatial-os-send-system.md
+++ b/docs/api/core/custom-spatial-os-send-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/CustomSpatialOSSendSystem.cs/#L15">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/CustomSpatialOSSendSystem.cs/#L15">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -61,7 +61,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WorkerSystem</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/CustomSpatialOSSendSystem.cs/#L22">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/CustomSpatialOSSendSystem.cs/#L22">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -93,7 +93,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/CustomSpatialOSSendSystem.cs/#L26">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/CustomSpatialOSSendSystem.cs/#L26">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/default-worker-connector.md
+++ b/docs/api/core/default-worker-connector.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DefaultWorkerConnector.cs/#L8">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DefaultWorkerConnector.cs/#L8">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -43,7 +43,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>UseExternalIp</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DefaultWorkerConnector.cs/#L13">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DefaultWorkerConnector.cs/#L13">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -75,7 +75,7 @@ Denotes whether to connect using an external IP address.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetConnectionService</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DefaultWorkerConnector.cs/#L15">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DefaultWorkerConnector.cs/#L15">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -94,7 +94,7 @@ Determines which <a href="{{urlRoot}}/api/core/connection-service">ConnectionSer
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetConnectionParameters</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DefaultWorkerConnector.cs/#L36">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DefaultWorkerConnector.cs/#L36">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -123,7 +123,7 @@ Retrieves the ConnectionParameters needed to be able to connect to any connectio
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetReceptionistConfig</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DefaultWorkerConnector.cs/#L76">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DefaultWorkerConnector.cs/#L76">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -151,7 +151,7 @@ Retrieves the configuration needed to connect via the Receptionist service.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetLocatorConfig</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DefaultWorkerConnector.cs/#L101">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DefaultWorkerConnector.cs/#L101">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -170,7 +170,7 @@ Retrieves the configuration needed to connect via the Locator service.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetAlphaLocatorConfig</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DefaultWorkerConnector.cs/#L158">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DefaultWorkerConnector.cs/#L158">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/dynamic-converter.md
+++ b/docs/api/core/dynamic-converter.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicConverter.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicConverter.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -52,7 +52,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ForEachComponent</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicConverter.cs/#L18">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicConverter.cs/#L18">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -80,7 +80,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ForComponent</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicConverter.cs/#L26">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicConverter.cs/#L26">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -122,7 +122,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SnapshotToUpdate&lt;TSnapshot, out TUpdate&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicConverter.cs/#L7">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicConverter.cs/#L7">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/dynamic-converter/i-converter-handler.md
+++ b/docs/api/core/dynamic-converter/i-converter-handler.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/dynamic-converter">DynamicConverter</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicConverter.cs/#L11">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicConverter.cs/#L11">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Accept&lt;TSnapshot, TUpdate&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicConverter.cs/#L13">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicConverter.cs/#L13">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/dynamic-snapshot.md
+++ b/docs/api/core/dynamic-snapshot.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicSnapshot.cs/#L7">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicSnapshot.cs/#L7">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -52,7 +52,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ForEachSnapshotComponent</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicSnapshot.cs/#L21">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicSnapshot.cs/#L21">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -80,7 +80,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ForSnapshotComponent</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicSnapshot.cs/#L29">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicSnapshot.cs/#L29">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -109,7 +109,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetSnapshotComponentId&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicSnapshot.cs/#L39">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicSnapshot.cs/#L39">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -141,7 +141,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SnapshotDeserializer&lt;out T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicSnapshot.cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicSnapshot.cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -169,7 +169,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SnapshotSerializer&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicSnapshot.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicSnapshot.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/dynamic-snapshot/i-snapshot-handler.md
+++ b/docs/api/core/dynamic-snapshot/i-snapshot-handler.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/dynamic-snapshot">DynamicSnapshot</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicSnapshot.cs/#L13">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicSnapshot.cs/#L13">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Accept&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicSnapshot.cs/#L15">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/DynamicSnapshot.cs/#L15">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/dynamic.md
+++ b/docs/api/core/dynamic.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/Dynamic.cs/#L12">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/Dynamic.cs/#L12">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -51,7 +51,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ForEachComponent</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/Dynamic.cs/#L23">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/Dynamic.cs/#L23">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -79,7 +79,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ForComponent</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/Dynamic.cs/#L31">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/Dynamic.cs/#L31">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -108,7 +108,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponentId&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/Dynamic.cs/#L41">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/Dynamic.cs/#L41">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/dynamic/i-handler.md
+++ b/docs/api/core/dynamic/i-handler.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/dynamic">Dynamic</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/Dynamic.cs/#L14">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/Dynamic.cs/#L14">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Accept&lt;TData, TUpdate&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/Dynamic.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/Dynamic.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/ecs-view-system.md
+++ b/docs/api/core/ecs-view-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/EcsViewSystem.cs/#L10">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/EcsViewSystem.cs/#L10">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/EcsViewSystem.cs/#L53">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/EcsViewSystem.cs/#L53">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnDestroyManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/EcsViewSystem.cs/#L71">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/EcsViewSystem.cs/#L71">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -86,7 +86,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/EcsViewSystem.cs/#L81">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/EcsViewSystem.cs/#L81">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/entity-component.md
+++ b/docs/api/core/entity-component.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/EntityComponent.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/EntityComponent.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -45,7 +45,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/EntityComponent.cs/#L7">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/EntityComponent.cs/#L7">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -60,7 +60,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ComponentId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/EntityComponent.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/EntityComponent.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -90,7 +90,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EntityComponent</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/EntityComponent.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/EntityComponent.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -131,7 +131,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Equals</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/EntityComponent.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/EntityComponent.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -171,7 +171,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Equals</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/EntityComponent.cs/#L21">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/EntityComponent.cs/#L21">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -199,7 +199,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetHashCode</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/EntityComponent.cs/#L31">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/EntityComponent.cs/#L31">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/entity-id.md
+++ b/docs/api/core/entity-id.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/EntityId.cs/#L12">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/EntityId.cs/#L12">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -58,7 +58,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Id</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/EntityId.cs/#L20">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/EntityId.cs/#L20">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -97,7 +97,7 @@ The value of the <a href="{{urlRoot}}/api/core/entity-id">EntityId</a>.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/EntityId.cs/#L25">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/EntityId.cs/#L25">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -137,7 +137,7 @@ Constructs a new instance of an <a href="{{urlRoot}}/api/core/entity-id">EntityI
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>IsValid</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/EntityId.cs/#L34">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/EntityId.cs/#L34">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -165,7 +165,7 @@ Whether this represents a valid SpatialOS entity ID. Specifically,
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Equals</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/EntityId.cs/#L51">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/EntityId.cs/#L51">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -205,7 +205,7 @@ Whether this represents a valid SpatialOS entity ID. Specifically,
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Equals</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/EntityId.cs/#L40">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/EntityId.cs/#L40">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -233,7 +233,7 @@ Whether this represents a valid SpatialOS entity ID. Specifically,
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetHashCode</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/EntityId.cs/#L73">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/EntityId.cs/#L73">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -252,7 +252,7 @@ Whether this represents a valid SpatialOS entity ID. Specifically,
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ToString</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/EntityId.cs/#L81">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/EntityId.cs/#L81">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -283,7 +283,7 @@ Whether this represents a valid SpatialOS entity ID. Specifically,
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>operator==</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/EntityId.cs/#L59">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/EntityId.cs/#L59">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -312,7 +312,7 @@ Returns true if entityId1 is exactly equal to entityId2.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>operator!=</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/EntityId.cs/#L67">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/EntityId.cs/#L67">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/entity-query-snapshot.md
+++ b/docs/api/core/entity-query-snapshot.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityQuerySnapshot.cs/#L15">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityQuerySnapshot.cs/#L15">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -53,7 +53,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponentSnapshot&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityQuerySnapshot.cs/#L53">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityQuerySnapshot.cs/#L53">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/entity-system.md
+++ b/docs/api/core/entity-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/EntitySystem.cs/#L9">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/EntitySystem.cs/#L9">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetEntitiesAdded</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/EntitySystem.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/EntitySystem.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetEntitiesRemoved</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/EntitySystem.cs/#L21">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/EntitySystem.cs/#L21">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -86,7 +86,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetEntitiesInView</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/EntitySystem.cs/#L26">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/EntitySystem.cs/#L26">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -117,7 +117,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/EntitySystem.cs/#L48">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/EntitySystem.cs/#L48">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -136,7 +136,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/EntitySystem.cs/#L55">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/EntitySystem.cs/#L55">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/entity-template.md
+++ b/docs/api/core/entity-template.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L11">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L11">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -13,7 +13,8 @@ code {
 }
 </style>
 </sup>
-<nav id="pageToc" class="page-toc"><ul><li><a href="#methods">Methods</a>
+<nav id="pageToc" class="page-toc"><ul><li><a href="#static-methods">Static Methods</a>
+<li><a href="#methods">Methods</a>
 </ul></nav>
 
 </p>
@@ -32,6 +33,45 @@ code {
 
 
 
+</p>
+<hr style="width:100%; border-top-color:#d8d8d8" />
+#### Static Methods
+
+
+</p>
+
+
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>GetWorkerAccessAttribute</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L26">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code>string GetWorkerAccessAttribute(string workerId)</code></p>
+Constructs a worker access attribute, given a worker ID. 
+</p><b>Returns:</b></br>A string representing the worker access attribute.
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>string workerId</code> : An ID of a worker.</li>
+</ul>
+
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+
 
 
 </p>
@@ -47,7 +87,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddComponent&lt;TSnapshot&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L35">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L45">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -103,7 +143,7 @@ Adds a SpatialOS component to the <a href="{{urlRoot}}/api/core/entity-template"
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponent&lt;TSnapshot&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L60">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L70">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -131,7 +171,7 @@ Attempts to get a component snapshot stored in the <a href="{{urlRoot}}/api/core
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>HasComponent</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L75">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L85">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -159,7 +199,7 @@ Checks if a component snapshot is stored in the <a href="{{urlRoot}}/api/core/en
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>HasComponent&lt;TSnapshot&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L85">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L95">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -187,7 +227,7 @@ Checks if a component snapshot is stored in the <a href="{{urlRoot}}/api/core/en
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SetComponent&lt;TSnapshot&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L98">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L108">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -233,7 +273,7 @@ Sets a component snapshot in the <a href="{{urlRoot}}/api/core/entity-template">
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RemoveComponent&lt;TSnapshot&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L107">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L117">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -261,7 +301,7 @@ Removes a component snapshot from the <a href="{{urlRoot}}/api/core/entity-templ
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponentWriteAccess</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L119">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L129">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -289,7 +329,7 @@ Retrieves the write access worker attribute for a given component.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponentWriteAccess&lt;TSnapshot&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L129">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L139">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -317,7 +357,7 @@ Retrieves the write access worker attribute for a given component.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SetComponentWriteAccess</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L139">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L149">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -346,7 +386,7 @@ Sets the write access worker attribute for a given component.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SetComponentWriteAccess&lt;TSnapshot&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L149">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L159">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -383,7 +423,7 @@ Sets the write access worker attribute for a given component.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SetReadAccess</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L159">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L169">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -411,7 +451,7 @@ Sets the worker attributes which should have read access over this entity.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetEntity</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L175">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityTemplate.cs/#L185">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/forwarding-dispatcher.md
+++ b/docs/api/core/forwarding-dispatcher.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs/#L11">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs/#L11">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -52,7 +52,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Connection</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs/#L17">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs/#L17">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -68,7 +68,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WorkerType</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs/#L18">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs/#L18">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -97,7 +97,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ForwardingDispatcher</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs/#L33">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs/#L33">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -137,7 +137,7 @@ Constructor for the Forwarding Dispatcher
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>HandleLog</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs/#L60">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs/#L60">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -166,7 +166,7 @@ Log locally and conditionally forward to the SpatialOS runtime.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Dispose</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs/#L114">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs/#L114">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-command-diff-deserializer.md
+++ b/docs/api/core/i-command-diff-deserializer.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L13">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L13">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponentId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L15">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L15">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -60,7 +60,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetCommandId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -79,7 +79,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddRequestToDiff</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L18">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L18">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -108,7 +108,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddResponseToDiff</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L19">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L19">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-command-diff-storage.md
+++ b/docs/api/core/i-command-diff-storage.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L20">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L20">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Clear</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L22">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L22">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-command-meta-data-storage.md
+++ b/docs/api/core/i-command-meta-data-storage.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/ICommandMetaDataStorage.cs/#L3">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/ICommandMetaDataStorage.cs/#L3">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponentId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/ICommandMetaDataStorage.cs/#L5">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/ICommandMetaDataStorage.cs/#L5">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -60,7 +60,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetCommandId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/ICommandMetaDataStorage.cs/#L6">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/ICommandMetaDataStorage.cs/#L6">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -79,7 +79,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RemoveMetaData</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/ICommandMetaDataStorage.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/ICommandMetaDataStorage.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -107,7 +107,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SetInternalRequestId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/ICommandMetaDataStorage.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/ICommandMetaDataStorage.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-command-payload-storage.md
+++ b/docs/api/core/i-command-payload-storage.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/ICommandMetaDataStorage.cs/#L13">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/ICommandMetaDataStorage.cs/#L13">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetPayload</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/ICommandMetaDataStorage.cs/#L15">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/ICommandMetaDataStorage.cs/#L15">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -69,7 +69,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddRequest</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/ICommandMetaDataStorage.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/ICommandMetaDataStorage.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-command-request-send-storage.md
+++ b/docs/api/core/i-command-request-send-storage.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandSendStorage .cs/#L22">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandSendStorage .cs/#L22">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddRequest</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandSendStorage .cs/#L24">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandSendStorage .cs/#L24">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-command-response-send-storage.md
+++ b/docs/api/core/i-command-response-send-storage.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandSendStorage .cs/#L28">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandSendStorage .cs/#L28">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddResponse</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandSendStorage .cs/#L30">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandSendStorage .cs/#L30">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-command-send-storage.md
+++ b/docs/api/core/i-command-send-storage.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandSendStorage .cs/#L7">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandSendStorage .cs/#L7">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Clear</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandSendStorage .cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandSendStorage .cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-command-serializer.md
+++ b/docs/api/core/i-command-serializer.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L29">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L29">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Serialize</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L31">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L31">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-component-command-diff-storage.md
+++ b/docs/api/core/i-component-command-diff-storage.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L25">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L25">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponentId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L27">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L27">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -66,7 +66,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetCommandId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L28">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L28">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -85,7 +85,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetRequestType</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L30">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L30">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -104,7 +104,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetResponseType</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L31">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L31">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -123,7 +123,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RemoveRequests</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L33">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L33">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-component-command-send-storage.md
+++ b/docs/api/core/i-component-command-send-storage.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandSendStorage .cs/#L12">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandSendStorage .cs/#L12">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponentId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandSendStorage .cs/#L14">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandSendStorage .cs/#L14">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -66,7 +66,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetCommandId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandSendStorage .cs/#L15">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandSendStorage .cs/#L15">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -85,7 +85,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetRequestType</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandSendStorage .cs/#L17">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandSendStorage .cs/#L17">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -104,7 +104,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetResponseType</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandSendStorage .cs/#L18">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/CommandSendStorage .cs/#L18">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-component-diff-deserializer.md
+++ b/docs/api/core/i-component-diff-deserializer.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponentId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L7">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L7">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -60,7 +60,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddUpdateToDiff</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -90,7 +90,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddComponentToDiff</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-component-diff-storage.md
+++ b/docs/api/core/i-component-diff-storage.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L7">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L7">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetEventTypes</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -60,7 +60,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetUpdateType</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -79,7 +79,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponentId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -98,7 +98,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Clear</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L13">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L13">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -117,7 +117,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RemoveEntityComponent</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L14">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L14">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -145,7 +145,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponentsAdded</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -164,7 +164,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponentsRemoved</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L17">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L17">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-component-serializer.md
+++ b/docs/api/core/i-component-serializer.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L22">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L22">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponentId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L24">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L24">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -60,7 +60,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Serialize</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L26">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessageSerialization.cs/#L26">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-connection-handler.md
+++ b/docs/api/core/i-connection-handler.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/IConnectionHandler.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/IConnectionHandler.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetMessagesReceived</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/IConnectionHandler.cs/#L7">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/IConnectionHandler.cs/#L7">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -75,7 +75,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetMessagesToSendContainer</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/IConnectionHandler.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/IConnectionHandler.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -94,7 +94,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>PushMessagesToSend</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/IConnectionHandler.cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/IConnectionHandler.cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -122,7 +122,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>IsConnected</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/IConnectionHandler.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/IConnectionHandler.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-diff-authority-storage.md
+++ b/docs/api/core/i-diff-authority-storage.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L41">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L41">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddAuthorityChange</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L43">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L43">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -75,7 +75,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetAuthorityChanges</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L44">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L44">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -94,7 +94,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetAuthorityChanges</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L45">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L45">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-diff-command-request-storage.md
+++ b/docs/api/core/i-diff-command-request-storage.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L65">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L65">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddRequest</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L67">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L67">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -75,7 +75,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetRequests</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L68">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L68">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -94,7 +94,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetRequests</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L69">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L69">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-diff-command-response-storage.md
+++ b/docs/api/core/i-diff-command-response-storage.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L73">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L73">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddResponse</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L75">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L75">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -75,7 +75,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetResponses</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L76">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L76">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -94,7 +94,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetResponse</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L77">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L77">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-diff-component-added-storage.md
+++ b/docs/api/core/i-diff-component-added-storage.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L36">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L36">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddEntityComponent</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L38">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L38">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-diff-event-storage.md
+++ b/docs/api/core/i-diff-event-storage.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L57">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L57">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddEvent</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L59">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L59">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -75,7 +75,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetEvents</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L60">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L60">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -94,7 +94,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetEvents</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L61">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L61">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-diff-update-storage.md
+++ b/docs/api/core/i-diff-update-storage.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L49">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L49">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L51">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L51">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -75,7 +75,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetUpdates</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L52">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L52">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -94,7 +94,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetUpdates</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L53">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/DiffStorage.cs/#L53">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-dynamic-invokable.md
+++ b/docs/api/core/i-dynamic-invokable.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/IDynamicInvokable.cs/#L3">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/IDynamicInvokable.cs/#L3">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ComponentId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/IDynamicInvokable.cs/#L5">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/IDynamicInvokable.cs/#L5">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -69,7 +69,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>InvokeHandler</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/IDynamicInvokable.cs/#L6">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/IDynamicInvokable.cs/#L6">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -97,7 +97,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>InvokeSnapshotHandler</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/IDynamicInvokable.cs/#L7">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/IDynamicInvokable.cs/#L7">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -125,7 +125,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>InvokeConvertHandler</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Dynamic/IDynamicInvokable.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Dynamic/IDynamicInvokable.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-ecs-view-manager.md
+++ b/docs/api/core/i-ecs-view-manager.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentManagers.cs/#L7">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentManagers.cs/#L7">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Init</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentManagers.cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentManagers.cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -69,7 +69,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Clean</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentManagers.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentManagers.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -97,7 +97,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponentId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentManagers.cs/#L12">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentManagers.cs/#L12">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -116,7 +116,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetInitialComponents</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentManagers.cs/#L14">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentManagers.cs/#L14">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -135,7 +135,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ApplyDiff</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentManagers.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/ComponentManagers.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-event.md
+++ b/docs/api/core/i-event.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/IEvent.cs/#L3">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/UpdatesAndEvents/IEvent.cs/#L3">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/core/i-log-dispatcher.md
+++ b/docs/api/core/i-log-dispatcher.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/ILogDispatcher.cs/#L11">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/ILogDispatcher.cs/#L11">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -51,7 +51,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Connection</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/ILogDispatcher.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/ILogDispatcher.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ The SpatialOS connection.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WorkerType</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/ILogDispatcher.cs/#L21">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/ILogDispatcher.cs/#L21">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -97,7 +97,7 @@ The worker type associated with this logger.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>HandleLog</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/ILogDispatcher.cs/#L23">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/ILogDispatcher.cs/#L23">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-received-entity-message.md
+++ b/docs/api/core/i-received-entity-message.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Collections/ReceivedMessages.cs/#L7">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Collections/ReceivedMessages.cs/#L7">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetEntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Collections/ReceivedMessages.cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Collections/ReceivedMessages.cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-received-message.md
+++ b/docs/api/core/i-received-message.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Collections/ReceivedMessages.cs/#L3">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Collections/ReceivedMessages.cs/#L3">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/core/i-snapshottable.md
+++ b/docs/api/core/i-snapshottable.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/ISnapshottable.cs/#L9">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/ISnapshottable.cs/#L9">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -53,7 +53,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ToComponentSnapshot</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/ISnapshottable.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/ISnapshottable.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-spatial-component-data.md
+++ b/docs/api/core/i-spatial-component-data.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/ISpatialComponentData.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/ISpatialComponentData.cs/#L6">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -44,7 +44,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ComponentId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/ISpatialComponentData.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/ISpatialComponentData.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-spatial-component-snapshot.md
+++ b/docs/api/core/i-spatial-component-snapshot.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/ISpatialComponentSnapshot.cs/#L3">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/ISpatialComponentSnapshot.cs/#L3">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -38,7 +38,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ComponentId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/ISpatialComponentSnapshot.cs/#L5">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/ISpatialComponentSnapshot.cs/#L5">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-spatial-component-update.md
+++ b/docs/api/core/i-spatial-component-update.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/ISpatialComponentUpdate.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/ISpatialComponentUpdate.cs/#L6">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/core/i-view-component-storage.md
+++ b/docs/api/core/i-view-component-storage.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs/#L18">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs/#L18">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponent</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs/#L20">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs/#L20">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-view-component-updater.md
+++ b/docs/api/core/i-view-component-updater.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs/#L23">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs/#L23">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ApplyUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs/#L25">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs/#L25">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/i-view-storage.md
+++ b/docs/api/core/i-view-storage.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs/#L6">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetSnapshotType</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -60,7 +60,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetUpdateType</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -79,7 +79,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponentId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -98,7 +98,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>HasComponent</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs/#L12">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs/#L12">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -126,7 +126,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetAuthority</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs/#L13">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs/#L13">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -154,7 +154,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ApplyDiff</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs/#L15">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/ViewStorage.cs/#L15">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/locator-config.md
+++ b/docs/api/core/locator-config.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L38">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L38">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -42,7 +42,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>LocatorHost</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L43">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L43">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -57,7 +57,7 @@ The host to connect to the Locator.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>LocatorParameters</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L48">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L48">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -72,7 +72,7 @@ The parameters needed to connect to the Locator.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>DeploymentListCallback</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L54">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L54">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/log-event.md
+++ b/docs/api/core/log-event.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs/#L10">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs/#L10">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -45,7 +45,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Message</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs/#L15">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs/#L15">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -60,7 +60,7 @@ The main content of the log.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Data</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs/#L20">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs/#L20">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -75,7 +75,7 @@ The data used for structured logging.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Context</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs/#L25">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs/#L25">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -90,7 +90,7 @@ Optional context object used with Unity logging.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Exception</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs/#L30">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs/#L30">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -120,7 +120,7 @@ An exception if the <a href="{{urlRoot}}/api/core/log-event">LogEvent</a> is ass
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>LogEvent</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs/#L36">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs/#L36">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -160,7 +160,7 @@ Constructor for the log event
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WithField</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs/#L50">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs/#L50">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -189,7 +189,7 @@ Sets additional information to be displayed with the log message.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WithContext</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs/#L62">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs/#L62">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -217,7 +217,7 @@ Adds a context object to be passed as the second parameter into UnityEngine.Debu
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WithException</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs/#L73">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs/#L73">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -257,7 +257,7 @@ Associates an exception to the <a href="{{urlRoot}}/api/core/log-event">LogEvent
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ToString</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs/#L79">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs/#L79">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/log-message-received.md
+++ b/docs/api/core/log-message-received.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/LogMessages.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/LogMessages.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -37,7 +37,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Message</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/LogMessages.cs/#L7">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/LogMessages.cs/#L7">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -52,7 +52,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>LogLevel</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/LogMessages.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/LogMessages.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -82,7 +82,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>LogMessageReceived</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/LogMessages.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/LogMessages.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/log-message-to-send.md
+++ b/docs/api/core/log-message-to-send.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/LogMessages.cs/#L17">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/LogMessages.cs/#L17">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -37,7 +37,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Message</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/LogMessages.cs/#L19">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/LogMessages.cs/#L19">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -52,7 +52,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>LoggerName</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/LogMessages.cs/#L20">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/LogMessages.cs/#L20">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>LogLevel</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/LogMessages.cs/#L21">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/LogMessages.cs/#L21">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -82,7 +82,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/LogMessages.cs/#L22">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/LogMessages.cs/#L22">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -112,7 +112,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>LogMessageToSend</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/LogMessages.cs/#L24">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/LogMessages.cs/#L24">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/logging-dispatcher.md
+++ b/docs/api/core/logging-dispatcher.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingDispatcher.cs/#L13">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingDispatcher.cs/#L13">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -57,7 +57,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Connection</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingDispatcher.cs/#L15">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingDispatcher.cs/#L15">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -73,7 +73,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WorkerType</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingDispatcher.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingDispatcher.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -103,7 +103,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>HandleLog</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingDispatcher.cs/#L23">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingDispatcher.cs/#L23">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -132,7 +132,7 @@ Log locally to the console.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Dispose</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingDispatcher.cs/#L42">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingDispatcher.cs/#L42">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/logging-utils.md
+++ b/docs/api/core/logging-utils.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingUtils.cs/#L12">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingUtils.cs/#L12">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -35,7 +35,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingUtils.cs/#L15">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingUtils.cs/#L15">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -50,7 +50,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>LoggerName</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingUtils.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingUtils.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -65,7 +65,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WorkerType</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingUtils.cs/#L17">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingUtils.cs/#L17">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -96,7 +96,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ExtractEntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingUtils.cs/#L19">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingUtils.cs/#L19">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -124,7 +124,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ExtractLoggerName</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingUtils.cs/#L37">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingUtils.cs/#L37">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/message-list/enumerator.md
+++ b/docs/api/core/message-list/enumerator.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.MessageList<br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Collections/MessageList.cs/#L156">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Collections/MessageList.cs/#L156">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -45,7 +45,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Current</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Collections/MessageList.cs/#L199">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Collections/MessageList.cs/#L199">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -73,7 +73,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Current</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Collections/MessageList.cs/#L186">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Collections/MessageList.cs/#L186">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -102,7 +102,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Enumerator</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Collections/MessageList.cs/#L162">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Collections/MessageList.cs/#L162">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -142,7 +142,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>MoveNext</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Collections/MessageList.cs/#L168">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Collections/MessageList.cs/#L168">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -161,7 +161,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Reset</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Collections/MessageList.cs/#L181">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Collections/MessageList.cs/#L181">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -180,7 +180,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Dispose</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Collections/MessageList.cs/#L201">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Collections/MessageList.cs/#L201">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/messages-to-send.md
+++ b/docs/api/core/messages-to-send.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessagesToSend.cs/#L8">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessagesToSend.cs/#L8">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>MessagesToSend</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessagesToSend.cs/#L38">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessagesToSend.cs/#L38">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -72,7 +72,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Clear</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessagesToSend.cs/#L88">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessagesToSend.cs/#L88">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -91,7 +91,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AcknowledgeAuthorityLoss</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessagesToSend.cs/#L105">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessagesToSend.cs/#L105">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -120,7 +120,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddComponentUpdate&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessagesToSend.cs/#L110">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessagesToSend.cs/#L110">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -149,7 +149,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddEvent&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessagesToSend.cs/#L120">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessagesToSend.cs/#L120">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -178,7 +178,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddCommandRequest&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessagesToSend.cs/#L129">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessagesToSend.cs/#L129">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -208,7 +208,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddCommandResponse&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessagesToSend.cs/#L135">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessagesToSend.cs/#L135">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -236,7 +236,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddLogMessage</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessagesToSend.cs/#L142">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessagesToSend.cs/#L142">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -264,7 +264,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddMetrics</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/MessagesToSend.cs/#L147">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/MessagesToSend.cs/#L147">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/mock-connection-handler.md
+++ b/docs/api/core/mock-connection-handler.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CreateEntity</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs/#L19">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs/#L19">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -76,7 +76,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ChangeAuthority</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs/#L25">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs/#L25">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -106,7 +106,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>UpdateComponent&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs/#L30">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs/#L30">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -136,7 +136,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddEvent&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs/#L35">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs/#L35">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -166,7 +166,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>UpdateComponentAndAddEvents&lt;TUpdate, TEvent&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs/#L40">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs/#L40">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -197,7 +197,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetMessagesReceived</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs/#L58">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs/#L58">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -225,7 +225,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetMessagesToSendContainer</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs/#L69">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs/#L69">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -244,7 +244,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>PushMessagesToSend</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs/#L74">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs/#L74">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -272,7 +272,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>IsConnected</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs/#L79">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs/#L79">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -291,7 +291,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Dispose</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs/#L118">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs/#L118">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/multi-threaded-spatial-os-connection-handler.md
+++ b/docs/api/core/multi-threaded-spatial-os-connection-handler.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/MultiThreadedSpatialOSConnectionHandler.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/MultiThreadedSpatialOSConnectionHandler.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>MultiThreadedSpatialOSConnectionHandler</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/MultiThreadedSpatialOSConnectionHandler.cs/#L14">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/MultiThreadedSpatialOSConnectionHandler.cs/#L14">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -87,7 +87,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>IsConnected</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/MultiThreadedSpatialOSConnectionHandler.cs/#L23">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/MultiThreadedSpatialOSConnectionHandler.cs/#L23">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -106,7 +106,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetMessagesReceived</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/MultiThreadedSpatialOSConnectionHandler.cs/#L28">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/MultiThreadedSpatialOSConnectionHandler.cs/#L28">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -134,7 +134,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetMessagesToSendContainer</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/MultiThreadedSpatialOSConnectionHandler.cs/#L43">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/MultiThreadedSpatialOSConnectionHandler.cs/#L43">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -153,7 +153,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>PushMessagesToSend</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/MultiThreadedSpatialOSConnectionHandler.cs/#L48">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/MultiThreadedSpatialOSConnectionHandler.cs/#L48">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -181,7 +181,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Dispose</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/MultiThreadedSpatialOSConnectionHandler.cs/#L64">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/MultiThreadedSpatialOSConnectionHandler.cs/#L64">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/newly-added-spatial-os-entity.md
+++ b/docs/api/core/newly-added-spatial-os-entity.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/NewlyAddedSpatialOSEntity.cs/#L11">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/NewlyAddedSpatialOSEntity.cs/#L11">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/core/on-connected.md
+++ b/docs/api/core/on-connected.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs/#L20">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs/#L20">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/core/on-disconnected.md
+++ b/docs/api/core/on-disconnected.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs/#L32">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs/#L32">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -54,7 +54,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ReasonForDisconnect</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs/#L37">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs/#L37">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/option.md
+++ b/docs/api/core/option.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L12">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L12">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -64,7 +64,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Empty</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L14">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L14">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -93,7 +93,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>HasValue</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L19">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L19">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -109,7 +109,7 @@ True if the <a href="{{urlRoot}}/api/core/option">Option</a> contains a value, f
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Value</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L29">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L29">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -147,7 +147,7 @@ Returns the value contained inside the <a href="{{urlRoot}}/api/core/option">Opt
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Option</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L51">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L51">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -196,7 +196,7 @@ Constructor for an option.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>TryGetValue</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L72">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L72">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -224,7 +224,7 @@ Attempts to get the value contained within the <a href="{{urlRoot}}/api/core/opt
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetValueOrDefault</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L93">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L93">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -252,7 +252,7 @@ Gets the value within the <a href="{{urlRoot}}/api/core/option">Option</a> or th
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Equals</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L103">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L103">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -292,7 +292,7 @@ Gets the value within the <a href="{{urlRoot}}/api/core/option">Option</a> or th
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Equals</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L98">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L98">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -320,7 +320,7 @@ Gets the value within the <a href="{{urlRoot}}/api/core/option">Option</a> or th
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetHashCode</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L128">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L128">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -339,7 +339,7 @@ Gets the value within the <a href="{{urlRoot}}/api/core/option">Option</a> or th
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ToString</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L133">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L133">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -370,7 +370,7 @@ Gets the value within the <a href="{{urlRoot}}/api/core/option">Option</a> or th
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>operator==</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L118">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L118">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -399,7 +399,7 @@ Gets the value within the <a href="{{urlRoot}}/api/core/option">Option</a> or th
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>operator!=</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L123">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L123">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -428,7 +428,7 @@ Gets the value within the <a href="{{urlRoot}}/api/core/option">Option</a> or th
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>operator Option&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L138">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L138">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -456,7 +456,7 @@ Gets the value within the <a href="{{urlRoot}}/api/core/option">Option</a> or th
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>operator T</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L143">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs/#L143">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/received-messages-span.md
+++ b/docs/api/core/received-messages-span.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Collections/ReceivedMessagesSpan.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Collections/ReceivedMessagesSpan.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -38,7 +38,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Count</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Collections/ReceivedMessagesSpan.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Collections/ReceivedMessagesSpan.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -66,7 +66,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>this[int index]</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Collections/ReceivedMessagesSpan.cs/#L33">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Collections/ReceivedMessagesSpan.cs/#L33">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -96,7 +96,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ToArray</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Collections/ReceivedMessagesSpan.cs/#L46">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Collections/ReceivedMessagesSpan.cs/#L46">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/receptionist-config.md
+++ b/docs/api/core/receptionist-config.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L76">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L76">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -42,7 +42,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ReceptionistHost</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L81">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L81">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -57,7 +57,7 @@ The host used to connect to the Receptionist.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ReceptionistPort</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L86">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L86">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -72,7 +72,7 @@ The port used to connect to the Receptionist.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WorkerId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L91">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L91">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/remove-at-end-of-tick-attribute.md
+++ b/docs/api/core/remove-at-end-of-tick-attribute.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Attributes/RemoveAtEndOfTickAttribute.cs/#L11">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Attributes/RemoveAtEndOfTickAttribute.cs/#L11">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/core/runtime-config-defaults.md
+++ b/docs/api/core/runtime-config-defaults.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L9">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L9">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -40,7 +40,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>LinkProtocol</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -55,7 +55,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>LocatorHost</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L12">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L12">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -70,7 +70,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ReceptionistHost</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L13">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L13">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -85,7 +85,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ReceptionistPort</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L14">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L14">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -100,7 +100,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AnonymousAuthenticationPort</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L15">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L15">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/runtime-config-names.md
+++ b/docs/api/core/runtime-config-names.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L21">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L21">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -40,7 +40,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>LinkProtocol</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L23">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L23">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -55,7 +55,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>LocatorHost</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L24">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L24">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -70,7 +70,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>LoginToken</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L25">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L25">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -85,7 +85,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>PlayerIdentityToken</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L26">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L26">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -100,7 +100,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ProjectName</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L27">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L27">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -115,7 +115,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ReceptionistHost</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L28">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L28">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -130,7 +130,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ReceptionistPort</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L29">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L29">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -145,7 +145,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SteamDeploymentTag</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L30">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L30">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -160,7 +160,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SteamTicket</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L31">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L31">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -175,7 +175,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WorkerId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L32">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs/#L32">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/schema-object-extensions.md
+++ b/docs/api/core/schema-object-extensions.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/SchemaObjectExtensions.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/SchemaObjectExtensions.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddEntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/SchemaObjectExtensions.cs/#L7">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/SchemaObjectExtensions.cs/#L7">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -69,7 +69,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetEntityIdStruct</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/SchemaObjectExtensions.cs/#L12">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/SchemaObjectExtensions.cs/#L12">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -98,7 +98,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>IndexEntityIdStruct</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/SchemaObjectExtensions.cs/#L17">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/SchemaObjectExtensions.cs/#L17">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/serialized-messages-to-send.md
+++ b/docs/api/core/serialized-messages-to-send.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L8">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L8">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SerializedMessagesToSend</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L48">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L48">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -72,7 +72,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SerializeFrom</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L86">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L86">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -101,7 +101,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Clear</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L110">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L110">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -120,7 +120,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SendAndClear</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L125">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L125">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -148,7 +148,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddComponentUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L203">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L203">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -177,7 +177,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddRequest</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L208">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L208">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -209,7 +209,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddResponse</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L213">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L213">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -238,7 +238,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddFailure</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L218">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L218">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -267,7 +267,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddCreateEntityRequest</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L223">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L223">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -298,7 +298,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddDeleteEntityRequest</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L228">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L228">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -328,7 +328,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddReserveEntityIdsRequest</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L233">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L233">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -358,7 +358,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddEntityQueryRequest</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L238">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/SerializedMessagesToSend.cs/#L238">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/snapshot.md
+++ b/docs/api/core/snapshot.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/Snapshot.cs/#L10">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/Snapshot.cs/#L10">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -43,7 +43,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Count</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/Snapshot.cs/#L14">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/Snapshot.cs/#L14">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -74,7 +74,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddEntity</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/Snapshot.cs/#L24">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/Snapshot.cs/#L24">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -111,7 +111,7 @@ Adds an entity to the snapshot
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WriteToFile</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/Snapshot.cs/#L35">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/Snapshot.cs/#L35">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/spatial-entity-id.md
+++ b/docs/api/core/spatial-entity-id.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/SpatialEntityId.cs/#L8">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/SpatialEntityId.cs/#L8">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/SpatialEntityId.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/SpatialEntityId.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/spatial-os-connection-handler.md
+++ b/docs/api/core/spatial-os-connection-handler.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/SpatialOSConnectionHandler/SpatialOSConnectionHandler.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/SpatialOSConnectionHandler/SpatialOSConnectionHandler.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SpatialOSConnectionHandler</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/SpatialOSConnectionHandler/SpatialOSConnectionHandler.cs/#L15">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/SpatialOSConnectionHandler/SpatialOSConnectionHandler.cs/#L15">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -87,7 +87,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>IsConnected</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/SpatialOSConnectionHandler/SpatialOSConnectionHandler.cs/#L20">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/SpatialOSConnectionHandler/SpatialOSConnectionHandler.cs/#L20">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -106,7 +106,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetMessagesReceived</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/SpatialOSConnectionHandler/SpatialOSConnectionHandler.cs/#L25">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/SpatialOSConnectionHandler/SpatialOSConnectionHandler.cs/#L25">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -134,7 +134,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetMessagesToSendContainer</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/SpatialOSConnectionHandler/SpatialOSConnectionHandler.cs/#L40">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/SpatialOSConnectionHandler/SpatialOSConnectionHandler.cs/#L40">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -153,7 +153,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>PushMessagesToSend</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/SpatialOSConnectionHandler/SpatialOSConnectionHandler.cs/#L45">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/SpatialOSConnectionHandler/SpatialOSConnectionHandler.cs/#L45">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -181,7 +181,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Dispose</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/SpatialOSConnectionHandler/SpatialOSConnectionHandler.cs/#L54">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/SpatialOSConnectionHandler/SpatialOSConnectionHandler.cs/#L54">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/spatial-os-receive-group.md
+++ b/docs/api/core/spatial-os-receive-group.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/UpdateGroups.cs/#L7">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/UpdateGroups.cs/#L7">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/core/spatial-os-receive-group/internal-spatial-os-receive-group.md
+++ b/docs/api/core/spatial-os-receive-group/internal-spatial-os-receive-group.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/spatial-os-receive-group">SpatialOSReceiveGroup</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/UpdateGroups.cs/#L10">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/UpdateGroups.cs/#L10">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/core/spatial-os-receive-system.md
+++ b/docs/api/core/spatial-os-receive-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs/#L12">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs/#L12">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -54,7 +54,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs/#L20">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs/#L20">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -73,7 +73,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs/#L31">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs/#L31">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/spatial-os-send-group.md
+++ b/docs/api/core/spatial-os-send-group.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/UpdateGroups.cs/#L16">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/UpdateGroups.cs/#L16">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/core/spatial-os-send-group/custom-spatial-os-send-group.md
+++ b/docs/api/core/spatial-os-send-group/custom-spatial-os-send-group.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/spatial-os-send-group">SpatialOSSendGroup</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/UpdateGroups.cs/#L19">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/UpdateGroups.cs/#L19">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/core/spatial-os-send-group/internal-spatial-os-clean-group.md
+++ b/docs/api/core/spatial-os-send-group/internal-spatial-os-clean-group.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/spatial-os-send-group">SpatialOSSendGroup</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/UpdateGroups.cs/#L31">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/UpdateGroups.cs/#L31">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/core/spatial-os-send-group/internal-spatial-os-send-group.md
+++ b/docs/api/core/spatial-os-send-group/internal-spatial-os-send-group.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a>.<a href="{{urlRoot}}/api/core/spatial-os-send-group">SpatialOSSendGroup</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/UpdateGroups.cs/#L25">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/UpdateGroups.cs/#L25">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/core/spatial-os-send-system.md
+++ b/docs/api/core/spatial-os-send-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSSendSystem.cs/#L8">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSSendSystem.cs/#L8">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSSendSystem.cs/#L12">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSSendSystem.cs/#L12">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSSendSystem.cs/#L19">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSSendSystem.cs/#L19">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/spatial-os-update-group.md
+++ b/docs/api/core/spatial-os-update-group.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/UpdateGroups.cs/#L38">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/UpdateGroups.cs/#L38">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/core/unity-object-destroyer.md
+++ b/docs/api/core/unity-object-destroyer.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/UnityObjectDestroyer.cs/#L8">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/UnityObjectDestroyer.cs/#L8">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -45,7 +45,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Destroy</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/UnityObjectDestroyer.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/UnityObjectDestroyer.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/view-command-buffer.md
+++ b/docs/api/core/view-command-buffer.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/ViewCommandBuffer.cs/#L15">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/ViewCommandBuffer.cs/#L15">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ViewCommandBuffer</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/ViewCommandBuffer.cs/#L32">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/ViewCommandBuffer.cs/#L32">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -88,7 +88,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddComponent&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/ViewCommandBuffer.cs/#L46">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/ViewCommandBuffer.cs/#L46">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -126,7 +126,7 @@ Adds a GameObject Component to an ECS entity.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddComponent</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/ViewCommandBuffer.cs/#L57">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/ViewCommandBuffer.cs/#L57">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -156,7 +156,7 @@ Adds a GameObject Component to an ECS entity.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RemoveComponent</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/ViewCommandBuffer.cs/#L73">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/ViewCommandBuffer.cs/#L73">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -185,7 +185,7 @@ Removes a GameObject Component from an ECS entity.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>FlushBuffer</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Utility/ViewCommandBuffer.cs/#L87">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Utility/ViewCommandBuffer.cs/#L87">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/view-diff.md
+++ b/docs/api/core/view-diff.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L8">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L8">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>DisconnectMessage</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Disconnected</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L12">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L12">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -83,7 +83,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>InCriticalSection</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L14">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L14">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -112,7 +112,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ViewDiff</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L43">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L43">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -143,7 +143,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Clear</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L94">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L94">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -162,7 +162,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddEntity</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L115">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L115">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -190,7 +190,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RemoveEntity</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L123">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L123">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -218,7 +218,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddComponent&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L131">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L131">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -248,7 +248,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RemoveComponent</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L143">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L143">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -277,7 +277,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SetAuthority</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L155">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L155">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -307,7 +307,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddComponentUpdate&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L180">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L180">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -338,7 +338,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddEvent&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L194">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L194">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -369,7 +369,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddCommandRequest&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L207">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L207">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -399,7 +399,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddCommandResponse&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L222">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L222">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -429,7 +429,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddCreateEntityResponse</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L238">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L238">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -457,7 +457,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddDeleteEntityResponse</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L243">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L243">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -485,7 +485,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddReserveEntityIdsResponse</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L248">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L248">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -513,7 +513,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddEntityQueryResponse</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L253">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L253">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -541,7 +541,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddLogMessage</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L258">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L258">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -570,7 +570,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddMetrics</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L263">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L263">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -598,7 +598,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Disconnect</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L275">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L275">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -626,7 +626,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SetCriticalSection</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L281">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ViewDiff.cs/#L281">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/view.md
+++ b/docs/api/core/view.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L8">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L8">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>View</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -72,7 +72,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>UpdateComponent&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L31">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L31">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -101,7 +101,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetEntityIds</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L37">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L37">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -120,7 +120,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>HasEntity</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L42">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L42">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -148,7 +148,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponent&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L48">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L48">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -176,7 +176,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>HasComponent&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L59">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L59">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -204,7 +204,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>HasComponent</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L70">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L70">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -233,7 +233,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetAuthority&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L81">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L81">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -261,7 +261,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetAuthority</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L91">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L91">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -290,7 +290,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>IsAuthoritative&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L101">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L101">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -318,7 +318,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>IsAuthoritative</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L111">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/View/View.cs/#L111">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/worker-connector.md
+++ b/docs/api/core/worker-connector.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L17">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L17">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -52,7 +52,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>MaxConnectionAttempts</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L24">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L24">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ The number of connection attempts before giving up.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Worker</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L32">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L32">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -91,7 +91,7 @@ Represents a SpatialOS worker.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>DevelopmentAuthToken</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L34">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L34">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -119,7 +119,7 @@ Represents a SpatialOS worker.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnWorkerCreationFinished</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L41">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L41">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -147,7 +147,7 @@ An event that triggers when the worker has been fully created.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CreateNewWorkerId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L343">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L343">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -188,7 +188,7 @@ An event that triggers when the worker has been fully created.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnApplicationQuit</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L57">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L57">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -207,7 +207,7 @@ An event that triggers when the worker has been fully created.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnDestroy</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L62">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L62">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -226,7 +226,7 @@ An event that triggers when the worker has been fully created.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetConnectionService</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L165">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L165">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -245,7 +245,7 @@ Determines which <a href="{{urlRoot}}/api/core/connection-service">ConnectionSer
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetConnectionParameters</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L173">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L173">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -274,7 +274,7 @@ Retrieves the ConnectionParameters needed to be able to connect to any connectio
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetLocatorConfig</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L179">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L179">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -293,7 +293,7 @@ Retrieves the configuration needed to connect via the Locator service.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetAlphaLocatorConfig</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L188">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L188">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -330,7 +330,7 @@ Retrieves the configuration needed to connect via the Alpha Locator service.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetReceptionistConfig</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L195">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L195">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -358,7 +358,7 @@ Retrieves the configuration needed to connect via the Receptionist service.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetPlayerId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L201">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L201">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -377,7 +377,7 @@ Retrieves the player id for the player trying to connect via the anonymous authe
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetDisplayName</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L210">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L210">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -396,7 +396,7 @@ Retrieves the display name for the player trying to connect via the anonymous au
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SelectDeploymentName</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L220">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L220">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -424,7 +424,7 @@ Selects which deployment to connect to.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SelectLoginToken</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L230">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L230">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -452,7 +452,7 @@ Selects which login token to use to connect via the anonymous authentication flo
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetDevelopmentPlayerIdentityToken</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L248">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L248">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -482,7 +482,7 @@ Retrieves the player identity token needed to generate a login token when using 
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetDevelopmentLoginTokens</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L282">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L282">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -511,7 +511,7 @@ Retrieves the login tokens for all active deployments that the player can connec
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>HandleWorkerConnectionEstablished</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L310">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L310">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -530,7 +530,7 @@ Retrieves the login tokens for all active deployments that the player can connec
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>HandleWorkerConnectionFailure</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L314">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L314">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -558,7 +558,7 @@ Retrieves the login tokens for all active deployments that the player can connec
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Connect</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L77">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L77">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -596,7 +596,7 @@ Asynchronously connects a worker to the SpatialOS runtime.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Dispose</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L363">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs/#L363">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/worker-disconnect-callback-system.md
+++ b/docs/api/core/worker-disconnect-callback-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerDisconnectCallbackSystem.cs/#L14">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerDisconnectCallbackSystem.cs/#L14">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -54,7 +54,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerDisconnectCallbackSystem.cs/#L33">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerDisconnectCallbackSystem.cs/#L33">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -73,7 +73,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerDisconnectCallbackSystem.cs/#L40">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerDisconnectCallbackSystem.cs/#L40">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/worker-entity-tag.md
+++ b/docs/api/core/worker-entity-tag.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs/#L8">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs/#L8">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/core/worker-system.md
+++ b/docs/api/core/worker-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L13">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L13">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -51,7 +51,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WorkerEntity</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L18">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L18">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -66,7 +66,7 @@ An ECS entity that represents the <a href="{{urlRoot}}/api/core/worker">Worker</
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Connection</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L20">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L20">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -81,7 +81,7 @@ An ECS entity that represents the <a href="{{urlRoot}}/api/core/worker">Worker</
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>LogDispatcher</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L21">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L21">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -96,7 +96,7 @@ An ECS entity that represents the <a href="{{urlRoot}}/api/core/worker">Worker</
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WorkerType</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L22">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L22">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -111,7 +111,7 @@ An ECS entity that represents the <a href="{{urlRoot}}/api/core/worker">Worker</
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Origin</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L23">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L23">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -141,7 +141,7 @@ An ECS entity that represents the <a href="{{urlRoot}}/api/core/worker">Worker</
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WorkerSystem</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L34">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L34">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -185,7 +185,7 @@ An ECS entity that represents the <a href="{{urlRoot}}/api/core/worker">Worker</
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>TryGetEntity</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L56">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L56">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -214,7 +214,7 @@ Attempts to find an ECS entity associated with a SpatialOS entity ID.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>HasEntity</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L66">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L66">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -242,7 +242,7 @@ Checks whether a SpatialOS entity is checked out on this worker.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SendLogMessage</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L71">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L71">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -273,7 +273,7 @@ Checks whether a SpatialOS entity is checked out on this worker.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SendMetrics</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L76">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L76">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -313,7 +313,7 @@ Checks whether a SpatialOS entity is checked out on this worker.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L92">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L92">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -332,7 +332,7 @@ Checks whether a SpatialOS entity is checked out on this worker.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnDestroyManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L100">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L100">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -351,7 +351,7 @@ Checks whether a SpatialOS entity is checked out on this worker.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L106">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs/#L106">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/worker.md
+++ b/docs/api/core/worker.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L15">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L15">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -51,7 +51,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Origin</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L20">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L20">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -66,7 +66,7 @@ The origin of the worker in global Unity space.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WorkerType</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L25">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L25">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -81,7 +81,7 @@ The type of the worker.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WorkerId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L33">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L33">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -105,7 +105,7 @@ The worker ID.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>LogDispatcher</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L38">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L38">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -133,7 +133,7 @@ The logger for this worker.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Connection</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L43">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L43">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -149,7 +149,7 @@ The connection to the SpatialOS runtime.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>World</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L48">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L48">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -165,7 +165,7 @@ The ECS world associated with this worker.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnDisconnect</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L55">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L55">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -193,7 +193,7 @@ An event that triggers when the worker is disconnected.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CreateWorkerAsync</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L135">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L135">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -224,7 +224,7 @@ Connects to the SpatialOS Runtime via the Receptionist service and creates a <a 
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CreateWorkerAsync</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L163">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L163">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -255,7 +255,7 @@ Connects to the SpatialOS Runtime via the Locator service and creates a <a href=
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CreateWorkerAsync</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L201">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L201">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -299,7 +299,7 @@ Connects to the SpatialOS Runtime via the Alpha Locator service and creates a <a
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Dispose</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L266">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs/#L266">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/world-command-meta-data-storage.md
+++ b/docs/api/core/world-command-meta-data-storage.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/WorldCommandMetaDataStorage.cs/#L11">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/WorldCommandMetaDataStorage.cs/#L11">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -51,7 +51,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponentId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/WorldCommandMetaDataStorage.cs/#L28">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/WorldCommandMetaDataStorage.cs/#L28">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -70,7 +70,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetCommandId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/WorldCommandMetaDataStorage.cs/#L33">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/WorldCommandMetaDataStorage.cs/#L33">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -89,7 +89,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RemoveMetaData</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/WorldCommandMetaDataStorage.cs/#L38">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/WorldCommandMetaDataStorage.cs/#L38">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -117,7 +117,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SetInternalRequestId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/WorldCommandMetaDataStorage.cs/#L53">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/WorldCommandMetaDataStorage.cs/#L53">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -146,7 +146,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddRequest</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/WorldCommandMetaDataStorage.cs/#L58">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/WorldCommandMetaDataStorage.cs/#L58">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -174,7 +174,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddRequest</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/WorldCommandMetaDataStorage.cs/#L63">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/WorldCommandMetaDataStorage.cs/#L63">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -202,7 +202,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddRequest</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/WorldCommandMetaDataStorage.cs/#L68">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/WorldCommandMetaDataStorage.cs/#L68">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -230,7 +230,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddRequest</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/WorldCommandMetaDataStorage.cs/#L73">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/ConnectionHandlers/WorldCommandMetaDataStorage.cs/#L73">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/world-command-sender-subscription-manager.md
+++ b/docs/api/core/world-command-sender-subscription-manager.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L11">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L11">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WorldCommandSenderSubscriptionManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L20">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L20">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -88,7 +88,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Subscribe</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L57">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L57">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -116,7 +116,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Cancel</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L81">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L81">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -144,7 +144,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ResetValue</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L97">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L97">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/world-command-sender.md
+++ b/docs/api/core/world-command-sender.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L102">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L102">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -38,7 +38,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>IsValid</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L104">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L104">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -68,7 +68,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WorldCommandSender</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L110">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L110">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -109,7 +109,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SendCreateEntityCommand</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L119">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L119">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -138,7 +138,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SendDeleteEntityCommand</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L138">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L138">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -167,7 +167,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SendReserveEntityIdsCommand</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L157">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L157">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -196,7 +196,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SendEntityQueryCommand</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L176">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs/#L176">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/world-command-serializer.md
+++ b/docs/api/core/world-command-serializer.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandSerializer.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandSerializer.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Serialize</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandSerializer.cs/#L7">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandSerializer.cs/#L7">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/world-commands-received-storage.md
+++ b/docs/api/core/world-commands-received-storage.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsReceivedStorage.cs/#L10">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsReceivedStorage.cs/#L10">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -51,7 +51,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Clear</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsReceivedStorage.cs/#L31">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsReceivedStorage.cs/#L31">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -70,7 +70,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddResponse</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsReceivedStorage.cs/#L43">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsReceivedStorage.cs/#L43">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -98,7 +98,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddResponse</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsReceivedStorage.cs/#L48">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsReceivedStorage.cs/#L48">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -126,7 +126,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddResponse</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsReceivedStorage.cs/#L53">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsReceivedStorage.cs/#L53">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -154,7 +154,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddResponse</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsReceivedStorage.cs/#L58">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsReceivedStorage.cs/#L58">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/world-commands-to-send-storage.md
+++ b/docs/api/core/world-commands-to-send-storage.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsToSendStorage.cs/#L10">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsToSendStorage.cs/#L10">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -51,7 +51,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Clear</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsToSendStorage.cs/#L24">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsToSendStorage.cs/#L24">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -70,7 +70,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddRequest</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsToSendStorage.cs/#L32">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsToSendStorage.cs/#L32">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -100,7 +100,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddRequest</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsToSendStorage.cs/#L39">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsToSendStorage.cs/#L39">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -130,7 +130,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddRequest</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsToSendStorage.cs/#L46">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsToSendStorage.cs/#L46">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -160,7 +160,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddRequest</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsToSendStorage.cs/#L53">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Worker/WorldCommandsToSendStorage.cs/#L53">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/core/worlds-initialization-helper.md
+++ b/docs/api/core/worlds-initialization-helper.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/core-index">Core</a><br/>
 GDK package: Core<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/WorldsInitializationHelper.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/WorldsInitializationHelper.cs/#L6">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SetupInjectionHooks</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/WorldsInitializationHelper.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/WorldsInitializationHelper.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -58,7 +58,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>DomainUnloadShutdown</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/WorldsInitializationHelper.cs/#L29">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/WorldsInitializationHelper.cs/#L29">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/game-object-creation/game-object-creation-helper.md
+++ b/docs/api/game-object-creation/game-object-creation-helper.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/game-object-creation-index">GameObjectCreation</a><br/>
 GDK package: GameObjectCreation<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectCreationHelper.cs/#L9">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectCreationHelper.cs/#L9">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EnableStandardGameObjectCreation</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectCreationHelper.cs/#L13">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectCreationHelper.cs/#L13">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -68,7 +68,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EnableStandardGameObjectCreation</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectCreationHelper.cs/#L26">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectCreationHelper.cs/#L26">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/game-object-creation/game-object-creator-from-metadata.md
+++ b/docs/api/game-object-creation/game-object-creator-from-metadata.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/game-object-creation-index">GameObjectCreation</a><br/>
 GDK package: GameObjectCreation<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectCreatorFromMetadata.cs/#L11">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectCreatorFromMetadata.cs/#L11">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GameObjectCreatorFromMetadata</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectCreatorFromMetadata.cs/#L30">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectCreatorFromMetadata.cs/#L30">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -89,7 +89,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnEntityCreated</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectCreatorFromMetadata.cs/#L37">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectCreatorFromMetadata.cs/#L37">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -118,7 +118,7 @@ Called when a new SpatialOS Entity is checked out by the worker.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnEntityRemoved</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectCreatorFromMetadata.cs/#L80">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectCreatorFromMetadata.cs/#L80">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/game-object-creation/game-object-initialization-group.md
+++ b/docs/api/game-object-creation/game-object-initialization-group.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/game-object-creation-index">GameObjectCreation</a><br/>
 GDK package: GameObjectCreation<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/UpdateGroups.cs/#L9">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/UpdateGroups.cs/#L9">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/game-object-creation/i-entity-game-object-creator.md
+++ b/docs/api/game-object-creation/i-entity-game-object-creator.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/game-object-creation-index">GameObjectCreation</a><br/>
 GDK package: GameObjectCreation<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/IEntityGameObjectCreator.cs/#L12">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/IEntityGameObjectCreator.cs/#L12">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnEntityCreated</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/IEntityGameObjectCreator.cs/#L20">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/IEntityGameObjectCreator.cs/#L20">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -76,7 +76,7 @@ Called when a new SpatialOS Entity is checked out by the worker.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnEntityRemoved</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/IEntityGameObjectCreator.cs/#L25">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/IEntityGameObjectCreator.cs/#L25">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/game-object-creation/spatial-os-entity.md
+++ b/docs/api/game-object-creation/spatial-os-entity.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/game-object-creation-index">GameObjectCreation</a><br/>
 GDK package: GameObjectCreation<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/SpatialOSEntity.cs/#L10">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/SpatialOSEntity.cs/#L10">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -43,7 +43,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SpatialOSEntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/SpatialOSEntity.cs/#L12">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/SpatialOSEntity.cs/#L12">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -74,7 +74,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>HasComponent&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/SpatialOSEntity.cs/#L23">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/SpatialOSEntity.cs/#L23">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -93,7 +93,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetComponent&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/SpatialOSEntity.cs/#L28">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/SpatialOSEntity.cs/#L28">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/mobile/android/android-device-info.md
+++ b/docs/api/mobile/android/android-device-info.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/mobile-index">Mobile</a>.<a href="{{urlRoot}}/api/mobile/android-index">Android</a><br/>
 GDK package: Mobile<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.mobile/Android/Utility/AndroidDeviceInfo.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.mobile/Android/Utility/AndroidDeviceInfo.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -35,7 +35,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EmulatorDefaultCallbackIp</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.mobile/Android/Utility/AndroidDeviceInfo.cs/#L7">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.mobile/Android/Utility/AndroidDeviceInfo.cs/#L7">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -64,7 +64,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ActiveDeviceType</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.mobile/Android/Utility/AndroidDeviceInfo.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.mobile/Android/Utility/AndroidDeviceInfo.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/mobile/android/launch-arguments.md
+++ b/docs/api/mobile/android/launch-arguments.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/mobile-index">Mobile</a>.<a href="{{urlRoot}}/api/mobile/android-index">Android</a><br/>
 GDK package: Mobile<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.mobile/Android/Utility/LaunchArguments.cs/#L8">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.mobile/Android/Utility/LaunchArguments.cs/#L8">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetArguments</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.mobile/Android/Utility/LaunchArguments.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.mobile/Android/Utility/LaunchArguments.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/mobile/i-os/i-os-device-info.md
+++ b/docs/api/mobile/i-os/i-os-device-info.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/mobile-index">Mobile</a>.<a href="{{urlRoot}}/api/mobile/i-os-index">iOS</a><br/>
 GDK package: Mobile<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.mobile/iOS/Utility/iOSDeviceInfo.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.mobile/iOS/Utility/iOSDeviceInfo.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -37,7 +37,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ActiveDeviceType</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.mobile/iOS/Utility/iOSDeviceInfo.cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.mobile/iOS/Utility/iOSDeviceInfo.cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/mobile/launch-menu.md
+++ b/docs/api/mobile/launch-menu.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/mobile-index">Mobile</a><br/>
 GDK package: Mobile<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs/#L10">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs/#L10">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/mobile/mobile-device-type.md
+++ b/docs/api/mobile/mobile-device-type.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/mobile-index">Mobile</a><br/>
 GDK package: Mobile<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.mobile/Utility/MobileDeviceType.cs/#L3">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.mobile/Utility/MobileDeviceType.cs/#L3">Source</a>
 </sup>
 
 

--- a/docs/api/mobile/mobile-worker-connector.md
+++ b/docs/api/mobile/mobile-worker-connector.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/mobile-index">Mobile</a><br/>
 GDK package: Mobile<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs/#L9">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs/#L9">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetHostIp</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -79,7 +79,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetConnectionParameters</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs/#L13">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs/#L13">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -108,7 +108,7 @@ Retrieves the ConnectionParameters needed to be able to connect to any connectio
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetReceptionistConfig</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs/#L36">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs/#L36">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -136,7 +136,7 @@ Retrieves the configuration needed to connect via the Receptionist service.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetLocatorConfig</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs/#L46">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs/#L46">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -155,7 +155,7 @@ Retrieves the configuration needed to connect via the Locator service.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetAlphaLocatorConfig</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs/#L51">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs/#L51">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/player-lifecycle/handle-create-player-request-system.md
+++ b/docs/api/player-lifecycle/handle-create-player-request-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/player-lifecycle-index">PlayerLifecycle</a><br/>
 GDK package: PlayerLifecycle<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/HandleCreatePlayerRequestSystem.cs/#L12">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/HandleCreatePlayerRequestSystem.cs/#L12">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/HandleCreatePlayerRequestSystem.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/HandleCreatePlayerRequestSystem.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/HandleCreatePlayerRequestSystem.cs/#L27">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/HandleCreatePlayerRequestSystem.cs/#L27">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/player-lifecycle/handle-player-heartbeat-request-system.md
+++ b/docs/api/player-lifecycle/handle-player-heartbeat-request-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/player-lifecycle-index">PlayerLifecycle</a><br/>
 GDK package: PlayerLifecycle<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatRequestSystem.cs/#L11">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatRequestSystem.cs/#L11">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatRequestSystem.cs/#L15">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatRequestSystem.cs/#L15">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatRequestSystem.cs/#L22">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatRequestSystem.cs/#L22">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/player-lifecycle/handle-player-heartbeat-response-system.md
+++ b/docs/api/player-lifecycle/handle-player-heartbeat-response-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/player-lifecycle-index">PlayerLifecycle</a><br/>
 GDK package: PlayerLifecycle<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatResponseSystem.cs/#L14">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatResponseSystem.cs/#L14">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatResponseSystem.cs/#L23">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatResponseSystem.cs/#L23">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatResponseSystem.cs/#L32">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatResponseSystem.cs/#L32">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/player-lifecycle/heartbeat-data.md
+++ b/docs/api/player-lifecycle/heartbeat-data.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/player-lifecycle-index">PlayerLifecycle</a><br/>
 GDK package: PlayerLifecycle<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Components/HeartbeatData.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Components/HeartbeatData.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -42,7 +42,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>NumFailedHeartbeats</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Components/HeartbeatData.cs/#L7">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Components/HeartbeatData.cs/#L7">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/player-lifecycle/player-heartbeat-initialization-system.md
+++ b/docs/api/player-lifecycle/player-heartbeat-initialization-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/player-lifecycle-index">PlayerLifecycle</a><br/>
 GDK package: PlayerLifecycle<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/PlayerHeartbeatInitializationSystem.cs/#L12">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/PlayerHeartbeatInitializationSystem.cs/#L12">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/PlayerHeartbeatInitializationSystem.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/PlayerHeartbeatInitializationSystem.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/PlayerHeartbeatInitializationSystem.cs/#L36">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/PlayerHeartbeatInitializationSystem.cs/#L36">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/player-lifecycle/player-lifecycle-config.md
+++ b/docs/api/player-lifecycle/player-lifecycle-config.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/player-lifecycle-index">PlayerLifecycle</a><br/>
 GDK package: PlayerLifecycle<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Config/PlayerLifecycleConfig.cs/#L9">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Config/PlayerLifecycleConfig.cs/#L26">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -13,53 +13,11 @@ code {
 }
 </style>
 </sup>
-<nav id="pageToc" class="page-toc"><ul><li><a href="#const-fields">Const Fields</a>
-<li><a href="#static-fields">Static Fields</a>
+<nav id="pageToc" class="page-toc"><ul><li><a href="#static-fields">Static Fields</a>
 </ul></nav>
 
 
 
-
-
-
-</p>
-<hr style="width:100%; border-top-color:#d8d8d8" />
-#### Const Fields
-
-
-</p>
-
-
-
-
-<table width="100%">
-    <tr>
-        <td style="border-right:none"><b>PlayerHeartbeatIntervalSeconds</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Config/PlayerLifecycleConfig.cs/#L11">Source</a></td>
-    </tr>
-    <tr>
-        <td colspan="2">
-<code>const float PlayerHeartbeatIntervalSeconds = 5f</code></p>
-
-
-</td>
-    </tr>
-</table>
-
-
-<table width="100%">
-    <tr>
-        <td style="border-right:none"><b>MaxNumFailedPlayerHeartbeats</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Config/PlayerLifecycleConfig.cs/#L12">Source</a></td>
-    </tr>
-    <tr>
-        <td colspan="2">
-<code>const int MaxNumFailedPlayerHeartbeats = 2</code></p>
-
-
-</td>
-    </tr>
-</table>
 
 
 
@@ -76,12 +34,117 @@ code {
 
 <table width="100%">
     <tr>
+        <td style="border-right:none"><b>PlayerHeartbeatIntervalSeconds</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Config/PlayerLifecycleConfig.cs/#L35">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code> float PlayerHeartbeatIntervalSeconds</code></p>
+The time in seconds between player heartbeat requests. 
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>This is used by the <a href="{{urlRoot}}/api/player-lifecycle/send-player-heartbeat-request-system">SendPlayerHeartbeatRequestSystem</a> on the server-worker to determine how often to send a  request to client-workers. </li>
+</ul>
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>MaxNumFailedPlayerHeartbeats</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Config/PlayerLifecycleConfig.cs/#L44">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code> int MaxNumFailedPlayerHeartbeats</code></p>
+The maximum number of failed heartbeats before a player is disconnected. 
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>The <a href="{{urlRoot}}/api/player-lifecycle/handle-player-heartbeat-response-system">HandlePlayerHeartbeatResponseSystem</a> deletes a player entity if the corresponding client-worker fails to respond successfully to this number of consecutive  requests. </li>
+</ul>
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>MaxPlayerCreationRetries</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Config/PlayerLifecycleConfig.cs/#L53">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code> int MaxPlayerCreationRetries</code></p>
+The maximum number of retries for player creation requests. 
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>The number of times a player creation request is retried after the first attempt. Setting this to 0 disables retrying player creation after calling . </li>
+</ul>
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>MaxPlayerCreatorQueryRetries</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Config/PlayerLifecycleConfig.cs/#L63">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code> int MaxPlayerCreatorQueryRetries</code></p>
+The maximum number of retries for finding player creator entities, before any player creation occurs. 
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>All player creation requests must be sent to a player creator entity, which are initially queried for when the <a href="{{urlRoot}}/api/player-lifecycle/send-create-player-request-system">SendCreatePlayerRequestSystem</a> starts. This field indicates the maximum number of retries for the </li>
+</ul>
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
         <td style="border-right:none"><b>AutoRequestPlayerCreation</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Config/PlayerLifecycleConfig.cs/#L14">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Config/PlayerLifecycleConfig.cs/#L73">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
 <code> bool AutoRequestPlayerCreation</code></p>
+This indicates whether a player should be created automatically upon a worker connecting to SpatialOS. 
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>If , a Player entity is automatically created upon a client-worker connecting to SpatialOS. However, to be able to send arbitrary serialized data in the player creation request, or to provide a callback to be invoked upon receiving a player creation response, this field must be set to . </li>
+</ul>
 
 
 </td>
@@ -92,11 +155,20 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CreatePlayerEntityTemplate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Config/PlayerLifecycleConfig.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Config/PlayerLifecycleConfig.cs/#L82">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
 <code> GetPlayerEntityTemplateDelegate CreatePlayerEntityTemplate</code></p>
+The delegate responsible for returning a player EntityTemplate when creating a player. 
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>This must be set before initiating any player creation because it is called by the <a href="{{urlRoot}}/api/player-lifecycle/handle-create-player-request-system">HandleCreatePlayerRequestSystem</a>. The system uses this delegate to request a new player entity based on the returned EntityTemplate. </li>
+</ul>
 
 
 </td>

--- a/docs/api/player-lifecycle/player-lifecycle-helper.md
+++ b/docs/api/player-lifecycle/player-lifecycle-helper.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/player-lifecycle-index">PlayerLifecycle</a><br/>
 GDK package: PlayerLifecycle<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/PlayerLifecycleHelper.cs/#L10">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/PlayerLifecycleHelper.cs/#L10">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,12 +39,12 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddPlayerLifecycleComponents</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/PlayerLifecycleHelper.cs/#L12">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/PlayerLifecycleHelper.cs/#L18">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
-<code>void AddPlayerLifecycleComponents(<a href="{{urlRoot}}/api/core/entity-template">EntityTemplate</a> template, string workerId, string clientAccess, string serverAccess)</code></p>
-
+<code>void AddPlayerLifecycleComponents(<a href="{{urlRoot}}/api/core/entity-template">EntityTemplate</a> template, string clientWorkerId, string serverAccess)</code></p>
+Adds the SpatialOS components used by the player lifecycle module to an entity template. 
 
 
 </p>
@@ -52,10 +52,9 @@ code {
 <b>Parameters</b>
 
 <ul>
-<li><code><a href="{{urlRoot}}/api/core/entity-template">EntityTemplate</a> template</code> : </li>
-<li><code>string workerId</code> : </li>
-<li><code>string clientAccess</code> : </li>
-<li><code>string serverAccess</code> : </li>
+<li><code><a href="{{urlRoot}}/api/core/entity-template">EntityTemplate</a> template</code> : The entity template to add player lifecycle components to.</li>
+<li><code>string clientWorkerId</code> : The ID of the client-worker.</li>
+<li><code>string serverAccess</code> : The server-worker write access attribute.</li>
 </ul>
 
 
@@ -70,21 +69,21 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>IsOwningWorker</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/PlayerLifecycleHelper.cs/#L26">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/PlayerLifecycleHelper.cs/#L41">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
 <code>bool IsOwningWorker(<a href="{{urlRoot}}/api/core/spatial-entity-id">SpatialEntityId</a> entityId, World workerWorld)</code></p>
-
-
+Returns whether an entity is owned by a worker. It can be used to determine whether a client-worker is responsible for a particular player entity. 
+</p><b>Returns:</b></br>True if the entity with ID entityId contains an OwningWorker component with a value matching the workerWorld's workerId. False if the entity does not contain an OwningWorker component, or if the value does not match the workerId. Throws an InvalidOperationException if workerWorld does not contain a WorkerSystem, or if the entity does not exist in the worker's view. 
 
 </p>
 
 <b>Parameters</b>
 
 <ul>
-<li><code><a href="{{urlRoot}}/api/core/spatial-entity-id">SpatialEntityId</a> entityId</code> : </li>
-<li><code>World workerWorld</code> : </li>
+<li><code><a href="{{urlRoot}}/api/core/spatial-entity-id">SpatialEntityId</a> entityId</code> : An ECS component containing a SpatialOS Entity ID.</li>
+<li><code>World workerWorld</code> : An ECS World associated with a worker.</li>
 </ul>
 
 
@@ -99,12 +98,12 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddClientSystems</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/PlayerLifecycleHelper.cs/#L52">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/PlayerLifecycleHelper.cs/#L72">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
 <code>void AddClientSystems(World world, bool autoRequestPlayerCreation = true)</code></p>
-
+Adds all the systems a client-worker requires for the player lifecycle module. 
 
 
 </p>
@@ -112,8 +111,8 @@ code {
 <b>Parameters</b>
 
 <ul>
-<li><code>World world</code> : </li>
-<li><code>bool autoRequestPlayerCreation</code> : </li>
+<li><code>World world</code> : A world that belongs to a client-worker.</li>
+<li><code>bool autoRequestPlayerCreation</code> : An option to toggle automatic player creation.</li>
 </ul>
 
 
@@ -128,12 +127,12 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddServerSystems</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/PlayerLifecycleHelper.cs/#L59">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/PlayerLifecycleHelper.cs/#L83">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
 <code>void AddServerSystems(World world)</code></p>
-
+Adds all the systems a server-worker requires for the player lifecycle module. 
 
 
 </p>
@@ -141,7 +140,7 @@ code {
 <b>Parameters</b>
 
 <ul>
-<li><code>World world</code> : </li>
+<li><code>World world</code> : A world that belongs to a server-worker.</li>
 </ul>
 
 

--- a/docs/api/player-lifecycle/send-create-player-request-system.md
+++ b/docs/api/player-lifecycle/send-create-player-request-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/player-lifecycle-index">PlayerLifecycle</a><br/>
 GDK package: PlayerLifecycle<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/SendCreatePlayerRequestSystem.cs/#L12">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/SendCreatePlayerRequestSystem.cs/#L17">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,12 +48,12 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RequestPlayerCreation</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/SendCreatePlayerRequestSystem.cs/#L38">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/SendCreatePlayerRequestSystem.cs/#L115">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
-<code>void RequestPlayerCreation(byte [] serializedArguments = null)</code></p>
-
+<code>void RequestPlayerCreation(byte [] serializedArguments = null, Action&lt;PlayerCreator.CreatePlayer.ReceivedResponse&gt; callback = null)</code></p>
+Queues a request for player creation, if none are currently in progress. If player creation entities have already been found, the request is sent in the next tick. 
 
 
 </p>
@@ -61,7 +61,8 @@ code {
 <b>Parameters</b>
 
 <ul>
-<li><code>byte [] serializedArguments</code> : </li>
+<li><code>byte [] serializedArguments</code> : A serialized byte array of arbitrary player creation arguments.</li>
+<li><code>Action&lt;PlayerCreator.CreatePlayer.ReceivedResponse&gt; callback</code> : An action to be invoked when the worker receives a response to the player creation request. </li>
 </ul>
 
 
@@ -88,7 +89,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/SendCreatePlayerRequestSystem.cs/#L24">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/SendCreatePlayerRequestSystem.cs/#L41">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -107,7 +108,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/SendCreatePlayerRequestSystem.cs/#L51">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/SendCreatePlayerRequestSystem.cs/#L219">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/player-lifecycle/send-player-heartbeat-request-system.md
+++ b/docs/api/player-lifecycle/send-player-heartbeat-request-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/player-lifecycle-index">PlayerLifecycle</a><br/>
 GDK package: PlayerLifecycle<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/SendPlayerHeartbeatRequestSystem.cs/#L21">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/SendPlayerHeartbeatRequestSystem.cs/#L21">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/SendPlayerHeartbeatRequestSystem.cs/#L27">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/SendPlayerHeartbeatRequestSystem.cs/#L27">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/SendPlayerHeartbeatRequestSystem.cs/#L41">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/SendPlayerHeartbeatRequestSystem.cs/#L41">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/query-based-interest-index.md
+++ b/docs/api/query-based-interest-index.md
@@ -1,0 +1,33 @@
+
+# Improbable.Gdk.QueryBasedInterest Namespace
+<nav id="pageToc" class="page-toc"><ul><li><a href="#classes">Classes</a>
+</ul></nav>
+<sup>
+Namespace: Improbable.Gdk<br/>
+GDK package: QueryBasedInterest<br />
+</sup>
+
+
+</p>
+
+#### Classes
+
+<table>
+<tr>
+<td style="padding: 14px; border: none; width: 16ch"><a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a></td>
+<td style="padding: 14px; border: none;">Utility class to help define QueryConstraint objects for Interest queries. </td>
+</tr>
+<tr>
+<td style="padding: 14px; border: none; width: 16ch"><a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a></td>
+<td style="padding: 14px; border: none;">Utility class to help construct ComponentInterest.Query objects. </td>
+</tr>
+<tr>
+<td style="padding: 14px; border: none; width: 16ch"><a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a></td>
+<td style="padding: 14px; border: none;">Utility class to help construct Interest component snapshots. </td>
+</tr>
+</table>
+
+
+
+
+

--- a/docs/api/query-based-interest/constraint.md
+++ b/docs/api/query-based-interest/constraint.md
@@ -1,0 +1,611 @@
+
+# Constraint Class
+<sup>
+Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/query-based-interest-index">QueryBasedInterest</a><br/>
+GDK package: QueryBasedInterest<br/>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/Constraint.cs/#L11">Source</a>
+<style>
+a code {
+                    padding: 0em 0.25em!important;
+}
+code {
+                    background-color: #ffffff!important;
+}
+</style>
+</sup>
+<nav id="pageToc" class="page-toc"><ul><li><a href="#static-methods">Static Methods</a>
+<li><a href="#methods">Methods</a>
+</ul></nav>
+
+</p>
+
+
+
+<p>Utility class to help define QueryConstraint objects for Interest queries. </p>
+
+
+
+
+
+
+
+
+
+
+
+</p>
+<hr style="width:100%; border-top-color:#d8d8d8" />
+#### Static Methods
+
+
+</p>
+
+
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>Sphere</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/Constraint.cs/#L41">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> Sphere(double radius, Coordinates center)</code></p>
+Creates a <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object with a Sphere QueryConstraint. 
+</p><b>Returns:</b></br>A <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>double radius</code> : Radius of the Sphere QueryConstraint. </li>
+<li><code>Coordinates center</code> : Center of the Sphere QueryConstraint. </li>
+</ul>
+
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>Sphere</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/Constraint.cs/#L70">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> Sphere(double radius, double centerX, double centerY, double centerZ)</code></p>
+Creates a <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object with a Sphere QueryConstraint. 
+</p><b>Returns:</b></br>A <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>double radius</code> : Radius of the Sphere QueryConstraint. </li>
+<li><code>double centerX</code> : X coordinate of the center of the Sphere QueryConstraint. </li>
+<li><code>double centerY</code> : Y coordinate of the center of the Sphere QueryConstraint. </li>
+<li><code>double centerZ</code> : Z coordinate of the center of the Sphere QueryConstraint. </li>
+</ul>
+
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>Cylinder</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/Constraint.cs/#L91">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> Cylinder(double radius, Coordinates center)</code></p>
+Creates a <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object with a Cylinder QueryConstraint. 
+</p><b>Returns:</b></br>A <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>double radius</code> : Radius of the Cylinder QueryConstraint. </li>
+<li><code>Coordinates center</code> : Center of the Cylinder QueryConstraint. </li>
+</ul>
+
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>Cylinder</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/Constraint.cs/#L120">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> Cylinder(double radius, double centerX, double centerY, double centerZ)</code></p>
+Creates a <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object with a Cylinder QueryConstraint. 
+</p><b>Returns:</b></br>A <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>double radius</code> : Radius of the Cylinder QueryConstraint. </li>
+<li><code>double centerX</code> : X coordinate of the center of the Cylinder QueryConstraint. </li>
+<li><code>double centerY</code> : Y coordinate of the center of the Cylinder QueryConstraint. </li>
+<li><code>double centerZ</code> : Z coordinate of the center of the Cylinder QueryConstraint. </li>
+</ul>
+
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>Box</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/Constraint.cs/#L147">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> Box(double xWidth, double yHeight, double zDepth, Coordinates center)</code></p>
+Creates a <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object with a Box queryConstraint. 
+</p><b>Returns:</b></br>A <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>double xWidth</code> : Width of Box QueryConstraint in the X-axis. </li>
+<li><code>double yHeight</code> : Height of Box QueryConstraint in the Y-axis. </li>
+<li><code>double zDepth</code> : Depth of Box QueryConstraint in the Z-axis. </li>
+<li><code>Coordinates center</code> : Center of the Box QueryConstraint. </li>
+</ul>
+
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>Box</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/Constraint.cs/#L186">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> Box(double xWidth, double yHeight, double zDepth, double centerX, double centerY, double centerZ)</code></p>
+Creates a <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object with a Box QueryConstraint. 
+</p><b>Returns:</b></br>A <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>double xWidth</code> : Width of Box QueryConstraint in the X-axis. </li>
+<li><code>double yHeight</code> : Height of Box QueryConstraint in the Y-axis. </li>
+<li><code>double zDepth</code> : Depth of Box QueryConstraint in the Z-axis. </li>
+<li><code>double centerX</code> : X coordinate of the center of the Box QueryConstraint. </li>
+<li><code>double centerY</code> : Y coordinate of the center of the Box QueryConstraint. </li>
+<li><code>double centerZ</code> : Z coordinate of the center of the Box QueryConstraint. </li>
+</ul>
+
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>RelativeSphere</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/Constraint.cs/#L209">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> RelativeSphere(double radius)</code></p>
+Creates a <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object with a RelativeSphere QueryConstraint. 
+</p><b>Returns:</b></br>A <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>double radius</code> : Radius of the RelativeSphere QueryConstraint. </li>
+</ul>
+
+
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>This <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> defines a sphere relative to the position of the entity. </li>
+</ul>
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>RelativeCylinder</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/Constraint.cs/#L231">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> RelativeCylinder(double radius)</code></p>
+Creates a <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object with a RelativeCylinder QueryConstraint. 
+</p><b>Returns:</b></br>A <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>double radius</code> : Radius of the cylinder QueryConstraint. </li>
+</ul>
+
+
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>This <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> defines a cylinder relative to the position of the entity. </li>
+</ul>
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>RelativeBox</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/Constraint.cs/#L259">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> RelativeBox(double xWidth, double yHeight, double zDepth)</code></p>
+Creates a <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object with a RelativeBox QueryConstraint. 
+</p><b>Returns:</b></br>A <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>double xWidth</code> : Width of box QueryConstraint in the X-axis. </li>
+<li><code>double yHeight</code> : Height of box QueryConstraint in the Y-axis. </li>
+<li><code>double zDepth</code> : Depth of box QueryConstraint in the Z-axis. </li>
+</ul>
+
+
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>This <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> defines a box relative to the position of the entity. </li>
+</ul>
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>EntityId</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/Constraint.cs/#L278">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> EntityId(<a href="{{urlRoot}}/api/core/entity-id">EntityId</a> entityId)</code></p>
+Creates a <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object with an EntityId QueryConstraint. 
+</p><b>Returns:</b></br>A <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code><a href="{{urlRoot}}/api/core/entity-id">EntityId</a> entityId</code> : EntityId of an entity to interested in. </li>
+</ul>
+
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>Component&lt;T&gt;</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/Constraint.cs/#L294">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> Component&lt;T&gt;()</code></p>
+Creates a <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object with an Component QueryConstraint. 
+</p><b>Returns:</b></br>A <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object. 
+
+
+
+</p>
+
+<b>Type parameters:</b>
+
+<ul>
+<li><code>T</code> : Type of the component to constrain. </li>
+</ul>
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>Component</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/Constraint.cs/#L310">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> Component(uint componentId)</code></p>
+Creates a <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object with a Component QueryConstraint. 
+</p><b>Returns:</b></br>A <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>uint componentId</code> : Component ID of the component to constrain. </li>
+</ul>
+
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>All</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/Constraint.cs/#L332">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> All(<a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> constraint, params <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> [] constraints)</code></p>
+Creates a <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object with an And QueryConstraint. 
+</p><b>Returns:</b></br>A <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code><a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> constraint</code> : First <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> in the list of conjunctions. </li>
+<li><code>params <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> [] constraints</code> : Further Constraints for the list of conjunctions. </li>
+</ul>
+
+
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>At least one <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> must be provided to create a valid "All" QueryConstraint. </li>
+</ul>
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>All</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/Constraint.cs/#L353">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> All(IEnumerable&lt;<a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a>&gt; constraints)</code></p>
+Creates a <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object with an And QueryConstraint. 
+</p><b>Returns:</b></br>A <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>IEnumerable&lt;<a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a>&gt; constraints</code> : Constraints for the list of conjunctions. </li>
+</ul>
+
+
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>At least one <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> must be provided to create a valid "All" QueryConstraint. </li>
+</ul>
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>Any</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/Constraint.cs/#L382">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> Any(<a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> constraint, params <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> [] constraints)</code></p>
+Creates a <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object with an Or QueryConstraint. 
+</p><b>Returns:</b></br>A <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code><a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> constraint</code> : First <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> in the list of disjunctions. </li>
+<li><code>params <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> [] constraints</code> : Further Constraints for the list of disjunctions. </li>
+</ul>
+
+
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>At least one <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> must be provided to create a valid "Any" QueryConstraint. </li>
+</ul>
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>Any</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/Constraint.cs/#L403">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> Any(IEnumerable&lt;<a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a>&gt; constraints)</code></p>
+Creates a <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object with an Or queryConstraint. 
+</p><b>Returns:</b></br>A <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>IEnumerable&lt;<a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a>&gt; constraints</code> : Set of Constraints for the list of disjunctions. </li>
+</ul>
+
+
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>At least one <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> must be provided to create a valid "Any" QueryConstraint. </li>
+</ul>
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+
+
+
+</p>
+<hr style="width:100%; border-top-color:#d8d8d8" />
+#### Methods
+
+
+</p>
+
+
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>AsQueryConstraint</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/Constraint.cs/#L423">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code>ComponentInterest.QueryConstraint AsQueryConstraint()</code></p>
+Returns a QueryConstraint object from a <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a>. 
+</p><b>Returns:</b></br>A QueryConstraint object. 
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+
+
+

--- a/docs/api/query-based-interest/interest-query.md
+++ b/docs/api/query-based-interest/interest-query.md
@@ -1,0 +1,192 @@
+
+# InterestQuery Class
+<sup>
+Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/query-based-interest-index">QueryBasedInterest</a><br/>
+GDK package: QueryBasedInterest<br/>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/InterestQuery.cs/#L10">Source</a>
+<style>
+a code {
+                    padding: 0em 0.25em!important;
+}
+code {
+                    background-color: #ffffff!important;
+}
+</style>
+</sup>
+<nav id="pageToc" class="page-toc"><ul><li><a href="#static-methods">Static Methods</a>
+<li><a href="#methods">Methods</a>
+</ul></nav>
+
+</p>
+
+
+
+<p>Utility class to help construct ComponentInterest.Query objects. </p>
+
+
+
+
+
+
+
+
+
+
+
+</p>
+<hr style="width:100%; border-top-color:#d8d8d8" />
+#### Static Methods
+
+
+</p>
+
+
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>Query</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/InterestQuery.cs/#L30">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> Query(<a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> constraint)</code></p>
+Creates an <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a>. 
+</p><b>Returns:</b></br>An <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code><a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> constraint</code> : A <a href="{{urlRoot}}/api/query-based-interest/constraint">Constraint</a> object defining the constraints of the query. </li>
+</ul>
+
+
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>Returns the full snapshot result by default. </li>
+</ul>
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+
+
+
+</p>
+<hr style="width:100%; border-top-color:#d8d8d8" />
+#### Methods
+
+
+</p>
+
+
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>FilterResults</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/InterestQuery.cs/#L78">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> FilterResults(uint resultComponentId, params uint [] resultComponentIds)</code></p>
+Defines what components to return in the query results. 
+</p><b>Returns:</b></br>An updated <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>uint resultComponentId</code> : First ID of a component to return from the query results. </li>
+<li><code>params uint [] resultComponentIds</code> : Further IDs of components to return from the query results. </li>
+</ul>
+
+
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>At least one component ID must be provided. </li>
+</ul>
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>FilterResults</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/InterestQuery.cs/#L99">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> FilterResults(IEnumerable&lt;uint&gt; resultComponentIds)</code></p>
+Defines what components to return in the query results. 
+</p><b>Returns:</b></br>An updated <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>IEnumerable&lt;uint&gt; resultComponentIds</code> : Set of IDs of components to return from the query results. </li>
+</ul>
+
+
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>At least one component ID must be provided. Query results are not filtered if resultComponentIds is empty. </li>
+</ul>
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>AsComponentInterestQuery</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/InterestQuery.cs/#L115">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code>ComponentInterest.Query AsComponentInterestQuery()</code></p>
+Returns the underlying ComponentInterest.Query object from the <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> class. 
+
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+
+
+

--- a/docs/api/query-based-interest/interest-template.md
+++ b/docs/api/query-based-interest/interest-template.md
@@ -1,0 +1,607 @@
+
+# InterestTemplate Class
+<sup>
+Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/query-based-interest-index">QueryBasedInterest</a><br/>
+GDK package: QueryBasedInterest<br/>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/InterestTemplate.cs/#L11">Source</a>
+<style>
+a code {
+                    padding: 0em 0.25em!important;
+}
+code {
+                    background-color: #ffffff!important;
+}
+</style>
+</sup>
+<nav id="pageToc" class="page-toc"><ul><li><a href="#static-methods">Static Methods</a>
+<li><a href="#methods">Methods</a>
+</ul></nav>
+
+</p>
+
+
+
+<p>Utility class to help construct Interest component snapshots. </p>
+
+
+
+
+
+
+
+
+
+
+
+</p>
+<hr style="width:100%; border-top-color:#d8d8d8" />
+#### Static Methods
+
+
+</p>
+
+
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>Create</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/InterestTemplate.cs/#L26">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> Create()</code></p>
+Creates a new <a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> object. 
+</p><b>Returns:</b></br>A new <a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> object. 
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>Create</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/InterestTemplate.cs/#L43">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> Create(<a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> interestTemplate)</code></p>
+Creates a new <a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> object given an existing <a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a>. 
+</p><b>Returns:</b></br>An <a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code><a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> interestTemplate</code> : An existing <a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a>. </li>
+</ul>
+
+
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>The underlying data is deep copied. </li>
+</ul>
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>Create</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/InterestTemplate.cs/#L60">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> Create(Dictionary&lt;uint, ComponentInterest&gt; interest)</code></p>
+Creates a new <a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> object from the content of an existing Interest component. 
+</p><b>Returns:</b></br>An <a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>Dictionary&lt;uint, ComponentInterest&gt; interest</code> : The underlying dictionary of an Interest component. </li>
+</ul>
+
+
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>The underlying data is deep copied. </li>
+</ul>
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+
+
+
+</p>
+<hr style="width:100%; border-top-color:#d8d8d8" />
+#### Methods
+
+
+</p>
+
+
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>AddQueries&lt;T&gt;</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/InterestTemplate.cs/#L103">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> AddQueries&lt;T&gt;(<a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> interestQuery, params <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> [] interestQueries)</code></p>
+Add InterestQueries to the Interest component. 
+</p><b>Returns:</b></br>An <a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code><a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> interestQuery</code> : First <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> to add for a given authoritative component. </li>
+<li><code>params <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> [] interestQueries</code> : Further InterestQueries to add for a given authoritative component. </li>
+</ul>
+
+
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>At least one <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> must be provided to update the Interest component. </li>
+</ul>
+
+
+
+</p>
+
+<b>Type parameters:</b>
+
+<ul>
+<li><code>T</code> : Type of the authoritative component to add the InterestQueries to. </li>
+</ul>
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>AddQueries</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/InterestTemplate.cs/#L128">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> AddQueries(uint componentId, <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> interestQuery, params <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> [] interestQueries)</code></p>
+Add InterestQueries to the Interest component. 
+</p><b>Returns:</b></br>An <a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>uint componentId</code> : Component ID of the authoritative component to add the InterestQueries to. </li>
+<li><code><a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> interestQuery</code> : First <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> to add for a given authoritative component. </li>
+<li><code>params <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> [] interestQueries</code> : Further InterestQueries to add for a given authoritative component. </li>
+</ul>
+
+
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>At least one <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> must be provided to update the Interest component. </li>
+</ul>
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>AddQueries&lt;T&gt;</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/InterestTemplate.cs/#L150">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> AddQueries&lt;T&gt;(IEnumerable&lt;<a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a>&gt; interestQueries)</code></p>
+Add InterestQueries to the Interest component. 
+</p><b>Returns:</b></br>An <a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>IEnumerable&lt;<a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a>&gt; interestQueries</code> : Set of InterestQueries to add for a given authoritative component. </li>
+</ul>
+
+
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>At least one <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> must be provided to update the Interest component. </li>
+</ul>
+
+
+
+</p>
+
+<b>Type parameters:</b>
+
+<ul>
+<li><code>T</code> : Type of the authoritative component to add the InterestQueries to. </li>
+</ul>
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>AddQueries</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/InterestTemplate.cs/#L172">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> AddQueries(uint componentId, IEnumerable&lt;<a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a>&gt; interestQueries)</code></p>
+Add InterestQueries to the Interest component. 
+</p><b>Returns:</b></br>An <a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>uint componentId</code> : Component ID of the authoritative component to add the InterestQueries to. </li>
+<li><code>IEnumerable&lt;<a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a>&gt; interestQueries</code> : Set of InterestQueries to add for a given authoritative component. </li>
+</ul>
+
+
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>At least one <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> must be provided to update the Interest component. No queries are added if interestQueries is empty. </li>
+</ul>
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>ReplaceQueries&lt;T&gt;</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/InterestTemplate.cs/#L216">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> ReplaceQueries&lt;T&gt;(<a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> interestQuery, params <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> [] interestQueries)</code></p>
+Replaces a component's InterestQueries in the Interest component. 
+</p><b>Returns:</b></br>An <a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code><a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> interestQuery</code> : First <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> to add for a given authoritative component. </li>
+<li><code>params <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> [] interestQueries</code> : Further InterestQueries to add for a given authoritative component. </li>
+</ul>
+
+
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>At least one <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> must be provided to replace a component's interest. </li>
+</ul>
+
+
+
+</p>
+
+<b>Type parameters:</b>
+
+<ul>
+<li><code>T</code> : Type of the authoritative component to replace InterestQueries of. </li>
+</ul>
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>ReplaceQueries</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/InterestTemplate.cs/#L241">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> ReplaceQueries(uint componentId, <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> interestQuery, params <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> [] interestQueries)</code></p>
+Replaces a component's InterestQueries in the Interest component. 
+</p><b>Returns:</b></br>An <a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>uint componentId</code> : Component ID of the authoritative component to replace InterestQueries of. </li>
+<li><code><a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> interestQuery</code> : First <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> to add for a given authoritative component. </li>
+<li><code>params <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> [] interestQueries</code> : Further InterestQueries to add for a given authoritative component. </li>
+</ul>
+
+
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>At least one <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> must be provided to replace a component's interest. </li>
+</ul>
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>ReplaceQueries&lt;T&gt;</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/InterestTemplate.cs/#L263">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> ReplaceQueries&lt;T&gt;(IEnumerable&lt;<a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a>&gt; interestQueries)</code></p>
+Replaces a component's InterestQueries in the Interest component. 
+</p><b>Returns:</b></br>An <a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>IEnumerable&lt;<a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a>&gt; interestQueries</code> : Set of InterestQueries to add for a given authoritative component. </li>
+</ul>
+
+
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>At least one <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> must be provided to replace a component's interest. </li>
+</ul>
+
+
+
+</p>
+
+<b>Type parameters:</b>
+
+<ul>
+<li><code>T</code> : Type of the authoritative component to replace InterestQueries of. </li>
+</ul>
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>ReplaceQueries</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/InterestTemplate.cs/#L285">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> ReplaceQueries(uint componentId, IEnumerable&lt;<a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a>&gt; interestQueries)</code></p>
+Replaces a component's InterestQueries in the Interest component. 
+</p><b>Returns:</b></br>An <a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>uint componentId</code> : Component ID of the authoritative component to replace InterestQueries of. </li>
+<li><code>IEnumerable&lt;<a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a>&gt; interestQueries</code> : Set of InterestQueries to add for a given authoritative component. </li>
+</ul>
+
+
+
+</p>
+
+<b>Notes:</b>
+
+<ul>
+<li>At least one <a href="{{urlRoot}}/api/query-based-interest/interest-query">InterestQuery</a> must be provided to replace a component's interest. No queries are replaced if interestQueries is empty. </li>
+</ul>
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>ClearQueries&lt;T&gt;</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/InterestTemplate.cs/#L322">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> ClearQueries&lt;T&gt;()</code></p>
+Clears all InterestQueries for a given authoritative component. 
+</p><b>Returns:</b></br>An <a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> object. 
+
+
+
+</p>
+
+<b>Type parameters:</b>
+
+<ul>
+<li><code>T</code> : Type of the authoritative component to clear InterestQueries from. </li>
+</ul>
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>ClearQueries</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/InterestTemplate.cs/#L337">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> ClearQueries(uint componentId)</code></p>
+Clears all InterestQueries for a given authoritative component. 
+</p><b>Returns:</b></br>An <a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> object. 
+
+</p>
+
+<b>Parameters</b>
+
+<ul>
+<li><code>uint componentId</code> : Component ID of the authoritative component to clear InterestQueries from. </li>
+</ul>
+
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>ClearAllQueries</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/InterestTemplate.cs/#L349">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code><a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> ClearAllQueries()</code></p>
+Clears all InterestQueries. 
+</p><b>Returns:</b></br>An <a href="{{urlRoot}}/api/query-based-interest/interest-template">InterestTemplate</a> object. 
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>ToSnapshot</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/InterestTemplate.cs/#L361">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code>Interest.Snapshot ToSnapshot()</code></p>
+Builds the Interest snapshot. 
+</p><b>Returns:</b></br>A Interest.Snapshot object. 
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+<table width="100%">
+    <tr>
+        <td style="border-right:none"><b>AsComponentInterest</b></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper/InterestTemplate.cs/#L372">Source</a></td>
+    </tr>
+    <tr>
+        <td colspan="2">
+<code>Dictionary&lt;uint, ComponentInterest&gt; AsComponentInterest()</code></p>
+Returns the underlying data of an Interest component. 
+</p><b>Returns:</b></br>A Dictionary<uint, ComponentInterest>. 
+
+
+
+
+</td>
+    </tr>
+</table>
+
+
+
+
+

--- a/docs/api/reactive-components/abstract-acknowledge-authority-loss-handler.md
+++ b/docs/api/reactive-components/abstract-acknowledge-authority-loss-handler.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/reactive-components-index">ReactiveComponents</a><br/>
 GDK package: ReactiveComponents<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/AcknowledgeAuthorityLossHandler.cs/#L7">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/AcknowledgeAuthorityLossHandler.cs/#L7">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Query</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/AcknowledgeAuthorityLossHandler.cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/AcknowledgeAuthorityLossHandler.cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -69,7 +69,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AcknowledgeAuthorityLoss</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/AcknowledgeAuthorityLossHandler.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/AcknowledgeAuthorityLossHandler.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/reactive-components/acknowledge-authority-loss-system.md
+++ b/docs/api/reactive-components/acknowledge-authority-loss-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/reactive-components-index">ReactiveComponents</a><br/>
 GDK package: ReactiveComponents<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/AcknowledgeAuthorityLossSystem.cs/#L17">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/AcknowledgeAuthorityLossSystem.cs/#L17">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -54,7 +54,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/AcknowledgeAuthorityLossSystem.cs/#L27">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/AcknowledgeAuthorityLossSystem.cs/#L27">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -73,7 +73,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnDestroyManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/AcknowledgeAuthorityLossSystem.cs/#L36">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/AcknowledgeAuthorityLossSystem.cs/#L36">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -92,7 +92,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/AcknowledgeAuthorityLossSystem.cs/#L56">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/AcknowledgeAuthorityLossSystem.cs/#L56">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/reactive-components/authoritative.md
+++ b/docs/api/reactive-components/authoritative.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/reactive-components-index">ReactiveComponents</a><br/>
 GDK package: ReactiveComponents<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityComponents.cs/#L10">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityComponents.cs/#L10">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/reactive-components/authority-changes-provider.md
+++ b/docs/api/reactive-components/authority-changes-provider.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/reactive-components-index">ReactiveComponents</a><br/>
 GDK package: ReactiveComponents<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityChangesProvider.cs/#L9">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityChangesProvider.cs/#L9">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Allocate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityChangesProvider.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityChangesProvider.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Get</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityChangesProvider.cs/#L25">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityChangesProvider.cs/#L25">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -95,7 +95,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Set</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityChangesProvider.cs/#L35">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityChangesProvider.cs/#L35">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -124,7 +124,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Free</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityChangesProvider.cs/#L45">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityChangesProvider.cs/#L45">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -152,7 +152,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CleanDataInWorld</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityChangesProvider.cs/#L51">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityChangesProvider.cs/#L51">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/reactive-components/authority-changes.md
+++ b/docs/api/reactive-components/authority-changes.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/reactive-components-index">ReactiveComponents</a><br/>
 GDK package: ReactiveComponents<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityChanges.cs/#L17">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityChanges.cs/#L17">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -61,7 +61,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Handle</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityChanges.cs/#L19">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityChanges.cs/#L19">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -89,7 +89,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Changes</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityChanges.cs/#L21">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityChanges.cs/#L21">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/reactive-components/authority-loss-imminent.md
+++ b/docs/api/reactive-components/authority-loss-imminent.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/reactive-components-index">ReactiveComponents</a><br/>
 GDK package: ReactiveComponents<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityComponents.cs/#L30">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityComponents.cs/#L30">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -60,7 +60,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AcknowledgeAuthorityLoss</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityComponents.cs/#L32">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityComponents.cs/#L32">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/reactive-components/clean-reactive-components-system.md
+++ b/docs/api/reactive-components/clean-reactive-components-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/reactive-components-index">ReactiveComponents</a><br/>
 GDK package: ReactiveComponents<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/CleanReactiveComponentsSystem.cs/#L17">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/CleanReactiveComponentsSystem.cs/#L17">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -54,7 +54,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/CleanReactiveComponentsSystem.cs/#L23">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/CleanReactiveComponentsSystem.cs/#L23">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -73,7 +73,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnDestroyManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/CleanReactiveComponentsSystem.cs/#L31">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/CleanReactiveComponentsSystem.cs/#L31">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -92,7 +92,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/CleanReactiveComponentsSystem.cs/#L52">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/CleanReactiveComponentsSystem.cs/#L52">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/reactive-components/command-sender-component-system.md
+++ b/docs/api/reactive-components/command-sender-component-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/reactive-components-index">ReactiveComponents</a><br/>
 GDK package: ReactiveComponents<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/CommandSenderComponentSystem.cs/#L12">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/CommandSenderComponentSystem.cs/#L12">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/CommandSenderComponentSystem.cs/#L19">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/CommandSenderComponentSystem.cs/#L19">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnDestroyManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/CommandSenderComponentSystem.cs/#L36">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/CommandSenderComponentSystem.cs/#L36">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -86,7 +86,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/CommandSenderComponentSystem.cs/#L46">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/CommandSenderComponentSystem.cs/#L46">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/reactive-components/component-added.md
+++ b/docs/api/reactive-components/component-added.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/reactive-components-index">ReactiveComponents</a><br/>
 GDK package: ReactiveComponents<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Components/ReactiveComponents.cs/#L16">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Components/ReactiveComponents.cs/#L16">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/reactive-components/component-cleanup-handler.md
+++ b/docs/api/reactive-components/component-cleanup-handler.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/reactive-components-index">ReactiveComponents</a><br/>
 GDK package: ReactiveComponents<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/ComponentCleanupHandler.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/ComponentCleanupHandler.cs/#L6">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CleanupArchetypeQuery</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/ComponentCleanupHandler.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/ComponentCleanupHandler.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -69,7 +69,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CleanComponents</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/ComponentCleanupHandler.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/ComponentCleanupHandler.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/reactive-components/component-removed.md
+++ b/docs/api/reactive-components/component-removed.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/reactive-components-index">ReactiveComponents</a><br/>
 GDK package: ReactiveComponents<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Components/ReactiveComponents.cs/#L30">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Components/ReactiveComponents.cs/#L30">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/reactive-components/i-command-sender-component-manager.md
+++ b/docs/api/reactive-components/i-command-sender-component-manager.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/reactive-components-index">ReactiveComponents</a><br/>
 GDK package: ReactiveComponents<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/ICommandSenderComponentManager.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/ICommandSenderComponentManager.cs/#L6">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddComponents</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/ICommandSenderComponentManager.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/ICommandSenderComponentManager.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -71,7 +71,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RemoveComponents</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/ICommandSenderComponentManager.cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/ICommandSenderComponentManager.cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -101,7 +101,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Clean</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/ICommandSenderComponentManager.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/ICommandSenderComponentManager.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/reactive-components/i-reactive-command-component-manager.md
+++ b/docs/api/reactive-components/i-reactive-command-component-manager.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/reactive-components-index">ReactiveComponents</a><br/>
 GDK package: ReactiveComponents<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveCommandComponentManager.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveCommandComponentManager.cs/#L6">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>PopulateReactiveCommandComponents</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveCommandComponentManager.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveCommandComponentManager.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -72,7 +72,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Clean</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveCommandComponentManager.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveCommandComponentManager.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/reactive-components/i-reactive-component-manager.md
+++ b/docs/api/reactive-components/i-reactive-component-manager.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/reactive-components-index">ReactiveComponents</a><br/>
 GDK package: ReactiveComponents<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveComponentManager.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveComponentManager.cs/#L6">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>PopulateReactiveComponents</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveComponentManager.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveComponentManager.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -72,7 +72,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Clean</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveComponentManager.cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveComponentManager.cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/reactive-components/i-reactive-component-replication-handler.md
+++ b/docs/api/reactive-components/i-reactive-component-replication-handler.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/reactive-components-index">ReactiveComponents</a><br/>
 GDK package: ReactiveComponents<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveComponentReplicationHandler.cs/#L7">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveComponentReplicationHandler.cs/#L7">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ComponentId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveComponentReplicationHandler.cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveComponentReplicationHandler.cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -55,7 +55,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EventQuery</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveComponentReplicationHandler.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveComponentReplicationHandler.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -71,7 +71,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CommandQueries</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveComponentReplicationHandler.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveComponentReplicationHandler.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -101,7 +101,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SendEvents</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveComponentReplicationHandler.cs/#L13">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveComponentReplicationHandler.cs/#L13">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -131,7 +131,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SendCommands</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveComponentReplicationHandler.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/CodegenAdapters/IReactiveComponentReplicationHandler.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/reactive-components/not-authoritative.md
+++ b/docs/api/reactive-components/not-authoritative.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/reactive-components-index">ReactiveComponents</a><br/>
 GDK package: ReactiveComponents<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityComponents.cs/#L18">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityComponents.cs/#L18">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/reactive-components/reactive-command-component-system.md
+++ b/docs/api/reactive-components/reactive-command-component-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/reactive-components-index">ReactiveComponents</a><br/>
 GDK package: ReactiveComponents<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveCommandComponentSystem.cs/#L12">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveCommandComponentSystem.cs/#L12">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveCommandComponentSystem.cs/#L20">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveCommandComponentSystem.cs/#L20">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnDestroyManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveCommandComponentSystem.cs/#L35">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveCommandComponentSystem.cs/#L35">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -86,7 +86,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveCommandComponentSystem.cs/#L45">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveCommandComponentSystem.cs/#L45">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/reactive-components/reactive-component-send-system.md
+++ b/docs/api/reactive-components/reactive-component-send-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/reactive-components-index">ReactiveComponents</a><br/>
 GDK package: ReactiveComponents<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveComponentSendSystem.cs/#L19">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveComponentSendSystem.cs/#L19">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -54,7 +54,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveComponentSendSystem.cs/#L27">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveComponentSendSystem.cs/#L27">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -73,7 +73,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnDestroyManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveComponentSendSystem.cs/#L38">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveComponentSendSystem.cs/#L38">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -92,7 +92,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveComponentSendSystem.cs/#L44">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveComponentSendSystem.cs/#L44">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/reactive-components/reactive-component-system.md
+++ b/docs/api/reactive-components/reactive-component-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/reactive-components-index">ReactiveComponents</a><br/>
 GDK package: ReactiveComponents<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveComponentSystem.cs/#L12">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveComponentSystem.cs/#L12">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveComponentSystem.cs/#L20">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveComponentSystem.cs/#L20">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnDestroyManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveComponentSystem.cs/#L35">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveComponentSystem.cs/#L35">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -86,7 +86,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveComponentSystem.cs/#L45">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveComponentSystem.cs/#L45">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/reactive-components/reactive-components-helper.md
+++ b/docs/api/reactive-components/reactive-components-helper.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/reactive-components-index">ReactiveComponents</a><br/>
 GDK package: ReactiveComponents<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/ReactiveComponentsHelper.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/ReactiveComponentsHelper.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddClientSystems</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/ReactiveComponentsHelper.cs/#L7">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/ReactiveComponentsHelper.cs/#L7">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddServerSystems</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/ReactiveComponentsHelper.cs/#L12">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/ReactiveComponentsHelper.cs/#L12">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/reactive-components/world-commands-clean-system.md
+++ b/docs/api/reactive-components/world-commands-clean-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/reactive-components-index">ReactiveComponents</a><br/>
 GDK package: ReactiveComponents<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/WorldCommandsCleanSystem.cs/#L15">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/WorldCommandsCleanSystem.cs/#L15">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -54,7 +54,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/WorldCommandsCleanSystem.cs/#L32">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/WorldCommandsCleanSystem.cs/#L32">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -73,7 +73,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/WorldCommandsCleanSystem.cs/#L38">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/WorldCommandsCleanSystem.cs/#L38">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/reactive-components/world-commands-send-system.md
+++ b/docs/api/reactive-components/world-commands-send-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/reactive-components-index">ReactiveComponents</a><br/>
 GDK package: ReactiveComponents<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/WorldCommandsSendSystem.cs/#L16">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/WorldCommandsSendSystem.cs/#L16">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -54,7 +54,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/WorldCommandsSendSystem.cs/#L35">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/WorldCommandsSendSystem.cs/#L35">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -73,7 +73,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/WorldCommandsSendSystem.cs/#L43">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/WorldCommandsSendSystem.cs/#L43">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/auto-register-subscription-manager-attribute.md
+++ b/docs/api/subscriptions/auto-register-subscription-manager-attribute.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/AutoRegisterSubscriptionManagerAttribute.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/AutoRegisterSubscriptionManagerAttribute.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/subscriptions/command-callback-system.md
+++ b/docs/api/subscriptions/command-callback-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/CommandCallbackSystem.cs/#L13">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/CommandCallbackSystem.cs/#L13">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RegisterCommandRequestCallback&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/CommandCallbackSystem.cs/#L23">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/CommandCallbackSystem.cs/#L23">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -77,7 +77,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RegisterCommandResponseCallback&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/CommandCallbackSystem.cs/#L37">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/CommandCallbackSystem.cs/#L37">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -106,7 +106,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>UnregisterCommandRequestCallback</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/CommandCallbackSystem.cs/#L51">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/CommandCallbackSystem.cs/#L51">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -146,7 +146,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/CommandCallbackSystem.cs/#L67">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/CommandCallbackSystem.cs/#L67">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -165,7 +165,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/CommandCallbackSystem.cs/#L73">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/CommandCallbackSystem.cs/#L73">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/command-request-callback-manager.md
+++ b/docs/api/subscriptions/command-request-callback-manager.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/CalllbackManagers/CommandRequestCallbackManager.cs/#L8">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/CalllbackManagers/CommandRequestCallbackManager.cs/#L8">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CommandRequestCallbackManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/CalllbackManagers/CommandRequestCallbackManager.cs/#L15">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/CalllbackManagers/CommandRequestCallbackManager.cs/#L15">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -87,7 +87,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>InvokeCallbacks</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/CalllbackManagers/CommandRequestCallbackManager.cs/#L20">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/CalllbackManagers/CommandRequestCallbackManager.cs/#L20">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -106,7 +106,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RegisterCallback</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/CalllbackManagers/CommandRequestCallbackManager.cs/#L30">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/CalllbackManagers/CommandRequestCallbackManager.cs/#L30">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -135,7 +135,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>UnregisterCallback</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/CalllbackManagers/CommandRequestCallbackManager.cs/#L36">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/CalllbackManagers/CommandRequestCallbackManager.cs/#L36">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/command-response-callback-manager.md
+++ b/docs/api/subscriptions/command-response-callback-manager.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/CalllbackManagers/CommandResponseCallbackManager.cs/#L8">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/CalllbackManagers/CommandResponseCallbackManager.cs/#L8">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CommandResponseCallbackManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/CalllbackManagers/CommandResponseCallbackManager.cs/#L15">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/CalllbackManagers/CommandResponseCallbackManager.cs/#L15">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -87,7 +87,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>InvokeCallbacks</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/CalllbackManagers/CommandResponseCallbackManager.cs/#L20">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/CalllbackManagers/CommandResponseCallbackManager.cs/#L20">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -106,7 +106,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RegisterCallback</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/CalllbackManagers/CommandResponseCallbackManager.cs/#L31">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/CalllbackManagers/CommandResponseCallbackManager.cs/#L31">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -135,7 +135,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>UnregisterCallback</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/CalllbackManagers/CommandResponseCallbackManager.cs/#L37">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/CalllbackManagers/CommandResponseCallbackManager.cs/#L37">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/component-callback-system.md
+++ b/docs/api/subscriptions/component-callback-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentCallbackSystem.cs/#L13">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentCallbackSystem.cs/#L13">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RegisterComponentUpdateCallback&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentCallbackSystem.cs/#L26">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentCallbackSystem.cs/#L26">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -77,7 +77,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RegisterComponentEventCallback&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentCallbackSystem.cs/#L40">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentCallbackSystem.cs/#L40">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -106,7 +106,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RegisterAuthorityCallback</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentCallbackSystem.cs/#L54">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentCallbackSystem.cs/#L54">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -136,7 +136,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>UnregisterCallback</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentCallbackSystem.cs/#L67">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentCallbackSystem.cs/#L67">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -176,7 +176,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentCallbackSystem.cs/#L89">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentCallbackSystem.cs/#L89">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -195,7 +195,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentCallbackSystem.cs/#L95">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentCallbackSystem.cs/#L95">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/component-constraints-callback-system.md
+++ b/docs/api/subscriptions/component-constraints-callback-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentConstraintsCallbackSystem.cs/#L11">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentConstraintsCallbackSystem.cs/#L11">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentConstraintsCallbackSystem.cs/#L113">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentConstraintsCallbackSystem.cs/#L113">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentConstraintsCallbackSystem.cs/#L121">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentConstraintsCallbackSystem.cs/#L121">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/editor/prefab-preprocessor.md
+++ b/docs/api/subscriptions/editor/prefab-preprocessor.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a>.<a href="{{urlRoot}}/api/subscriptions/editor-index">Editor</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Editor/Prefabs/PrefabPreprocessor.cs/#L20">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Editor/Prefabs/PrefabPreprocessor.cs/#L20">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -54,7 +54,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>callbackOrder</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Editor/Prefabs/PrefabPreprocessor.cs/#L23">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Editor/Prefabs/PrefabPreprocessor.cs/#L23">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/entity-game-object-linker.md
+++ b/docs/api/subscriptions/entity-game-object-linker.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntityGameObjectLinker.cs/#L10">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntityGameObjectLinker.cs/#L10">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EntityGameObjectLinker</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntityGameObjectLinker.cs/#L29">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntityGameObjectLinker.cs/#L29">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -81,7 +81,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>LinkGameObjectToSpatialOSEntity</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntityGameObjectLinker.cs/#L55">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntityGameObjectLinker.cs/#L55">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -111,7 +111,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>UnlinkGameObjectFromEntity</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntityGameObjectLinker.cs/#L112">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntityGameObjectLinker.cs/#L112">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -140,7 +140,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>UnlinkAllGameObjects</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntityGameObjectLinker.cs/#L162">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntityGameObjectLinker.cs/#L162">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -159,7 +159,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>UnlinkAllGameObjectsFromEntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntityGameObjectLinker.cs/#L171">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntityGameObjectLinker.cs/#L171">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -187,7 +187,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>FlushCommandBuffer</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntityGameObjectLinker.cs/#L186">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntityGameObjectLinker.cs/#L186">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/entity-id-subscription-manager.md
+++ b/docs/api/subscriptions/entity-id-subscription-manager.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntityIdSubscriptionManager.cs/#L7">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntityIdSubscriptionManager.cs/#L7">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EntityIdSubscriptionManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntityIdSubscriptionManager.cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntityIdSubscriptionManager.cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -88,7 +88,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Subscribe</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntityIdSubscriptionManager.cs/#L13">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntityIdSubscriptionManager.cs/#L13">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -116,7 +116,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Cancel</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntityIdSubscriptionManager.cs/#L21">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntityIdSubscriptionManager.cs/#L21">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -144,7 +144,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ResetValue</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntityIdSubscriptionManager.cs/#L25">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntityIdSubscriptionManager.cs/#L25">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/entity-subscription-manager.md
+++ b/docs/api/subscriptions/entity-subscription-manager.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntitySubscriptionManager.cs/#L9">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntitySubscriptionManager.cs/#L9">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EntitySubscriptionManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntitySubscriptionManager.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntitySubscriptionManager.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -88,7 +88,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Subscribe</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntitySubscriptionManager.cs/#L71">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntitySubscriptionManager.cs/#L71">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -116,7 +116,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Cancel</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntitySubscriptionManager.cs/#L90">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntitySubscriptionManager.cs/#L90">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -144,7 +144,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ResetValue</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntitySubscriptionManager.cs/#L100">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntitySubscriptionManager.cs/#L100">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/entity-subscriptions.md
+++ b/docs/api/subscriptions/entity-subscriptions.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntitySubscriptions.cs/#L7">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntitySubscriptions.cs/#L7">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Subscribe&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntitySubscriptions.cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntitySubscriptions.cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -68,7 +68,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>TryRegisterManager&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntitySubscriptions.cs/#L20">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntitySubscriptions.cs/#L20">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -97,7 +97,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>TryRegisterManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntitySubscriptions.cs/#L25">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntitySubscriptions.cs/#L25">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/i-subscription-availability-handler.md
+++ b/docs/api/subscriptions/i-subscription-availability-handler.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/ISubscriptionAvailabilityHandler.cs/#L3">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/ISubscriptionAvailabilityHandler.cs/#L3">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnAvailable</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/ISubscriptionAvailabilityHandler.cs/#L5">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/ISubscriptionAvailabilityHandler.cs/#L5">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -60,7 +60,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUnavailable</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/ISubscriptionAvailabilityHandler.cs/#L6">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/ISubscriptionAvailabilityHandler.cs/#L6">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/i-subscription.md
+++ b/docs/api/subscriptions/i-subscription.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L7">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L7">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>HasValue</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -55,7 +55,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -85,7 +85,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SetAvailabilityHandler</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L14">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L14">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -113,7 +113,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetAvailabilityHandler</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L15">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L15">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -132,7 +132,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetErasedValue</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -151,7 +151,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Cancel</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L18">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L18">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -170,7 +170,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ResetValue</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L19">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L19">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/indexed-callbacks.md
+++ b/docs/api/subscriptions/indexed-callbacks.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs/#L123">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs/#L123">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Add</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs/#L128">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs/#L128">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -71,7 +71,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Remove</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs/#L140">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs/#L140">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -99,7 +99,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>InvokeAll</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs/#L152">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs/#L152">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -128,7 +128,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>InvokeAllReverse</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs/#L160">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs/#L160">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/linked-entity-component.md
+++ b/docs/api/subscriptions/linked-entity-component.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/LinkedEntityComponent.cs/#L7">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/LinkedEntityComponent.cs/#L7">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -42,7 +42,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/LinkedEntityComponent.cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/LinkedEntityComponent.cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -57,7 +57,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>World</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/LinkedEntityComponent.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/LinkedEntityComponent.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -72,7 +72,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Worker</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/LinkedEntityComponent.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/LinkedEntityComponent.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -87,7 +87,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>IsValid</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/LinkedEntityComponent.cs/#L12">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/LinkedEntityComponent.cs/#L12">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/log-dispatcher-subscription-manager.md
+++ b/docs/api/subscriptions/log-dispatcher-subscription-manager.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/LogDispatcherSubscriptionManager.cs/#L7">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/LogDispatcherSubscriptionManager.cs/#L7">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>LogDispatcherSubscriptionManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/LogDispatcherSubscriptionManager.cs/#L12">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/LogDispatcherSubscriptionManager.cs/#L12">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -88,7 +88,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Subscribe</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/LogDispatcherSubscriptionManager.cs/#L17">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/LogDispatcherSubscriptionManager.cs/#L17">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -116,7 +116,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Cancel</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/LogDispatcherSubscriptionManager.cs/#L28">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/LogDispatcherSubscriptionManager.cs/#L28">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -144,7 +144,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ResetValue</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/LogDispatcherSubscriptionManager.cs/#L33">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/LogDispatcherSubscriptionManager.cs/#L33">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/require-attribute.md
+++ b/docs/api/subscriptions/require-attribute.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/RequireAttribute.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/RequireAttribute.cs/#L6">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/subscriptions/require-lifecycle-group.md
+++ b/docs/api/subscriptions/require-lifecycle-group.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/UpdateGroups.cs/#L8">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/UpdateGroups.cs/#L8">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/subscriptions/require-lifecycle-system.md
+++ b/docs/api/subscriptions/require-lifecycle-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/RequireLifecycleSystem.cs/#L9">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/RequireLifecycleSystem.cs/#L9">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/RequireLifecycleSystem.cs/#L30">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/RequireLifecycleSystem.cs/#L30">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/RequireLifecycleSystem.cs/#L39">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/RequireLifecycleSystem.cs/#L39">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/required-subscriptions-injector.md
+++ b/docs/api/subscriptions/required-subscriptions-injector.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/RequiredSubscriptionsInjector.cs/#L9">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/RequiredSubscriptionsInjector.cs/#L9">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RequiredSubscriptionsInjector</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/RequiredSubscriptionsInjector.cs/#L20">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/RequiredSubscriptionsInjector.cs/#L20">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -85,7 +85,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CancelSubscriptions</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/RequiredSubscriptionsInjector.cs/#L38">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/RequiredSubscriptionsInjector.cs/#L38">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/required-subscriptions-injector/handler/pool.md
+++ b/docs/api/subscriptions/required-subscriptions-injector/handler/pool.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a>.<a href="{{urlRoot}}/api/subscriptions/required-subscriptions-injector">RequiredSubscriptionsInjector</a>.Handler<br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/RequiredSubscriptionsInjector.cs/#L99">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/RequiredSubscriptionsInjector.cs/#L99">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Rent</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/RequiredSubscriptionsInjector.cs/#L103">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/RequiredSubscriptionsInjector.cs/#L103">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Return</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/RequiredSubscriptionsInjector.cs/#L113">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/RequiredSubscriptionsInjector.cs/#L113">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/single-use-index-callbacks.md
+++ b/docs/api/subscriptions/single-use-index-callbacks.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs/#L170">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs/#L170">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Add</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs/#L174">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs/#L174">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -71,7 +71,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RemoveAllCallbacksForIndex</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs/#L185">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs/#L185">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -99,7 +99,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Remove</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs/#L193">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs/#L193">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -127,7 +127,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>InvokeAll</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs/#L206">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs/#L206">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -156,7 +156,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>InvokeAllReverse</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs/#L214">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs/#L214">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/subscription-aggregate.md
+++ b/docs/api/subscriptions/subscription-aggregate.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionAggregate.cs/#L7">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionAggregate.cs/#L7">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -41,7 +41,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SubscriptionAggregate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionAggregate.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionAggregate.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -83,7 +83,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SetAvailabilityHandler</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionAggregate.cs/#L31">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionAggregate.cs/#L31">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -111,7 +111,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetAvailabilityHandler</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionAggregate.cs/#L40">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionAggregate.cs/#L40">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -130,7 +130,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetValue&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionAggregate.cs/#L45">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionAggregate.cs/#L45">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -149,7 +149,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetErasedValue</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionAggregate.cs/#L62">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionAggregate.cs/#L62">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -177,7 +177,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Cancel</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionAggregate.cs/#L77">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionAggregate.cs/#L77">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/subscription-aggregate/handler/pool.md
+++ b/docs/api/subscriptions/subscription-aggregate/handler/pool.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a>.<a href="{{urlRoot}}/api/subscriptions/subscription-aggregate">SubscriptionAggregate</a>.Handler<br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionAggregate.cs/#L124">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionAggregate.cs/#L124">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Rent</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionAggregate.cs/#L128">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionAggregate.cs/#L128">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Return</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionAggregate.cs/#L139">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionAggregate.cs/#L139">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/subscription-manager-base.md
+++ b/docs/api/subscriptions/subscription-manager-base.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionManagerBase.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionManagerBase.cs/#L6">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SubscriptionType</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionManagerBase.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionManagerBase.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -69,7 +69,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SubscribeTypeErased</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionManagerBase.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionManagerBase.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -97,7 +97,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Cancel</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionManagerBase.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionManagerBase.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -125,7 +125,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ResetValue</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionManagerBase.cs/#L12">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionManagerBase.cs/#L12">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/subscription-manager.md
+++ b/docs/api/subscriptions/subscription-manager.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionManagerBase.cs/#L15">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionManagerBase.cs/#L15">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -44,7 +44,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SubscriptionType</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionManagerBase.cs/#L19">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionManagerBase.cs/#L19">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -75,7 +75,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Subscribe</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionManagerBase.cs/#L17">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionManagerBase.cs/#L17">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -115,7 +115,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SubscribeTypeErased</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionManagerBase.cs/#L21">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/SubscriptionManagerBase.cs/#L21">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/subscription-system.md
+++ b/docs/api/subscriptions/subscription-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/SubscriptionSystem.cs/#L10">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/SubscriptionSystem.cs/#L10">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RegisterSubscriptionManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/SubscriptionSystem.cs/#L15">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/SubscriptionSystem.cs/#L15">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -77,7 +77,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Subscribe&lt;T&gt;</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/SubscriptionSystem.cs/#L25">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/SubscriptionSystem.cs/#L25">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -105,7 +105,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Subscribe</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/SubscriptionSystem.cs/#L35">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/SubscriptionSystem.cs/#L35">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -146,7 +146,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/SubscriptionSystem.cs/#L45">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/SubscriptionSystem.cs/#L45">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -165,7 +165,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/SubscriptionSystem.cs/#L53">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/SubscriptionSystem.cs/#L53">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/subscription.md
+++ b/docs/api/subscriptions/subscription.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L24">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L24">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -46,7 +46,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>HasValue</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L27">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L27">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -62,7 +62,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EntityId</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L28">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L28">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -78,7 +78,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnAvailable</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L36">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L36">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -94,7 +94,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Value</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L59">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L59">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -123,7 +123,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Subscription</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L72">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L72">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -164,7 +164,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Cancel</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L78">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L78">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -183,7 +183,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SetAvailable</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L85">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L85">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -211,7 +211,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SetUnavailable</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L101">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Subscription.cs/#L101">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/worker-type-attribute.md
+++ b/docs/api/subscriptions/worker-type-attribute.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/WorkerTypeAttribute.cs/#L9">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/WorkerTypeAttribute.cs/#L9">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -49,7 +49,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WorkerTypes</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/WorkerTypeAttribute.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/WorkerTypeAttribute.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -79,7 +79,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WorkerTypeAttribute</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/WorkerTypeAttribute.cs/#L13">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/WorkerTypeAttribute.cs/#L13">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/subscriptions/world-subscription-manager.md
+++ b/docs/api/subscriptions/world-subscription-manager.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/subscriptions-index">Subscriptions</a><br/>
 GDK package: Subscriptions<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldSubscriptionManager.cs/#L7">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldSubscriptionManager.cs/#L7">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WorldSubscriptionManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldSubscriptionManager.cs/#L12">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldSubscriptionManager.cs/#L12">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -88,7 +88,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Subscribe</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldSubscriptionManager.cs/#L17">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldSubscriptionManager.cs/#L17">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -116,7 +116,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Cancel</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldSubscriptionManager.cs/#L28">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldSubscriptionManager.cs/#L28">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -144,7 +144,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ResetValue</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldSubscriptionManager.cs/#L33">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldSubscriptionManager.cs/#L33">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/test-utils/hybrid-gdk-system-test-base.md
+++ b/docs/api/test-utils/hybrid-gdk-system-test-base.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/test-utils-index">TestUtils</a><br/>
 GDK package: TestUtils<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/HybridGdkSystemTestBase.cs/#L9">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/HybridGdkSystemTestBase.cs/#L9">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -40,7 +40,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CleanupAllInjectionHooks</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/HybridGdkSystemTestBase.cs/#L47">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/HybridGdkSystemTestBase.cs/#L47">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -72,7 +72,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OneTimeSetUp</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/HybridGdkSystemTestBase.cs/#L25">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/HybridGdkSystemTestBase.cs/#L25">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -91,7 +91,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OneTimeTearDown</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/HybridGdkSystemTestBase.cs/#L40">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/HybridGdkSystemTestBase.cs/#L40">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/test-utils/test-log-dispatcher.md
+++ b/docs/api/test-utils/test-log-dispatcher.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/test-utils-index">TestUtils</a><br/>
 GDK package: TestUtils<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/TestLogDispatcher.cs/#L18">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/TestLogDispatcher.cs/#L18">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -69,7 +69,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Connection</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/TestLogDispatcher.cs/#L22">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/TestLogDispatcher.cs/#L22">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -85,7 +85,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WorkerType</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/TestLogDispatcher.cs/#L23">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/TestLogDispatcher.cs/#L23">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -115,7 +115,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>HandleLog</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/TestLogDispatcher.cs/#L25">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/TestLogDispatcher.cs/#L25">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -144,7 +144,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>EnterExpectingScope</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/TestLogDispatcher.cs/#L44">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/TestLogDispatcher.cs/#L44">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -172,7 +172,7 @@ Creates and returns an disposable <a href="{{urlRoot}}/api/test-utils/test-log-d
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ExitExpectingScope</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/TestLogDispatcher.cs/#L56">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/TestLogDispatcher.cs/#L56">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -191,7 +191,7 @@ Creates and returns an disposable <a href="{{urlRoot}}/api/test-utils/test-log-d
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Dispose</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/TestLogDispatcher.cs/#L67">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/TestLogDispatcher.cs/#L67">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/test-utils/test-log-dispatcher/expecting-scope.md
+++ b/docs/api/test-utils/test-log-dispatcher/expecting-scope.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/test-utils-index">TestUtils</a>.<a href="{{urlRoot}}/api/test-utils/test-log-dispatcher">TestLogDispatcher</a><br/>
 GDK package: TestUtils<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/TestLogDispatcher.cs/#L72">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/TestLogDispatcher.cs/#L72">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Expect</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/TestLogDispatcher.cs/#L84">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/TestLogDispatcher.cs/#L84">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -76,7 +76,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Dispose</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/TestLogDispatcher.cs/#L89">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/TestLogDispatcher.cs/#L89">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/test-utils/test-mono-behaviour.md
+++ b/docs/api/test-utils/test-mono-behaviour.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/test-utils-index">TestUtils</a><br/>
 GDK package: TestUtils<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/TestMonoBehaviour.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/TestMonoBehaviour.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/test-utils/worker-op-factory.md
+++ b/docs/api/test-utils/worker-op-factory.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/test-utils-index">TestUtils</a><br/>
 GDK package: TestUtils<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L12">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L12">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -45,7 +45,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CreateAddEntityOp</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L14">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L14">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -73,7 +73,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CreateRemoveEntityOp</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L23">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L23">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -101,7 +101,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CreateAddComponentOp</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L32">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L32">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -130,7 +130,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CreateComponentUpdateOp</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L43">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L43">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -159,7 +159,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CreateRemoveComponentOp</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L55">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L55">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -188,7 +188,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CreateAuthorityChangeOp</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L66">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L66">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -217,7 +217,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CreateCommandRequestOp</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L77">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L77">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -247,7 +247,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CreateCommandResponseOp</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L89">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L89">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -277,7 +277,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CreateDisconnectOp</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L102">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L102">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -305,7 +305,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CreateCreateEntityResponseOp</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L108">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L108">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -333,7 +333,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CreateDeleteEntityResponseOp</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L118">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L118">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -361,7 +361,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CreateReserveEntityIdsResponseOp</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L128">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L128">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -389,7 +389,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CreateEntityQueryResponseOp</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L138">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L138">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/test-utils/wrapped-op.md
+++ b/docs/api/test-utils/wrapped-op.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/test-utils-index">TestUtils</a><br/>
 GDK package: TestUtils<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L156">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L156">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -55,7 +55,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Op</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L158">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L158">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -86,7 +86,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Dispose</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L165">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.testutils/WorkerOpFactory.cs/#L165">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/tools/common.md
+++ b/docs/api/tools/common.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/tools-index">Tools</a><br/>
 GDK package: Tools<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/Common.cs/#L15">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/Common.cs/#L16">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -43,7 +43,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ProductName</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/Common.cs/#L36">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/Common.cs/#L37">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -58,7 +58,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>PackagesDir</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/Common.cs/#L38">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/Common.cs/#L39">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -85,7 +85,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SpatialProjectRootDir</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/Common.cs/#L27">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/Common.cs/#L28">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -100,7 +100,7 @@ The absolute path to the root folder of the SpatialOS project.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SpatialBinary</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/Common.cs/#L32">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/Common.cs/#L33">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -115,26 +115,11 @@ The absolute path to the  binary, or the empty string if it doesn't exist.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>DotNetBinary</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/Common.cs/#L34">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/Common.cs/#L35">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
 <code> string DotNetBinary</code></p>
-
-
-</td>
-    </tr>
-</table>
-
-
-<table width="100%">
-    <tr>
-        <td style="border-right:none"><b>ManifestPath</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/Common.cs/#L39">Source</a></td>
-    </tr>
-    <tr>
-        <td colspan="2">
-<code> readonly string ManifestPath</code></p>
 
 
 </td>
@@ -158,7 +143,7 @@ The absolute path to the  binary, or the empty string if it doesn't exist.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CoreSdkVersion</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/Common.cs/#L21">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/Common.cs/#L22">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -187,7 +172,7 @@ The version of the CoreSdk the GDK is pinned to. Modify the core-sdk.version fil
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetPackagePath</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/Common.cs/#L67">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/Common.cs/#L67">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -215,7 +200,7 @@ Finds the "file:" reference path from the package manifest.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CheckDependencies</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/Common.cs/#L173">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/Common.cs/#L139">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/tools/cpu-type.md
+++ b/docs/api/tools/cpu-type.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/tools-index">Tools</a><br/>
 GDK package: Tools<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/Plugins/PluginCompatibilitySetting.cs/#L13">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/Plugins/PluginCompatibilitySetting.cs/#L13">Source</a>
 </sup>
 
 

--- a/docs/api/tools/dev-auth-token-utils.md
+++ b/docs/api/tools/dev-auth-token-utils.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/tools-index">Tools</a><br/>
 GDK package: Tools<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/DevAuthTokenUtils.cs/#L10">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/DevAuthTokenUtils.cs/#L10">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/tools/download-result.md
+++ b/docs/api/tools/download-result.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/tools-index">Tools</a><br/>
 GDK package: Tools<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/DownloadCoreSdk.cs/#L10">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/DownloadCoreSdk.cs/#L10">Source</a>
 </sup>
 
 

--- a/docs/api/tools/editor-config.md
+++ b/docs/api/tools/editor-config.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/tools-index">Tools</a><br/>
 GDK package: Tools<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/EditorConfig.cs/#L3">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/EditorConfig.cs/#L3">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -34,7 +34,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>MenuOffset</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/EditorConfig.cs/#L5">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/EditorConfig.cs/#L5">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -49,7 +49,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ParentMenu</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/EditorConfig.cs/#L6">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/EditorConfig.cs/#L6">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/tools/gdk-tools-configuration-window.md
+++ b/docs/api/tools/gdk-tools-configuration-window.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/tools-index">Tools</a><br/>
 GDK package: Tools<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationWindow.cs/#L11">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationWindow.cs/#L11">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -52,7 +52,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ShowWindow</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationWindow.cs/#L35">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationWindow.cs/#L35">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -84,7 +84,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnGUI</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationWindow.cs/#L53">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationWindow.cs/#L53">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/tools/gdk-tools-configuration.md
+++ b/docs/api/tools/gdk-tools-configuration.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/tools-index">Tools</a><br/>
 GDK package: Tools<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L11">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L11">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -38,7 +38,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SchemaStdLibDir</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L13">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L13">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -53,7 +53,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SchemaSourceDirs</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L14">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L14">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -68,7 +68,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>CodegenOutputDir</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L15">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L15">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -83,7 +83,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RuntimeIp</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -98,7 +98,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>DevAuthTokenDir</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L17">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L17">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -113,7 +113,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>DevAuthTokenLifetimeDays</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L18">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L18">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -128,7 +128,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>DevAuthTokenFullDir</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L20">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L20">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -143,7 +143,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>DevAuthTokenFilepath</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L21">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L21">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -158,7 +158,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>DevAuthTokenLifetimeHours</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L22">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L22">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -187,7 +187,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GetOrCreateInstance</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L85">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L85">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -219,7 +219,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Save</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L31">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs/#L31">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/tools/gui-color-scope.md
+++ b/docs/api/tools/gui-color-scope.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/tools-index">Tools</a><br/>
 GDK package: Tools<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/GUIColorScope.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/GUIColorScope.cs/#L6">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -47,7 +47,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>GUIColorScope</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/GUIColorScope.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/GUIColorScope.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -87,7 +87,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Dispose</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/GUIColorScope.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/GUIColorScope.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/tools/local-launch.md
+++ b/docs/api/tools/local-launch.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/tools-index">Tools</a><br/>
 GDK package: Tools<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/LocalLaunch.cs/#L12">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/LocalLaunch.cs/#L12">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>BuildConfig</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/LocalLaunch.cs/#L57">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/LocalLaunch.cs/#L57">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -58,7 +58,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>LaunchClient</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/LocalLaunch.cs/#L70">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/LocalLaunch.cs/#L70">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -77,7 +77,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>LaunchLocalDeployment</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/LocalLaunch.cs/#L202">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/LocalLaunch.cs/#L202">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/tools/mini-json/json.md
+++ b/docs/api/tools/mini-json/json.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/tools-index">Tools</a>.<a href="{{urlRoot}}/api/tools/mini-json-index">MiniJSON</a><br/>
 GDK package: Tools<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/MiniJson.cs/#L79">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/MiniJson.cs/#L79">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -45,7 +45,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Deserialize</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/MiniJson.cs/#L86">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/MiniJson.cs/#L86">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -73,7 +73,7 @@ Parses the string json into a value
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Serialize</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/MiniJson.cs/#L445">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/MiniJson.cs/#L445">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/tools/output-redirect-behaviour.md
+++ b/docs/api/tools/output-redirect-behaviour.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/tools-index">Tools</a><br/>
 GDK package: Tools<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L21">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L21">Source</a>
 </sup>
 
 

--- a/docs/api/tools/plugin-type.md
+++ b/docs/api/tools/plugin-type.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/tools-index">Tools</a><br/>
 GDK package: Tools<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/Plugins/PluginCompatibilitySetting.cs/#L7">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/Plugins/PluginCompatibilitySetting.cs/#L7">Source</a>
 </sup>
 
 

--- a/docs/api/tools/redirected-process-result.md
+++ b/docs/api/tools/redirected-process-result.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/tools-index">Tools</a><br/>
 GDK package: Tools<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L13">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L13">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -36,7 +36,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ExitCode</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L15">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L15">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -51,7 +51,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Stdout</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -66,7 +66,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Stderr</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L17">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L17">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/tools/redirected-process.md
+++ b/docs/api/tools/redirected-process.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/tools-index">Tools</a><br/>
 GDK package: Tools<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L52">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L52">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -46,7 +46,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Command</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L68">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L68">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -87,7 +87,7 @@ Creates the redirected process for the command.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WithArgs</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L78">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L78">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -115,7 +115,7 @@ Adds arguments to process command call.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>InDirectory</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L88">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L88">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -143,7 +143,7 @@ Sets which directory run the process in.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddOutputProcessing</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L98">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L98">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -171,7 +171,7 @@ Adds custom processing for regular output of process.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddErrorProcessing</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L108">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L108">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -199,7 +199,7 @@ Adds custom processing for error output of process.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RedirectOutputOptions</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L118">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L118">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -227,7 +227,7 @@ Adds custom processing for error output of process.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Run</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L127">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L127">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -246,7 +246,7 @@ Runs the redirected process and waits for it to return.
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>RunAsync</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L273">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/RedirectedProcess.cs/#L273">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/tools/show-progress-bar-scope.md
+++ b/docs/api/tools/show-progress-bar-scope.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/tools-index">Tools</a><br/>
 GDK package: Tools<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/ShowProgressBarScope.cs/#L9">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/ShowProgressBarScope.cs/#L9">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -53,7 +53,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ShowProgressBarScope</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/ShowProgressBarScope.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/ShowProgressBarScope.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -93,7 +93,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Dispose</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.tools/ShowProgressBarScope.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.tools/ShowProgressBarScope.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/buffered-transform.md
+++ b/docs/api/transform-synchronization/buffered-transform.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/BufferedTransform.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/BufferedTransform.cs/#L6">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -42,7 +42,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Position</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/BufferedTransform.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/BufferedTransform.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -57,7 +57,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Velocity</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/BufferedTransform.cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/BufferedTransform.cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -72,7 +72,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Orientation</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/BufferedTransform.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/BufferedTransform.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -87,7 +87,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>PhysicsTick</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/BufferedTransform.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/BufferedTransform.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/default-apply-latest-transform-system.md
+++ b/docs/api/transform-synchronization/default-apply-latest-transform-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DefaultApplyLatestTransformSystem.cs/#L18">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DefaultApplyLatestTransformSystem.cs/#L18">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DefaultApplyLatestTransformSystem.cs/#L23">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DefaultApplyLatestTransformSystem.cs/#L23">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DefaultApplyLatestTransformSystem.cs/#L41">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DefaultApplyLatestTransformSystem.cs/#L41">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/default-update-latest-transform-system.md
+++ b/docs/api/transform-synchronization/default-update-latest-transform-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DefaultUpdateLatestTransformSystem.cs/#L17">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DefaultUpdateLatestTransformSystem.cs/#L17">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DefaultUpdateLatestTransformSystem.cs/#L22">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DefaultUpdateLatestTransformSystem.cs/#L22">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DefaultUpdateLatestTransformSystem.cs/#L40">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DefaultUpdateLatestTransformSystem.cs/#L40">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/deferred-update-transform.md
+++ b/docs/api/transform-synchronization/deferred-update-transform.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/DeferredUpdateTransform.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/DeferredUpdateTransform.cs/#L6">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -42,7 +42,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Transform</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/DeferredUpdateTransform.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/DeferredUpdateTransform.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/direct-receive-strategy.md
+++ b/docs/api/transform-synchronization/direct-receive-strategy.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/ScriptableObjects/ReceiveStrategies/DirectReceiveStrategy.cs/#L7">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/ScriptableObjects/ReceiveStrategies/DirectReceiveStrategy.cs/#L7">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/transform-synchronization/direct-receive-tag.md
+++ b/docs/api/transform-synchronization/direct-receive-tag.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/DirectReceiveTag.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/DirectReceiveTag.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/transform-synchronization/direct-transform-update-system.md
+++ b/docs/api/transform-synchronization/direct-transform-update-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DirectTransformUpdateSystem.cs/#L16">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DirectTransformUpdateSystem.cs/#L16">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DirectTransformUpdateSystem.cs/#L23">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DirectTransformUpdateSystem.cs/#L23">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DirectTransformUpdateSystem.cs/#L38">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DirectTransformUpdateSystem.cs/#L38">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/get-transform-from-game-object-tag.md
+++ b/docs/api/transform-synchronization/get-transform-from-game-object-tag.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/GetTransformFromGameObjectTag.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/GetTransformFromGameObjectTag.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/transform-synchronization/get-transform-value-to-set-system.md
+++ b/docs/api/transform-synchronization/get-transform-value-to-set-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/GetTransformValueToSetSystem.cs/#L17">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/GetTransformValueToSetSystem.cs/#L17">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/GetTransformValueToSetSystem.cs/#L23">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/GetTransformValueToSetSystem.cs/#L23">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/GetTransformValueToSetSystem.cs/#L35">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/GetTransformValueToSetSystem.cs/#L35">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/interpolate-transform-system.md
+++ b/docs/api/transform-synchronization/interpolate-transform-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/InterpolateTransformSystem.cs/#L20">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/InterpolateTransformSystem.cs/#L20">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/InterpolateTransformSystem.cs/#L25">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/InterpolateTransformSystem.cs/#L25">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/InterpolateTransformSystem.cs/#L40">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/InterpolateTransformSystem.cs/#L40">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/interpolation-config.md
+++ b/docs/api/transform-synchronization/interpolation-config.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/InterpolationConfig.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/InterpolationConfig.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -42,7 +42,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>TargetBufferSize</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/InterpolationConfig.cs/#L7">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/InterpolationConfig.cs/#L7">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -57,7 +57,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>MaxLoadMatchedBufferSize</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/InterpolationConfig.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/InterpolationConfig.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/interpolation-receive-strategy.md
+++ b/docs/api/transform-synchronization/interpolation-receive-strategy.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/ScriptableObjects/ReceiveStrategies/InterpolationReceiveStrategy.cs/#L8">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/ScriptableObjects/ReceiveStrategies/InterpolationReceiveStrategy.cs/#L8">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -42,7 +42,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>TargetBufferSize</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/ScriptableObjects/ReceiveStrategies/InterpolationReceiveStrategy.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/ScriptableObjects/ReceiveStrategies/InterpolationReceiveStrategy.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -57,7 +57,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>MaxBufferSize</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/ScriptableObjects/ReceiveStrategies/InterpolationReceiveStrategy.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/ScriptableObjects/ReceiveStrategies/InterpolationReceiveStrategy.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/kinematic-state-when-auth.md
+++ b/docs/api/transform-synchronization/kinematic-state-when-auth.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/KinematicStateWhenAuth.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/KinematicStateWhenAuth.cs/#L6">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -42,7 +42,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>KinematicWhenAuthoritative</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/KinematicStateWhenAuth.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/KinematicStateWhenAuth.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/last-position-sent-data.md
+++ b/docs/api/transform-synchronization/last-position-sent-data.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/LastPositionSentData.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/LastPositionSentData.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -42,7 +42,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Position</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/LastPositionSentData.cs/#L7">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/LastPositionSentData.cs/#L7">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -57,7 +57,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>TimeSinceLastUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/LastPositionSentData.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/LastPositionSentData.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/last-transform-sent-data.md
+++ b/docs/api/transform-synchronization/last-transform-sent-data.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/LastTransformSentData.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/LastTransformSentData.cs/#L6">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -42,7 +42,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Transform</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/LastTransformSentData.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/LastTransformSentData.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -57,7 +57,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>TimeSinceLastUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/LastTransformSentData.cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/LastTransformSentData.cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/manage-kinematic-on-authority-change-tag.md
+++ b/docs/api/transform-synchronization/manage-kinematic-on-authority-change-tag.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/ManageKinematicOnAuthorityChangeTag.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/ManageKinematicOnAuthorityChangeTag.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/transform-synchronization/rate-limited-position-send-system.md
+++ b/docs/api/transform-synchronization/rate-limited-position-send-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/RateLimitedPositionSendSystem.cs/#L18">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/RateLimitedPositionSendSystem.cs/#L18">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/RateLimitedPositionSendSystem.cs/#L22">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/RateLimitedPositionSendSystem.cs/#L22">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/RateLimitedPositionSendSystem.cs/#L34">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/RateLimitedPositionSendSystem.cs/#L34">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/rate-limited-send-config.md
+++ b/docs/api/transform-synchronization/rate-limited-send-config.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/RateLimitedSendConfig.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/RateLimitedSendConfig.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -42,7 +42,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>MaxTransformUpdateRateHz</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/RateLimitedSendConfig.cs/#L7">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/RateLimitedSendConfig.cs/#L7">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -57,7 +57,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>MaxPositionUpdateRateHz</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/RateLimitedSendConfig.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/RateLimitedSendConfig.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/rate-limited-send-strategy.md
+++ b/docs/api/transform-synchronization/rate-limited-send-strategy.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/ScriptableObjects/SendStrategies/RateLimitedSendStrategy.cs/#L7">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/ScriptableObjects/SendStrategies/RateLimitedSendStrategy.cs/#L7">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -42,7 +42,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>MaxTransformUpdateRateHz</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/ScriptableObjects/SendStrategies/RateLimitedSendStrategy.cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/ScriptableObjects/SendStrategies/RateLimitedSendStrategy.cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -57,7 +57,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>MaxPositionUpdateRateHz</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/ScriptableObjects/SendStrategies/RateLimitedSendStrategy.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/ScriptableObjects/SendStrategies/RateLimitedSendStrategy.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/rate-limited-transform-send-system.md
+++ b/docs/api/transform-synchronization/rate-limited-transform-send-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/RateLimitedTransformSendSystem.cs/#L11">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/RateLimitedTransformSendSystem.cs/#L11">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/RateLimitedTransformSendSystem.cs/#L17">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/RateLimitedTransformSendSystem.cs/#L17">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/RateLimitedTransformSendSystem.cs/#L33">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/RateLimitedTransformSendSystem.cs/#L33">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/reset-for-authority-gained-system.md
+++ b/docs/api/transform-synchronization/reset-for-authority-gained-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/ResetForAuthorityGainedSystem.cs/#L18">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/ResetForAuthorityGainedSystem.cs/#L18">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/ResetForAuthorityGainedSystem.cs/#L25">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/ResetForAuthorityGainedSystem.cs/#L25">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/ResetForAuthorityGainedSystem.cs/#L52">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/ResetForAuthorityGainedSystem.cs/#L52">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/set-kinematic-from-authority-system.md
+++ b/docs/api/transform-synchronization/set-kinematic-from-authority-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/SetKinematicFromAuthoritySystem.cs/#L23">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/SetKinematicFromAuthoritySystem.cs/#L23">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/SetKinematicFromAuthoritySystem.cs/#L30">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/SetKinematicFromAuthoritySystem.cs/#L30">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/SetKinematicFromAuthoritySystem.cs/#L49">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/SetKinematicFromAuthoritySystem.cs/#L49">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/set-transform-to-game-object-tag.md
+++ b/docs/api/transform-synchronization/set-transform-to-game-object-tag.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/SetTransformToGameObjectTag.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/SetTransformToGameObjectTag.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/transform-synchronization/teleport-only-receive-tag.md
+++ b/docs/api/transform-synchronization/teleport-only-receive-tag.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TeleportOnlyReceiveTag.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TeleportOnlyReceiveTag.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/transform-synchronization/teleport-only-send-tag.md
+++ b/docs/api/transform-synchronization/teleport-only-send-tag.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TeleportOnlySendTag.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TeleportOnlySendTag.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;

--- a/docs/api/transform-synchronization/tick-rate-estimation-system.md
+++ b/docs/api/transform-synchronization/tick-rate-estimation-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TickRateEstimationSystem.cs/#L21">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TickRateEstimationSystem.cs/#L21">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -43,7 +43,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>PhysicsTicksPerRealSecond</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TickRateEstimationSystem.cs/#L24">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TickRateEstimationSystem.cs/#L24">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -75,7 +75,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TickRateEstimationSystem.cs/#L30">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TickRateEstimationSystem.cs/#L30">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -94,7 +94,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TickRateEstimationSystem.cs/#L36">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TickRateEstimationSystem.cs/#L36">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/tick-system.md
+++ b/docs/api/transform-synchronization/tick-system.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TickSystem.cs/#L19">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TickSystem.cs/#L19">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -48,7 +48,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnCreateManager</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TickSystem.cs/#L23">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TickSystem.cs/#L23">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -67,7 +67,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>OnUpdate</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TickSystem.cs/#L33">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TickSystem.cs/#L33">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/ticks-since-last-transform-update.md
+++ b/docs/api/transform-synchronization/ticks-since-last-transform-update.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TicksSinceLastTransformUpdate.cs/#L5">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TicksSinceLastTransformUpdate.cs/#L5">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -42,7 +42,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>NumberOfTicks</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TicksSinceLastTransformUpdate.cs/#L7">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TicksSinceLastTransformUpdate.cs/#L7">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/transform-defaults.md
+++ b/docs/api/transform-synchronization/transform-defaults.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Config/TransformDefaults.cs/#L3">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Config/TransformDefaults.cs/#L3">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -34,7 +34,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>InterpolationTargetBufferSize</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Config/TransformDefaults.cs/#L5">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Config/TransformDefaults.cs/#L5">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -49,7 +49,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>InterpolationMaxBufferSize</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Config/TransformDefaults.cs/#L6">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Config/TransformDefaults.cs/#L6">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -64,7 +64,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>MaxTickSmearFactor</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Config/TransformDefaults.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Config/TransformDefaults.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -79,7 +79,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>MaxTransformUpdateRateHz</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Config/TransformDefaults.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Config/TransformDefaults.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -94,7 +94,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>MaxPositionUpdateRateHz</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Config/TransformDefaults.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Config/TransformDefaults.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/transform-synchronization-helper.md
+++ b/docs/api/transform-synchronization/transform-synchronization-helper.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformSynchronizationHelper.cs/#L9">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformSynchronizationHelper.cs/#L9">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddTransformSynchronizationComponents</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformSynchronizationHelper.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformSynchronizationHelper.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -70,7 +70,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddTransformSynchronizationComponents</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformSynchronizationHelper.cs/#L22">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformSynchronizationHelper.cs/#L22">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -102,7 +102,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddClientSystems</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformSynchronizationHelper.cs/#L39">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformSynchronizationHelper.cs/#L39">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -130,7 +130,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>AddServerSystems</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformSynchronizationHelper.cs/#L54">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformSynchronizationHelper.cs/#L54">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/transform-synchronization-receive-strategy.md
+++ b/docs/api/transform-synchronization/transform-synchronization-receive-strategy.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/ScriptableObjects/TransformSynchronizationReceiveStrategy.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/ScriptableObjects/TransformSynchronizationReceiveStrategy.cs/#L6">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -42,7 +42,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WorkerType</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/ScriptableObjects/TransformSynchronizationReceiveStrategy.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/ScriptableObjects/TransformSynchronizationReceiveStrategy.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/transform-synchronization-send-strategy.md
+++ b/docs/api/transform-synchronization/transform-synchronization-send-strategy.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/ScriptableObjects/TransformSynchronizationSendStrategy.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/ScriptableObjects/TransformSynchronizationSendStrategy.cs/#L6">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -42,7 +42,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>WorkerType</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/ScriptableObjects/TransformSynchronizationSendStrategy.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/ScriptableObjects/TransformSynchronizationSendStrategy.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/transform-synchronization.md
+++ b/docs/api/transform-synchronization/transform-synchronization.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/MonoBehaviours/TransformSynchronization.cs/#L15">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/MonoBehaviours/TransformSynchronization.cs/#L15">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -43,7 +43,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ReceiveStrategies</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/MonoBehaviours/TransformSynchronization.cs/#L23">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/MonoBehaviours/TransformSynchronization.cs/#L23">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -58,7 +58,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SendStrategies</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/MonoBehaviours/TransformSynchronization.cs/#L24">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/MonoBehaviours/TransformSynchronization.cs/#L24">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -73,7 +73,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>SetKinematicWhenNotAuthoritative</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/MonoBehaviours/TransformSynchronization.cs/#L26">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/MonoBehaviours/TransformSynchronization.cs/#L26">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -101,7 +101,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>TickNumber</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/MonoBehaviours/TransformSynchronization.cs/#L32">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/MonoBehaviours/TransformSynchronization.cs/#L32">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/transform-to-send.md
+++ b/docs/api/transform-synchronization/transform-to-send.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TransformToSend.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TransformToSend.cs/#L6">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -42,7 +42,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Position</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TransformToSend.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TransformToSend.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -57,7 +57,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Velocity</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TransformToSend.cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TransformToSend.cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -72,7 +72,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Orientation</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TransformToSend.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TransformToSend.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/transform-to-set.md
+++ b/docs/api/transform-synchronization/transform-to-set.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TransformToSet.cs/#L6">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TransformToSet.cs/#L6">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -42,7 +42,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Position</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TransformToSet.cs/#L8">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TransformToSet.cs/#L8">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -57,7 +57,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Velocity</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TransformToSet.cs/#L9">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TransformToSet.cs/#L9">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -72,7 +72,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>Orientation</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TransformToSet.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TransformToSet.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -87,7 +87,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ApproximateRemoteTick</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TransformToSet.cs/#L11">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/TransformToSet.cs/#L11">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">

--- a/docs/api/transform-synchronization/transform-utils.md
+++ b/docs/api/transform-synchronization/transform-utils.md
@@ -3,7 +3,7 @@
 <sup>
 Namespace: Improbable.Gdk.<a href="{{urlRoot}}/api/transform-synchronization-index">TransformSynchronization</a><br/>
 GDK package: TransformSynchronization<br/>
-<a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformUtils.cs/#L7">Source</a>
+<a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformUtils.cs/#L7">Source</a>
 <style>
 a code {
                     padding: 0em 0.25em!important;
@@ -39,7 +39,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>HasChanged</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformUtils.cs/#L10">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformUtils.cs/#L10">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -68,7 +68,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>HasChanged</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformUtils.cs/#L16">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformUtils.cs/#L16">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -97,7 +97,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>HasChanged</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformUtils.cs/#L22">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformUtils.cs/#L22">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -126,7 +126,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ToUnityQuaternion</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformUtils.cs/#L27">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformUtils.cs/#L27">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -154,7 +154,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ToImprobableQuaternion</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformUtils.cs/#L32">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformUtils.cs/#L32">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -182,7 +182,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ToUnityVector3</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformUtils.cs/#L38">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformUtils.cs/#L38">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -210,7 +210,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ToImprobableLocation</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformUtils.cs/#L43">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformUtils.cs/#L43">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -238,7 +238,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ToUnityVector3</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformUtils.cs/#L48">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformUtils.cs/#L48">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -266,7 +266,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ToImprobableVelocity</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformUtils.cs/#L53">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformUtils.cs/#L53">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">
@@ -294,7 +294,7 @@ code {
 <table width="100%">
     <tr>
         <td style="border-right:none"><b>ToCoordinates</b></td>
-        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/0.2.0/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformUtils.cs/#L58">Source</a></td>
+        <td style="border-left:none; text-align:right"><a href="https://www.github.com/spatialos/gdk-for-unity/blob/f54d7cdc/workers/unity/Packages/com.improbable.gdk.transformsynchronization/TransformUtils.cs/#L58">Source</a></td>
     </tr>
     <tr>
         <td colspan="2">


### PR DESCRIPTION
Need to link to the QBI Helper API reference docs, so here's an update to docs-next using the API docs generated from `f54d7cdc` of `develop`