### PR TITLE
Upgrade Playground API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
     - `Constraint` contains static methods to easily create constraints for an interest query.
 - Added a `WithTimeout(TimeSpan timeout)` method to the `RedirectedProcess` class. This allows you to set a timeout for the underlying process execution.
 - Added a `Improbable.Gdk.Core.Collections.Result<T, E>` struct to represent a result which can either contain a value `T` or an error `E`.
+- Added Scripting Define Symbol `DISABLE_REACTIVE_COMPONENTS`. Using this symbol will disable all reactive componts and systems.
+    - Currently not compatible with the FPS Starter Project.
 
 ### Changed
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyReactiveComponents.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System.Collections.Generic;
 using Unity.Entities;
 using Improbable.Gdk.Core;
@@ -232,3 +233,4 @@ namespace Improbable.Gdk.Tests
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyReactiveHandlers.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -159,3 +160,4 @@ namespace Improbable.Gdk.Tests
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueReactiveComponents.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System.Collections.Generic;
 using Unity.Entities;
 using Improbable.Gdk.Core;
@@ -232,3 +233,4 @@ namespace Improbable.Gdk.Tests
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueReactiveHandlers.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -159,3 +160,4 @@ namespace Improbable.Gdk.Tests
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalReactiveComponents.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System.Collections.Generic;
 using Unity.Entities;
 using Improbable.Gdk.Core;
@@ -232,3 +233,4 @@ namespace Improbable.Gdk.Tests
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalReactiveHandlers.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -159,3 +160,4 @@ namespace Improbable.Gdk.Tests
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedReactiveComponents.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System.Collections.Generic;
 using Unity.Entities;
 using Improbable.Gdk.Core;
@@ -232,3 +233,4 @@ namespace Improbable.Gdk.Tests
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedReactiveHandlers.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -159,3 +160,4 @@ namespace Improbable.Gdk.Tests
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularReactiveComponents.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System.Collections.Generic;
 using Unity.Entities;
 using Improbable.Gdk.Core;
@@ -232,3 +233,4 @@ namespace Improbable.Gdk.Tests
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularReactiveHandlers.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -159,3 +160,4 @@ namespace Improbable.Gdk.Tests
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentReactiveComponents.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System.Collections.Generic;
 using Unity.Entities;
 using Improbable.Gdk.Core;
@@ -232,3 +233,4 @@ namespace Improbable.Gdk.Tests
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentReactiveHandlers.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -159,3 +160,4 @@ namespace Improbable.Gdk.Tests
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionEvents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionEvents.cs
@@ -24,6 +24,8 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
             }
         }
 
+
+#if !DISABLE_REACTIVE_COMPONENTS
         public static class ReceivedEvents
         {
             public struct MyEvent : IComponentData
@@ -53,5 +55,6 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
             }
 
         }
+#endif
     }
 }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionReactiveComponents.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System.Collections.Generic;
 using Unity.Entities;
 using Improbable.Gdk.Core;
@@ -302,3 +303,4 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionReactiveHandlers.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -193,3 +194,4 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentCommandComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentCommandComponents.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System.Collections.Generic;
 using Unity.Entities;
 
@@ -98,3 +99,4 @@ namespace Improbable.Gdk.Tests.BlittableTypes
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentEvents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentEvents.cs
@@ -37,6 +37,8 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             }
         }
 
+
+#if !DISABLE_REACTIVE_COMPONENTS
         public static class ReceivedEvents
         {
             public struct FirstEvent : IComponentData
@@ -88,5 +90,6 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             }
 
         }
+#endif
     }
 }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentReactiveCommandComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentReactiveCommandComponents.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System;
 using System.Collections.Generic;
 using Unity.Entities;
@@ -275,3 +276,4 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentReactiveComponents.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System.Collections.Generic;
 using Unity.Entities;
 using Improbable.Gdk.Core;
@@ -372,3 +373,4 @@ namespace Improbable.Gdk.Tests.BlittableTypes
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentReactiveHandlers.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -364,3 +365,4 @@ namespace Improbable.Gdk.Tests.BlittableTypes
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsReactiveComponents.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System.Collections.Generic;
 using Unity.Entities;
 using Improbable.Gdk.Core;
@@ -232,3 +233,4 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsReactiveHandlers.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -159,3 +160,4 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsCommandComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsCommandComponents.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System.Collections.Generic;
 using Unity.Entities;
 
@@ -62,3 +63,4 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsReactiveCommandComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsReactiveCommandComponents.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System;
 using System.Collections.Generic;
 using Unity.Entities;
@@ -146,3 +147,4 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsReactiveComponents.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System.Collections.Generic;
 using Unity.Entities;
 using Improbable.Gdk.Core;
@@ -232,3 +233,4 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsReactiveHandlers.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -238,3 +239,4 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsEvents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsEvents.cs
@@ -24,6 +24,8 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             }
         }
 
+
+#if !DISABLE_REACTIVE_COMPONENTS
         public static class ReceivedEvents
         {
             public struct Evt : IComponentData
@@ -53,5 +55,6 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             }
 
         }
+#endif
     }
 }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsReactiveComponents.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System.Collections.Generic;
 using Unity.Entities;
 using Improbable.Gdk.Core;
@@ -302,3 +303,4 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsReactiveHandlers.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -193,3 +194,4 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentCommandComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentCommandComponents.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System.Collections.Generic;
 using Unity.Entities;
 
@@ -98,3 +99,4 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentEvents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentEvents.cs
@@ -37,6 +37,8 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             }
         }
 
+
+#if !DISABLE_REACTIVE_COMPONENTS
         public static class ReceivedEvents
         {
             public struct FirstEvent : IComponentData
@@ -88,5 +90,6 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             }
 
         }
+#endif
     }
 }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentReactiveCommandComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentReactiveCommandComponents.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System;
 using System.Collections.Generic;
 using Unity.Entities;
@@ -275,3 +276,4 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentReactiveComponents.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System.Collections.Generic;
 using Unity.Entities;
 using Improbable.Gdk.Core;
@@ -372,3 +373,4 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
         }
     }
 }
+#endif

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentReactiveHandlers.cs
@@ -2,6 +2,7 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // ===========
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -364,3 +365,4 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
         }
     }
 }
+#endif

--- a/workers/unity/Assets/Playground/Scripts/Camera/InitCameraSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Camera/InitCameraSystem.cs
@@ -4,42 +4,45 @@ using Unity.Collections;
 using Unity.Entities;
 using UnityEngine;
 
-#region Diagnostic control
-
-#pragma warning disable 649
-// ReSharper disable UnassignedReadonlyField
-// ReSharper disable UnusedMember.Global
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
-
 namespace Playground
 {
     [UpdateInGroup(typeof(SpatialOSUpdateGroup))]
     public class InitCameraSystem : ComponentSystem
     {
-        private struct Data
-        {
-            public readonly int Length;
-            public EntityArray Entites;
-            [ReadOnly] public ComponentDataArray<Authoritative<PlayerInput.Component>> PlayerInput;
-            [ReadOnly] public ComponentDataArray<AuthorityChanges<PlayerInput.Component>> PlayerInputAuthority;
-        }
+        [Inject] private ComponentUpdateSystem componentUpdateSystem;
 
-        [Inject] private Data data;
+        private ComponentGroup inputGroup;
+
+        protected override void OnCreateManager()
+        {
+            base.OnCreateManager();
+
+            inputGroup = GetComponentGroup(
+                ComponentType.ReadOnly<PlayerInput.ComponentAuthority>(),
+                ComponentType.ReadOnly<SpatialEntityId>()
+            );
+            inputGroup.SetFilter(new PlayerInput.ComponentAuthority(true));
+        }
 
         protected override void OnUpdate()
         {
-            for (var i = 0; i < data.Length; i++)
+            var entities = inputGroup.GetEntityArray();
+            var spatialIdData = inputGroup.GetComponentDataArray<SpatialEntityId>();
+
+            for (var i = 0; i < entities.Length; i++)
             {
-                var entity = data.Entites[i];
-                PostUpdateCommands.AddComponent(entity, CameraComponentDefaults.Input);
-                PostUpdateCommands.AddComponent(entity, CameraComponentDefaults.Transform);
+                var authChanges = componentUpdateSystem.GetAuthorityChangesReceived(spatialIdData[i].EntityId, PlayerInput.ComponentId);
+                if (authChanges.Count > 0)
+                {
+                    var entity = entities[i];
+                    PostUpdateCommands.AddComponent(entity, CameraComponentDefaults.Input);
+                    PostUpdateCommands.AddComponent(entity, CameraComponentDefaults.Transform);
 
-                Cursor.lockState = CursorLockMode.Locked;
+                    Cursor.lockState = CursorLockMode.Locked;
 
-                // Disable system after first run.
-                Enabled = false;
+                    // Disable system after first run.
+                    Enabled = false;
+                }
             }
         }
 

--- a/workers/unity/Assets/Playground/Scripts/Camera/InitCameraSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Camera/InitCameraSystem.cs
@@ -1,6 +1,4 @@
 using Improbable.Gdk.Core;
-using Improbable.Gdk.ReactiveComponents;
-using Unity.Collections;
 using Unity.Entities;
 using UnityEngine;
 
@@ -9,19 +7,20 @@ namespace Playground
     [UpdateInGroup(typeof(SpatialOSUpdateGroup))]
     public class InitCameraSystem : ComponentSystem
     {
-        [Inject] private ComponentUpdateSystem componentUpdateSystem;
-
+        private ComponentUpdateSystem componentUpdateSystem;
         private ComponentGroup inputGroup;
 
         protected override void OnCreateManager()
         {
             base.OnCreateManager();
 
+            componentUpdateSystem = World.GetExistingManager<ComponentUpdateSystem>();
+
             inputGroup = GetComponentGroup(
                 ComponentType.ReadOnly<PlayerInput.ComponentAuthority>(),
                 ComponentType.ReadOnly<SpatialEntityId>()
             );
-            inputGroup.SetFilter(new PlayerInput.ComponentAuthority(true));
+            inputGroup.SetFilter(PlayerInput.ComponentAuthority.Authoritative);
         }
 
         protected override void OnUpdate()

--- a/workers/unity/Assets/Playground/Scripts/Cubes/CollisionProcessSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Cubes/CollisionProcessSystem.cs
@@ -29,33 +29,39 @@ namespace Playground
     [UpdateInGroup(typeof(SpatialOSUpdateGroup))]
     internal class CollisionProcessSystem : ComponentSystem
     {
-        private struct Data
-        {
-            public readonly int Length;
-            public EntityArray Entities;
-
-            // Gets updated through PostUpdate
-            [ReadOnly] public ComponentDataArray<Launchable.Component> Launchable;
-            [ReadOnly] public ComponentDataArray<CollisionComponent> Collision;
-            public ComponentDataArray<Launcher.CommandSenders.IncreaseScore> Sender;
-            [ReadOnly] public ComponentDataArray<Authoritative<Launchable.Component>> DenotesAuthority;
-        }
-
-        [Inject] private Data data;
-
         private static readonly EntityId InvalidEntityId = new EntityId(0);
+
+        private ComponentGroup collisionGroup;
+
+        [Inject] private CommandSystem commandSystem;
+
+        protected override void OnCreateManager()
+        {
+            base.OnCreateManager();
+
+            collisionGroup = GetComponentGroup(
+                ComponentType.ReadOnly<Launchable.Component>(),
+                ComponentType.ReadOnly<Launchable.ComponentAuthority>(),
+                ComponentType.ReadOnly<CollisionComponent>()
+            );
+            collisionGroup.SetFilter(new Launchable.ComponentAuthority(true));
+        }
 
         protected override void OnUpdate()
         {
-            for (var i = 0; i < data.Length; i++)
+            var entities = collisionGroup.GetEntityArray();
+            var launchableData = collisionGroup.GetComponentDataArray<Launchable.Component>();
+            var collisionData = collisionGroup.GetComponentDataArray<CollisionComponent>();
+            var launchableForEntity = GetComponentDataFromEntity<Launchable.Component>(true);
+
+            for (var i = 0; i < entities.Length; i++)
             {
                 // Handle all the different possible outcomes of the collision.
                 // This requires looking at their most recent launchers.
-                var launchable = data.Launchable[i];
-                var collision = data.Collision[i];
-                var sender = data.Sender[i];
+                var launchable = launchableData[i];
+                var collision = collisionData[i];
 
-                var otherLaunchable = EntityManager.GetComponentData<Launchable.Component>(collision.OtherEntity);
+                var otherLaunchable = launchableForEntity[collision.OtherEntity];
                 var ourOwner = launchable.MostRecentLauncher;
                 var otherOwner = otherLaunchable.MostRecentLauncher;
 
@@ -63,18 +69,20 @@ namespace Playground
                 {
                     if (ourOwner.IsValid())
                     {
-                        sender.RequestsToSend.Add(new Launcher.IncreaseScore.Request(
-                            ourOwner, new ScoreIncreaseRequest(1)));
-                        data.Sender[i] = sender;
+                        var request = new Launcher.IncreaseScore.Request(
+                            ourOwner, new ScoreIncreaseRequest(1));
+
+                        commandSystem.SendCommand(request, entities[i]);
                     }
                 }
                 else if (otherOwner.IsValid())
                 {
                     if (!ourOwner.IsValid())
                     {
-                        sender.RequestsToSend.Add(new Launcher.IncreaseScore.Request(otherOwner,
-                            new ScoreIncreaseRequest(1)));
-                        data.Sender[i] = sender;
+                        var request = new Launcher.IncreaseScore.Request(otherOwner,
+                            new ScoreIncreaseRequest(1));
+
+                        commandSystem.SendCommand(request, entities[i]);
 
                         launchable.MostRecentLauncher = otherOwner;
                     }
@@ -83,7 +91,7 @@ namespace Playground
                         launchable.MostRecentLauncher = InvalidEntityId;
                     }
 
-                    PostUpdateCommands.SetComponent(data.Entities[i], launchable);
+                    PostUpdateCommands.SetComponent(entities[i], launchable);
                 }
             }
         }

--- a/workers/unity/Assets/Playground/Scripts/Cubes/CollisionProcessSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Cubes/CollisionProcessSystem.cs
@@ -1,17 +1,6 @@
 using Improbable.Gdk.Core;
-using Improbable.Gdk.ReactiveComponents;
-using Unity.Collections;
 using Unity.Entities;
 using Entity = Unity.Entities.Entity;
-
-#region Diagnostic control
-
-#pragma warning disable 649
-// ReSharper disable UnassignedReadonlyField
-// ReSharper disable UnusedMember.Global
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
 
 namespace Playground
 {
@@ -19,11 +8,6 @@ namespace Playground
     public struct CollisionComponent : IComponentData
     {
         public Entity OtherEntity;
-
-        public CollisionComponent(Entity otherEntity)
-        {
-            OtherEntity = otherEntity;
-        }
     }
 
     [UpdateInGroup(typeof(SpatialOSUpdateGroup))]
@@ -32,19 +16,20 @@ namespace Playground
         private static readonly EntityId InvalidEntityId = new EntityId(0);
 
         private ComponentGroup collisionGroup;
-
-        [Inject] private CommandSystem commandSystem;
+        private CommandSystem commandSystem;
 
         protected override void OnCreateManager()
         {
             base.OnCreateManager();
+
+            commandSystem = World.GetExistingManager<CommandSystem>();
 
             collisionGroup = GetComponentGroup(
                 ComponentType.ReadOnly<Launchable.Component>(),
                 ComponentType.ReadOnly<Launchable.ComponentAuthority>(),
                 ComponentType.ReadOnly<CollisionComponent>()
             );
-            collisionGroup.SetFilter(new Launchable.ComponentAuthority(true));
+            collisionGroup.SetFilter(Launchable.ComponentAuthority.Authoritative);
         }
 
         protected override void OnUpdate()

--- a/workers/unity/Assets/Playground/Scripts/Cubes/CubeMovementSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Cubes/CubeMovementSystem.cs
@@ -6,29 +6,12 @@ using Unity.Entities;
 using UnityEngine;
 using UnityEngine.Experimental.PlayerLoop;
 
-#region Diagnostic control
-
-#pragma warning disable 649
-// ReSharper disable UnassignedReadonlyField
-// ReSharper disable UnusedMember.Global
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
-
 namespace Playground
 {
     [UpdateBefore(typeof(FixedUpdate.PhysicsFixedUpdate))]
     internal class CubeMovementSystem : ComponentSystem
     {
-        private struct Data
-        {
-            public readonly int Length;
-            public ComponentArray<Rigidbody> Rigidbody;
-            public ComponentDataArray<CubeTargetVelocity.Component> Cube;
-            [ReadOnly] public ComponentDataArray<Authoritative<CubeTargetVelocity.Component>> DenoteAuthority;
-        }
-
-        [Inject] private Data data;
+        private ComponentGroup cubeGroup;
 
         private Vector3 origin;
 
@@ -37,28 +20,37 @@ namespace Playground
             base.OnCreateManager();
 
             origin = World.GetExistingManager<WorkerSystem>().Origin;
+
+            cubeGroup = GetComponentGroup(
+                ComponentType.Create<CubeTargetVelocity.Component>(),
+                ComponentType.ReadOnly<CubeTargetVelocity.ComponentAuthority>(),
+                ComponentType.Create<Rigidbody>()
+            );
+            cubeGroup.SetFilter(new CubeTargetVelocity.ComponentAuthority(true));
         }
 
         protected override void OnUpdate()
         {
-            for (var i = 0; i < data.Length; i++)
+            var entities = cubeGroup.GetEntityArray();
+            var cubeVelocityData = cubeGroup.GetComponentDataArray<CubeTargetVelocity.Component>();
+
+            for (var i = 0; i < cubeVelocityData.Length; i++)
             {
-                var rigidbody = data.Rigidbody[i];
-                var cubeComponent = data.Cube[i];
+                var rigidbody = EntityManager.GetComponentObject<Rigidbody>(entities[i]);
+                var cubeComponent = cubeVelocityData[i];
 
                 if (cubeComponent.TargetVelocity.X > 0 && rigidbody.position.x - origin.x > 10)
                 {
                     cubeComponent.TargetVelocity = new Vector3f { X = -2.0f };
-                    data.Cube[i] = cubeComponent;
+                    cubeVelocityData[i] = cubeComponent;
                 }
                 else if (cubeComponent.TargetVelocity.X < 0 && rigidbody.position.x - origin.x < -10)
                 {
                     cubeComponent.TargetVelocity = new Vector3f { X = 2.0f };
-                    data.Cube[i] = cubeComponent;
+                    cubeVelocityData[i] = cubeComponent;
                 }
 
-                var velocity = new Vector3(cubeComponent.TargetVelocity.X, cubeComponent.TargetVelocity.Y, cubeComponent.TargetVelocity.Z);
-                rigidbody.MovePosition(rigidbody.position + Time.fixedDeltaTime * velocity);
+                rigidbody.MovePosition(rigidbody.position + cubeComponent.TargetVelocity.ToUnityVector() * Time.fixedDeltaTime);
             }
         }
     }

--- a/workers/unity/Assets/Playground/Scripts/Cubes/CubeMovementSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Cubes/CubeMovementSystem.cs
@@ -26,7 +26,7 @@ namespace Playground
                 ComponentType.ReadOnly<CubeTargetVelocity.ComponentAuthority>(),
                 ComponentType.Create<Rigidbody>()
             );
-            cubeGroup.SetFilter(new CubeTargetVelocity.ComponentAuthority(true));
+            cubeGroup.SetFilter(CubeTargetVelocity.ComponentAuthority.Authoritative);
         }
 
         protected override void OnUpdate()

--- a/workers/unity/Assets/Playground/Scripts/Cubes/ProcessColorChangeSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Cubes/ProcessColorChangeSystem.cs
@@ -1,31 +1,25 @@
 using System.Collections.Generic;
 using Improbable.Gdk.Core;
-using Unity.Collections;
 using Unity.Entities;
 using UnityEngine;
-
-#region Diagnostic control
-
-#pragma warning disable 649
-// ReSharper disable UnassignedReadonlyField
-// ReSharper disable UnusedMember.Global
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
 
 namespace Playground
 {
     [UpdateInGroup(typeof(SpatialOSUpdateGroup))]
     public class ProcessColorChangeSystem : ComponentSystem
     {
-        [Inject] private ComponentUpdateSystem updateSystem;
-        [Inject] private WorkerSystem workerSystem;
+        private ComponentUpdateSystem updateSystem;
+        private WorkerSystem workerSystem;
 
         private Dictionary<Color, MaterialPropertyBlock> materialPropertyBlocks;
 
         protected override void OnCreateManager()
         {
             base.OnCreateManager();
+
+            updateSystem = World.GetExistingManager<ComponentUpdateSystem>();
+            workerSystem = World.GetExistingManager<WorkerSystem>();
+
             ColorTranslationUtil.PopulateMaterialPropertyBlockMap(out materialPropertyBlocks);
         }
 

--- a/workers/unity/Assets/Playground/Scripts/DisconnectSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/DisconnectSystem.cs
@@ -1,35 +1,30 @@
 using Improbable.Gdk.Core;
-using Unity.Collections;
 using Unity.Entities;
 using UnityEngine;
-
-#region Diagnostic control
-
-#pragma warning disable 649
-// ReSharper disable UnassignedReadonlyField
-// ReSharper disable UnusedMember.Global
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
 
 namespace Playground
 {
     [UpdateInGroup(typeof(SpatialOSUpdateGroup))]
     internal class DisconnectSystem : ComponentSystem
     {
-        public struct DisconnectData
-        {
-            public readonly int Length;
-            [ReadOnly] public SharedComponentDataArray<OnDisconnected> DisconnectMessage;
-            [ReadOnly] public ComponentDataArray<WorkerEntityTag> DenotesWorkerEntity;
-        }
+        private ComponentGroup group;
 
-        [Inject] private DisconnectData data;
+        protected override void OnCreateManager()
+        {
+            base.OnCreateManager();
+
+            group = GetComponentGroup(
+                ComponentType.ReadOnly<OnDisconnected>(),
+                ComponentType.ReadOnly<WorkerEntityTag>()
+            );
+        }
 
         protected override void OnUpdate()
         {
+            var disconnectData = group.GetSharedComponentDataArray<OnDisconnected>();
+
             Debug.LogWarningFormat("Disconnected from SpatialOS with reason: \"{0}\"",
-                data.DisconnectMessage[0].ReasonForDisconnect);
+                disconnectData[0].ReasonForDisconnect);
         }
     }
 }

--- a/workers/unity/Assets/Playground/Scripts/Metrics/MetricSendSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Metrics/MetricSendSystem.cs
@@ -4,12 +4,6 @@ using Improbable.Worker.CInterop;
 using Unity.Entities;
 using UnityEngine;
 
-#region Diagnostic control
-
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
-
 namespace Playground
 {
     public class MetricSendSystem : ComponentSystem

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/CubeSpawnerInputBehaviour.cs
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/CubeSpawnerInputBehaviour.cs
@@ -6,17 +6,11 @@ using Improbable.Gdk.Subscriptions;
 using Unity.Entities;
 using UnityEngine;
 
-#region Diagnostic control
-
-// Disable the "variable is never assigned" for injected fields.
-#pragma warning disable 649
-
-#endregion
-
 namespace Playground.MonoBehaviours
 {
     public class CubeSpawnerInputBehaviour : MonoBehaviour
     {
+#pragma warning disable 649
         [Require] private PlayerInputWriter playerInputWriter;
         [Require] private CubeSpawnerReader cubeSpawnerReader;
         [Require] private CubeSpawnerCommandSender cubeSpawnerCommandSender;
@@ -25,6 +19,7 @@ namespace Playground.MonoBehaviours
         [Require] private World world;
 
         [Require] private ILogDispatcher logDispatcher;
+#pragma warning restore 649
 
         private void OnSpawnCubeResponse(CubeSpawner.SpawnCube.ReceivedResponse response)
         {

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/DeleteCubeCommandReceiver.cs
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/DeleteCubeCommandReceiver.cs
@@ -6,22 +6,17 @@ using Improbable.Gdk.Subscriptions;
 using Improbable.Worker.CInterop;
 using UnityEngine;
 
-#region Diagnostic control
-
-// Disable the "variable is never assigned" for injected fields.
-#pragma warning disable 649
-
-#endregion
-
 namespace Playground.MonoBehaviours
 {
     public class DeleteCubeCommandReceiver : MonoBehaviour
     {
+#pragma warning disable 649
         [Require] private CubeSpawnerWriter cubeSpawnerWriter;
         [Require] private CubeSpawnerCommandReceiver cubeSpawnerReceiver;
         [Require] private WorldCommandSender worldCommandSender;
 
         [Require] private ILogDispatcher logDispatcher;
+#pragma warning restore 649
 
         public void OnEnable()
         {

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/RotationBehaviour.cs
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/RotationBehaviour.cs
@@ -4,12 +4,6 @@ using UnityEngine;
 using SpatialQuaternion = Improbable.Transform.Quaternion;
 using Quaternion = UnityEngine.Quaternion;
 
-#region Diagnostic control
-
-#pragma warning disable 169
-
-#endregion
-
 public class RotationBehaviour : MonoBehaviour
 {
     public bool RotatingClockWise = true;

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/SpawnCubeCommandReceiver.cs
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/SpawnCubeCommandReceiver.cs
@@ -9,25 +9,18 @@ using Improbable.Worker.CInterop;
 using UnityEngine;
 using Quaternion = Improbable.Transform.Quaternion;
 
-#region Diagnostic control
-
-// Disable the "variable is never assigned" for injected fields.
-#pragma warning disable 649
-
-// ReSharper disable PossibleInvalidOperationException
-
-#endregion
-
 namespace Playground.MonoBehaviours
 {
     public class SpawnCubeCommandReceiver : MonoBehaviour
     {
+#pragma warning disable 649
         [Require] private TransformInternalReader transformReader;
         [Require] private CubeSpawnerCommandReceiver cubeSpawnerCommandRequestHandler;
         [Require] private CubeSpawnerWriter cubeSpawnerWriter;
         [Require] private WorldCommandSender worldCommandRequestSender;
 
         [Require] private ILogDispatcher logDispatcher;
+#pragma warning restore 649
 
         public void OnEnable()
         {

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/ToggleRotationCommandReceiver.cs
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/ToggleRotationCommandReceiver.cs
@@ -2,23 +2,17 @@ using Improbable.Common;
 using Improbable.Gdk.Subscriptions;
 using UnityEngine;
 
-#region Diagnostic control
-
-// Disable the "variable is never assigned" for injected fields.
-#pragma warning disable 649
-
-#endregion
-
 namespace Playground.MonoBehaviours
 {
     public class ToggleRotationCommandReceiver : MonoBehaviour
     {
         public float TimeBetweenSpinChanges = 1.0f;
 
+#pragma warning disable 649
         [Require] private SpinnerRotationCommandReceiver requestHandler;
+#pragma warning restore 649
 
         private RotationBehaviour rotationBehaviour;
-
         private float nextAvailableSpinChangeTime;
 
         private void OnEnable()

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/ToggleRotationCommandSender.cs
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/ToggleRotationCommandSender.cs
@@ -4,37 +4,16 @@ using Improbable.Worker.CInterop;
 using Improbable.Gdk.Subscriptions;
 using UnityEngine;
 
-#region Diagnostic control
-
-// Disable the "variable is never assigned" for injected fields.
-#pragma warning disable 649
-
-#endregion
-
 namespace Playground.MonoBehaviours
 {
     public class ToggleRotationCommandSender : MonoBehaviour
     {
+#pragma warning disable 649
         [Require] private SpinnerRotationReader reader;
         [Require] private SpinnerRotationCommandSender requestSender;
 
         [Require] private EntityId ownEntityId;
-
-        private void OnEnable()
-        {
-            //ownEntityId = GetComponent<SpatialOSComponent>().SpatialEntityId;
-            //responseHandler.OnSpinnerToggleRotationResponse += ResponseHandlerOnOnSpinnerToggleRotationResponse;
-        }
-
-        private void ResponseHandlerOnOnSpinnerToggleRotationResponse(
-            SpinnerRotation.SpinnerToggleRotation.ReceivedResponse obj)
-        {
-            if (obj.StatusCode != StatusCode.Success)
-            {
-                // GetComponent<SpatialOSComponent>().Worker.LogDispatcher.HandleLog(LogType.Error,
-                //     new LogEvent($"Spin command request failed: {obj.StatusCode}, message: {obj.Message}"));
-            }
-        }
+#pragma warning restore 649
 
         private void Update()
         {

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/UpdateSpinnerColor.cs
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/UpdateSpinnerColor.cs
@@ -2,18 +2,13 @@
 using Improbable.Gdk.Subscriptions;
 using UnityEngine;
 
-#region Diagnostic control
-
-// Disable the "variable is never assigned" for injected fields.
-#pragma warning disable 649
-
-#endregion
-
 namespace Playground.MonoBehaviours
 {
     public class UpdateSpinnerColor : MonoBehaviour
     {
+#pragma warning disable 649
         [Require] private SpinnerColorWriter spinnerColorWriter;
+#pragma warning restore 649
 
         private Array colorValues;
         private int colorIndex;

--- a/workers/unity/Assets/Playground/Scripts/Player/LocalPlayerInputSync.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/LocalPlayerInputSync.cs
@@ -4,43 +4,41 @@ using Improbable.Gdk.ReactiveComponents;
 using Unity.Entities;
 using UnityEngine;
 
-#region Diagnostic control
-
-#pragma warning disable 649
-// ReSharper disable UnassignedReadonlyField
-// ReSharper disable UnusedMember.Global
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
-
 namespace Playground
 {
     [UpdateInGroup(typeof(SpatialOSUpdateGroup))]
     internal class LocalPlayerInputSync : ComponentSystem
     {
-        private struct PlayerInputData
-        {
-            public readonly int Length;
-            public ComponentDataArray<PlayerInput.Component> PlayerInput;
-            public ComponentDataArray<CameraTransform> CameraTransform;
-            public ComponentDataArray<Authoritative<PlayerInput.Component>> PlayerInputAuthority;
-        }
-
-        [Inject] private PlayerInputData playerInputData;
-
         private const float MinInputChange = 0.01f;
+
+        private ComponentGroup inputGroup;
+
+        protected override void OnCreateManager()
+        {
+            base.OnCreateManager();
+
+            inputGroup = GetComponentGroup(
+                ComponentType.Create<PlayerInput.Component>(),
+                ComponentType.Create<CameraTransform>(),
+                ComponentType.ReadOnly<PlayerInput.ComponentAuthority>()
+            );
+            inputGroup.SetFilter(new PlayerInput.ComponentAuthority(true));
+        }
 
         protected override void OnUpdate()
         {
-            for (var i = 0; i < playerInputData.Length; i++)
+            var cameraTransformData = inputGroup.GetComponentDataArray<CameraTransform>();
+            var playerInputData = inputGroup.GetComponentDataArray<PlayerInput.Component>();
+
+            for (var i = 0; i < cameraTransformData.Length; i++)
             {
-                var cameraTransform = playerInputData.CameraTransform[i];
+                var cameraTransform = cameraTransformData[i];
                 var forward = cameraTransform.Rotation * Vector3.up;
                 var right = cameraTransform.Rotation * Vector3.right;
                 var input = Input.GetAxisRaw("Horizontal") * right + Input.GetAxisRaw("Vertical") * forward;
                 var isShiftDown = Input.GetKey(KeyCode.LeftShift);
 
-                var oldPlayerInput = playerInputData.PlayerInput[i];
+                var oldPlayerInput = playerInputData[i];
 
                 if (Math.Abs(oldPlayerInput.Horizontal - input.x) > MinInputChange
                     || Math.Abs(oldPlayerInput.Vertical - input.z) > MinInputChange
@@ -52,7 +50,8 @@ namespace Playground
                         Vertical = input.z,
                         Running = isShiftDown
                     };
-                    playerInputData.PlayerInput[i] = newPlayerInput;
+
+                    playerInputData[i] = newPlayerInput;
                 }
             }
         }

--- a/workers/unity/Assets/Playground/Scripts/Player/LocalPlayerInputSync.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/LocalPlayerInputSync.cs
@@ -1,6 +1,5 @@
 using System;
 using Improbable.Gdk.Core;
-using Improbable.Gdk.ReactiveComponents;
 using Unity.Entities;
 using UnityEngine;
 
@@ -22,7 +21,7 @@ namespace Playground
                 ComponentType.Create<CameraTransform>(),
                 ComponentType.ReadOnly<PlayerInput.ComponentAuthority>()
             );
-            inputGroup.SetFilter(new PlayerInput.ComponentAuthority(true));
+            inputGroup.SetFilter(PlayerInput.ComponentAuthority.Authoritative);
         }
 
         protected override void OnUpdate()

--- a/workers/unity/Assets/Playground/Scripts/Player/MoveLocalPlayerSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/MoveLocalPlayerSystem.cs
@@ -5,15 +5,6 @@ using Unity.Collections;
 using Unity.Entities;
 using UnityEngine;
 
-#region Diagnostic control
-
-#pragma warning disable 649
-// ReSharper disable UnassignedReadonlyField
-// ReSharper disable UnusedMember.Global
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
-
 namespace Playground
 {
     [UpdateInGroup(typeof(SpatialOSUpdateGroup))]
@@ -26,26 +17,8 @@ namespace Playground
             public float SpeedSmoothVelocity;
         }
 
-        private struct NewPlayerData
-        {
-            public readonly int Length;
-            public EntityArray Entity;
-            [ReadOnly] public ComponentDataArray<PlayerInput.Component> PlayerInput;
-            [ReadOnly] public ComponentDataArray<Authoritative<TransformInternal.Component>> TransformAuthority;
-            public SubtractiveComponent<Speed> NoSpeed;
-        }
-
-        private struct PlayerInputData
-        {
-            public readonly int Length;
-            public ComponentArray<Rigidbody> Rigidbody;
-            public ComponentDataArray<Speed> SpeedData;
-            [ReadOnly] public ComponentDataArray<PlayerInput.Component> PlayerInput;
-            [ReadOnly] public ComponentDataArray<Authoritative<TransformInternal.Component>> TransformAuthority;
-        }
-
-        [Inject] private NewPlayerData newPlayerData;
-        [Inject] private PlayerInputData playerInputData;
+        private ComponentGroup newPlayerGroup;
+        private ComponentGroup playerInputGroup;
 
         private const float WalkSpeed = 2.0f;
         private const float RunSpeed = 6.0f;
@@ -56,28 +29,51 @@ namespace Playground
 
         private const float SpeedSmoothTime = 0.1f;
 
+        protected override void OnCreateManager()
+        {
+            base.OnCreateManager();
+
+            newPlayerGroup = GetComponentGroup(
+                ComponentType.ReadOnly<PlayerInput.Component>(),
+                ComponentType.ReadOnly<PlayerInput.ComponentAuthority>(),
+                ComponentType.Subtractive<Speed>()
+            );
+            newPlayerGroup.SetFilter(new PlayerInput.ComponentAuthority(true));
+
+            playerInputGroup = GetComponentGroup(
+                ComponentType.Create<Rigidbody>(),
+                ComponentType.Create<Speed>(),
+                ComponentType.ReadOnly<PlayerInput.Component>(),
+                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>()
+            );
+            playerInputGroup.SetFilter(new TransformInternal.ComponentAuthority(true));
+        }
+
         protected override void OnUpdate()
         {
-            for (var i = 0; i < newPlayerData.Length; i++)
+            var newSpeedEntities = newPlayerGroup.GetEntityArray();
+
+            for (var i = 0; i < newSpeedEntities.Length; i++)
             {
-                var entity = newPlayerData.Entity[i];
                 var speed = new Speed
                 {
                     CurrentSpeed = 0f,
                     SpeedSmoothVelocity = 0f
                 };
 
-                PostUpdateCommands.AddComponent(entity, speed);
+                PostUpdateCommands.AddComponent(newSpeedEntities[i], speed);
             }
+
+            var entities = playerInputGroup.GetEntityArray();
+            var playerInputData = playerInputGroup.GetComponentDataArray<PlayerInput.Component>();
+            var speedData = playerInputGroup.GetComponentDataArray<Speed>();
 
             for (var i = 0; i < playerInputData.Length; i++)
             {
-                var rigidbody = playerInputData.Rigidbody[i];
-                var playerInput = playerInputData.PlayerInput[i];
+                var rigidbody = EntityManager.GetComponentObject<Rigidbody>(entities[i]);
+                var playerInput = playerInputData[i];
 
-                var input = new Vector2(playerInput.Horizontal, playerInput.Vertical);
-                var inputDir = input.normalized;
-
+                var inputDir = new Vector2(playerInput.Horizontal, playerInput.Vertical).normalized;
                 if (inputDir != Vector2.zero)
                 {
                     var targetRotation = Mathf.Atan2(inputDir.x, inputDir.y) * Mathf.Rad2Deg;
@@ -87,17 +83,20 @@ namespace Playground
                 }
 
                 var targetSpeed = (playerInput.Running ? RunSpeed : WalkSpeed) * inputDir.magnitude;
-                var speed = playerInputData.SpeedData[i];
+
+                var speed = speedData[i];
                 var currentSpeed = speed.CurrentSpeed;
                 var speedSmoothVelocity = speed.SpeedSmoothVelocity;
 
                 currentSpeed = Mathf.SmoothDamp(currentSpeed, targetSpeed, ref speedSmoothVelocity, SpeedSmoothTime,
                     MaxSpeed, Time.deltaTime);
-                playerInputData.SpeedData[i] = new Speed
+                var newSpeed = new Speed
                 {
                     CurrentSpeed = currentSpeed,
                     SpeedSmoothVelocity = speedSmoothVelocity
                 };
+
+                speedData[i] = newSpeed;
 
                 // This needs to be used instead of add force because this is running in update.
                 // It would be better to store this in another component and have something else use it on fixed update.

--- a/workers/unity/Assets/Playground/Scripts/Player/MoveLocalPlayerSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/MoveLocalPlayerSystem.cs
@@ -1,7 +1,5 @@
 using Improbable.Gdk.Core;
-using Improbable.Gdk.ReactiveComponents;
 using Improbable.Transform;
-using Unity.Collections;
 using Unity.Entities;
 using UnityEngine;
 
@@ -38,7 +36,7 @@ namespace Playground
                 ComponentType.ReadOnly<PlayerInput.ComponentAuthority>(),
                 ComponentType.Subtractive<Speed>()
             );
-            newPlayerGroup.SetFilter(new PlayerInput.ComponentAuthority(true));
+            newPlayerGroup.SetFilter(PlayerInput.ComponentAuthority.Authoritative);
 
             playerInputGroup = GetComponentGroup(
                 ComponentType.Create<Rigidbody>(),
@@ -46,7 +44,7 @@ namespace Playground
                 ComponentType.ReadOnly<PlayerInput.Component>(),
                 ComponentType.ReadOnly<TransformInternal.ComponentAuthority>()
             );
-            playerInputGroup.SetFilter(new TransformInternal.ComponentAuthority(true));
+            playerInputGroup.SetFilter(TransformInternal.ComponentAuthority.Authoritative);
         }
 
         protected override void OnUpdate()

--- a/workers/unity/Assets/Playground/Scripts/Player/PlayerCommandsSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/PlayerCommandsSystem.cs
@@ -1,20 +1,9 @@
 using System;
 using Improbable;
 using Improbable.Gdk.Core;
-using Improbable.Gdk.ReactiveComponents;
 using Playground.Scripts.UI;
-using Unity.Collections;
 using Unity.Entities;
 using UnityEngine;
-
-#region Diagnostic control
-
-#pragma warning disable 649
-// ReSharper disable UnassignedReadonlyField
-// ReSharper disable UnusedMember.Global
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
 
 namespace Playground
 {
@@ -32,27 +21,29 @@ namespace Playground
         private const float LargeEnergy = 50.0f;
         private const float SmallEnergy = 10.0f;
 
+        private CommandSystem commandSystem;
+        private ComponentGroup launchGroup;
 
-        private struct PlayerData
+        protected override void OnCreateManager()
         {
-            public readonly int Length;
-            [ReadOnly] public ComponentDataArray<SpatialEntityId> SpatialEntity;
-            [ReadOnly] public ComponentDataArray<Authoritative<PlayerInput.Component>> PlayerInputAuthority;
-            public ComponentDataArray<Launcher.CommandSenders.LaunchEntity> Sender;
-        }
+            base.OnCreateManager();
 
-        [Inject] private PlayerData playerData;
+            commandSystem = World.GetExistingManager<CommandSystem>();
+            launchGroup = GetComponentGroup(
+                ComponentType.ReadOnly<SpatialEntityId>(),
+                ComponentType.ReadOnly<PlayerInput.ComponentAuthority>()
+            );
+            launchGroup.SetFilter(new PlayerInput.ComponentAuthority(true));
+        }
 
         protected override void OnUpdate()
         {
-            if (playerData.Length == 0)
-            {
-                return;
-            }
+            var entities = launchGroup.GetEntityArray();
+            var spatialIdData = launchGroup.GetComponentDataArray<SpatialEntityId>();
 
-            if (playerData.Length > 1)
+            if (spatialIdData.Length > 1)
             {
-                throw new InvalidOperationException($"Expected at most 1 playerData but got {playerData.Length}");
+                throw new InvalidOperationException($"Expected at most 1 playerData but got {spatialIdData.Length}");
             }
 
             PlayerCommand command;
@@ -76,8 +67,7 @@ namespace Playground
             }
 
             var rigidBody = info.rigidbody;
-            var sender = playerData.Sender[0];
-            var playerId = playerData.SpatialEntity[0].EntityId;
+            var playerId = spatialIdData[0].EntityId;
 
             var component = rigidBody.gameObject.GetComponent<LaunchableBehaviour>();
 
@@ -89,13 +79,13 @@ namespace Playground
             var impactPoint = Vector3f.FromUnityVector(info.point);
             var launchDirection = Vector3f.FromUnityVector(ray.direction);
 
-            sender.RequestsToSend.Add(new Launcher.LaunchEntity.Request(playerId,
+            var request = new Launcher.LaunchEntity.Request(playerId,
                 new LaunchCommandRequest(component.EntityId, impactPoint, launchDirection,
                     command == PlayerCommand.LaunchLarge ? LargeEnergy : SmallEnergy,
                     playerId
-                )));
+                ));
 
-            playerData.Sender[0] = sender;
+            commandSystem.SendCommand(request, entities[0]);
         }
     }
 }

--- a/workers/unity/Assets/Playground/Scripts/Player/PlayerCommandsSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/PlayerCommandsSystem.cs
@@ -33,7 +33,7 @@ namespace Playground
                 ComponentType.ReadOnly<SpatialEntityId>(),
                 ComponentType.ReadOnly<PlayerInput.ComponentAuthority>()
             );
-            launchGroup.SetFilter(new PlayerInput.ComponentAuthority(true));
+            launchGroup.SetFilter(PlayerInput.ComponentAuthority.Authoritative);
         }
 
         protected override void OnUpdate()

--- a/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Improbable.Gdk.Core;
 using Unity.Collections;
 using Unity.Entities;
@@ -20,95 +21,101 @@ namespace Playground
     {
         private const float RechargeTime = 2.0f;
 
-        private struct LaunchCommandData
-        {
-            public readonly int Length;
-            public EntityArray Entity;
-            public ComponentDataArray<Launcher.Component> Launcher;
-            public ComponentDataArray<Launchable.CommandSenders.LaunchMe> Senders;
-            [ReadOnly] public ComponentDataArray<Launcher.CommandRequests.LaunchEntity> Requests;
-        }
-
-        private struct LaunchableData
-        {
-            public readonly int Length;
-            public ComponentDataArray<Launchable.Component> Launchable;
-            public ComponentArray<Rigidbody> Rigidbody;
-            public ComponentDataArray<Launcher.CommandSenders.IncreaseScore> Sender;
-            [ReadOnly] public ComponentDataArray<Launchable.CommandRequests.LaunchMe> Requests;
-        }
-
-        [Inject] private CommandSystem commandSender;
-        [Inject] private LaunchCommandData launchCommandData;
-        [Inject] private LaunchableData launchableData;
+        [Inject] private CommandSystem commandSystem;
+        [Inject] private WorkerSystem workerSystem;
 
         protected override void OnUpdate()
         {
+            HandleLaunchEntityRequests();
+            HandleLaunchMeRequests();
+        }
+
+        private void HandleLaunchEntityRequests()
+        {
+            var requests = commandSystem.GetRequests<Launcher.LaunchEntity.ReceivedRequest>();
+            var launcherComponents = GetComponentDataFromEntity<Launcher.Component>();
+
             // Handle Launch Commands from players. Only allow if they have energy etc.
-            for (var i = 0; i < launchCommandData.Length; i++)
+            for (var i = 0; i < requests.Count; i++)
             {
-                var launcher = launchCommandData.Launcher[i];
-                var entity = launchCommandData.Entity[i];
-
-                if (launcher.RechargeTimeLeft > 0)
+                ref readonly var request = ref requests[i];
+                if (!workerSystem.TryGetEntity(request.EntityId, out var entity))
                 {
-                    return;
+                    continue;
                 }
 
-                var requests = launchCommandData.Requests[i].Requests;
-                var energyLeft = launcher.EnergyLeft;
-                var j = 0;
-                while (energyLeft > 0f && j < requests.Count)
+                var launcher = launcherComponents[entity];
+
+                if (launcher.RechargeTimeLeft <= 0)
                 {
-                    var info = requests[j].Payload;
+                    var energyLeft = launcher.EnergyLeft;
+                    var info = request.Payload;
                     var energy = math.min(info.LaunchEnergy, energyLeft);
-                    var request = new Launchable.LaunchMe.Request(info.EntityToLaunch,
-                        new LaunchMeCommandRequest(info.ImpactPoint, info.LaunchDirection,
-                            energy, info.Player));
-                    commandSender.SendCommand(request, entity);
+                    var launchMeRequest = new Launchable.LaunchMe.Request(info.EntityToLaunch,
+                        new LaunchMeCommandRequest(
+                            info.ImpactPoint,
+                            info.LaunchDirection,
+                            energy,
+                            info.Player)
+                    );
+
+                    commandSystem.SendCommand(launchMeRequest, entity);
+
                     energyLeft -= energy;
-                    j++;
+                    if (energyLeft <= 0.01f)
+                    {
+                        launcher.EnergyLeft = 0.0f;
+                        launcher.RechargeTimeLeft = RechargeTime;
+                        PostUpdateCommands.AddComponent(entity, new Recharging());
+                    }
+                    else
+                    {
+                        launcher.EnergyLeft = energyLeft;
+                    }
+
+                    launcherComponents[entity] = launcher;
                 }
 
-                if (energyLeft <= 0.01f)
-                {
-                    launcher.EnergyLeft = 0.0f;
-                    launcher.RechargeTimeLeft = RechargeTime;
-                    PostUpdateCommands.AddComponent(launchCommandData.Entity[i], new Recharging());
-                }
-                else
-                {
-                    launcher.EnergyLeft = energyLeft;
-                }
-
-                launchCommandData.Launcher[i] = launcher;
+                commandSystem.SendResponse(new Launcher.LaunchEntity.Response(request.RequestId, new LaunchCommandResponse()));
             }
+        }
 
+        private void HandleLaunchMeRequests()
+        {
             // Handle Launch Me Commands by applying force to rigidbodies proportional to launch energy.
             // Also add launch energy to launcher component.
-            for (var i = 0; i < launchableData.Length; i++)
+            var requests = commandSystem.GetRequests<Launchable.LaunchMe.ReceivedRequest>();
+            var launchableComponents = GetComponentDataFromEntity<Launchable.Component>();
+
+            for (var i = 0; i < requests.Count; i++)
             {
-                var rigidbody = launchableData.Rigidbody[i];
-                var launchable = launchableData.Launchable[i];
-                var sender = launchableData.Sender[i];
-
-                foreach (var request in launchableData.Requests[i].Requests)
+                ref readonly var request = ref requests[i];
+                if (!workerSystem.TryGetEntity(request.EntityId, out var entity))
                 {
-                    var info = request.Payload;
-                    rigidbody.AddForceAtPosition(
-                        new Vector3(info.LaunchDirection.X, info.LaunchDirection.Y, info.LaunchDirection.Z) *
-                        info.LaunchEnergy * 100.0f,
-                        new Vector3(info.ImpactPoint.X, info.ImpactPoint.Y, info.ImpactPoint.Z)
-                    );
-                    launchable.MostRecentLauncher = info.Player;
-
-                    sender.RequestsToSend.Add(new Launcher.IncreaseScore.Request(
-                        launchable.MostRecentLauncher,
-                        new ScoreIncreaseRequest(1.0f)));
+                    continue;
                 }
 
-                launchableData.Sender[i] = sender;
-                launchableData.Launchable[i] = launchable;
+                var launchable = launchableComponents[entity];
+                var rigidbody = EntityManager.GetComponentObject<Rigidbody>(entity);
+
+                var info = request.Payload;
+
+                rigidbody.AddForceAtPosition(
+                    new Vector3(info.LaunchDirection.X, info.LaunchDirection.Y, info.LaunchDirection.Z) *
+                    info.LaunchEnergy * 100.0f,
+                    new Vector3(info.ImpactPoint.X, info.ImpactPoint.Y, info.ImpactPoint.Z)
+                );
+
+                launchable.MostRecentLauncher = info.Player;
+                launchableComponents[entity] = launchable;
+
+                commandSystem.SendCommand(
+                    new Launcher.IncreaseScore.Request(
+                        launchable.MostRecentLauncher,
+                        new ScoreIncreaseRequest(1.0f)
+                    ),
+                    entity
+                );
             }
         }
     }

--- a/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
@@ -1,18 +1,7 @@
-using System.Collections.Generic;
 using Improbable.Gdk.Core;
-using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
 using UnityEngine;
-
-#region Diagnostic control
-
-#pragma warning disable 649
-// ReSharper disable UnassignedReadonlyField
-// ReSharper disable UnusedMember.Global
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
 
 namespace Playground
 {
@@ -21,8 +10,16 @@ namespace Playground
     {
         private const float RechargeTime = 2.0f;
 
-        [Inject] private CommandSystem commandSystem;
-        [Inject] private WorkerSystem workerSystem;
+        private CommandSystem commandSystem;
+        private WorkerSystem workerSystem;
+
+        protected override void OnCreateManager()
+        {
+            base.OnCreateManager();
+
+            commandSystem = World.GetExistingManager<CommandSystem>();
+            workerSystem = World.GetExistingManager<WorkerSystem>();
+        }
 
         protected override void OnUpdate()
         {

--- a/workers/unity/Assets/Playground/Scripts/Player/ProcessScoresSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/ProcessScoresSystem.cs
@@ -1,23 +1,21 @@
 using Improbable.Gdk.Core;
-using Unity.Collections;
 using Unity.Entities;
-
-#region Diagnostic control
-
-#pragma warning disable 649
-// ReSharper disable UnassignedReadonlyField
-// ReSharper disable UnusedMember.Global
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
 
 namespace Playground
 {
     [UpdateInGroup(typeof(SpatialOSUpdateGroup))]
     internal class ProcessScoresSystem : ComponentSystem
     {
-        [Inject] private CommandSystem commandSystem;
-        [Inject] private WorkerSystem workerSystem;
+        private CommandSystem commandSystem;
+        private WorkerSystem workerSystem;
+
+        protected override void OnCreateManager()
+        {
+            base.OnCreateManager();
+
+            commandSystem = World.GetExistingManager<CommandSystem>();
+            workerSystem = World.GetExistingManager<WorkerSystem>();
+        }
 
         protected override void OnUpdate()
         {

--- a/workers/unity/Assets/Playground/Scripts/UI/InitUISystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/UI/InitUISystem.cs
@@ -1,50 +1,53 @@
 using Improbable.Gdk.Core;
-using Improbable.Gdk.ReactiveComponents;
 using Playground.Scripts.UI;
-using Unity.Collections;
 using Unity.Entities;
 using UnityEngine;
-
-#region Diagnostic control
-
-#pragma warning disable 649
-// ReSharper disable UnassignedReadonlyField
-// ReSharper disable UnusedMember.Global
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
 
 namespace Playground
 {
     [UpdateInGroup(typeof(SpatialOSUpdateGroup))]
     public class InitUISystem : ComponentSystem
     {
-        private struct Data
-        {
-            public readonly int Length;
-            public EntityArray Entites;
-            [ReadOnly] public ComponentDataArray<Launcher.Component> Launcher;
-            [ReadOnly] public ComponentDataArray<Score.Component> Score;
-            [ReadOnly] public ComponentDataArray<Authoritative<PlayerInput.Component>> PlayerInput;
-            [ReadOnly] public ComponentDataArray<AuthorityChanges<PlayerInput.Component>> PlayerInputAuthority;
-        }
+        private ComponentUpdateSystem componentUpdateSystem;
+        private ComponentGroup uiInitGroup;
 
-        [Inject] private Data data;
+        protected override void OnCreateManager()
+        {
+            base.OnCreateManager();
+
+            componentUpdateSystem = World.GetExistingManager<ComponentUpdateSystem>();
+            uiInitGroup = GetComponentGroup(
+                ComponentType.ReadOnly<Launcher.Component>(),
+                ComponentType.ReadOnly<Score.Component>(),
+                ComponentType.ReadOnly<PlayerInput.ComponentAuthority>(),
+                ComponentType.ReadOnly<SpatialEntityId>()
+            );
+            uiInitGroup.SetFilter(new PlayerInput.ComponentAuthority(true));
+        }
 
         protected override void OnUpdate()
         {
-            for (var i = 0; i < data.Length; i++)
-            {
-                var ui = Resources.Load("Prefabs/UIGameObject");
-                var inst = (GameObject) Object.Instantiate(ui, Vector3.zero, Quaternion.identity);
-                var uiComponent = inst.GetComponent<UIComponent>();
-                UIComponent.Main = uiComponent;
-                uiComponent.TestText.text = $"Energy: {data.Launcher[i].EnergyLeft}";
-                uiComponent.ScoreText.text = $"Score: {data.Score[i].Score}";
-            }
+            var launcherData = uiInitGroup.GetComponentDataArray<Launcher.Component>();
+            var scoreData = uiInitGroup.GetComponentDataArray<Score.Component>();
+            var spatialIdData = uiInitGroup.GetComponentDataArray<SpatialEntityId>();
 
-            // Disable system after first run.
-            Enabled = false;
+            for (var i = 0; i < spatialIdData.Length; i++)
+            {
+                var authUpdates =
+                    componentUpdateSystem.GetAuthorityChangesReceived(spatialIdData[i].EntityId,
+                        PlayerInput.ComponentId);
+                if (authUpdates.Count > 0)
+                {
+                    var ui = Resources.Load("Prefabs/UIGameObject");
+                    var inst = (GameObject) Object.Instantiate(ui, Vector3.zero, Quaternion.identity);
+                    var uiComponent = inst.GetComponent<UIComponent>();
+                    UIComponent.Main = uiComponent;
+                    uiComponent.TestText.text = $"Energy: {launcherData[i].EnergyLeft}";
+                    uiComponent.ScoreText.text = $"Score: {scoreData[i].Score}";
+
+                    Enabled = false;
+                }
+            }
         }
 
         protected override void OnDestroyManager()

--- a/workers/unity/Assets/Playground/Scripts/UI/InitUISystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/UI/InitUISystem.cs
@@ -22,7 +22,7 @@ namespace Playground
                 ComponentType.ReadOnly<PlayerInput.ComponentAuthority>(),
                 ComponentType.ReadOnly<SpatialEntityId>()
             );
-            uiInitGroup.SetFilter(new PlayerInput.ComponentAuthority(true));
+            uiInitGroup.SetFilter(PlayerInput.ComponentAuthority.Authoritative);
         }
 
         protected override void OnUpdate()

--- a/workers/unity/Assets/Playground/Scripts/UI/UpdateUISystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/UI/UpdateUISystem.cs
@@ -1,57 +1,69 @@
 using Improbable.Gdk.Core;
-using Improbable.Gdk.ReactiveComponents;
 using Playground.Scripts.UI;
-using Unity.Collections;
 using Unity.Entities;
-
-#region Diagnostic control
-
-#pragma warning disable 649
-// ReSharper disable UnassignedReadonlyField
-// ReSharper disable UnusedMember.Global
-// ReSharper disable ClassNeverInstantiated.Global
-// ReSharper disable UnassignedField.Global
-
-#endregion
 
 namespace Playground
 {
     [UpdateInGroup(typeof(SpatialOSUpdateGroup))]
     public class UpdateUISystem : ComponentSystem
     {
-        public struct PlayerDataLauncher
-        {
-            public readonly int Length;
-            [ReadOnly] public ComponentDataArray<Launcher.Component> Launcher;
-            [ReadOnly] public ComponentDataArray<Launcher.ReceivedUpdates> Updates;
-            [ReadOnly] public ComponentDataArray<Authoritative<PlayerInput.Component>> PlayerAuth;
-        }
+        private ComponentUpdateSystem componentUpdateSystem;
 
-        public struct PlayerDataScore
-        {
-            public readonly int Length;
-            [ReadOnly] public ComponentDataArray<Score.Component> Score;
-            [ReadOnly] public ComponentDataArray<Score.ReceivedUpdates> Updates;
-            [ReadOnly] public ComponentDataArray<Authoritative<PlayerInput.Component>> PlayerAuth;
-        }
+        private ComponentGroup launcherGroup;
+        private ComponentGroup scoreGroup;
 
-        [Inject] private PlayerDataLauncher playerDataLauncher;
-        [Inject] private PlayerDataScore playerDataScore;
+        protected override void OnCreateManager()
+        {
+            base.OnCreateManager();
+
+            componentUpdateSystem = World.GetExistingManager<ComponentUpdateSystem>();
+            launcherGroup = GetComponentGroup(
+                ComponentType.ReadOnly<Launcher.Component>(),
+                ComponentType.ReadOnly<SpatialEntityId>(),
+                ComponentType.ReadOnly<Launcher.ComponentAuthority>()
+            );
+            launcherGroup.SetFilter(new Launcher.ComponentAuthority(true));
+
+            scoreGroup = GetComponentGroup(
+                ComponentType.ReadOnly<Score.Component>(),
+                ComponentType.ReadOnly<SpatialEntityId>(),
+                ComponentType.ReadOnly<Score.ComponentAuthority>()
+            );
+            scoreGroup.SetFilter(new Score.ComponentAuthority(true));
+        }
 
         protected override void OnUpdate()
         {
-            for (var i = 0; i < playerDataLauncher.Length; i++)
-            {
-                var launcher = playerDataLauncher.Launcher[i];
+            var launcherSpatialIdData = launcherGroup.GetComponentDataArray<SpatialEntityId>();
+            var launcherData = launcherGroup.GetComponentDataArray<Launcher.Component>();
 
-                UIComponent.Main.TestText.text =
-                    launcher.RechargeTimeLeft > 0.0f ? "Recharging" : $"Energy: {launcher.EnergyLeft}";
+            for (var i = 0; i < launcherData.Length; i++)
+            {
+                var spatialId = launcherSpatialIdData[i].EntityId;
+                var launcherUpdates =
+                    componentUpdateSystem.GetEntityComponentUpdatesReceived<Launcher.Update>(spatialId);
+                if (launcherUpdates.Count > 0)
+                {
+                    var launcher = launcherData[i];
+
+                    UIComponent.Main.TestText.text = launcher.RechargeTimeLeft > 0.0f
+                        ? "Recharging"
+                        : $"Energy: {launcher.EnergyLeft}";
+                }
             }
 
-            for (var i = 0; i < playerDataScore.Length; i++)
+            var scoreSpatialIdData = scoreGroup.GetComponentDataArray<SpatialEntityId>();
+            var scoreData = scoreGroup.GetComponentDataArray<Score.Component>();
+
+            for (var i = 0; i < scoreData.Length; i++)
             {
-                var score = playerDataScore.Score[i];
-                UIComponent.Main.ScoreText.text = $"Score: {score.Score}";
+                var spatialId = scoreSpatialIdData[i].EntityId;
+                var launcherUpdates =
+                    componentUpdateSystem.GetEntityComponentUpdatesReceived<Score.Update>(spatialId);
+                if (launcherUpdates.Count > 0)
+                {
+                    UIComponent.Main.ScoreText.text = $"Score: {scoreData[i].Score}";
+                }
             }
         }
     }

--- a/workers/unity/Assets/Playground/Scripts/UI/UpdateUISystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/UI/UpdateUISystem.cs
@@ -22,14 +22,14 @@ namespace Playground
                 ComponentType.ReadOnly<SpatialEntityId>(),
                 ComponentType.ReadOnly<Launcher.ComponentAuthority>()
             );
-            launcherGroup.SetFilter(new Launcher.ComponentAuthority(true));
+            launcherGroup.SetFilter(Launcher.ComponentAuthority.Authoritative);
 
             scoreGroup = GetComponentGroup(
                 ComponentType.ReadOnly<Score.Component>(),
                 ComponentType.ReadOnly<SpatialEntityId>(),
                 ComponentType.ReadOnly<Score.ComponentAuthority>()
             );
-            scoreGroup.SetFilter(new Score.ComponentAuthority(true));
+            scoreGroup.SetFilter(Score.ComponentAuthority.Authoritative);
         }
 
         protected override void OnUpdate()

--- a/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingUtils.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingUtils.cs
@@ -1,11 +1,4 @@
 using System.Collections.Generic;
-using Improbable.Worker.CInterop;
-
-#region Diagnostic control
-
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
 
 namespace Improbable.Gdk.Core
 {

--- a/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityChanges.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityChanges.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if !DISABLE_REACTIVE_COMPONENTS
+using System.Collections.Generic;
 using Improbable.Gdk.Core;
 using Improbable.Worker.CInterop;
 using Unity.Entities;
@@ -25,3 +26,4 @@ namespace Improbable.Gdk.ReactiveComponents
         }
     }
 }
+#endif

--- a/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityChangesProvider.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityChangesProvider.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !DISABLE_REACTIVE_COMPONENTS
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Improbable.Worker.CInterop;
@@ -71,3 +72,4 @@ namespace Improbable.Gdk.ReactiveComponents
         }
     }
 }
+#endif

--- a/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityComponents.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Authority/AuthorityComponents.cs
@@ -1,3 +1,4 @@
+#if !DISABLE_REACTIVE_COMPONENTS
 using Improbable.Gdk.Core;
 using Unity.Entities;
 
@@ -32,3 +33,4 @@ namespace Improbable.Gdk.ReactiveComponents
         public BlittableBool AcknowledgeAuthorityLoss;
     }
 }
+#endif

--- a/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/ReactiveComponentsHelper.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/ReactiveComponentsHelper.cs
@@ -1,3 +1,4 @@
+#if !DISABLE_REACTIVE_COMPONENTS
 using Unity.Entities;
 
 namespace Improbable.Gdk.ReactiveComponents
@@ -27,3 +28,4 @@ namespace Improbable.Gdk.ReactiveComponents
         }
     }
 }
+#endif

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
@@ -1,6 +1,7 @@
 using System;
 using Unity.Entities;
 using UnityEngine;
+using UnityEngine.Profiling;
 
 namespace Improbable.Gdk.Core
 {
@@ -32,13 +33,21 @@ namespace Improbable.Gdk.Core
         {
             try
             {
+                Profiler.BeginSample("GetMessages");
                 worker.GetMessages();
+                Profiler.EndSample();
 
                 var diff = worker.Diff;
 
+                Profiler.BeginSample("ApplyDiff ECS");
                 ecsViewSystem.ApplyDiff(diff);
+                Profiler.EndSample();
+                Profiler.BeginSample("ApplyDiff Entity");
                 entitySystem.ApplyDiff(diff);
+                Profiler.EndSample();
+                Profiler.BeginSample("ApplyDiff View");
                 view.ApplyDiff(diff);
+                Profiler.EndSample();
             }
             catch (Exception e)
             {

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerDisconnectCallbackSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerDisconnectCallbackSystem.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Unity.Collections;
 using Unity.Entities;
 using UnityEngine;
 
@@ -13,39 +12,34 @@ namespace Improbable.Gdk.Core
     [UpdateAfter(typeof(SpatialOSReceiveSystem))]
     public class WorkerDisconnectCallbackSystem : ComponentSystem
     {
-#pragma warning disable 649
-        private struct Data
-        {
-            public readonly int Length;
-            [ReadOnly] public SharedComponentDataArray<OnDisconnected> DisconnectedMessage;
-            [ReadOnly] public ComponentDataArray<WorkerEntityTag> DenotesWorkerEntity;
-        }
-#pragma warning restore 649
-
         public event Action<string> OnDisconnected;
 
         private WorkerSystem worker;
-
-#pragma warning disable 649
-        [Inject] private Data data;
-#pragma warning restore 649
+        private ComponentGroup group;
 
         protected override void OnCreateManager()
         {
             base.OnCreateManager();
+
+            group = GetComponentGroup(
+                ComponentType.ReadOnly<OnDisconnected>(),
+                ComponentType.ReadOnly<WorkerEntityTag>()
+            );
 
             worker = World.GetExistingManager<WorkerSystem>();
         }
 
         protected override void OnUpdate()
         {
-            if (data.Length != 1)
+            var disconnectData = group.GetSharedComponentDataArray<OnDisconnected>();
+
+            if (disconnectData.Length != 1)
             {
                 worker.LogDispatcher.HandleLog(LogType.Error,
                     new LogEvent($"{typeof(WorkerEntityTag)} should only be present on a single entity"));
             }
 
-            OnDisconnected?.Invoke(data.DisconnectedMessage[0].ReasonForDisconnect);
+            OnDisconnected?.Invoke(disconnectData[0].ReasonForDisconnect);
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs
@@ -94,7 +94,6 @@ namespace Improbable.Gdk.Core
             base.OnCreateManager();
             var entityManager = World.GetOrCreateManager<EntityManager>();
             WorkerEntity = entityManager.CreateEntity(typeof(OnConnected), typeof(WorkerEntityTag));
-            Debug.Log("WORKER ENTITY CREATED");
             Enabled = false;
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs
@@ -94,6 +94,7 @@ namespace Improbable.Gdk.Core
             base.OnCreateManager();
             var entityManager = World.GetOrCreateManager<EntityManager>();
             WorkerEntity = entityManager.CreateEntity(typeof(OnConnected), typeof(WorkerEntityTag));
+            Debug.Log("WORKER ENTITY CREATED");
             Enabled = false;
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs
@@ -259,8 +259,10 @@ namespace Improbable.Gdk.Core
             World.GetOrCreateManager<RequireLifecycleSystem>();
             World.GetOrCreateManager<SubscriptionSystem>();
 
+#if !DISABLE_REACTIVE_COMPONENTS
             // Reactive components
             ReactiveComponentsHelper.AddCommonSystems(World);
+#endif
         }
 
         public void Dispose()

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/SendPlayerHeartbeatRequestSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/SendPlayerHeartbeatRequestSystem.cs
@@ -1,18 +1,8 @@
 using Improbable.Common;
 using Improbable.Gdk.Core;
-using Improbable.Gdk.ReactiveComponents;
 using Improbable.PlayerLifecycle;
 using Unity.Entities;
 using UnityEngine;
-
-#region Diagnostic control
-
-#pragma warning disable 649
-// ReSharper disable UnassignedReadonlyField
-// ReSharper disable UnusedMember.Global
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
 
 namespace Improbable.Gdk.PlayerLifecycle
 {
@@ -33,7 +23,7 @@ namespace Improbable.Gdk.PlayerLifecycle
                 ComponentType.Create<HeartbeatData>(),
                 ComponentType.ReadOnly<SpatialEntityId>()
             );
-            group.SetFilter(new PlayerHeartbeatServer.ComponentAuthority(true));
+            group.SetFilter(PlayerHeartbeatServer.ComponentAuthority.Authoritative);
 
             commandSystem = World.GetExistingManager<CommandSystem>();
         }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ReactiveCommandComponentGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ReactiveCommandComponentGenerator.tt
@@ -7,6 +7,7 @@
 #>
 <#= generatedHeader #>
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System;
 using System.Collections.Generic;
 using Unity.Entities;
@@ -161,3 +162,4 @@ namespace <#= qualifiedNamespace #>
 <# } #>
     }
 }
+#endif

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ReactiveComponentGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ReactiveComponentGenerator.tt
@@ -8,6 +8,7 @@
 #>
 <#= generatedHeader #>
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System.Collections.Generic;
 using Unity.Entities;
 using Improbable.Gdk.Core;
@@ -313,3 +314,4 @@ namespace <#= qualifiedNamespace #>
         }
     }
 }
+#endif

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityCommandComponentsGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityCommandComponentsGenerator.tt
@@ -7,6 +7,7 @@
 #>
 <#= generatedHeader #>
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System.Collections.Generic;
 using Unity.Entities;
 
@@ -75,3 +76,4 @@ namespace <#= qualifiedNamespace #>
         }
     }
 }
+#endif

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityEventGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityEventGenerator.tt
@@ -31,6 +31,8 @@ namespace <#= qualifiedNamespace #>
         }
 
 <# } #>
+
+#if !DISABLE_REACTIVE_COMPONENTS
         public static class ReceivedEvents
         {
 <# foreach (var eventDetails in eventDetailsList) { #>
@@ -64,5 +66,6 @@ namespace <#= qualifiedNamespace #>
 
 <# } #>
         }
+#endif
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityReactiveComponentHandlersGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityReactiveComponentHandlersGenerator.tt
@@ -11,6 +11,7 @@
 #>
 <#= generatedHeader #>
 
+#if !DISABLE_REACTIVE_COMPONENTS
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -337,3 +338,4 @@ for (var j = 0; j < commandDetailsList.Count; j++) {
         }
     }
 }
+#endif

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DefaultApplyLatestTransformSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DefaultApplyLatestTransformSystem.cs
@@ -3,14 +3,6 @@ using Unity.Entities;
 using UnityEngine;
 using UnityEngine.Experimental.PlayerLoop;
 
-#region Diagnostic control
-
-#pragma warning disable 169
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
-
-
 namespace Improbable.Gdk.TransformSynchronization
 {
     [DisableAutoCreation]
@@ -28,14 +20,18 @@ namespace Improbable.Gdk.TransformSynchronization
                 ComponentType.ReadOnly<Rigidbody>(),
                 ComponentType.ReadOnly<TransformToSet>(),
                 ComponentType.ReadOnly<SetTransformToGameObjectTag>(),
-                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>());
+                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>()
+            );
+            rigidbodyGroup.SetFilter(TransformInternal.ComponentAuthority.NotAuthoritative);
 
             transformGroup = GetComponentGroup(
                 ComponentType.Subtractive<Rigidbody>(),
                 ComponentType.ReadOnly<UnityEngine.Transform>(),
                 ComponentType.ReadOnly<TransformToSet>(),
                 ComponentType.ReadOnly<SetTransformToGameObjectTag>(),
-                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>());
+                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>()
+            );
+            transformGroup.SetFilter(TransformInternal.ComponentAuthority.NotAuthoritative);
         }
 
         protected override void OnUpdate()
@@ -46,8 +42,6 @@ namespace Improbable.Gdk.TransformSynchronization
 
         private void UpdateRigidbodyData()
         {
-            rigidbodyGroup.SetFilter(TransformInternal.ComponentAuthority.NotAuthoritative);
-
             var rigidbodyArray = rigidbodyGroup.GetComponentArray<Rigidbody>();
             var transformToSetArray = rigidbodyGroup.GetComponentDataArray<TransformToSet>();
 
@@ -63,8 +57,6 @@ namespace Improbable.Gdk.TransformSynchronization
 
         private void UpdateTransformData()
         {
-            transformGroup.SetFilter(TransformInternal.ComponentAuthority.NotAuthoritative);
-
             var transformArray = transformGroup.GetComponentArray<UnityEngine.Transform>();
             var transformToSetArray = transformGroup.GetComponentDataArray<TransformToSet>();
 

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DefaultUpdateLatestTransformSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DefaultUpdateLatestTransformSystem.cs
@@ -3,13 +3,6 @@ using Improbable.Transform;
 using Unity.Entities;
 using UnityEngine;
 
-#region Diagnostic control
-
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
-
-
 namespace Improbable.Gdk.TransformSynchronization
 {
     [DisableAutoCreation]
@@ -27,14 +20,18 @@ namespace Improbable.Gdk.TransformSynchronization
                 ComponentType.ReadOnly<Rigidbody>(),
                 ComponentType.Create<TransformToSend>(),
                 ComponentType.ReadOnly<GetTransformFromGameObjectTag>(),
-                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>());
+                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>()
+            );
+            rigidbodyGroup.SetFilter(TransformInternal.ComponentAuthority.Authoritative);
 
             transformGroup = GetComponentGroup(
                 ComponentType.Subtractive<Rigidbody>(),
                 ComponentType.ReadOnly<UnityEngine.Transform>(),
                 ComponentType.Create<TransformToSend>(),
                 ComponentType.ReadOnly<GetTransformFromGameObjectTag>(),
-                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>());
+                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>()
+            );
+            transformGroup.SetFilter(TransformInternal.ComponentAuthority.Authoritative);
         }
 
         protected override void OnUpdate()
@@ -45,8 +42,6 @@ namespace Improbable.Gdk.TransformSynchronization
 
         private void UpdateRigidbodyData()
         {
-            rigidbodyGroup.SetFilter(TransformInternal.ComponentAuthority.Authoritative);
-
             var rigidbodyArray = rigidbodyGroup.GetComponentArray<Rigidbody>();
             var transformToSendArray = rigidbodyGroup.GetComponentDataArray<TransformToSend>();
 
@@ -65,8 +60,6 @@ namespace Improbable.Gdk.TransformSynchronization
 
         private void UpdateTransformData()
         {
-            transformGroup.SetFilter(TransformInternal.ComponentAuthority.Authoritative);
-
             var transformArray = transformGroup.GetComponentArray<UnityEngine.Transform>();
             var transformToSendArray = transformGroup.GetComponentDataArray<TransformToSend>();
 

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DirectTransformUpdateSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/DirectTransformUpdateSystem.cs
@@ -2,12 +2,6 @@ using Improbable.Gdk.Core;
 using Improbable.Transform;
 using Unity.Entities;
 
-#region Diagnostic control
-
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
-
 namespace Improbable.Gdk.TransformSynchronization
 {
     [DisableAutoCreation]
@@ -32,13 +26,13 @@ namespace Improbable.Gdk.TransformSynchronization
                 ComponentType.ReadOnly<TransformInternal.Component>(),
                 ComponentType.ReadOnly<SpatialEntityId>(),
                 ComponentType.ReadOnly<DirectReceiveTag>(),
-                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>());
+                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>()
+            );
+            transformGroup.SetFilter(TransformInternal.ComponentAuthority.NotAuthoritative);
         }
 
         protected override void OnUpdate()
         {
-            transformGroup.SetFilter(TransformInternal.ComponentAuthority.NotAuthoritative);
-
             var transformToSetArray = transformGroup.GetComponentDataArray<TransformToSet>();
             var spatialEntityIdArray = transformGroup.GetComponentDataArray<SpatialEntityId>();
             var transformComponentArray = transformGroup.GetComponentDataArray<TransformInternal.Component>();

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/GetTransformValueToSetSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/GetTransformValueToSetSystem.cs
@@ -3,13 +3,6 @@ using Improbable.Transform;
 using Unity.Entities;
 using UnityEngine.Experimental.PlayerLoop;
 
-#region Diagnostic control
-
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
-
-
 namespace Improbable.Gdk.TransformSynchronization
 {
     [DisableAutoCreation]
@@ -29,13 +22,13 @@ namespace Improbable.Gdk.TransformSynchronization
             transformGroup = GetComponentGroup(
                 ComponentType.Create<BufferedTransform>(),
                 ComponentType.Create<TransformToSet>(),
-                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>());
+                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>()
+            );
+            transformGroup.SetFilter(TransformInternal.ComponentAuthority.NotAuthoritative);
         }
 
         protected override void OnUpdate()
         {
-            transformGroup.SetFilter(TransformInternal.ComponentAuthority.NotAuthoritative);
-
             var transformToSetArray = transformGroup.GetComponentDataArray<TransformToSet>();
             var transformBufferArray = transformGroup.GetBufferArray<BufferedTransform>();
 

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/InterpolateTransformSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/InterpolateTransformSystem.cs
@@ -5,14 +5,6 @@ using Unity.Mathematics;
 using UnityEngine;
 using Quaternion = UnityEngine.Quaternion;
 
-#region Diagnostic control
-
-#pragma warning disable 169
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
-
-
 namespace Improbable.Gdk.TransformSynchronization
 {
     [DisableAutoCreation]
@@ -34,13 +26,13 @@ namespace Improbable.Gdk.TransformSynchronization
                 ComponentType.ReadOnly<TransformInternal.Component>(),
                 ComponentType.ReadOnly<SpatialEntityId>(),
                 ComponentType.ReadOnly<InterpolationConfig>(),
-                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>());
+                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>()
+            );
+            interpolationGroup.SetFilter(TransformInternal.ComponentAuthority.NotAuthoritative);
         }
 
         protected override void OnUpdate()
         {
-            interpolationGroup.SetFilter(TransformInternal.ComponentAuthority.NotAuthoritative);
-
             var interpolationConfigArray = interpolationGroup.GetSharedComponentDataArray<InterpolationConfig>();
             var bufferedTransformArray = interpolationGroup.GetBufferArray<BufferedTransform>();
             var spatialEntityIdArray = interpolationGroup.GetComponentDataArray<SpatialEntityId>();

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/RateLimitedPositionSendSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/RateLimitedPositionSendSystem.cs
@@ -3,12 +3,6 @@ using Improbable.Transform;
 using Unity.Entities;
 using UnityEngine;
 
-#region Diagnostic control
-
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
-
 namespace Improbable.Gdk.TransformSynchronization
 {
     [DisableAutoCreation]
@@ -28,13 +22,13 @@ namespace Improbable.Gdk.TransformSynchronization
                 ComponentType.Create<Position.Component>(),
                 ComponentType.ReadOnly<TransformInternal.Component>(),
                 ComponentType.ReadOnly<RateLimitedSendConfig>(),
-                ComponentType.ReadOnly<Position.ComponentAuthority>());
+                ComponentType.ReadOnly<Position.ComponentAuthority>()
+            );
+            positionGroup.SetFilter(Position.ComponentAuthority.Authoritative);
         }
 
         protected override void OnUpdate()
         {
-            positionGroup.SetFilter(Position.ComponentAuthority.Authoritative);
-
             var rateLimitedConfigArray = positionGroup.GetSharedComponentDataArray<RateLimitedSendConfig>();
             var positionArray = positionGroup.GetComponentDataArray<Position.Component>();
             var transformArray = positionGroup.GetComponentDataArray<TransformInternal.Component>();

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/ResetForAuthorityGainedSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/ResetForAuthorityGainedSystem.cs
@@ -3,13 +3,6 @@ using Improbable.Transform;
 using Unity.Entities;
 using UnityEngine;
 
-#region Diagnostic control
-
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
-
-
 namespace Improbable.Gdk.TransformSynchronization
 {
     [DisableAutoCreation]
@@ -36,7 +29,9 @@ namespace Improbable.Gdk.TransformSynchronization
                 ComponentType.Create<TicksSinceLastTransformUpdate>(),
                 ComponentType.Create<BufferedTransform>(),
                 ComponentType.Subtractive<NewlyAddedSpatialOSEntity>(),
-                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>());
+                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>()
+            );
+            rigidbodyGroup.SetFilter(TransformInternal.ComponentAuthority.Authoritative);
 
             transformGroup = GetComponentGroup(
                 ComponentType.ReadOnly<UnityEngine.Transform>(),
@@ -46,7 +41,9 @@ namespace Improbable.Gdk.TransformSynchronization
                 ComponentType.Create<BufferedTransform>(),
                 ComponentType.Subtractive<NewlyAddedSpatialOSEntity>(),
                 ComponentType.Subtractive<Rigidbody>(),
-                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>());
+                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>()
+            );
+            transformGroup.SetFilter(TransformInternal.ComponentAuthority.Authoritative);
         }
 
         protected override void OnUpdate()
@@ -57,8 +54,6 @@ namespace Improbable.Gdk.TransformSynchronization
 
         private void UpdateTransformData()
         {
-            rigidbodyGroup.SetFilter(TransformInternal.ComponentAuthority.Authoritative);
-
             var ticksSinceLastUpdateArray = rigidbodyGroup.GetComponentDataArray<TicksSinceLastTransformUpdate>();
             var transformComponentArray = rigidbodyGroup.GetComponentDataArray<TransformInternal.Component>();
             var bufferedTransformArray = rigidbodyGroup.GetBufferArray<BufferedTransform>();
@@ -88,8 +83,6 @@ namespace Improbable.Gdk.TransformSynchronization
 
         private void UpdateRigidbodyData()
         {
-            transformGroup.SetFilter(TransformInternal.ComponentAuthority.Authoritative);
-
             var ticksSinceLastUpdateArray = transformGroup.GetComponentDataArray<TicksSinceLastTransformUpdate>();
             var transformComponentArray = transformGroup.GetComponentDataArray<TransformInternal.Component>();
             var bufferedTransformArray = transformGroup.GetBufferArray<BufferedTransform>();

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/SetKinematicFromAuthoritySystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/SetKinematicFromAuthoritySystem.cs
@@ -4,16 +4,6 @@ using Improbable.Worker.CInterop;
 using Unity.Entities;
 using UnityEngine;
 
-#region Diagnostic control
-
-#pragma warning disable 649
-// ReSharper disable UnassignedReadonlyField
-// ReSharper disable UnusedMember.Global
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
-
-
 namespace Improbable.Gdk.TransformSynchronization
 {
     [DisableAutoCreation]
@@ -37,13 +27,16 @@ namespace Improbable.Gdk.TransformSynchronization
                 ComponentType.Create<KinematicStateWhenAuth>(),
                 ComponentType.ReadOnly<Rigidbody>(),
                 ComponentType.ReadOnly<NewlyAddedSpatialOSEntity>(),
-                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>());
+                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>()
+            );
+            newEntityGroup.SetFilter(TransformInternal.ComponentAuthority.NotAuthoritative);
 
             authChangeGroup = GetComponentGroup(
                 ComponentType.Create<KinematicStateWhenAuth>(),
                 ComponentType.ReadOnly<Rigidbody>(),
                 ComponentType.ReadOnly<SpatialEntityId>(),
-                ComponentType.Subtractive<NewlyAddedSpatialOSEntity>());
+                ComponentType.Subtractive<NewlyAddedSpatialOSEntity>()
+            );
         }
 
         protected override void OnUpdate()
@@ -54,8 +47,6 @@ namespace Improbable.Gdk.TransformSynchronization
 
         private void UpdateNewEntityGroup()
         {
-            newEntityGroup.SetFilter(TransformInternal.ComponentAuthority.NotAuthoritative);
-
             var rigidbodyArray = newEntityGroup.GetComponentArray<Rigidbody>();
             var kinematicStateWhenAuthArray = newEntityGroup.GetComponentDataArray<KinematicStateWhenAuth>();
 

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TickRateEstimationSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TickRateEstimationSystem.cs
@@ -4,15 +4,6 @@ using Unity.Entities;
 using UnityEngine;
 using UnityEngine.Experimental.PlayerLoop;
 
-#region Diagnostic control
-
-#pragma warning disable 649
-// ReSharper disable UnassignedReadonlyField
-// ReSharper disable UnusedMember.Global
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
-
 namespace Improbable.Gdk.TransformSynchronization
 {
     [DisableAutoCreation]

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TickSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TickSystem.cs
@@ -2,16 +2,6 @@ using Improbable.Transform;
 using Unity.Entities;
 using UnityEngine.Experimental.PlayerLoop;
 
-#region Diagnostic control
-
-#pragma warning disable 649
-// ReSharper disable UnassignedReadonlyField
-// ReSharper disable UnusedMember.Global
-// ReSharper disable ClassNeverInstantiated.Global
-
-#endregion
-
-
 namespace Improbable.Gdk.TransformSynchronization
 {
     [DisableAutoCreation]
@@ -27,13 +17,13 @@ namespace Improbable.Gdk.TransformSynchronization
             transformGroup = GetComponentGroup(
                 ComponentType.Create<TicksSinceLastTransformUpdate>(),
                 ComponentType.ReadOnly<TransformInternal.Component>(),
-                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>());
+                ComponentType.ReadOnly<TransformInternal.ComponentAuthority>()
+            );
+            transformGroup.SetFilter(TransformInternal.ComponentAuthority.Authoritative);
         }
 
         protected override void OnUpdate()
         {
-            transformGroup.SetFilter(TransformInternal.ComponentAuthority.Authoritative);
-
             var ticksSinceLastUpdateArray = transformGroup.GetComponentDataArray<TicksSinceLastTransformUpdate>();
 
             for (int i = 0; i < ticksSinceLastUpdateArray.Length; ++i)


### PR DESCRIPTION
#### Description
Added the ability to NOT compile reactive components, using the `DISABLE_REACTIVE_COMPONENTS` scriptable define symbol.
The playground no longer uses reactive components.

#### Tests
Playground remains equal in functionality with our without the define.
FPS Breaks when using the symbol, as it still uses reactive components.

#### Documentation
Added a changelog
