### PR TITLE
Fixing name clashes between packages and component / type names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 - Fixed an issue where player creation requests could retry infinitely without logging failure.
 - Fixed an issue where if you called `RedirectedProcess.Command(...)` in a non-main thread, it would throw an exception.
+- Fixed an issue where having the same name for a schema package and a schema component would lead to generating invalid code.
 
 ### Internal
 

--- a/test-project/Assets/.Schema/improbable/gdk/tests/same_names.schema
+++ b/test-project/Assets/.Schema/improbable/gdk/tests/same_names.schema
@@ -1,0 +1,7 @@
+package name;
+
+component Name
+{
+    id = 200;
+    float name = 1;
+}

--- a/test-project/Assets/.Schema/improbable/gdk/tests/same_names.schema
+++ b/test-project/Assets/.Schema/improbable/gdk/tests/same_names.schema
@@ -1,6 +1,6 @@
 package name;
 
-type Name {
+type Test {
     float color = 1;
 }
 

--- a/test-project/Assets/.Schema/improbable/gdk/tests/same_names.schema
+++ b/test-project/Assets/.Schema/improbable/gdk/tests/same_names.schema
@@ -1,5 +1,9 @@
 package name;
 
+type Name {
+    float color = 1;
+}
+
 component Name
 {
     id = 200;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKey.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKey.cs
@@ -421,7 +421,7 @@ namespace Improbable.Gdk.Tests
 
         public static class Serialization
         {
-            public static void SerializeComponent(Improbable.Gdk.Tests.ExhaustiveMapKey.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static void SerializeComponent(global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
                 {
                     foreach (var keyValuePair in component.Field1)
@@ -587,7 +587,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.ExhaustiveMapKey.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
                 {
@@ -916,7 +916,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.ExhaustiveMapKey.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.ExhaustiveMapKey.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
                 {
@@ -1245,7 +1245,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void SerializeSnapshot(Improbable.Gdk.Tests.ExhaustiveMapKey.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static void SerializeSnapshot(global::Improbable.Gdk.Tests.ExhaustiveMapKey.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
             {
                 {
                     foreach (var keyValuePair in snapshot.Field1)
@@ -1411,9 +1411,9 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static Improbable.Gdk.Tests.ExhaustiveMapKey.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
-                var component = new Improbable.Gdk.Tests.ExhaustiveMapKey.Component();
+                var component = new global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component();
 
                 component.field1Handle = Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field1Provider.Allocate(world);
                 {
@@ -1670,9 +1670,9 @@ namespace Improbable.Gdk.Tests
                 return component;
             }
 
-            public static Improbable.Gdk.Tests.ExhaustiveMapKey.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static global::Improbable.Gdk.Tests.ExhaustiveMapKey.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
-                var update = new Improbable.Gdk.Tests.ExhaustiveMapKey.Update();
+                var update = new global::Improbable.Gdk.Tests.ExhaustiveMapKey.Update();
                 var obj = updateObj.GetFields();
 
                 var clearedFields = updateObj.GetClearedFields();
@@ -2112,9 +2112,9 @@ namespace Improbable.Gdk.Tests
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.ExhaustiveMapKey.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
+            public static global::Improbable.Gdk.Tests.ExhaustiveMapKey.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
             {
-                var update = new Improbable.Gdk.Tests.ExhaustiveMapKey.Update();
+                var update = new global::Improbable.Gdk.Tests.ExhaustiveMapKey.Update();
                 var obj = data.GetFields();
 
                 {
@@ -2336,9 +2336,9 @@ namespace Improbable.Gdk.Tests
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.ExhaustiveMapKey.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static global::Improbable.Gdk.Tests.ExhaustiveMapKey.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
             {
-                var component = new Improbable.Gdk.Tests.ExhaustiveMapKey.Snapshot();
+                var component = new global::Improbable.Gdk.Tests.ExhaustiveMapKey.Snapshot();
 
                 {
                     component.Field1 = new global::System.Collections.Generic.Dictionary<BlittableBool,string>();
@@ -2595,7 +2595,7 @@ namespace Improbable.Gdk.Tests
                 return component;
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.ExhaustiveMapKey.Component component)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component component)
             {
                 var obj = updateObj.GetFields();
 
@@ -3035,7 +3035,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.ExhaustiveMapKey.Snapshot snapshot)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.ExhaustiveMapKey.Snapshot snapshot)
             {
                 var obj = updateObj.GetFields();
 
@@ -3505,7 +3505,7 @@ namespace Improbable.Gdk.Tests
             internal uint handle;
             public global::System.Collections.Generic.List<Update> Updates
             {
-                get => Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+                get => global::Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyComponentDiffDeserializer.cs
@@ -18,7 +18,7 @@ namespace Improbable.Gdk.Tests
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = Improbable.Gdk.Tests.ExhaustiveMapKey.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                var update = global::Improbable.Gdk.Tests.ExhaustiveMapKey.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
                 diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyEcsViewManager.cs
@@ -101,7 +101,7 @@ namespace Improbable.Gdk.Tests
             {
                 workerSystem.TryGetEntity(entityId, out var entity);
 
-                var component = new Improbable.Gdk.Tests.ExhaustiveMapKey.Component();
+                var component = new global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component();
 
                 component.field1Handle = Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field1Provider.Allocate(world);
                 component.field2Handle = Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field2Provider.Allocate(world);
@@ -131,7 +131,7 @@ namespace Improbable.Gdk.Tests
                 workerSystem.TryGetEntity(entityId, out var entity);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
-                var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>(entity);
+                var data = entityManager.GetComponentData<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>(entity);
                 ExhaustiveMapKey.ReferenceTypeProviders.Field1Provider.Free(data.field1Handle);
                 ExhaustiveMapKey.ReferenceTypeProviders.Field2Provider.Free(data.field2Handle);
                 ExhaustiveMapKey.ReferenceTypeProviders.Field3Provider.Free(data.field3Handle);
@@ -151,7 +151,7 @@ namespace Improbable.Gdk.Tests
                 ExhaustiveMapKey.ReferenceTypeProviders.Field17Provider.Free(data.field17Handle);
                 ExhaustiveMapKey.ReferenceTypeProviders.Field18Provider.Free(data.field18Handle);
 
-                entityManager.RemoveComponent<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>(entity);
+                entityManager.RemoveComponent<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>(entity);
             }
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyProviders.cs
@@ -15,7 +15,7 @@ namespace Improbable.Gdk.Tests
         {
             public static class UpdatesProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.ExhaustiveMapKey.Update>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.ExhaustiveMapKey.Update>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Update>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -24,13 +24,13 @@ namespace Improbable.Gdk.Tests
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.ExhaustiveMapKey.Update>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Update>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.ExhaustiveMapKey.Update> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Update> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -40,7 +40,7 @@ namespace Improbable.Gdk.Tests
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.ExhaustiveMapKey.Update> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Update> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyReactiveComponents.cs
@@ -28,9 +28,9 @@ namespace Improbable.Gdk.Tests
                     }
 
                     List<Update> updates;
-                    if (entityManager.HasComponent<Improbable.Gdk.Tests.ExhaustiveMapKey.ReceivedUpdates>(entity))
+                    if (entityManager.HasComponent<global::Improbable.Gdk.Tests.ExhaustiveMapKey.ReceivedUpdates>(entity))
                     {
-                        updates = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveMapKey.ReceivedUpdates>(entity).Updates;
+                        updates = entityManager.GetComponentData<global::Improbable.Gdk.Tests.ExhaustiveMapKey.ReceivedUpdates>(entity).Updates;
                     }
                     else
                     {
@@ -49,7 +49,7 @@ namespace Improbable.Gdk.Tests
 
             public void Clean(World world)
             {
-                ExhaustiveMapKey.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
+                global::Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
             }
         }
 
@@ -158,7 +158,7 @@ namespace Improbable.Gdk.Tests
                 {
                     workerSystem.TryGetEntity(entityId, out var entity);
                     entityManager.AddComponent(entity,
-                        ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>());
+                        ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>());
                 }
 
                 for (int i = 0; i < authorityChanges.Count; ++i)
@@ -182,39 +182,39 @@ namespace Improbable.Gdk.Tests
                 switch (authority)
                 {
                     case Authority.Authoritative:
-                        if (!entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entity))
+                        if (!entityManager.HasComponent<NotAuthoritative<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.Authoritative, Authority.NotAuthoritative, entityId);
                             return;
                         }
 
-                        entityManager.RemoveComponent<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>());
+                        entityManager.RemoveComponent<NotAuthoritative<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>());
 
                         break;
                     case Authority.AuthorityLossImminent:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.AuthorityLossImminent, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>());
                         break;
                     case Authority.NotAuthoritative:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.NotAuthoritative, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        if (entityManager.HasComponent<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entity))
+                        if (entityManager.HasComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entity))
                         {
-                            entityManager.RemoveComponent<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entity);
+                            entityManager.RemoveComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entity);
                         }
 
-                        entityManager.RemoveComponent<Authoritative<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>());
+                        entityManager.RemoveComponent<Authoritative<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>());
                         break;
                 }
             }
@@ -227,7 +227,7 @@ namespace Improbable.Gdk.Tests
                 //     .WithField(LoggingUtils.EntityId, entityId.Id)
                 //     .WithField("New Authority", newAuthority)
                 //     .WithField("Expected Old Authority", expectedOldAuthority)
-                //     .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveMapKey")
+                //     .WithField("Component", "global::Improbable.Gdk.Tests.ExhaustiveMapKey")
                 // );
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyReactiveHandlers.cs
@@ -52,10 +52,10 @@ namespace Improbable.Gdk.Tests
                 All = Array.Empty<ComponentType>(),
                 Any = new ComponentType[]
                 {
-                    ComponentType.Create<ComponentAdded<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(),
-                    ComponentType.Create<ComponentRemoved<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.ExhaustiveMapKey.ReceivedUpdates>(),
-                    ComponentType.Create<AuthorityChanges<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(),
+                    ComponentType.Create<ComponentAdded<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(),
+                    ComponentType.Create<ComponentRemoved<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ExhaustiveMapKey.ReceivedUpdates>(),
+                    ComponentType.Create<AuthorityChanges<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(),
                 },
                 None = Array.Empty<ComponentType>(),
             };
@@ -64,10 +64,10 @@ namespace Improbable.Gdk.Tests
                 EntityCommandBuffer buffer)
             {
                 var entityType = system.GetArchetypeChunkEntityType();
-                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>();
-                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>();
-                var receivedUpdateType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ExhaustiveMapKey.ReceivedUpdates>();
-                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>();
+                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>();
+                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>();
+                var receivedUpdateType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.ExhaustiveMapKey.ReceivedUpdates>();
+                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>();
 
                 foreach (var chunk in chunkArray)
                 {
@@ -79,12 +79,12 @@ namespace Improbable.Gdk.Tests
                         var updateArray = chunk.GetNativeArray(receivedUpdateType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<Improbable.Gdk.Tests.ExhaustiveMapKey.ReceivedUpdates>(entities[i]);
+                            buffer.RemoveComponent<global::Improbable.Gdk.Tests.ExhaustiveMapKey.ReceivedUpdates>(entities[i]);
                             var updateList = updateArray[i].Updates;
 
                             // Pool update lists to avoid excessive allocation
                             updateList.Clear();
-                            Improbable.Gdk.Tests.ExhaustiveMapKey.Update.Pool.Push(updateList);
+                            global::Improbable.Gdk.Tests.ExhaustiveMapKey.Update.Pool.Push(updateList);
 
                             ReferenceTypeProviders.UpdatesProvider.Free(updateArray[i].handle);
                         }
@@ -95,7 +95,7 @@ namespace Improbable.Gdk.Tests
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentAdded<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentAdded<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entities[i]);
                         }
                     }
 
@@ -104,7 +104,7 @@ namespace Improbable.Gdk.Tests
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentRemoved<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentRemoved<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entities[i]);
                         }
                     }
 
@@ -114,7 +114,7 @@ namespace Improbable.Gdk.Tests
                         var authorityChangeArray = chunk.GetNativeArray(authorityChangeType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<AuthorityChanges<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entities[i]);
+                            buffer.RemoveComponent<AuthorityChanges<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entities[i]);
                             AuthorityChangesProvider.Free(authorityChangeArray[i].Handle);
                         }
                     }
@@ -129,7 +129,7 @@ namespace Improbable.Gdk.Tests
             {
                 All = new ComponentType[]
                 {
-                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(),
+                    ComponentType.ReadOnly<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -139,7 +139,7 @@ namespace Improbable.Gdk.Tests
             public override void AcknowledgeAuthorityLoss(NativeArray<ArchetypeChunk> chunkArray, ComponentSystemBase system,
                 ComponentUpdateSystem updateSystem)
             {
-                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>();
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>();
                 var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
 
                 foreach (var chunk in chunkArray)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyUpdateSender.cs
@@ -24,8 +24,8 @@ namespace Improbable.Gdk.Tests
             {
                 All = new[]
                 {
-                    ComponentType.Create<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.ExhaustiveMapKey.ComponentAuthority>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ExhaustiveMapKey.ComponentAuthority>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -41,7 +41,7 @@ namespace Improbable.Gdk.Tests
                 Profiler.BeginSample("ExhaustiveMapKey");
 
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>();
+                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Component>();
 
                 var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValue.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValue.cs
@@ -421,7 +421,7 @@ namespace Improbable.Gdk.Tests
 
         public static class Serialization
         {
-            public static void SerializeComponent(Improbable.Gdk.Tests.ExhaustiveMapValue.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static void SerializeComponent(global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
                 {
                     foreach (var keyValuePair in component.Field1)
@@ -587,7 +587,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.ExhaustiveMapValue.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
                 {
@@ -916,7 +916,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.ExhaustiveMapValue.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.ExhaustiveMapValue.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
                 {
@@ -1245,7 +1245,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void SerializeSnapshot(Improbable.Gdk.Tests.ExhaustiveMapValue.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static void SerializeSnapshot(global::Improbable.Gdk.Tests.ExhaustiveMapValue.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
             {
                 {
                     foreach (var keyValuePair in snapshot.Field1)
@@ -1411,9 +1411,9 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static Improbable.Gdk.Tests.ExhaustiveMapValue.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
-                var component = new Improbable.Gdk.Tests.ExhaustiveMapValue.Component();
+                var component = new global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component();
 
                 component.field1Handle = Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field1Provider.Allocate(world);
                 {
@@ -1670,9 +1670,9 @@ namespace Improbable.Gdk.Tests
                 return component;
             }
 
-            public static Improbable.Gdk.Tests.ExhaustiveMapValue.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static global::Improbable.Gdk.Tests.ExhaustiveMapValue.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
-                var update = new Improbable.Gdk.Tests.ExhaustiveMapValue.Update();
+                var update = new global::Improbable.Gdk.Tests.ExhaustiveMapValue.Update();
                 var obj = updateObj.GetFields();
 
                 var clearedFields = updateObj.GetClearedFields();
@@ -2112,9 +2112,9 @@ namespace Improbable.Gdk.Tests
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.ExhaustiveMapValue.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
+            public static global::Improbable.Gdk.Tests.ExhaustiveMapValue.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
             {
-                var update = new Improbable.Gdk.Tests.ExhaustiveMapValue.Update();
+                var update = new global::Improbable.Gdk.Tests.ExhaustiveMapValue.Update();
                 var obj = data.GetFields();
 
                 {
@@ -2336,9 +2336,9 @@ namespace Improbable.Gdk.Tests
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.ExhaustiveMapValue.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static global::Improbable.Gdk.Tests.ExhaustiveMapValue.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
             {
-                var component = new Improbable.Gdk.Tests.ExhaustiveMapValue.Snapshot();
+                var component = new global::Improbable.Gdk.Tests.ExhaustiveMapValue.Snapshot();
 
                 {
                     component.Field1 = new global::System.Collections.Generic.Dictionary<string,BlittableBool>();
@@ -2595,7 +2595,7 @@ namespace Improbable.Gdk.Tests
                 return component;
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.ExhaustiveMapValue.Component component)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component component)
             {
                 var obj = updateObj.GetFields();
 
@@ -3035,7 +3035,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.ExhaustiveMapValue.Snapshot snapshot)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.ExhaustiveMapValue.Snapshot snapshot)
             {
                 var obj = updateObj.GetFields();
 
@@ -3505,7 +3505,7 @@ namespace Improbable.Gdk.Tests
             internal uint handle;
             public global::System.Collections.Generic.List<Update> Updates
             {
-                get => Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+                get => global::Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueComponentDiffDeserializer.cs
@@ -18,7 +18,7 @@ namespace Improbable.Gdk.Tests
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = Improbable.Gdk.Tests.ExhaustiveMapValue.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                var update = global::Improbable.Gdk.Tests.ExhaustiveMapValue.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
                 diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueEcsViewManager.cs
@@ -101,7 +101,7 @@ namespace Improbable.Gdk.Tests
             {
                 workerSystem.TryGetEntity(entityId, out var entity);
 
-                var component = new Improbable.Gdk.Tests.ExhaustiveMapValue.Component();
+                var component = new global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component();
 
                 component.field1Handle = Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field1Provider.Allocate(world);
                 component.field2Handle = Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field2Provider.Allocate(world);
@@ -131,7 +131,7 @@ namespace Improbable.Gdk.Tests
                 workerSystem.TryGetEntity(entityId, out var entity);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
-                var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>(entity);
+                var data = entityManager.GetComponentData<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>(entity);
                 ExhaustiveMapValue.ReferenceTypeProviders.Field1Provider.Free(data.field1Handle);
                 ExhaustiveMapValue.ReferenceTypeProviders.Field2Provider.Free(data.field2Handle);
                 ExhaustiveMapValue.ReferenceTypeProviders.Field3Provider.Free(data.field3Handle);
@@ -151,7 +151,7 @@ namespace Improbable.Gdk.Tests
                 ExhaustiveMapValue.ReferenceTypeProviders.Field17Provider.Free(data.field17Handle);
                 ExhaustiveMapValue.ReferenceTypeProviders.Field18Provider.Free(data.field18Handle);
 
-                entityManager.RemoveComponent<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>(entity);
+                entityManager.RemoveComponent<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>(entity);
             }
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueProviders.cs
@@ -15,7 +15,7 @@ namespace Improbable.Gdk.Tests
         {
             public static class UpdatesProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.ExhaustiveMapValue.Update>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.ExhaustiveMapValue.Update>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Update>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -24,13 +24,13 @@ namespace Improbable.Gdk.Tests
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.ExhaustiveMapValue.Update>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Update>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.ExhaustiveMapValue.Update> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Update> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -40,7 +40,7 @@ namespace Improbable.Gdk.Tests
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.ExhaustiveMapValue.Update> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Update> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueReactiveComponents.cs
@@ -28,9 +28,9 @@ namespace Improbable.Gdk.Tests
                     }
 
                     List<Update> updates;
-                    if (entityManager.HasComponent<Improbable.Gdk.Tests.ExhaustiveMapValue.ReceivedUpdates>(entity))
+                    if (entityManager.HasComponent<global::Improbable.Gdk.Tests.ExhaustiveMapValue.ReceivedUpdates>(entity))
                     {
-                        updates = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveMapValue.ReceivedUpdates>(entity).Updates;
+                        updates = entityManager.GetComponentData<global::Improbable.Gdk.Tests.ExhaustiveMapValue.ReceivedUpdates>(entity).Updates;
                     }
                     else
                     {
@@ -49,7 +49,7 @@ namespace Improbable.Gdk.Tests
 
             public void Clean(World world)
             {
-                ExhaustiveMapValue.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
+                global::Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
             }
         }
 
@@ -158,7 +158,7 @@ namespace Improbable.Gdk.Tests
                 {
                     workerSystem.TryGetEntity(entityId, out var entity);
                     entityManager.AddComponent(entity,
-                        ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>());
+                        ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>());
                 }
 
                 for (int i = 0; i < authorityChanges.Count; ++i)
@@ -182,39 +182,39 @@ namespace Improbable.Gdk.Tests
                 switch (authority)
                 {
                     case Authority.Authoritative:
-                        if (!entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entity))
+                        if (!entityManager.HasComponent<NotAuthoritative<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.Authoritative, Authority.NotAuthoritative, entityId);
                             return;
                         }
 
-                        entityManager.RemoveComponent<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>());
+                        entityManager.RemoveComponent<NotAuthoritative<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>());
 
                         break;
                     case Authority.AuthorityLossImminent:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.AuthorityLossImminent, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>());
                         break;
                     case Authority.NotAuthoritative:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.NotAuthoritative, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        if (entityManager.HasComponent<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entity))
+                        if (entityManager.HasComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entity))
                         {
-                            entityManager.RemoveComponent<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entity);
+                            entityManager.RemoveComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entity);
                         }
 
-                        entityManager.RemoveComponent<Authoritative<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>());
+                        entityManager.RemoveComponent<Authoritative<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>());
                         break;
                 }
             }
@@ -227,7 +227,7 @@ namespace Improbable.Gdk.Tests
                 //     .WithField(LoggingUtils.EntityId, entityId.Id)
                 //     .WithField("New Authority", newAuthority)
                 //     .WithField("Expected Old Authority", expectedOldAuthority)
-                //     .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveMapValue")
+                //     .WithField("Component", "global::Improbable.Gdk.Tests.ExhaustiveMapValue")
                 // );
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueReactiveHandlers.cs
@@ -52,10 +52,10 @@ namespace Improbable.Gdk.Tests
                 All = Array.Empty<ComponentType>(),
                 Any = new ComponentType[]
                 {
-                    ComponentType.Create<ComponentAdded<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(),
-                    ComponentType.Create<ComponentRemoved<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.ExhaustiveMapValue.ReceivedUpdates>(),
-                    ComponentType.Create<AuthorityChanges<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(),
+                    ComponentType.Create<ComponentAdded<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(),
+                    ComponentType.Create<ComponentRemoved<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ExhaustiveMapValue.ReceivedUpdates>(),
+                    ComponentType.Create<AuthorityChanges<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(),
                 },
                 None = Array.Empty<ComponentType>(),
             };
@@ -64,10 +64,10 @@ namespace Improbable.Gdk.Tests
                 EntityCommandBuffer buffer)
             {
                 var entityType = system.GetArchetypeChunkEntityType();
-                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>();
-                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>();
-                var receivedUpdateType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ExhaustiveMapValue.ReceivedUpdates>();
-                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>();
+                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>();
+                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>();
+                var receivedUpdateType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.ExhaustiveMapValue.ReceivedUpdates>();
+                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>();
 
                 foreach (var chunk in chunkArray)
                 {
@@ -79,12 +79,12 @@ namespace Improbable.Gdk.Tests
                         var updateArray = chunk.GetNativeArray(receivedUpdateType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<Improbable.Gdk.Tests.ExhaustiveMapValue.ReceivedUpdates>(entities[i]);
+                            buffer.RemoveComponent<global::Improbable.Gdk.Tests.ExhaustiveMapValue.ReceivedUpdates>(entities[i]);
                             var updateList = updateArray[i].Updates;
 
                             // Pool update lists to avoid excessive allocation
                             updateList.Clear();
-                            Improbable.Gdk.Tests.ExhaustiveMapValue.Update.Pool.Push(updateList);
+                            global::Improbable.Gdk.Tests.ExhaustiveMapValue.Update.Pool.Push(updateList);
 
                             ReferenceTypeProviders.UpdatesProvider.Free(updateArray[i].handle);
                         }
@@ -95,7 +95,7 @@ namespace Improbable.Gdk.Tests
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentAdded<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentAdded<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entities[i]);
                         }
                     }
 
@@ -104,7 +104,7 @@ namespace Improbable.Gdk.Tests
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentRemoved<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentRemoved<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entities[i]);
                         }
                     }
 
@@ -114,7 +114,7 @@ namespace Improbable.Gdk.Tests
                         var authorityChangeArray = chunk.GetNativeArray(authorityChangeType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<AuthorityChanges<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entities[i]);
+                            buffer.RemoveComponent<AuthorityChanges<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entities[i]);
                             AuthorityChangesProvider.Free(authorityChangeArray[i].Handle);
                         }
                     }
@@ -129,7 +129,7 @@ namespace Improbable.Gdk.Tests
             {
                 All = new ComponentType[]
                 {
-                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(),
+                    ComponentType.ReadOnly<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -139,7 +139,7 @@ namespace Improbable.Gdk.Tests
             public override void AcknowledgeAuthorityLoss(NativeArray<ArchetypeChunk> chunkArray, ComponentSystemBase system,
                 ComponentUpdateSystem updateSystem)
             {
-                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>();
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>();
                 var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
 
                 foreach (var chunk in chunkArray)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueUpdateSender.cs
@@ -24,8 +24,8 @@ namespace Improbable.Gdk.Tests
             {
                 All = new[]
                 {
-                    ComponentType.Create<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.ExhaustiveMapValue.ComponentAuthority>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ExhaustiveMapValue.ComponentAuthority>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -41,7 +41,7 @@ namespace Improbable.Gdk.Tests
                 Profiler.BeginSample("ExhaustiveMapValue");
 
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>();
+                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Component>();
 
                 var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptional.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptional.cs
@@ -421,7 +421,7 @@ namespace Improbable.Gdk.Tests
 
         public static class Serialization
         {
-            public static void SerializeComponent(Improbable.Gdk.Tests.ExhaustiveOptional.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static void SerializeComponent(global::Improbable.Gdk.Tests.ExhaustiveOptional.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
                 {
                     if (component.Field1.HasValue)
@@ -551,7 +551,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.ExhaustiveOptional.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.ExhaustiveOptional.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
                 {
@@ -844,7 +844,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.ExhaustiveOptional.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.ExhaustiveOptional.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
                 {
@@ -1137,7 +1137,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void SerializeSnapshot(Improbable.Gdk.Tests.ExhaustiveOptional.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static void SerializeSnapshot(global::Improbable.Gdk.Tests.ExhaustiveOptional.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
             {
                 {
                     if (snapshot.Field1.HasValue)
@@ -1267,9 +1267,9 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static Improbable.Gdk.Tests.ExhaustiveOptional.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static global::Improbable.Gdk.Tests.ExhaustiveOptional.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
-                var component = new Improbable.Gdk.Tests.ExhaustiveOptional.Component();
+                var component = new global::Improbable.Gdk.Tests.ExhaustiveOptional.Component();
 
                 component.field1Handle = Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field1Provider.Allocate(world);
                 {
@@ -1418,9 +1418,9 @@ namespace Improbable.Gdk.Tests
                 return component;
             }
 
-            public static Improbable.Gdk.Tests.ExhaustiveOptional.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static global::Improbable.Gdk.Tests.ExhaustiveOptional.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
-                var update = new Improbable.Gdk.Tests.ExhaustiveOptional.Update();
+                var update = new global::Improbable.Gdk.Tests.ExhaustiveOptional.Update();
                 var obj = updateObj.GetFields();
 
                 var clearedFields = updateObj.GetClearedFields();
@@ -1806,9 +1806,9 @@ namespace Improbable.Gdk.Tests
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.ExhaustiveOptional.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
+            public static global::Improbable.Gdk.Tests.ExhaustiveOptional.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
             {
-                var update = new Improbable.Gdk.Tests.ExhaustiveOptional.Update();
+                var update = new global::Improbable.Gdk.Tests.ExhaustiveOptional.Update();
                 var obj = data.GetFields();
 
                 {
@@ -1958,9 +1958,9 @@ namespace Improbable.Gdk.Tests
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.ExhaustiveOptional.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static global::Improbable.Gdk.Tests.ExhaustiveOptional.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
             {
-                var component = new Improbable.Gdk.Tests.ExhaustiveOptional.Snapshot();
+                var component = new global::Improbable.Gdk.Tests.ExhaustiveOptional.Snapshot();
 
                 {
                     if (obj.GetBoolCount(1) == 1)
@@ -2109,7 +2109,7 @@ namespace Improbable.Gdk.Tests
                 return component;
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.ExhaustiveOptional.Component component)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.ExhaustiveOptional.Component component)
             {
                 var obj = updateObj.GetFields();
 
@@ -2495,7 +2495,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.ExhaustiveOptional.Snapshot snapshot)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.ExhaustiveOptional.Snapshot snapshot)
             {
                 var obj = updateObj.GetFields();
 
@@ -2911,7 +2911,7 @@ namespace Improbable.Gdk.Tests
             internal uint handle;
             public global::System.Collections.Generic.List<Update> Updates
             {
-                get => Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+                get => global::Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalComponentDiffDeserializer.cs
@@ -18,7 +18,7 @@ namespace Improbable.Gdk.Tests
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = Improbable.Gdk.Tests.ExhaustiveOptional.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                var update = global::Improbable.Gdk.Tests.ExhaustiveOptional.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
                 diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalEcsViewManager.cs
@@ -101,7 +101,7 @@ namespace Improbable.Gdk.Tests
             {
                 workerSystem.TryGetEntity(entityId, out var entity);
 
-                var component = new Improbable.Gdk.Tests.ExhaustiveOptional.Component();
+                var component = new global::Improbable.Gdk.Tests.ExhaustiveOptional.Component();
 
                 component.field1Handle = Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field1Provider.Allocate(world);
                 component.field2Handle = Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field2Provider.Allocate(world);
@@ -131,7 +131,7 @@ namespace Improbable.Gdk.Tests
                 workerSystem.TryGetEntity(entityId, out var entity);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
-                var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveOptional.Component>(entity);
+                var data = entityManager.GetComponentData<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>(entity);
                 ExhaustiveOptional.ReferenceTypeProviders.Field1Provider.Free(data.field1Handle);
                 ExhaustiveOptional.ReferenceTypeProviders.Field2Provider.Free(data.field2Handle);
                 ExhaustiveOptional.ReferenceTypeProviders.Field3Provider.Free(data.field3Handle);
@@ -151,7 +151,7 @@ namespace Improbable.Gdk.Tests
                 ExhaustiveOptional.ReferenceTypeProviders.Field17Provider.Free(data.field17Handle);
                 ExhaustiveOptional.ReferenceTypeProviders.Field18Provider.Free(data.field18Handle);
 
-                entityManager.RemoveComponent<Improbable.Gdk.Tests.ExhaustiveOptional.Component>(entity);
+                entityManager.RemoveComponent<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>(entity);
             }
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalProviders.cs
@@ -15,7 +15,7 @@ namespace Improbable.Gdk.Tests
         {
             public static class UpdatesProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.ExhaustiveOptional.Update>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.ExhaustiveOptional.Update>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.ExhaustiveOptional.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.ExhaustiveOptional.Update>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -24,13 +24,13 @@ namespace Improbable.Gdk.Tests
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.ExhaustiveOptional.Update>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.ExhaustiveOptional.Update>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.ExhaustiveOptional.Update> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.ExhaustiveOptional.Update> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -40,7 +40,7 @@ namespace Improbable.Gdk.Tests
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.ExhaustiveOptional.Update> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.ExhaustiveOptional.Update> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalReactiveComponents.cs
@@ -28,9 +28,9 @@ namespace Improbable.Gdk.Tests
                     }
 
                     List<Update> updates;
-                    if (entityManager.HasComponent<Improbable.Gdk.Tests.ExhaustiveOptional.ReceivedUpdates>(entity))
+                    if (entityManager.HasComponent<global::Improbable.Gdk.Tests.ExhaustiveOptional.ReceivedUpdates>(entity))
                     {
-                        updates = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveOptional.ReceivedUpdates>(entity).Updates;
+                        updates = entityManager.GetComponentData<global::Improbable.Gdk.Tests.ExhaustiveOptional.ReceivedUpdates>(entity).Updates;
                     }
                     else
                     {
@@ -49,7 +49,7 @@ namespace Improbable.Gdk.Tests
 
             public void Clean(World world)
             {
-                ExhaustiveOptional.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
+                global::Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
             }
         }
 
@@ -158,7 +158,7 @@ namespace Improbable.Gdk.Tests
                 {
                     workerSystem.TryGetEntity(entityId, out var entity);
                     entityManager.AddComponent(entity,
-                        ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>());
+                        ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>>());
                 }
 
                 for (int i = 0; i < authorityChanges.Count; ++i)
@@ -182,39 +182,39 @@ namespace Improbable.Gdk.Tests
                 switch (authority)
                 {
                     case Authority.Authoritative:
-                        if (!entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entity))
+                        if (!entityManager.HasComponent<NotAuthoritative<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.Authoritative, Authority.NotAuthoritative, entityId);
                             return;
                         }
 
-                        entityManager.RemoveComponent<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>());
+                        entityManager.RemoveComponent<NotAuthoritative<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>>());
 
                         break;
                     case Authority.AuthorityLossImminent:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.AuthorityLossImminent, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>>());
                         break;
                     case Authority.NotAuthoritative:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.NotAuthoritative, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        if (entityManager.HasComponent<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entity))
+                        if (entityManager.HasComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entity))
                         {
-                            entityManager.RemoveComponent<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entity);
+                            entityManager.RemoveComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entity);
                         }
 
-                        entityManager.RemoveComponent<Authoritative<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>());
+                        entityManager.RemoveComponent<Authoritative<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>>());
                         break;
                 }
             }
@@ -227,7 +227,7 @@ namespace Improbable.Gdk.Tests
                 //     .WithField(LoggingUtils.EntityId, entityId.Id)
                 //     .WithField("New Authority", newAuthority)
                 //     .WithField("Expected Old Authority", expectedOldAuthority)
-                //     .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveOptional")
+                //     .WithField("Component", "global::Improbable.Gdk.Tests.ExhaustiveOptional")
                 // );
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalReactiveHandlers.cs
@@ -52,10 +52,10 @@ namespace Improbable.Gdk.Tests
                 All = Array.Empty<ComponentType>(),
                 Any = new ComponentType[]
                 {
-                    ComponentType.Create<ComponentAdded<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(),
-                    ComponentType.Create<ComponentRemoved<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.ExhaustiveOptional.ReceivedUpdates>(),
-                    ComponentType.Create<AuthorityChanges<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(),
+                    ComponentType.Create<ComponentAdded<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(),
+                    ComponentType.Create<ComponentRemoved<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ExhaustiveOptional.ReceivedUpdates>(),
+                    ComponentType.Create<AuthorityChanges<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(),
                 },
                 None = Array.Empty<ComponentType>(),
             };
@@ -64,10 +64,10 @@ namespace Improbable.Gdk.Tests
                 EntityCommandBuffer buffer)
             {
                 var entityType = system.GetArchetypeChunkEntityType();
-                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>();
-                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>();
-                var receivedUpdateType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ExhaustiveOptional.ReceivedUpdates>();
-                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>();
+                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>>();
+                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>>();
+                var receivedUpdateType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.ExhaustiveOptional.ReceivedUpdates>();
+                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>>();
 
                 foreach (var chunk in chunkArray)
                 {
@@ -79,12 +79,12 @@ namespace Improbable.Gdk.Tests
                         var updateArray = chunk.GetNativeArray(receivedUpdateType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<Improbable.Gdk.Tests.ExhaustiveOptional.ReceivedUpdates>(entities[i]);
+                            buffer.RemoveComponent<global::Improbable.Gdk.Tests.ExhaustiveOptional.ReceivedUpdates>(entities[i]);
                             var updateList = updateArray[i].Updates;
 
                             // Pool update lists to avoid excessive allocation
                             updateList.Clear();
-                            Improbable.Gdk.Tests.ExhaustiveOptional.Update.Pool.Push(updateList);
+                            global::Improbable.Gdk.Tests.ExhaustiveOptional.Update.Pool.Push(updateList);
 
                             ReferenceTypeProviders.UpdatesProvider.Free(updateArray[i].handle);
                         }
@@ -95,7 +95,7 @@ namespace Improbable.Gdk.Tests
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentAdded<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentAdded<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entities[i]);
                         }
                     }
 
@@ -104,7 +104,7 @@ namespace Improbable.Gdk.Tests
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentRemoved<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentRemoved<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entities[i]);
                         }
                     }
 
@@ -114,7 +114,7 @@ namespace Improbable.Gdk.Tests
                         var authorityChangeArray = chunk.GetNativeArray(authorityChangeType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<AuthorityChanges<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entities[i]);
+                            buffer.RemoveComponent<AuthorityChanges<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entities[i]);
                             AuthorityChangesProvider.Free(authorityChangeArray[i].Handle);
                         }
                     }
@@ -129,7 +129,7 @@ namespace Improbable.Gdk.Tests
             {
                 All = new ComponentType[]
                 {
-                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(),
+                    ComponentType.ReadOnly<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -139,7 +139,7 @@ namespace Improbable.Gdk.Tests
             public override void AcknowledgeAuthorityLoss(NativeArray<ArchetypeChunk> chunkArray, ComponentSystemBase system,
                 ComponentUpdateSystem updateSystem)
             {
-                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>();
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>>();
                 var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
 
                 foreach (var chunk in chunkArray)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalUpdateSender.cs
@@ -24,8 +24,8 @@ namespace Improbable.Gdk.Tests
             {
                 All = new[]
                 {
-                    ComponentType.Create<Improbable.Gdk.Tests.ExhaustiveOptional.Component>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.ExhaustiveOptional.ComponentAuthority>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ExhaustiveOptional.ComponentAuthority>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -41,7 +41,7 @@ namespace Improbable.Gdk.Tests
                 Profiler.BeginSample("ExhaustiveOptional");
 
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ExhaustiveOptional.Component>();
+                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.ExhaustiveOptional.Component>();
 
                 var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeated.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeated.cs
@@ -421,7 +421,7 @@ namespace Improbable.Gdk.Tests
 
         public static class Serialization
         {
-            public static void SerializeComponent(Improbable.Gdk.Tests.ExhaustiveRepeated.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static void SerializeComponent(global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
                 {
                     foreach (var value in component.Field1)
@@ -551,7 +551,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.ExhaustiveRepeated.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
                 {
@@ -844,7 +844,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.ExhaustiveRepeated.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.ExhaustiveRepeated.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
                 {
@@ -1137,7 +1137,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void SerializeSnapshot(Improbable.Gdk.Tests.ExhaustiveRepeated.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static void SerializeSnapshot(global::Improbable.Gdk.Tests.ExhaustiveRepeated.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
             {
                 {
                     foreach (var value in snapshot.Field1)
@@ -1267,9 +1267,9 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static Improbable.Gdk.Tests.ExhaustiveRepeated.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
-                var component = new Improbable.Gdk.Tests.ExhaustiveRepeated.Component();
+                var component = new global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component();
 
                 component.field1Handle = Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field1Provider.Allocate(world);
                 {
@@ -1472,9 +1472,9 @@ namespace Improbable.Gdk.Tests
                 return component;
             }
 
-            public static Improbable.Gdk.Tests.ExhaustiveRepeated.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static global::Improbable.Gdk.Tests.ExhaustiveRepeated.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
-                var update = new Improbable.Gdk.Tests.ExhaustiveRepeated.Update();
+                var update = new global::Improbable.Gdk.Tests.ExhaustiveRepeated.Update();
                 var obj = updateObj.GetFields();
 
                 var clearedFields = updateObj.GetClearedFields();
@@ -1878,9 +1878,9 @@ namespace Improbable.Gdk.Tests
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.ExhaustiveRepeated.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
+            public static global::Improbable.Gdk.Tests.ExhaustiveRepeated.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
             {
-                var update = new Improbable.Gdk.Tests.ExhaustiveRepeated.Update();
+                var update = new global::Improbable.Gdk.Tests.ExhaustiveRepeated.Update();
                 var obj = data.GetFields();
 
                 {
@@ -2066,9 +2066,9 @@ namespace Improbable.Gdk.Tests
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.ExhaustiveRepeated.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static global::Improbable.Gdk.Tests.ExhaustiveRepeated.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
             {
-                var component = new Improbable.Gdk.Tests.ExhaustiveRepeated.Snapshot();
+                var component = new global::Improbable.Gdk.Tests.ExhaustiveRepeated.Snapshot();
 
                 {
                     component.Field1 = new global::System.Collections.Generic.List<BlittableBool>();
@@ -2271,7 +2271,7 @@ namespace Improbable.Gdk.Tests
                 return component;
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.ExhaustiveRepeated.Component component)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component component)
             {
                 var obj = updateObj.GetFields();
 
@@ -2675,7 +2675,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.ExhaustiveRepeated.Snapshot snapshot)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.ExhaustiveRepeated.Snapshot snapshot)
             {
                 var obj = updateObj.GetFields();
 
@@ -3109,7 +3109,7 @@ namespace Improbable.Gdk.Tests
             internal uint handle;
             public global::System.Collections.Generic.List<Update> Updates
             {
-                get => Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+                get => global::Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedComponentDiffDeserializer.cs
@@ -18,7 +18,7 @@ namespace Improbable.Gdk.Tests
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = Improbable.Gdk.Tests.ExhaustiveRepeated.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                var update = global::Improbable.Gdk.Tests.ExhaustiveRepeated.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
                 diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedEcsViewManager.cs
@@ -101,7 +101,7 @@ namespace Improbable.Gdk.Tests
             {
                 workerSystem.TryGetEntity(entityId, out var entity);
 
-                var component = new Improbable.Gdk.Tests.ExhaustiveRepeated.Component();
+                var component = new global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component();
 
                 component.field1Handle = Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field1Provider.Allocate(world);
                 component.field2Handle = Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field2Provider.Allocate(world);
@@ -131,7 +131,7 @@ namespace Improbable.Gdk.Tests
                 workerSystem.TryGetEntity(entityId, out var entity);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
-                var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>(entity);
+                var data = entityManager.GetComponentData<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>(entity);
                 ExhaustiveRepeated.ReferenceTypeProviders.Field1Provider.Free(data.field1Handle);
                 ExhaustiveRepeated.ReferenceTypeProviders.Field2Provider.Free(data.field2Handle);
                 ExhaustiveRepeated.ReferenceTypeProviders.Field3Provider.Free(data.field3Handle);
@@ -151,7 +151,7 @@ namespace Improbable.Gdk.Tests
                 ExhaustiveRepeated.ReferenceTypeProviders.Field17Provider.Free(data.field17Handle);
                 ExhaustiveRepeated.ReferenceTypeProviders.Field18Provider.Free(data.field18Handle);
 
-                entityManager.RemoveComponent<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>(entity);
+                entityManager.RemoveComponent<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>(entity);
             }
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedProviders.cs
@@ -15,7 +15,7 @@ namespace Improbable.Gdk.Tests
         {
             public static class UpdatesProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.ExhaustiveRepeated.Update>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.ExhaustiveRepeated.Update>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Update>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -24,13 +24,13 @@ namespace Improbable.Gdk.Tests
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.ExhaustiveRepeated.Update>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Update>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.ExhaustiveRepeated.Update> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Update> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -40,7 +40,7 @@ namespace Improbable.Gdk.Tests
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.ExhaustiveRepeated.Update> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Update> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedReactiveComponents.cs
@@ -28,9 +28,9 @@ namespace Improbable.Gdk.Tests
                     }
 
                     List<Update> updates;
-                    if (entityManager.HasComponent<Improbable.Gdk.Tests.ExhaustiveRepeated.ReceivedUpdates>(entity))
+                    if (entityManager.HasComponent<global::Improbable.Gdk.Tests.ExhaustiveRepeated.ReceivedUpdates>(entity))
                     {
-                        updates = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveRepeated.ReceivedUpdates>(entity).Updates;
+                        updates = entityManager.GetComponentData<global::Improbable.Gdk.Tests.ExhaustiveRepeated.ReceivedUpdates>(entity).Updates;
                     }
                     else
                     {
@@ -49,7 +49,7 @@ namespace Improbable.Gdk.Tests
 
             public void Clean(World world)
             {
-                ExhaustiveRepeated.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
+                global::Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
             }
         }
 
@@ -158,7 +158,7 @@ namespace Improbable.Gdk.Tests
                 {
                     workerSystem.TryGetEntity(entityId, out var entity);
                     entityManager.AddComponent(entity,
-                        ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>());
+                        ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>());
                 }
 
                 for (int i = 0; i < authorityChanges.Count; ++i)
@@ -182,39 +182,39 @@ namespace Improbable.Gdk.Tests
                 switch (authority)
                 {
                     case Authority.Authoritative:
-                        if (!entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entity))
+                        if (!entityManager.HasComponent<NotAuthoritative<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.Authoritative, Authority.NotAuthoritative, entityId);
                             return;
                         }
 
-                        entityManager.RemoveComponent<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>());
+                        entityManager.RemoveComponent<NotAuthoritative<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>());
 
                         break;
                     case Authority.AuthorityLossImminent:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.AuthorityLossImminent, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>());
                         break;
                     case Authority.NotAuthoritative:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.NotAuthoritative, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        if (entityManager.HasComponent<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entity))
+                        if (entityManager.HasComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entity))
                         {
-                            entityManager.RemoveComponent<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entity);
+                            entityManager.RemoveComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entity);
                         }
 
-                        entityManager.RemoveComponent<Authoritative<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>());
+                        entityManager.RemoveComponent<Authoritative<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>());
                         break;
                 }
             }
@@ -227,7 +227,7 @@ namespace Improbable.Gdk.Tests
                 //     .WithField(LoggingUtils.EntityId, entityId.Id)
                 //     .WithField("New Authority", newAuthority)
                 //     .WithField("Expected Old Authority", expectedOldAuthority)
-                //     .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveRepeated")
+                //     .WithField("Component", "global::Improbable.Gdk.Tests.ExhaustiveRepeated")
                 // );
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedReactiveHandlers.cs
@@ -52,10 +52,10 @@ namespace Improbable.Gdk.Tests
                 All = Array.Empty<ComponentType>(),
                 Any = new ComponentType[]
                 {
-                    ComponentType.Create<ComponentAdded<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(),
-                    ComponentType.Create<ComponentRemoved<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.ExhaustiveRepeated.ReceivedUpdates>(),
-                    ComponentType.Create<AuthorityChanges<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(),
+                    ComponentType.Create<ComponentAdded<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(),
+                    ComponentType.Create<ComponentRemoved<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ExhaustiveRepeated.ReceivedUpdates>(),
+                    ComponentType.Create<AuthorityChanges<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(),
                 },
                 None = Array.Empty<ComponentType>(),
             };
@@ -64,10 +64,10 @@ namespace Improbable.Gdk.Tests
                 EntityCommandBuffer buffer)
             {
                 var entityType = system.GetArchetypeChunkEntityType();
-                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>();
-                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>();
-                var receivedUpdateType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ExhaustiveRepeated.ReceivedUpdates>();
-                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>();
+                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>();
+                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>();
+                var receivedUpdateType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.ExhaustiveRepeated.ReceivedUpdates>();
+                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>();
 
                 foreach (var chunk in chunkArray)
                 {
@@ -79,12 +79,12 @@ namespace Improbable.Gdk.Tests
                         var updateArray = chunk.GetNativeArray(receivedUpdateType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<Improbable.Gdk.Tests.ExhaustiveRepeated.ReceivedUpdates>(entities[i]);
+                            buffer.RemoveComponent<global::Improbable.Gdk.Tests.ExhaustiveRepeated.ReceivedUpdates>(entities[i]);
                             var updateList = updateArray[i].Updates;
 
                             // Pool update lists to avoid excessive allocation
                             updateList.Clear();
-                            Improbable.Gdk.Tests.ExhaustiveRepeated.Update.Pool.Push(updateList);
+                            global::Improbable.Gdk.Tests.ExhaustiveRepeated.Update.Pool.Push(updateList);
 
                             ReferenceTypeProviders.UpdatesProvider.Free(updateArray[i].handle);
                         }
@@ -95,7 +95,7 @@ namespace Improbable.Gdk.Tests
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentAdded<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentAdded<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entities[i]);
                         }
                     }
 
@@ -104,7 +104,7 @@ namespace Improbable.Gdk.Tests
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentRemoved<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentRemoved<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entities[i]);
                         }
                     }
 
@@ -114,7 +114,7 @@ namespace Improbable.Gdk.Tests
                         var authorityChangeArray = chunk.GetNativeArray(authorityChangeType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<AuthorityChanges<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entities[i]);
+                            buffer.RemoveComponent<AuthorityChanges<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entities[i]);
                             AuthorityChangesProvider.Free(authorityChangeArray[i].Handle);
                         }
                     }
@@ -129,7 +129,7 @@ namespace Improbable.Gdk.Tests
             {
                 All = new ComponentType[]
                 {
-                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(),
+                    ComponentType.ReadOnly<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -139,7 +139,7 @@ namespace Improbable.Gdk.Tests
             public override void AcknowledgeAuthorityLoss(NativeArray<ArchetypeChunk> chunkArray, ComponentSystemBase system,
                 ComponentUpdateSystem updateSystem)
             {
-                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>();
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>();
                 var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
 
                 foreach (var chunk in chunkArray)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedUpdateSender.cs
@@ -24,8 +24,8 @@ namespace Improbable.Gdk.Tests
             {
                 All = new[]
                 {
-                    ComponentType.Create<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.ExhaustiveRepeated.ComponentAuthority>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ExhaustiveRepeated.ComponentAuthority>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -41,7 +41,7 @@ namespace Improbable.Gdk.Tests
                 Profiler.BeginSample("ExhaustiveRepeated");
 
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>();
+                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Component>();
 
                 var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingular.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingular.cs
@@ -421,7 +421,7 @@ namespace Improbable.Gdk.Tests
 
         public static class Serialization
         {
-            public static void SerializeComponent(Improbable.Gdk.Tests.ExhaustiveSingular.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static void SerializeComponent(global::Improbable.Gdk.Tests.ExhaustiveSingular.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
                 {
                     obj.AddBool(1, component.Field1);
@@ -479,7 +479,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.ExhaustiveSingular.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.ExhaustiveSingular.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
                 {
@@ -610,7 +610,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.ExhaustiveSingular.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.ExhaustiveSingular.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
                 {
@@ -741,7 +741,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void SerializeSnapshot(Improbable.Gdk.Tests.ExhaustiveSingular.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static void SerializeSnapshot(global::Improbable.Gdk.Tests.ExhaustiveSingular.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
             {
                 {
                     obj.AddBool(1, snapshot.Field1);
@@ -799,9 +799,9 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static Improbable.Gdk.Tests.ExhaustiveSingular.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static global::Improbable.Gdk.Tests.ExhaustiveSingular.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
-                var component = new Improbable.Gdk.Tests.ExhaustiveSingular.Component();
+                var component = new global::Improbable.Gdk.Tests.ExhaustiveSingular.Component();
 
                 {
                     component.Field1 = obj.GetBool(1);
@@ -862,9 +862,9 @@ namespace Improbable.Gdk.Tests
                 return component;
             }
 
-            public static Improbable.Gdk.Tests.ExhaustiveSingular.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static global::Improbable.Gdk.Tests.ExhaustiveSingular.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
-                var update = new Improbable.Gdk.Tests.ExhaustiveSingular.Update();
+                var update = new global::Improbable.Gdk.Tests.ExhaustiveSingular.Update();
                 var obj = updateObj.GetFields();
 
                 {
@@ -1014,9 +1014,9 @@ namespace Improbable.Gdk.Tests
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.ExhaustiveSingular.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
+            public static global::Improbable.Gdk.Tests.ExhaustiveSingular.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
             {
-                var update = new Improbable.Gdk.Tests.ExhaustiveSingular.Update();
+                var update = new global::Improbable.Gdk.Tests.ExhaustiveSingular.Update();
                 var obj = data.GetFields();
 
                 {
@@ -1112,9 +1112,9 @@ namespace Improbable.Gdk.Tests
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.ExhaustiveSingular.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static global::Improbable.Gdk.Tests.ExhaustiveSingular.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
             {
-                var component = new Improbable.Gdk.Tests.ExhaustiveSingular.Snapshot();
+                var component = new global::Improbable.Gdk.Tests.ExhaustiveSingular.Snapshot();
 
                 {
                     component.Field1 = obj.GetBool(1);
@@ -1191,7 +1191,7 @@ namespace Improbable.Gdk.Tests
                 return component;
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.ExhaustiveSingular.Component component)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.ExhaustiveSingular.Component component)
             {
                 var obj = updateObj.GetFields();
 
@@ -1341,7 +1341,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.ExhaustiveSingular.Snapshot snapshot)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.ExhaustiveSingular.Snapshot snapshot)
             {
                 var obj = updateObj.GetFields();
 
@@ -1521,7 +1521,7 @@ namespace Improbable.Gdk.Tests
             internal uint handle;
             public global::System.Collections.Generic.List<Update> Updates
             {
-                get => Improbable.Gdk.Tests.ExhaustiveSingular.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+                get => global::Improbable.Gdk.Tests.ExhaustiveSingular.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularComponentDiffDeserializer.cs
@@ -18,7 +18,7 @@ namespace Improbable.Gdk.Tests
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = Improbable.Gdk.Tests.ExhaustiveSingular.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                var update = global::Improbable.Gdk.Tests.ExhaustiveSingular.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
                 diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularEcsViewManager.cs
@@ -85,7 +85,7 @@ namespace Improbable.Gdk.Tests
             {
                 workerSystem.TryGetEntity(entityId, out var entity);
 
-                var component = new Improbable.Gdk.Tests.ExhaustiveSingular.Component();
+                var component = new global::Improbable.Gdk.Tests.ExhaustiveSingular.Component();
 
                 component.field3Handle = Improbable.Gdk.Tests.ExhaustiveSingular.ReferenceTypeProviders.Field3Provider.Allocate(world);
                 component.field7Handle = Improbable.Gdk.Tests.ExhaustiveSingular.ReferenceTypeProviders.Field7Provider.Allocate(world);
@@ -99,11 +99,11 @@ namespace Improbable.Gdk.Tests
                 workerSystem.TryGetEntity(entityId, out var entity);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
-                var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveSingular.Component>(entity);
+                var data = entityManager.GetComponentData<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>(entity);
                 ExhaustiveSingular.ReferenceTypeProviders.Field3Provider.Free(data.field3Handle);
                 ExhaustiveSingular.ReferenceTypeProviders.Field7Provider.Free(data.field7Handle);
 
-                entityManager.RemoveComponent<Improbable.Gdk.Tests.ExhaustiveSingular.Component>(entity);
+                entityManager.RemoveComponent<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>(entity);
             }
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularProviders.cs
@@ -15,7 +15,7 @@ namespace Improbable.Gdk.Tests
         {
             public static class UpdatesProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.ExhaustiveSingular.Update>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.ExhaustiveSingular.Update>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.ExhaustiveSingular.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.ExhaustiveSingular.Update>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -24,13 +24,13 @@ namespace Improbable.Gdk.Tests
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.ExhaustiveSingular.Update>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.ExhaustiveSingular.Update>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.ExhaustiveSingular.Update> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.ExhaustiveSingular.Update> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -40,7 +40,7 @@ namespace Improbable.Gdk.Tests
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.ExhaustiveSingular.Update> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.ExhaustiveSingular.Update> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularReactiveComponents.cs
@@ -28,9 +28,9 @@ namespace Improbable.Gdk.Tests
                     }
 
                     List<Update> updates;
-                    if (entityManager.HasComponent<Improbable.Gdk.Tests.ExhaustiveSingular.ReceivedUpdates>(entity))
+                    if (entityManager.HasComponent<global::Improbable.Gdk.Tests.ExhaustiveSingular.ReceivedUpdates>(entity))
                     {
-                        updates = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveSingular.ReceivedUpdates>(entity).Updates;
+                        updates = entityManager.GetComponentData<global::Improbable.Gdk.Tests.ExhaustiveSingular.ReceivedUpdates>(entity).Updates;
                     }
                     else
                     {
@@ -49,7 +49,7 @@ namespace Improbable.Gdk.Tests
 
             public void Clean(World world)
             {
-                ExhaustiveSingular.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
+                global::Improbable.Gdk.Tests.ExhaustiveSingular.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
             }
         }
 
@@ -158,7 +158,7 @@ namespace Improbable.Gdk.Tests
                 {
                     workerSystem.TryGetEntity(entityId, out var entity);
                     entityManager.AddComponent(entity,
-                        ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>());
+                        ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>>());
                 }
 
                 for (int i = 0; i < authorityChanges.Count; ++i)
@@ -182,39 +182,39 @@ namespace Improbable.Gdk.Tests
                 switch (authority)
                 {
                     case Authority.Authoritative:
-                        if (!entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entity))
+                        if (!entityManager.HasComponent<NotAuthoritative<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.Authoritative, Authority.NotAuthoritative, entityId);
                             return;
                         }
 
-                        entityManager.RemoveComponent<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>());
+                        entityManager.RemoveComponent<NotAuthoritative<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>>());
 
                         break;
                     case Authority.AuthorityLossImminent:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.AuthorityLossImminent, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>>());
                         break;
                     case Authority.NotAuthoritative:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.NotAuthoritative, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        if (entityManager.HasComponent<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entity))
+                        if (entityManager.HasComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entity))
                         {
-                            entityManager.RemoveComponent<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entity);
+                            entityManager.RemoveComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entity);
                         }
 
-                        entityManager.RemoveComponent<Authoritative<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>());
+                        entityManager.RemoveComponent<Authoritative<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>>());
                         break;
                 }
             }
@@ -227,7 +227,7 @@ namespace Improbable.Gdk.Tests
                 //     .WithField(LoggingUtils.EntityId, entityId.Id)
                 //     .WithField("New Authority", newAuthority)
                 //     .WithField("Expected Old Authority", expectedOldAuthority)
-                //     .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveSingular")
+                //     .WithField("Component", "global::Improbable.Gdk.Tests.ExhaustiveSingular")
                 // );
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularReactiveHandlers.cs
@@ -52,10 +52,10 @@ namespace Improbable.Gdk.Tests
                 All = Array.Empty<ComponentType>(),
                 Any = new ComponentType[]
                 {
-                    ComponentType.Create<ComponentAdded<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(),
-                    ComponentType.Create<ComponentRemoved<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.ExhaustiveSingular.ReceivedUpdates>(),
-                    ComponentType.Create<AuthorityChanges<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(),
+                    ComponentType.Create<ComponentAdded<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(),
+                    ComponentType.Create<ComponentRemoved<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ExhaustiveSingular.ReceivedUpdates>(),
+                    ComponentType.Create<AuthorityChanges<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(),
                 },
                 None = Array.Empty<ComponentType>(),
             };
@@ -64,10 +64,10 @@ namespace Improbable.Gdk.Tests
                 EntityCommandBuffer buffer)
             {
                 var entityType = system.GetArchetypeChunkEntityType();
-                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>();
-                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>();
-                var receivedUpdateType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ExhaustiveSingular.ReceivedUpdates>();
-                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>();
+                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>>();
+                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>>();
+                var receivedUpdateType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.ExhaustiveSingular.ReceivedUpdates>();
+                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>>();
 
                 foreach (var chunk in chunkArray)
                 {
@@ -79,12 +79,12 @@ namespace Improbable.Gdk.Tests
                         var updateArray = chunk.GetNativeArray(receivedUpdateType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<Improbable.Gdk.Tests.ExhaustiveSingular.ReceivedUpdates>(entities[i]);
+                            buffer.RemoveComponent<global::Improbable.Gdk.Tests.ExhaustiveSingular.ReceivedUpdates>(entities[i]);
                             var updateList = updateArray[i].Updates;
 
                             // Pool update lists to avoid excessive allocation
                             updateList.Clear();
-                            Improbable.Gdk.Tests.ExhaustiveSingular.Update.Pool.Push(updateList);
+                            global::Improbable.Gdk.Tests.ExhaustiveSingular.Update.Pool.Push(updateList);
 
                             ReferenceTypeProviders.UpdatesProvider.Free(updateArray[i].handle);
                         }
@@ -95,7 +95,7 @@ namespace Improbable.Gdk.Tests
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentAdded<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentAdded<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entities[i]);
                         }
                     }
 
@@ -104,7 +104,7 @@ namespace Improbable.Gdk.Tests
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentRemoved<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentRemoved<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entities[i]);
                         }
                     }
 
@@ -114,7 +114,7 @@ namespace Improbable.Gdk.Tests
                         var authorityChangeArray = chunk.GetNativeArray(authorityChangeType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<AuthorityChanges<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entities[i]);
+                            buffer.RemoveComponent<AuthorityChanges<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entities[i]);
                             AuthorityChangesProvider.Free(authorityChangeArray[i].Handle);
                         }
                     }
@@ -129,7 +129,7 @@ namespace Improbable.Gdk.Tests
             {
                 All = new ComponentType[]
                 {
-                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(),
+                    ComponentType.ReadOnly<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -139,7 +139,7 @@ namespace Improbable.Gdk.Tests
             public override void AcknowledgeAuthorityLoss(NativeArray<ArchetypeChunk> chunkArray, ComponentSystemBase system,
                 ComponentUpdateSystem updateSystem)
             {
-                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>();
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>>();
                 var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
 
                 foreach (var chunk in chunkArray)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularUpdateSender.cs
@@ -24,8 +24,8 @@ namespace Improbable.Gdk.Tests
             {
                 All = new[]
                 {
-                    ComponentType.Create<Improbable.Gdk.Tests.ExhaustiveSingular.Component>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.ExhaustiveSingular.ComponentAuthority>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ExhaustiveSingular.ComponentAuthority>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -41,7 +41,7 @@ namespace Improbable.Gdk.Tests
                 Profiler.BeginSample("ExhaustiveSingular");
 
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ExhaustiveSingular.Component>();
+                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.ExhaustiveSingular.Component>();
 
                 var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponent.cs
@@ -167,14 +167,14 @@ namespace Improbable.Gdk.Tests
 
         public static class Serialization
         {
-            public static void SerializeComponent(Improbable.Gdk.Tests.NestedComponent.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static void SerializeComponent(global::Improbable.Gdk.Tests.NestedComponent.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
                 {
                     global::Improbable.Gdk.Tests.TypeName.Serialization.Serialize(component.NestedType, obj.AddObject(1));
                 }
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.NestedComponent.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.NestedComponent.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
                 {
@@ -186,7 +186,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.NestedComponent.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.NestedComponent.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
                 {
@@ -198,16 +198,16 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void SerializeSnapshot(Improbable.Gdk.Tests.NestedComponent.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static void SerializeSnapshot(global::Improbable.Gdk.Tests.NestedComponent.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
             {
                 {
                     global::Improbable.Gdk.Tests.TypeName.Serialization.Serialize(snapshot.NestedType, obj.AddObject(1));
                 }
             }
 
-            public static Improbable.Gdk.Tests.NestedComponent.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static global::Improbable.Gdk.Tests.NestedComponent.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
-                var component = new Improbable.Gdk.Tests.NestedComponent.Component();
+                var component = new global::Improbable.Gdk.Tests.NestedComponent.Component();
 
                 {
                     component.NestedType = global::Improbable.Gdk.Tests.TypeName.Serialization.Deserialize(obj.GetObject(1));
@@ -215,9 +215,9 @@ namespace Improbable.Gdk.Tests
                 return component;
             }
 
-            public static Improbable.Gdk.Tests.NestedComponent.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static global::Improbable.Gdk.Tests.NestedComponent.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
-                var update = new Improbable.Gdk.Tests.NestedComponent.Update();
+                var update = new global::Improbable.Gdk.Tests.NestedComponent.Update();
                 var obj = updateObj.GetFields();
 
                 {
@@ -231,9 +231,9 @@ namespace Improbable.Gdk.Tests
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.NestedComponent.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
+            public static global::Improbable.Gdk.Tests.NestedComponent.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
             {
-                var update = new Improbable.Gdk.Tests.NestedComponent.Update();
+                var update = new global::Improbable.Gdk.Tests.NestedComponent.Update();
                 var obj = data.GetFields();
 
                 {
@@ -244,9 +244,9 @@ namespace Improbable.Gdk.Tests
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.NestedComponent.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static global::Improbable.Gdk.Tests.NestedComponent.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
             {
-                var component = new Improbable.Gdk.Tests.NestedComponent.Snapshot();
+                var component = new global::Improbable.Gdk.Tests.NestedComponent.Snapshot();
 
                 {
                     component.NestedType = global::Improbable.Gdk.Tests.TypeName.Serialization.Deserialize(obj.GetObject(1));
@@ -255,7 +255,7 @@ namespace Improbable.Gdk.Tests
                 return component;
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.NestedComponent.Component component)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.NestedComponent.Component component)
             {
                 var obj = updateObj.GetFields();
 
@@ -269,7 +269,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.NestedComponent.Snapshot snapshot)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.NestedComponent.Snapshot snapshot)
             {
                 var obj = updateObj.GetFields();
 
@@ -296,7 +296,7 @@ namespace Improbable.Gdk.Tests
             internal uint handle;
             public global::System.Collections.Generic.List<Update> Updates
             {
-                get => Improbable.Gdk.Tests.NestedComponent.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+                get => global::Improbable.Gdk.Tests.NestedComponent.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentComponentDiffDeserializer.cs
@@ -18,7 +18,7 @@ namespace Improbable.Gdk.Tests
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = Improbable.Gdk.Tests.NestedComponent.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                var update = global::Improbable.Gdk.Tests.NestedComponent.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
                 diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentEcsViewManager.cs
@@ -83,7 +83,7 @@ namespace Improbable.Gdk.Tests
             {
                 workerSystem.TryGetEntity(entityId, out var entity);
 
-                var component = new Improbable.Gdk.Tests.NestedComponent.Component();
+                var component = new global::Improbable.Gdk.Tests.NestedComponent.Component();
 
                 component.MarkDataClean();
                 entityManager.AddSharedComponentData(entity, ComponentAuthority.NotAuthoritative);
@@ -95,7 +95,7 @@ namespace Improbable.Gdk.Tests
                 workerSystem.TryGetEntity(entityId, out var entity);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
-                entityManager.RemoveComponent<Improbable.Gdk.Tests.NestedComponent.Component>(entity);
+                entityManager.RemoveComponent<global::Improbable.Gdk.Tests.NestedComponent.Component>(entity);
             }
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentProviders.cs
@@ -15,7 +15,7 @@ namespace Improbable.Gdk.Tests
         {
             public static class UpdatesProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.NestedComponent.Update>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.NestedComponent.Update>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.NestedComponent.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.NestedComponent.Update>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -24,13 +24,13 @@ namespace Improbable.Gdk.Tests
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.NestedComponent.Update>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.NestedComponent.Update>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.NestedComponent.Update> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.NestedComponent.Update> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -40,7 +40,7 @@ namespace Improbable.Gdk.Tests
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.NestedComponent.Update> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.NestedComponent.Update> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentReactiveComponents.cs
@@ -28,9 +28,9 @@ namespace Improbable.Gdk.Tests
                     }
 
                     List<Update> updates;
-                    if (entityManager.HasComponent<Improbable.Gdk.Tests.NestedComponent.ReceivedUpdates>(entity))
+                    if (entityManager.HasComponent<global::Improbable.Gdk.Tests.NestedComponent.ReceivedUpdates>(entity))
                     {
-                        updates = entityManager.GetComponentData<Improbable.Gdk.Tests.NestedComponent.ReceivedUpdates>(entity).Updates;
+                        updates = entityManager.GetComponentData<global::Improbable.Gdk.Tests.NestedComponent.ReceivedUpdates>(entity).Updates;
                     }
                     else
                     {
@@ -49,7 +49,7 @@ namespace Improbable.Gdk.Tests
 
             public void Clean(World world)
             {
-                NestedComponent.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
+                global::Improbable.Gdk.Tests.NestedComponent.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
             }
         }
 
@@ -158,7 +158,7 @@ namespace Improbable.Gdk.Tests
                 {
                     workerSystem.TryGetEntity(entityId, out var entity);
                     entityManager.AddComponent(entity,
-                        ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.NestedComponent.Component>>());
+                        ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.NestedComponent.Component>>());
                 }
 
                 for (int i = 0; i < authorityChanges.Count; ++i)
@@ -182,39 +182,39 @@ namespace Improbable.Gdk.Tests
                 switch (authority)
                 {
                     case Authority.Authoritative:
-                        if (!entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.NestedComponent.Component>>(entity))
+                        if (!entityManager.HasComponent<NotAuthoritative<global::Improbable.Gdk.Tests.NestedComponent.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.Authoritative, Authority.NotAuthoritative, entityId);
                             return;
                         }
 
-                        entityManager.RemoveComponent<NotAuthoritative<Improbable.Gdk.Tests.NestedComponent.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Improbable.Gdk.Tests.NestedComponent.Component>>());
+                        entityManager.RemoveComponent<NotAuthoritative<global::Improbable.Gdk.Tests.NestedComponent.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<global::Improbable.Gdk.Tests.NestedComponent.Component>>());
 
                         break;
                     case Authority.AuthorityLossImminent:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.NestedComponent.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.NestedComponent.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.AuthorityLossImminent, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Improbable.Gdk.Tests.NestedComponent.Component>>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<global::Improbable.Gdk.Tests.NestedComponent.Component>>());
                         break;
                     case Authority.NotAuthoritative:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.NestedComponent.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.NestedComponent.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.NotAuthoritative, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        if (entityManager.HasComponent<AuthorityLossImminent<Improbable.Gdk.Tests.NestedComponent.Component>>(entity))
+                        if (entityManager.HasComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.NestedComponent.Component>>(entity))
                         {
-                            entityManager.RemoveComponent<AuthorityLossImminent<Improbable.Gdk.Tests.NestedComponent.Component>>(entity);
+                            entityManager.RemoveComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.NestedComponent.Component>>(entity);
                         }
 
-                        entityManager.RemoveComponent<Authoritative<Improbable.Gdk.Tests.NestedComponent.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.NestedComponent.Component>>());
+                        entityManager.RemoveComponent<Authoritative<global::Improbable.Gdk.Tests.NestedComponent.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.NestedComponent.Component>>());
                         break;
                 }
             }
@@ -227,7 +227,7 @@ namespace Improbable.Gdk.Tests
                 //     .WithField(LoggingUtils.EntityId, entityId.Id)
                 //     .WithField("New Authority", newAuthority)
                 //     .WithField("Expected Old Authority", expectedOldAuthority)
-                //     .WithField("Component", "Improbable.Gdk.Tests.NestedComponent")
+                //     .WithField("Component", "global::Improbable.Gdk.Tests.NestedComponent")
                 // );
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentReactiveHandlers.cs
@@ -52,10 +52,10 @@ namespace Improbable.Gdk.Tests
                 All = Array.Empty<ComponentType>(),
                 Any = new ComponentType[]
                 {
-                    ComponentType.Create<ComponentAdded<Improbable.Gdk.Tests.NestedComponent.Component>>(),
-                    ComponentType.Create<ComponentRemoved<Improbable.Gdk.Tests.NestedComponent.Component>>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.NestedComponent.ReceivedUpdates>(),
-                    ComponentType.Create<AuthorityChanges<Improbable.Gdk.Tests.NestedComponent.Component>>(),
+                    ComponentType.Create<ComponentAdded<global::Improbable.Gdk.Tests.NestedComponent.Component>>(),
+                    ComponentType.Create<ComponentRemoved<global::Improbable.Gdk.Tests.NestedComponent.Component>>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.NestedComponent.ReceivedUpdates>(),
+                    ComponentType.Create<AuthorityChanges<global::Improbable.Gdk.Tests.NestedComponent.Component>>(),
                 },
                 None = Array.Empty<ComponentType>(),
             };
@@ -64,10 +64,10 @@ namespace Improbable.Gdk.Tests
                 EntityCommandBuffer buffer)
             {
                 var entityType = system.GetArchetypeChunkEntityType();
-                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<Improbable.Gdk.Tests.NestedComponent.Component>>();
-                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<Improbable.Gdk.Tests.NestedComponent.Component>>();
-                var receivedUpdateType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.NestedComponent.ReceivedUpdates>();
-                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<Improbable.Gdk.Tests.NestedComponent.Component>>();
+                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<global::Improbable.Gdk.Tests.NestedComponent.Component>>();
+                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<global::Improbable.Gdk.Tests.NestedComponent.Component>>();
+                var receivedUpdateType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.NestedComponent.ReceivedUpdates>();
+                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<global::Improbable.Gdk.Tests.NestedComponent.Component>>();
 
                 foreach (var chunk in chunkArray)
                 {
@@ -79,12 +79,12 @@ namespace Improbable.Gdk.Tests
                         var updateArray = chunk.GetNativeArray(receivedUpdateType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<Improbable.Gdk.Tests.NestedComponent.ReceivedUpdates>(entities[i]);
+                            buffer.RemoveComponent<global::Improbable.Gdk.Tests.NestedComponent.ReceivedUpdates>(entities[i]);
                             var updateList = updateArray[i].Updates;
 
                             // Pool update lists to avoid excessive allocation
                             updateList.Clear();
-                            Improbable.Gdk.Tests.NestedComponent.Update.Pool.Push(updateList);
+                            global::Improbable.Gdk.Tests.NestedComponent.Update.Pool.Push(updateList);
 
                             ReferenceTypeProviders.UpdatesProvider.Free(updateArray[i].handle);
                         }
@@ -95,7 +95,7 @@ namespace Improbable.Gdk.Tests
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentAdded<Improbable.Gdk.Tests.NestedComponent.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentAdded<global::Improbable.Gdk.Tests.NestedComponent.Component>>(entities[i]);
                         }
                     }
 
@@ -104,7 +104,7 @@ namespace Improbable.Gdk.Tests
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentRemoved<Improbable.Gdk.Tests.NestedComponent.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentRemoved<global::Improbable.Gdk.Tests.NestedComponent.Component>>(entities[i]);
                         }
                     }
 
@@ -114,7 +114,7 @@ namespace Improbable.Gdk.Tests
                         var authorityChangeArray = chunk.GetNativeArray(authorityChangeType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<AuthorityChanges<Improbable.Gdk.Tests.NestedComponent.Component>>(entities[i]);
+                            buffer.RemoveComponent<AuthorityChanges<global::Improbable.Gdk.Tests.NestedComponent.Component>>(entities[i]);
                             AuthorityChangesProvider.Free(authorityChangeArray[i].Handle);
                         }
                     }
@@ -129,7 +129,7 @@ namespace Improbable.Gdk.Tests
             {
                 All = new ComponentType[]
                 {
-                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.NestedComponent.Component>>(),
+                    ComponentType.ReadOnly<AuthorityLossImminent<global::Improbable.Gdk.Tests.NestedComponent.Component>>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -139,7 +139,7 @@ namespace Improbable.Gdk.Tests
             public override void AcknowledgeAuthorityLoss(NativeArray<ArchetypeChunk> chunkArray, ComponentSystemBase system,
                 ComponentUpdateSystem updateSystem)
             {
-                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.NestedComponent.Component>>();
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<global::Improbable.Gdk.Tests.NestedComponent.Component>>();
                 var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
 
                 foreach (var chunk in chunkArray)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentUpdateSender.cs
@@ -24,8 +24,8 @@ namespace Improbable.Gdk.Tests
             {
                 All = new[]
                 {
-                    ComponentType.Create<Improbable.Gdk.Tests.NestedComponent.Component>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.NestedComponent.ComponentAuthority>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.NestedComponent.Component>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.NestedComponent.ComponentAuthority>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -41,7 +41,7 @@ namespace Improbable.Gdk.Tests
                 Profiler.BeginSample("NestedComponent");
 
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.NestedComponent.Component>();
+                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.NestedComponent.Component>();
 
                 var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/Connection.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/Connection.cs
@@ -167,14 +167,14 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
 
         public static class Serialization
         {
-            public static void SerializeComponent(Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static void SerializeComponent(global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
                 {
                     obj.AddInt32(1, component.Value);
                 }
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
                 {
@@ -186,7 +186,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 }
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
                 {
@@ -198,16 +198,16 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 }
             }
 
-            public static void SerializeSnapshot(Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static void SerializeSnapshot(global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
             {
                 {
                     obj.AddInt32(1, snapshot.Value);
                 }
             }
 
-            public static Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
-                var component = new Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component();
+                var component = new global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component();
 
                 {
                     component.Value = obj.GetInt32(1);
@@ -215,9 +215,9 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 return component;
             }
 
-            public static Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
-                var update = new Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update();
+                var update = new global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update();
                 var obj = updateObj.GetFields();
 
                 {
@@ -231,9 +231,9 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
+            public static global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
             {
-                var update = new Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update();
+                var update = new global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update();
                 var obj = data.GetFields();
 
                 {
@@ -244,9 +244,9 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
             {
-                var component = new Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Snapshot();
+                var component = new global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Snapshot();
 
                 {
                     component.Value = obj.GetInt32(1);
@@ -255,7 +255,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 return component;
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component component)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component component)
             {
                 var obj = updateObj.GetFields();
 
@@ -269,7 +269,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 }
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Snapshot snapshot)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Snapshot snapshot)
             {
                 var obj = updateObj.GetFields();
 
@@ -296,7 +296,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
             internal uint handle;
             public global::System.Collections.Generic.List<Update> Updates
             {
-                get => Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+                get => global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionComponentDiffDeserializer.cs
@@ -18,7 +18,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                var update = global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
                 diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
                 var eventsObject = op.Update.SchemaData.Value.GetEvents();
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionEcsViewManager.cs
@@ -83,7 +83,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
             {
                 workerSystem.TryGetEntity(entityId, out var entity);
 
-                var component = new Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component();
+                var component = new global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component();
 
                 component.MarkDataClean();
                 entityManager.AddSharedComponentData(entity, ComponentAuthority.NotAuthoritative);
@@ -95,7 +95,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 workerSystem.TryGetEntity(entityId, out var entity);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
-                entityManager.RemoveComponent<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>(entity);
+                entityManager.RemoveComponent<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>(entity);
             }
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionEvents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionEvents.cs
@@ -34,8 +34,8 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
 
                 public List<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.RandomDataType> Events
                 {
-                    get => Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReferenceTypeProviders.MyEventProvider.Get(handle);
-                    internal set => Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReferenceTypeProviders.MyEventProvider.Set(handle, value);
+                    get => global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReferenceTypeProviders.MyEventProvider.Get(handle);
+                    internal set => global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReferenceTypeProviders.MyEventProvider.Set(handle, value);
                 }
             }
 
@@ -49,8 +49,8 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
 
                 public List<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.RandomDataType> Events
                 {
-                    get => Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReferenceTypeProviders.MyEventProvider.Get(handle);
-                    internal set => Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReferenceTypeProviders.MyEventProvider.Set(handle, value);
+                    get => global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReferenceTypeProviders.MyEventProvider.Get(handle);
+                    internal set => global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReferenceTypeProviders.MyEventProvider.Set(handle, value);
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionProviders.cs
@@ -15,7 +15,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
         {
             public static class UpdatesProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -24,13 +24,13 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -40,7 +40,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionReactiveComponents.cs
@@ -28,9 +28,9 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                     }
 
                     List<Update> updates;
-                    if (entityManager.HasComponent<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReceivedUpdates>(entity))
+                    if (entityManager.HasComponent<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReceivedUpdates>(entity))
                     {
-                        updates = entityManager.GetComponentData<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReceivedUpdates>(entity).Updates;
+                        updates = entityManager.GetComponentData<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReceivedUpdates>(entity).Updates;
                     }
                     else
                     {
@@ -49,7 +49,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
 
             public void Clean(World world)
             {
-                Connection.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
+                global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
             }
         }
 
@@ -214,7 +214,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
 
             public void Clean(World world)
             {
-                Connection.ReferenceTypeProviders.MyEventProvider.CleanDataInWorld(world);
+                global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReferenceTypeProviders.MyEventProvider.CleanDataInWorld(world);
             }
         }
 
@@ -228,7 +228,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 {
                     workerSystem.TryGetEntity(entityId, out var entity);
                     entityManager.AddComponent(entity,
-                        ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>());
+                        ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>());
                 }
 
                 for (int i = 0; i < authorityChanges.Count; ++i)
@@ -252,39 +252,39 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 switch (authority)
                 {
                     case Authority.Authoritative:
-                        if (!entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entity))
+                        if (!entityManager.HasComponent<NotAuthoritative<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.Authoritative, Authority.NotAuthoritative, entityId);
                             return;
                         }
 
-                        entityManager.RemoveComponent<NotAuthoritative<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>());
+                        entityManager.RemoveComponent<NotAuthoritative<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>());
 
                         break;
                     case Authority.AuthorityLossImminent:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.AuthorityLossImminent, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>());
                         break;
                     case Authority.NotAuthoritative:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.NotAuthoritative, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        if (entityManager.HasComponent<AuthorityLossImminent<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entity))
+                        if (entityManager.HasComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entity))
                         {
-                            entityManager.RemoveComponent<AuthorityLossImminent<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entity);
+                            entityManager.RemoveComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entity);
                         }
 
-                        entityManager.RemoveComponent<Authoritative<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>());
+                        entityManager.RemoveComponent<Authoritative<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>());
                         break;
                 }
             }
@@ -297,7 +297,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 //     .WithField(LoggingUtils.EntityId, entityId.Id)
                 //     .WithField("New Authority", newAuthority)
                 //     .WithField("Expected Old Authority", expectedOldAuthority)
-                //     .WithField("Component", "Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection")
+                //     .WithField("Component", "global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection")
                 // );
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionReactiveHandlers.cs
@@ -73,10 +73,10 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 All = Array.Empty<ComponentType>(),
                 Any = new ComponentType[]
                 {
-                    ComponentType.Create<ComponentAdded<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(),
-                    ComponentType.Create<ComponentRemoved<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReceivedUpdates>(),
-                    ComponentType.Create<AuthorityChanges<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(),
+                    ComponentType.Create<ComponentAdded<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(),
+                    ComponentType.Create<ComponentRemoved<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReceivedUpdates>(),
+                    ComponentType.Create<AuthorityChanges<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(),
                     ComponentType.Create<ReceivedEvents.MyEvent>(),
                 },
                 None = Array.Empty<ComponentType>(),
@@ -86,10 +86,10 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 EntityCommandBuffer buffer)
             {
                 var entityType = system.GetArchetypeChunkEntityType();
-                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>();
-                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>();
-                var receivedUpdateType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReceivedUpdates>();
-                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>();
+                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>();
+                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>();
+                var receivedUpdateType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReceivedUpdates>();
+                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>();
                 var myEventEventType = system.GetArchetypeChunkComponentType<ReceivedEvents.MyEvent>();
 
                 foreach (var chunk in chunkArray)
@@ -102,12 +102,12 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                         var updateArray = chunk.GetNativeArray(receivedUpdateType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReceivedUpdates>(entities[i]);
+                            buffer.RemoveComponent<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReceivedUpdates>(entities[i]);
                             var updateList = updateArray[i].Updates;
 
                             // Pool update lists to avoid excessive allocation
                             updateList.Clear();
-                            Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update.Pool.Push(updateList);
+                            global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update.Pool.Push(updateList);
 
                             ReferenceTypeProviders.UpdatesProvider.Free(updateArray[i].handle);
                         }
@@ -118,7 +118,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentAdded<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentAdded<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entities[i]);
                         }
                     }
 
@@ -127,7 +127,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentRemoved<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentRemoved<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entities[i]);
                         }
                     }
 
@@ -137,7 +137,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                         var authorityChangeArray = chunk.GetNativeArray(authorityChangeType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<AuthorityChanges<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entities[i]);
+                            buffer.RemoveComponent<AuthorityChanges<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entities[i]);
                             AuthorityChangesProvider.Free(authorityChangeArray[i].Handle);
                         }
                     }
@@ -163,7 +163,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
             {
                 All = new ComponentType[]
                 {
-                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(),
+                    ComponentType.ReadOnly<AuthorityLossImminent<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -173,7 +173,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
             public override void AcknowledgeAuthorityLoss(NativeArray<ArchetypeChunk> chunkArray, ComponentSystemBase system,
                 ComponentUpdateSystem updateSystem)
             {
-                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>();
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>();
                 var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
 
                 foreach (var chunk in chunkArray)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionUpdateSender.cs
@@ -24,8 +24,8 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
             {
                 All = new[]
                 {
-                    ComponentType.Create<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ComponentAuthority>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ComponentAuthority>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -41,7 +41,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 Profiler.BeginSample("Connection");
 
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>();
+                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>();
 
                 var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponent.cs
@@ -223,7 +223,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
         public static class Serialization
         {
-            public static void SerializeComponent(Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static void SerializeComponent(global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
                 {
                     obj.AddBool(1, component.BoolField);
@@ -242,7 +242,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 }
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
                 {
@@ -282,7 +282,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 }
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
                 {
@@ -322,7 +322,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 }
             }
 
-            public static void SerializeSnapshot(Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static void SerializeSnapshot(global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
             {
                 {
                     obj.AddBool(1, snapshot.BoolField);
@@ -341,9 +341,9 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 }
             }
 
-            public static Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
-                var component = new Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component();
+                var component = new global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component();
 
                 {
                     component.BoolField = obj.GetBool(1);
@@ -363,9 +363,9 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 return component;
             }
 
-            public static Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
-                var update = new Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update();
+                var update = new global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update();
                 var obj = updateObj.GetFields();
 
                 {
@@ -411,9 +411,9 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
+            public static global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
             {
-                var update = new Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update();
+                var update = new global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update();
                 var obj = data.GetFields();
 
                 {
@@ -444,9 +444,9 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
             {
-                var component = new Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Snapshot();
+                var component = new global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Snapshot();
 
                 {
                     component.BoolField = obj.GetBool(1);
@@ -471,7 +471,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 return component;
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component component)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component component)
             {
                 var obj = updateObj.GetFields();
 
@@ -517,7 +517,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 }
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Snapshot snapshot)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Snapshot snapshot)
             {
                 var obj = updateObj.GetFields();
 
@@ -580,7 +580,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             internal uint handle;
             public global::System.Collections.Generic.List<Update> Updates
             {
-                get => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+                get => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentCommandComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentCommandComponents.cs
@@ -15,19 +15,19 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             public struct FirstCommand : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Request> RequestsToSend
+                public List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Request> RequestsToSend
                 {
-                    get => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstCommandSenderProvider.Get(CommandListHandle);
-                    set => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstCommandSenderProvider.Set(CommandListHandle, value);
+                    get => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstCommandSenderProvider.Get(CommandListHandle);
+                    set => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstCommandSenderProvider.Set(CommandListHandle, value);
                 }
             }
             public struct SecondCommand : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Request> RequestsToSend
+                public List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Request> RequestsToSend
                 {
-                    get => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondCommandSenderProvider.Get(CommandListHandle);
-                    set => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondCommandSenderProvider.Set(CommandListHandle, value);
+                    get => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondCommandSenderProvider.Get(CommandListHandle);
+                    set => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondCommandSenderProvider.Set(CommandListHandle, value);
                 }
             }
         }
@@ -37,19 +37,19 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             public struct FirstCommand : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedRequest> Requests
+                public List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedRequest> Requests
                 {
-                    get => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstCommandRequestsProvider.Get(CommandListHandle);
-                    set => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstCommandRequestsProvider.Set(CommandListHandle, value);
+                    get => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstCommandRequestsProvider.Get(CommandListHandle);
+                    set => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstCommandRequestsProvider.Set(CommandListHandle, value);
                 }
             }
             public struct SecondCommand : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedRequest> Requests
+                public List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedRequest> Requests
                 {
-                    get => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondCommandRequestsProvider.Get(CommandListHandle);
-                    set => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondCommandRequestsProvider.Set(CommandListHandle, value);
+                    get => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondCommandRequestsProvider.Get(CommandListHandle);
+                    set => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondCommandRequestsProvider.Set(CommandListHandle, value);
                 }
             }
         }
@@ -59,19 +59,19 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             public struct FirstCommand : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Response> ResponsesToSend
+                public List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Response> ResponsesToSend
                 {
-                    get => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstCommandResponderProvider.Get(CommandListHandle);
-                    set => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstCommandResponderProvider.Set(CommandListHandle, value);
+                    get => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstCommandResponderProvider.Get(CommandListHandle);
+                    set => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstCommandResponderProvider.Set(CommandListHandle, value);
                 }
             }
             public struct SecondCommand : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Response> ResponsesToSend
+                public List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Response> ResponsesToSend
                 {
-                    get => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondCommandResponderProvider.Get(CommandListHandle);
-                    set => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondCommandResponderProvider.Set(CommandListHandle, value);
+                    get => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondCommandResponderProvider.Get(CommandListHandle);
+                    set => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondCommandResponderProvider.Set(CommandListHandle, value);
                 }
             }
         }
@@ -81,19 +81,19 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             public struct FirstCommand : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedResponse> Responses
+                public List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedResponse> Responses
                 {
-                    get => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstCommandResponsesProvider.Get(CommandListHandle);
-                    set => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstCommandResponsesProvider.Set(CommandListHandle, value);
+                    get => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstCommandResponsesProvider.Get(CommandListHandle);
+                    set => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstCommandResponsesProvider.Set(CommandListHandle, value);
                 }
             }
             public struct SecondCommand : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedResponse> Responses
+                public List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedResponse> Responses
                 {
-                    get => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondCommandResponsesProvider.Get(CommandListHandle);
-                    set => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondCommandResponsesProvider.Set(CommandListHandle, value);
+                    get => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondCommandResponsesProvider.Get(CommandListHandle);
+                    set => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondCommandResponsesProvider.Set(CommandListHandle, value);
                 }
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentCommandSenderReceiver.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentCommandSenderReceiver.cs
@@ -270,19 +270,19 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             IsValid = true;
         }
 
-        public void SendFirstCommandCommand(EntityId targetEntityId, global::Improbable.Gdk.Tests.BlittableTypes.FirstCommandRequest request, Action<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedResponse> callback = null)
+        public void SendFirstCommandCommand(EntityId targetEntityId, global::Improbable.Gdk.Tests.BlittableTypes.FirstCommandRequest request, Action<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedResponse> callback = null)
         {
             var commandRequest = new BlittableComponent.FirstCommand.Request(targetEntityId, request);
             SendFirstCommandCommand(commandRequest, callback);
         }
 
-        public void SendFirstCommandCommand(BlittableComponent.FirstCommand.Request request, Action<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedResponse> callback = null)
+        public void SendFirstCommandCommand(global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Request request, Action<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedResponse> callback = null)
         {
             int validCallbackEpoch = callbackEpoch;
             var requestId = commandSender.SendCommand(request, entity);
             if (callback != null)
             {
-                Action<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedResponse> wrappedCallback = response =>
+                Action<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedResponse> wrappedCallback = response =>
                 {
                     if (!this.IsValid || validCallbackEpoch != this.callbackEpoch)
                     {
@@ -294,19 +294,19 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 callbackSystem.RegisterCommandResponseCallback(requestId, wrappedCallback);
             }
         }
-        public void SendSecondCommandCommand(EntityId targetEntityId, global::Improbable.Gdk.Tests.BlittableTypes.SecondCommandRequest request, Action<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedResponse> callback = null)
+        public void SendSecondCommandCommand(EntityId targetEntityId, global::Improbable.Gdk.Tests.BlittableTypes.SecondCommandRequest request, Action<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedResponse> callback = null)
         {
             var commandRequest = new BlittableComponent.SecondCommand.Request(targetEntityId, request);
             SendSecondCommandCommand(commandRequest, callback);
         }
 
-        public void SendSecondCommandCommand(BlittableComponent.SecondCommand.Request request, Action<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedResponse> callback = null)
+        public void SendSecondCommandCommand(global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Request request, Action<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedResponse> callback = null)
         {
             int validCallbackEpoch = callbackEpoch;
             var requestId = commandSender.SendCommand(request, entity);
             if (callback != null)
             {
-                Action<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedResponse> wrappedCallback = response =>
+                Action<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedResponse> wrappedCallback = response =>
                 {
                     if (!this.IsValid || validCallbackEpoch != this.callbackEpoch)
                     {
@@ -333,15 +333,15 @@ namespace Improbable.Gdk.Tests.BlittableTypes
         private readonly CommandCallbackSystem callbackSystem;
         private readonly CommandSystem commandSystem;
 
-        private Dictionary<Action<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedRequest>, ulong> firstCommandCallbackToCallbackKey;
+        private Dictionary<Action<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedRequest>, ulong> firstCommandCallbackToCallbackKey;
 
-        public event Action<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedRequest> OnFirstCommandRequestReceived
+        public event Action<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedRequest> OnFirstCommandRequestReceived
         {
             add
             {
                 if (firstCommandCallbackToCallbackKey == null)
                 {
-                    firstCommandCallbackToCallbackKey = new Dictionary<Action<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedRequest>, ulong>();
+                    firstCommandCallbackToCallbackKey = new Dictionary<Action<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedRequest>, ulong>();
                 }
 
                 var key = callbackSystem.RegisterCommandRequestCallback(entityId, value);
@@ -358,15 +358,15 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 firstCommandCallbackToCallbackKey.Remove(value);
             }
         }
-        private Dictionary<Action<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedRequest>, ulong> secondCommandCallbackToCallbackKey;
+        private Dictionary<Action<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedRequest>, ulong> secondCommandCallbackToCallbackKey;
 
-        public event Action<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedRequest> OnSecondCommandRequestReceived
+        public event Action<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedRequest> OnSecondCommandRequestReceived
         {
             add
             {
                 if (secondCommandCallbackToCallbackKey == null)
                 {
-                    secondCommandCallbackToCallbackKey = new Dictionary<Action<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedRequest>, ulong>();
+                    secondCommandCallbackToCallbackKey = new Dictionary<Action<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedRequest>, ulong>();
                 }
 
                 var key = callbackSystem.RegisterCommandRequestCallback(entityId, value);
@@ -394,34 +394,34 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             IsValid = true;
         }
 
-        public void SendFirstCommandResponse(Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Response response)
+        public void SendFirstCommandResponse(global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Response response)
         {
             commandSystem.SendResponse(response);
         }
 
         public void SendFirstCommandResponse(long requestId, global::Improbable.Gdk.Tests.BlittableTypes.FirstCommandResponse response)
         {
-            commandSystem.SendResponse(new Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Response(requestId, response));
+            commandSystem.SendResponse(new global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Response(requestId, response));
         }
 
         public void SendFirstCommandFailure(long requestId, string failureMessage)
         {
-            commandSystem.SendResponse(new Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Response(requestId, failureMessage));
+            commandSystem.SendResponse(new global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Response(requestId, failureMessage));
         }
 
-        public void SendSecondCommandResponse(Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Response response)
+        public void SendSecondCommandResponse(global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Response response)
         {
             commandSystem.SendResponse(response);
         }
 
         public void SendSecondCommandResponse(long requestId, global::Improbable.Gdk.Tests.BlittableTypes.SecondCommandResponse response)
         {
-            commandSystem.SendResponse(new Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Response(requestId, response));
+            commandSystem.SendResponse(new global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Response(requestId, response));
         }
 
         public void SendSecondCommandFailure(long requestId, string failureMessage)
         {
-            commandSystem.SendResponse(new Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Response(requestId, failureMessage));
+            commandSystem.SendResponse(new global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Response(requestId, failureMessage));
         }
 
         public void RemoveAllCallbacks()

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentComponentDiffDeserializer.cs
@@ -18,7 +18,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                var update = global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
                 diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
                 var eventsObject = op.Update.SchemaData.Value.GetEvents();
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentEcsViewManager.cs
@@ -83,7 +83,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             {
                 workerSystem.TryGetEntity(entityId, out var entity);
 
-                var component = new Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component();
+                var component = new global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component();
 
                 component.MarkDataClean();
                 entityManager.AddSharedComponentData(entity, ComponentAuthority.NotAuthoritative);
@@ -95,7 +95,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 workerSystem.TryGetEntity(entityId, out var entity);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
-                entityManager.RemoveComponent<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>(entity);
+                entityManager.RemoveComponent<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>(entity);
             }
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentEvents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentEvents.cs
@@ -47,8 +47,8 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
                 public List<global::Improbable.Gdk.Tests.BlittableTypes.FirstEventPayload> Events
                 {
-                    get => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstEventProvider.Get(handle);
-                    internal set => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstEventProvider.Set(handle, value);
+                    get => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstEventProvider.Get(handle);
+                    internal set => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstEventProvider.Set(handle, value);
                 }
             }
 
@@ -58,8 +58,8 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
                 public List<global::Improbable.Gdk.Tests.BlittableTypes.SecondEventPayload> Events
                 {
-                    get => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondEventProvider.Get(handle);
-                    internal set => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondEventProvider.Set(handle, value);
+                    get => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondEventProvider.Get(handle);
+                    internal set => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondEventProvider.Set(handle, value);
                 }
             }
 
@@ -73,8 +73,8 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
                 public List<global::Improbable.Gdk.Tests.BlittableTypes.FirstEventPayload> Events
                 {
-                    get => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstEventProvider.Get(handle);
-                    internal set => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstEventProvider.Set(handle, value);
+                    get => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstEventProvider.Get(handle);
+                    internal set => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstEventProvider.Set(handle, value);
                 }
             }
 
@@ -84,8 +84,8 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
                 public List<global::Improbable.Gdk.Tests.BlittableTypes.SecondEventPayload> Events
                 {
-                    get => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondEventProvider.Get(handle);
-                    internal set => Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondEventProvider.Set(handle, value);
+                    get => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondEventProvider.Get(handle);
+                    internal set => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondEventProvider.Set(handle, value);
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentProviders.cs
@@ -15,7 +15,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
         {
             public static class UpdatesProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -24,13 +24,13 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -40,7 +40,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {
@@ -214,7 +214,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             
             public static class FirstCommandSenderProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Request>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Request>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Request>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Request>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -223,13 +223,13 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Request>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Request>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Request> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Request> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -239,7 +239,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Request> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Request> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {
@@ -280,7 +280,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             
             public static class FirstCommandRequestsProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedRequest>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedRequest>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedRequest>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedRequest>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -289,13 +289,13 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedRequest>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedRequest>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedRequest> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedRequest> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -305,7 +305,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedRequest> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedRequest> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {
@@ -346,7 +346,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             
             public static class FirstCommandResponderProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Response>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Response>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Response>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Response>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -355,13 +355,13 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Response>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Response>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Response> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Response> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -371,7 +371,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Response> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Response> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {
@@ -412,7 +412,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             
             public static class FirstCommandResponsesProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedResponse>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedResponse>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedResponse>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedResponse>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -421,13 +421,13 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedResponse>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedResponse>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedResponse> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedResponse> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -437,7 +437,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedResponse> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.ReceivedResponse> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {
@@ -479,7 +479,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
             public static class SecondCommandSenderProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Request>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Request>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Request>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Request>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -488,13 +488,13 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Request>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Request>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Request> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Request> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -504,7 +504,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Request> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Request> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {
@@ -545,7 +545,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             
             public static class SecondCommandRequestsProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedRequest>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedRequest>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedRequest>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedRequest>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -554,13 +554,13 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedRequest>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedRequest>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedRequest> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedRequest> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -570,7 +570,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedRequest> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedRequest> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {
@@ -611,7 +611,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             
             public static class SecondCommandResponderProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Response>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Response>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Response>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Response>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -620,13 +620,13 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Response>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Response>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Response> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Response> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -636,7 +636,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Response> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Response> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {
@@ -677,7 +677,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             
             public static class SecondCommandResponsesProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedResponse>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedResponse>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedResponse>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedResponse>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -686,13 +686,13 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedResponse>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedResponse>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedResponse> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedResponse> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -702,7 +702,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedResponse> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.ReceivedResponse> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentReactiveCommandComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentReactiveCommandComponents.cs
@@ -30,13 +30,13 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     }
 
                     List<FirstCommand.ReceivedRequest> requests;
-                    if (entityManager.HasComponent<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandRequests.FirstCommand>(entity))
+                    if (entityManager.HasComponent<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandRequests.FirstCommand>(entity))
                     {
-                        requests = entityManager.GetComponentData<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandRequests.FirstCommand>(entity).Requests;
+                        requests = entityManager.GetComponentData<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandRequests.FirstCommand>(entity).Requests;
                     }
                     else
                     {
-                        var data = new Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandRequests.FirstCommand
+                        var data = new global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandRequests.FirstCommand
                         {
                             CommandListHandle = ReferenceTypeProviders.FirstCommandRequestsProvider.Allocate(world)
                         };
@@ -61,13 +61,13 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     }
 
                     List<FirstCommand.ReceivedResponse> responses;
-                    if (entityManager.HasComponent<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponses.FirstCommand>(response.SendingEntity))
+                    if (entityManager.HasComponent<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponses.FirstCommand>(response.SendingEntity))
                     {
-                        responses = entityManager.GetComponentData<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponses.FirstCommand>(response.SendingEntity).Responses;
+                        responses = entityManager.GetComponentData<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponses.FirstCommand>(response.SendingEntity).Responses;
                     }
                     else
                     {
-                        var data = new Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponses.FirstCommand
+                        var data = new global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponses.FirstCommand
                         {
                             CommandListHandle = ReferenceTypeProviders.FirstCommandResponsesProvider.Allocate(world)
                         };
@@ -99,16 +99,16 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     ? entityManager.GetComponentData<SpatialEntityId>(entity).EntityId
                     : new EntityId(0);
 
-                var commandSender = new Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandSenders.FirstCommand();
-                commandSender.CommandListHandle = Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstCommandSenderProvider.Allocate(world);
-                commandSender.RequestsToSend = new List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Request>();
+                var commandSender = new global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandSenders.FirstCommand();
+                commandSender.CommandListHandle = global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstCommandSenderProvider.Allocate(world);
+                commandSender.RequestsToSend = new List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Request>();
 
                 entityManager.AddComponentData(entity, commandSender);
 
-                var commandResponder = new Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponders.FirstCommand();
+                var commandResponder = new global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponders.FirstCommand();
                 commandResponder.CommandListHandle =
-                    Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstCommandResponderProvider.Allocate(world);
-                commandResponder.ResponsesToSend = new List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Response>();
+                    global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstCommandResponderProvider.Allocate(world);
+                commandResponder.ResponsesToSend = new List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.FirstCommand.Response>();
 
                 entityManager.AddComponentData(entity, commandResponder);
 
@@ -159,13 +159,13 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     }
 
                     List<SecondCommand.ReceivedRequest> requests;
-                    if (entityManager.HasComponent<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandRequests.SecondCommand>(entity))
+                    if (entityManager.HasComponent<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandRequests.SecondCommand>(entity))
                     {
-                        requests = entityManager.GetComponentData<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandRequests.SecondCommand>(entity).Requests;
+                        requests = entityManager.GetComponentData<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandRequests.SecondCommand>(entity).Requests;
                     }
                     else
                     {
-                        var data = new Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandRequests.SecondCommand
+                        var data = new global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandRequests.SecondCommand
                         {
                             CommandListHandle = ReferenceTypeProviders.SecondCommandRequestsProvider.Allocate(world)
                         };
@@ -190,13 +190,13 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     }
 
                     List<SecondCommand.ReceivedResponse> responses;
-                    if (entityManager.HasComponent<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponses.SecondCommand>(response.SendingEntity))
+                    if (entityManager.HasComponent<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponses.SecondCommand>(response.SendingEntity))
                     {
-                        responses = entityManager.GetComponentData<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponses.SecondCommand>(response.SendingEntity).Responses;
+                        responses = entityManager.GetComponentData<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponses.SecondCommand>(response.SendingEntity).Responses;
                     }
                     else
                     {
-                        var data = new Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponses.SecondCommand
+                        var data = new global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponses.SecondCommand
                         {
                             CommandListHandle = ReferenceTypeProviders.SecondCommandResponsesProvider.Allocate(world)
                         };
@@ -228,16 +228,16 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     ? entityManager.GetComponentData<SpatialEntityId>(entity).EntityId
                     : new EntityId(0);
 
-                var commandSender = new Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandSenders.SecondCommand();
-                commandSender.CommandListHandle = Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondCommandSenderProvider.Allocate(world);
-                commandSender.RequestsToSend = new List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Request>();
+                var commandSender = new global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandSenders.SecondCommand();
+                commandSender.CommandListHandle = global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondCommandSenderProvider.Allocate(world);
+                commandSender.RequestsToSend = new List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Request>();
 
                 entityManager.AddComponentData(entity, commandSender);
 
-                var commandResponder = new Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponders.SecondCommand();
+                var commandResponder = new global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponders.SecondCommand();
                 commandResponder.CommandListHandle =
-                    Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondCommandResponderProvider.Allocate(world);
-                commandResponder.ResponsesToSend = new List<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Response>();
+                    global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondCommandResponderProvider.Allocate(world);
+                commandResponder.ResponsesToSend = new List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.SecondCommand.Response>();
 
                 entityManager.AddComponentData(entity, commandResponder);
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentReactiveComponents.cs
@@ -28,9 +28,9 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     }
 
                     List<Update> updates;
-                    if (entityManager.HasComponent<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReceivedUpdates>(entity))
+                    if (entityManager.HasComponent<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReceivedUpdates>(entity))
                     {
-                        updates = entityManager.GetComponentData<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReceivedUpdates>(entity).Updates;
+                        updates = entityManager.GetComponentData<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReceivedUpdates>(entity).Updates;
                     }
                     else
                     {
@@ -49,7 +49,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
             public void Clean(World world)
             {
-                BlittableComponent.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
+                global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
             }
         }
 
@@ -214,7 +214,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
             public void Clean(World world)
             {
-                BlittableComponent.ReferenceTypeProviders.FirstEventProvider.CleanDataInWorld(world);
+                global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.FirstEventProvider.CleanDataInWorld(world);
             }
         }
 
@@ -284,7 +284,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
             public void Clean(World world)
             {
-                BlittableComponent.ReferenceTypeProviders.SecondEventProvider.CleanDataInWorld(world);
+                global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.SecondEventProvider.CleanDataInWorld(world);
             }
         }
 
@@ -298,7 +298,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     workerSystem.TryGetEntity(entityId, out var entity);
                     entityManager.AddComponent(entity,
-                        ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>());
+                        ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>());
                 }
 
                 for (int i = 0; i < authorityChanges.Count; ++i)
@@ -322,39 +322,39 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 switch (authority)
                 {
                     case Authority.Authoritative:
-                        if (!entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entity))
+                        if (!entityManager.HasComponent<NotAuthoritative<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.Authoritative, Authority.NotAuthoritative, entityId);
                             return;
                         }
 
-                        entityManager.RemoveComponent<NotAuthoritative<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>());
+                        entityManager.RemoveComponent<NotAuthoritative<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>());
 
                         break;
                     case Authority.AuthorityLossImminent:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.AuthorityLossImminent, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>());
                         break;
                     case Authority.NotAuthoritative:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.NotAuthoritative, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        if (entityManager.HasComponent<AuthorityLossImminent<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entity))
+                        if (entityManager.HasComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entity))
                         {
-                            entityManager.RemoveComponent<AuthorityLossImminent<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entity);
+                            entityManager.RemoveComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entity);
                         }
 
-                        entityManager.RemoveComponent<Authoritative<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>());
+                        entityManager.RemoveComponent<Authoritative<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>());
                         break;
                 }
             }
@@ -367,7 +367,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 //     .WithField(LoggingUtils.EntityId, entityId.Id)
                 //     .WithField("New Authority", newAuthority)
                 //     .WithField("Expected Old Authority", expectedOldAuthority)
-                //     .WithField("Component", "Improbable.Gdk.Tests.BlittableTypes.BlittableComponent")
+                //     .WithField("Component", "global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent")
                 // );
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentReactiveHandlers.cs
@@ -40,8 +40,8 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     All = new[]
                     {
-                        ComponentType.Create<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandSenders.FirstCommand>(),
-                        ComponentType.Create<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponders.FirstCommand>(),
+                        ComponentType.Create<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandSenders.FirstCommand>(),
+                        ComponentType.Create<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponders.FirstCommand>(),
                     },
                     Any = Array.Empty<ComponentType>(),
                     None = Array.Empty<ComponentType>(),
@@ -50,8 +50,8 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     All = new[]
                     {
-                        ComponentType.Create<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandSenders.SecondCommand>(),
-                        ComponentType.Create<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponders.SecondCommand>(),
+                        ComponentType.Create<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandSenders.SecondCommand>(),
+                        ComponentType.Create<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponders.SecondCommand>(),
                     },
                     Any = Array.Empty<ComponentType>(),
                     None = Array.Empty<ComponentType>(),
@@ -94,10 +94,10 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             {
                 Profiler.BeginSample("BlittableComponent");
                 var entityType = system.GetArchetypeChunkEntityType();
-                var senderTypeFirstCommand = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandSenders.FirstCommand>(true);
-                var responderTypeFirstCommand = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponders.FirstCommand>(true);
-                var senderTypeSecondCommand = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandSenders.SecondCommand>(true);
-                var responderTypeSecondCommand = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponders.SecondCommand>(true);
+                var senderTypeFirstCommand = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandSenders.FirstCommand>(true);
+                var responderTypeFirstCommand = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponders.FirstCommand>(true);
+                var senderTypeSecondCommand = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandSenders.SecondCommand>(true);
+                var responderTypeSecondCommand = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponders.SecondCommand>(true);
 
                 foreach (var chunk in chunkArray)
                 {
@@ -181,10 +181,10 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 All = Array.Empty<ComponentType>(),
                 Any = new ComponentType[]
                 {
-                    ComponentType.Create<ComponentAdded<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(),
-                    ComponentType.Create<ComponentRemoved<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReceivedUpdates>(),
-                    ComponentType.Create<AuthorityChanges<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(),
+                    ComponentType.Create<ComponentAdded<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(),
+                    ComponentType.Create<ComponentRemoved<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReceivedUpdates>(),
+                    ComponentType.Create<AuthorityChanges<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(),
                     ComponentType.Create<ReceivedEvents.FirstEvent>(),
                     ComponentType.Create<ReceivedEvents.SecondEvent>(),
                     ComponentType.Create<CommandRequests.FirstCommand>(),
@@ -199,10 +199,10 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 EntityCommandBuffer buffer)
             {
                 var entityType = system.GetArchetypeChunkEntityType();
-                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>();
-                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>();
-                var receivedUpdateType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReceivedUpdates>();
-                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>();
+                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>();
+                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>();
+                var receivedUpdateType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReceivedUpdates>();
+                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>();
                 var firstEventEventType = system.GetArchetypeChunkComponentType<ReceivedEvents.FirstEvent>();
                 var secondEventEventType = system.GetArchetypeChunkComponentType<ReceivedEvents.SecondEvent>();
 
@@ -222,12 +222,12 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                         var updateArray = chunk.GetNativeArray(receivedUpdateType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReceivedUpdates>(entities[i]);
+                            buffer.RemoveComponent<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReceivedUpdates>(entities[i]);
                             var updateList = updateArray[i].Updates;
 
                             // Pool update lists to avoid excessive allocation
                             updateList.Clear();
-                            Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update.Pool.Push(updateList);
+                            global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update.Pool.Push(updateList);
 
                             ReferenceTypeProviders.UpdatesProvider.Free(updateArray[i].handle);
                         }
@@ -238,7 +238,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentAdded<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentAdded<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entities[i]);
                         }
                     }
 
@@ -247,7 +247,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentRemoved<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentRemoved<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entities[i]);
                         }
                     }
 
@@ -257,7 +257,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                         var authorityChangeArray = chunk.GetNativeArray(authorityChangeType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<AuthorityChanges<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entities[i]);
+                            buffer.RemoveComponent<AuthorityChanges<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entities[i]);
                             AuthorityChangesProvider.Free(authorityChangeArray[i].Handle);
                         }
                     }
@@ -334,7 +334,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             {
                 All = new ComponentType[]
                 {
-                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(),
+                    ComponentType.ReadOnly<AuthorityLossImminent<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -344,7 +344,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             public override void AcknowledgeAuthorityLoss(NativeArray<ArchetypeChunk> chunkArray, ComponentSystemBase system,
                 ComponentUpdateSystem updateSystem)
             {
-                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>();
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>();
                 var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
 
                 foreach (var chunk in chunkArray)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentUpdateSender.cs
@@ -24,8 +24,8 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             {
                 All = new[]
                 {
-                    ComponentType.Create<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ComponentAuthority>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ComponentAuthority>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -41,7 +41,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 Profiler.BeginSample("BlittableComponent");
 
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>();
+                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>();
 
                 var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFields.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFields.cs
@@ -120,61 +120,61 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
         public static class Serialization
         {
-            public static void SerializeComponent(Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static void SerializeComponent(global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
             }
 
-            public static void SerializeSnapshot(Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static void SerializeSnapshot(global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
             {
             }
 
-            public static Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
-                var component = new Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component();
+                var component = new global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component();
 
                 return component;
             }
 
-            public static Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
-                var update = new Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update();
+                var update = new global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update();
                 var obj = updateObj.GetFields();
 
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
+            public static global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
             {
-                var update = new Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update();
+                var update = new global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update();
                 var obj = data.GetFields();
 
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
             {
-                var component = new Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Snapshot();
+                var component = new global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Snapshot();
 
                 return component;
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component component)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component component)
             {
                 var obj = updateObj.GetFields();
 
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Snapshot snapshot)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Snapshot snapshot)
             {
                 var obj = updateObj.GetFields();
 
@@ -192,7 +192,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             internal uint handle;
             public global::System.Collections.Generic.List<Update> Updates
             {
-                get => Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+                get => global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsComponentDiffDeserializer.cs
@@ -18,7 +18,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                var update = global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
                 diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsEcsViewManager.cs
@@ -83,7 +83,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             {
                 workerSystem.TryGetEntity(entityId, out var entity);
 
-                var component = new Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component();
+                var component = new global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component();
 
                 component.MarkDataClean();
                 entityManager.AddSharedComponentData(entity, ComponentAuthority.NotAuthoritative);
@@ -95,7 +95,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 workerSystem.TryGetEntity(entityId, out var entity);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
-                entityManager.RemoveComponent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>(entity);
+                entityManager.RemoveComponent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>(entity);
             }
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsProviders.cs
@@ -15,7 +15,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
         {
             public static class UpdatesProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -24,13 +24,13 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -40,7 +40,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsReactiveComponents.cs
@@ -28,9 +28,9 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     }
 
                     List<Update> updates;
-                    if (entityManager.HasComponent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.ReceivedUpdates>(entity))
+                    if (entityManager.HasComponent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.ReceivedUpdates>(entity))
                     {
-                        updates = entityManager.GetComponentData<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.ReceivedUpdates>(entity).Updates;
+                        updates = entityManager.GetComponentData<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.ReceivedUpdates>(entity).Updates;
                     }
                     else
                     {
@@ -49,7 +49,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public void Clean(World world)
             {
-                ComponentWithNoFields.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
+                global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
             }
         }
 
@@ -158,7 +158,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 {
                     workerSystem.TryGetEntity(entityId, out var entity);
                     entityManager.AddComponent(entity,
-                        ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>());
+                        ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>());
                 }
 
                 for (int i = 0; i < authorityChanges.Count; ++i)
@@ -182,39 +182,39 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 switch (authority)
                 {
                     case Authority.Authoritative:
-                        if (!entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entity))
+                        if (!entityManager.HasComponent<NotAuthoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.Authoritative, Authority.NotAuthoritative, entityId);
                             return;
                         }
 
-                        entityManager.RemoveComponent<NotAuthoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>());
+                        entityManager.RemoveComponent<NotAuthoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>());
 
                         break;
                     case Authority.AuthorityLossImminent:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.AuthorityLossImminent, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>());
                         break;
                     case Authority.NotAuthoritative:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.NotAuthoritative, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        if (entityManager.HasComponent<AuthorityLossImminent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entity))
+                        if (entityManager.HasComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entity))
                         {
-                            entityManager.RemoveComponent<AuthorityLossImminent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entity);
+                            entityManager.RemoveComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entity);
                         }
 
-                        entityManager.RemoveComponent<Authoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>());
+                        entityManager.RemoveComponent<Authoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>());
                         break;
                 }
             }
@@ -227,7 +227,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 //     .WithField(LoggingUtils.EntityId, entityId.Id)
                 //     .WithField("New Authority", newAuthority)
                 //     .WithField("Expected Old Authority", expectedOldAuthority)
-                //     .WithField("Component", "Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields")
+                //     .WithField("Component", "global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields")
                 // );
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsReactiveHandlers.cs
@@ -52,10 +52,10 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 All = Array.Empty<ComponentType>(),
                 Any = new ComponentType[]
                 {
-                    ComponentType.Create<ComponentAdded<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(),
-                    ComponentType.Create<ComponentRemoved<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.ReceivedUpdates>(),
-                    ComponentType.Create<AuthorityChanges<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(),
+                    ComponentType.Create<ComponentAdded<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(),
+                    ComponentType.Create<ComponentRemoved<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.ReceivedUpdates>(),
+                    ComponentType.Create<AuthorityChanges<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(),
                 },
                 None = Array.Empty<ComponentType>(),
             };
@@ -64,10 +64,10 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 EntityCommandBuffer buffer)
             {
                 var entityType = system.GetArchetypeChunkEntityType();
-                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>();
-                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>();
-                var receivedUpdateType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.ReceivedUpdates>();
-                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>();
+                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>();
+                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>();
+                var receivedUpdateType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.ReceivedUpdates>();
+                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>();
 
                 foreach (var chunk in chunkArray)
                 {
@@ -79,12 +79,12 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                         var updateArray = chunk.GetNativeArray(receivedUpdateType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.ReceivedUpdates>(entities[i]);
+                            buffer.RemoveComponent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.ReceivedUpdates>(entities[i]);
                             var updateList = updateArray[i].Updates;
 
                             // Pool update lists to avoid excessive allocation
                             updateList.Clear();
-                            Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update.Pool.Push(updateList);
+                            global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update.Pool.Push(updateList);
 
                             ReferenceTypeProviders.UpdatesProvider.Free(updateArray[i].handle);
                         }
@@ -95,7 +95,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentAdded<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentAdded<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entities[i]);
                         }
                     }
 
@@ -104,7 +104,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentRemoved<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentRemoved<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entities[i]);
                         }
                     }
 
@@ -114,7 +114,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                         var authorityChangeArray = chunk.GetNativeArray(authorityChangeType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<AuthorityChanges<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entities[i]);
+                            buffer.RemoveComponent<AuthorityChanges<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entities[i]);
                             AuthorityChangesProvider.Free(authorityChangeArray[i].Handle);
                         }
                     }
@@ -129,7 +129,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             {
                 All = new ComponentType[]
                 {
-                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(),
+                    ComponentType.ReadOnly<AuthorityLossImminent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -139,7 +139,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             public override void AcknowledgeAuthorityLoss(NativeArray<ArchetypeChunk> chunkArray, ComponentSystemBase system,
                 ComponentUpdateSystem updateSystem)
             {
-                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>();
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>();
                 var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
 
                 foreach (var chunk in chunkArray)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsUpdateSender.cs
@@ -24,8 +24,8 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             {
                 All = new[]
                 {
-                    ComponentType.Create<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.ComponentAuthority>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.ComponentAuthority>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -41,7 +41,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 Profiler.BeginSample("ComponentWithNoFields");
 
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>();
+                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>();
 
                 var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommands.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommands.cs
@@ -120,61 +120,61 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
         public static class Serialization
         {
-            public static void SerializeComponent(Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static void SerializeComponent(global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
             }
 
-            public static void SerializeSnapshot(Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static void SerializeSnapshot(global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
             {
             }
 
-            public static Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
-                var component = new Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component();
+                var component = new global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component();
 
                 return component;
             }
 
-            public static Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
-                var update = new Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update();
+                var update = new global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update();
                 var obj = updateObj.GetFields();
 
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
+            public static global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
             {
-                var update = new Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update();
+                var update = new global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update();
                 var obj = data.GetFields();
 
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
             {
-                var component = new Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Snapshot();
+                var component = new global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Snapshot();
 
                 return component;
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component component)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component component)
             {
                 var obj = updateObj.GetFields();
 
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Snapshot snapshot)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Snapshot snapshot)
             {
                 var obj = updateObj.GetFields();
 
@@ -192,7 +192,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             internal uint handle;
             public global::System.Collections.Generic.List<Update> Updates
             {
-                get => Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+                get => global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsCommandComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsCommandComponents.cs
@@ -15,10 +15,10 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             public struct Cmd : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Request> RequestsToSend
+                public List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Request> RequestsToSend
                 {
-                    get => Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.CmdSenderProvider.Get(CommandListHandle);
-                    set => Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.CmdSenderProvider.Set(CommandListHandle, value);
+                    get => global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.CmdSenderProvider.Get(CommandListHandle);
+                    set => global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.CmdSenderProvider.Set(CommandListHandle, value);
                 }
             }
         }
@@ -28,10 +28,10 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             public struct Cmd : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedRequest> Requests
+                public List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedRequest> Requests
                 {
-                    get => Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.CmdRequestsProvider.Get(CommandListHandle);
-                    set => Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.CmdRequestsProvider.Set(CommandListHandle, value);
+                    get => global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.CmdRequestsProvider.Get(CommandListHandle);
+                    set => global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.CmdRequestsProvider.Set(CommandListHandle, value);
                 }
             }
         }
@@ -41,10 +41,10 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             public struct Cmd : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Response> ResponsesToSend
+                public List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Response> ResponsesToSend
                 {
-                    get => Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.CmdResponderProvider.Get(CommandListHandle);
-                    set => Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.CmdResponderProvider.Set(CommandListHandle, value);
+                    get => global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.CmdResponderProvider.Get(CommandListHandle);
+                    set => global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.CmdResponderProvider.Set(CommandListHandle, value);
                 }
             }
         }
@@ -54,10 +54,10 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             public struct Cmd : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedResponse> Responses
+                public List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedResponse> Responses
                 {
-                    get => Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.CmdResponsesProvider.Get(CommandListHandle);
-                    set => Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.CmdResponsesProvider.Set(CommandListHandle, value);
+                    get => global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.CmdResponsesProvider.Get(CommandListHandle);
+                    set => global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.CmdResponsesProvider.Set(CommandListHandle, value);
                 }
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsCommandSenderReceiver.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsCommandSenderReceiver.cs
@@ -270,19 +270,19 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             IsValid = true;
         }
 
-        public void SendCmdCommand(EntityId targetEntityId, global::Improbable.Gdk.Tests.ComponentsWithNoFields.Empty request, Action<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedResponse> callback = null)
+        public void SendCmdCommand(EntityId targetEntityId, global::Improbable.Gdk.Tests.ComponentsWithNoFields.Empty request, Action<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedResponse> callback = null)
         {
             var commandRequest = new ComponentWithNoFieldsWithCommands.Cmd.Request(targetEntityId, request);
             SendCmdCommand(commandRequest, callback);
         }
 
-        public void SendCmdCommand(ComponentWithNoFieldsWithCommands.Cmd.Request request, Action<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedResponse> callback = null)
+        public void SendCmdCommand(global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Request request, Action<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedResponse> callback = null)
         {
             int validCallbackEpoch = callbackEpoch;
             var requestId = commandSender.SendCommand(request, entity);
             if (callback != null)
             {
-                Action<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedResponse> wrappedCallback = response =>
+                Action<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedResponse> wrappedCallback = response =>
                 {
                     if (!this.IsValid || validCallbackEpoch != this.callbackEpoch)
                     {
@@ -309,15 +309,15 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
         private readonly CommandCallbackSystem callbackSystem;
         private readonly CommandSystem commandSystem;
 
-        private Dictionary<Action<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedRequest>, ulong> cmdCallbackToCallbackKey;
+        private Dictionary<Action<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedRequest>, ulong> cmdCallbackToCallbackKey;
 
-        public event Action<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedRequest> OnCmdRequestReceived
+        public event Action<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedRequest> OnCmdRequestReceived
         {
             add
             {
                 if (cmdCallbackToCallbackKey == null)
                 {
-                    cmdCallbackToCallbackKey = new Dictionary<Action<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedRequest>, ulong>();
+                    cmdCallbackToCallbackKey = new Dictionary<Action<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedRequest>, ulong>();
                 }
 
                 var key = callbackSystem.RegisterCommandRequestCallback(entityId, value);
@@ -345,19 +345,19 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             IsValid = true;
         }
 
-        public void SendCmdResponse(Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Response response)
+        public void SendCmdResponse(global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Response response)
         {
             commandSystem.SendResponse(response);
         }
 
         public void SendCmdResponse(long requestId, global::Improbable.Gdk.Tests.ComponentsWithNoFields.Empty response)
         {
-            commandSystem.SendResponse(new Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Response(requestId, response));
+            commandSystem.SendResponse(new global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Response(requestId, response));
         }
 
         public void SendCmdFailure(long requestId, string failureMessage)
         {
-            commandSystem.SendResponse(new Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Response(requestId, failureMessage));
+            commandSystem.SendResponse(new global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Response(requestId, failureMessage));
         }
 
         public void RemoveAllCallbacks()

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsComponentDiffDeserializer.cs
@@ -18,7 +18,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                var update = global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
                 diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsEcsViewManager.cs
@@ -83,7 +83,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             {
                 workerSystem.TryGetEntity(entityId, out var entity);
 
-                var component = new Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component();
+                var component = new global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component();
 
                 component.MarkDataClean();
                 entityManager.AddSharedComponentData(entity, ComponentAuthority.NotAuthoritative);
@@ -95,7 +95,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 workerSystem.TryGetEntity(entityId, out var entity);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
-                entityManager.RemoveComponent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>(entity);
+                entityManager.RemoveComponent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>(entity);
             }
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsProviders.cs
@@ -15,7 +15,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
         {
             public static class UpdatesProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -24,13 +24,13 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -40,7 +40,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {
@@ -82,7 +82,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public static class CmdSenderProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Request>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Request>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Request>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Request>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -91,13 +91,13 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Request>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Request>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Request> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Request> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -107,7 +107,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Request> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Request> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {
@@ -148,7 +148,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             
             public static class CmdRequestsProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedRequest>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedRequest>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedRequest>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedRequest>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -157,13 +157,13 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedRequest>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedRequest>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedRequest> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedRequest> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -173,7 +173,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedRequest> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedRequest> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {
@@ -214,7 +214,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             
             public static class CmdResponderProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Response>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Response>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Response>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Response>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -223,13 +223,13 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Response>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Response>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Response> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Response> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -239,7 +239,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Response> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Response> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {
@@ -280,7 +280,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             
             public static class CmdResponsesProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedResponse>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedResponse>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedResponse>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedResponse>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -289,13 +289,13 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedResponse>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedResponse>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedResponse> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedResponse> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -305,7 +305,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedResponse> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.ReceivedResponse> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsReactiveCommandComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsReactiveCommandComponents.cs
@@ -30,13 +30,13 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     }
 
                     List<Cmd.ReceivedRequest> requests;
-                    if (entityManager.HasComponent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandRequests.Cmd>(entity))
+                    if (entityManager.HasComponent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandRequests.Cmd>(entity))
                     {
-                        requests = entityManager.GetComponentData<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandRequests.Cmd>(entity).Requests;
+                        requests = entityManager.GetComponentData<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandRequests.Cmd>(entity).Requests;
                     }
                     else
                     {
-                        var data = new Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandRequests.Cmd
+                        var data = new global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandRequests.Cmd
                         {
                             CommandListHandle = ReferenceTypeProviders.CmdRequestsProvider.Allocate(world)
                         };
@@ -61,13 +61,13 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     }
 
                     List<Cmd.ReceivedResponse> responses;
-                    if (entityManager.HasComponent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandResponses.Cmd>(response.SendingEntity))
+                    if (entityManager.HasComponent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandResponses.Cmd>(response.SendingEntity))
                     {
-                        responses = entityManager.GetComponentData<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandResponses.Cmd>(response.SendingEntity).Responses;
+                        responses = entityManager.GetComponentData<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandResponses.Cmd>(response.SendingEntity).Responses;
                     }
                     else
                     {
-                        var data = new Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandResponses.Cmd
+                        var data = new global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandResponses.Cmd
                         {
                             CommandListHandle = ReferenceTypeProviders.CmdResponsesProvider.Allocate(world)
                         };
@@ -99,16 +99,16 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     ? entityManager.GetComponentData<SpatialEntityId>(entity).EntityId
                     : new EntityId(0);
 
-                var commandSender = new Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandSenders.Cmd();
-                commandSender.CommandListHandle = Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.CmdSenderProvider.Allocate(world);
-                commandSender.RequestsToSend = new List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Request>();
+                var commandSender = new global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandSenders.Cmd();
+                commandSender.CommandListHandle = global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.CmdSenderProvider.Allocate(world);
+                commandSender.RequestsToSend = new List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Request>();
 
                 entityManager.AddComponentData(entity, commandSender);
 
-                var commandResponder = new Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandResponders.Cmd();
+                var commandResponder = new global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandResponders.Cmd();
                 commandResponder.CommandListHandle =
-                    Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.CmdResponderProvider.Allocate(world);
-                commandResponder.ResponsesToSend = new List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Response>();
+                    global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.CmdResponderProvider.Allocate(world);
+                commandResponder.ResponsesToSend = new List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Cmd.Response>();
 
                 entityManager.AddComponentData(entity, commandResponder);
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsReactiveComponents.cs
@@ -28,9 +28,9 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     }
 
                     List<Update> updates;
-                    if (entityManager.HasComponent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReceivedUpdates>(entity))
+                    if (entityManager.HasComponent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReceivedUpdates>(entity))
                     {
-                        updates = entityManager.GetComponentData<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReceivedUpdates>(entity).Updates;
+                        updates = entityManager.GetComponentData<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReceivedUpdates>(entity).Updates;
                     }
                     else
                     {
@@ -49,7 +49,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public void Clean(World world)
             {
-                ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
+                global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
             }
         }
 
@@ -158,7 +158,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 {
                     workerSystem.TryGetEntity(entityId, out var entity);
                     entityManager.AddComponent(entity,
-                        ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>());
+                        ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>());
                 }
 
                 for (int i = 0; i < authorityChanges.Count; ++i)
@@ -182,39 +182,39 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 switch (authority)
                 {
                     case Authority.Authoritative:
-                        if (!entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entity))
+                        if (!entityManager.HasComponent<NotAuthoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.Authoritative, Authority.NotAuthoritative, entityId);
                             return;
                         }
 
-                        entityManager.RemoveComponent<NotAuthoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>());
+                        entityManager.RemoveComponent<NotAuthoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>());
 
                         break;
                     case Authority.AuthorityLossImminent:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.AuthorityLossImminent, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>());
                         break;
                     case Authority.NotAuthoritative:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.NotAuthoritative, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        if (entityManager.HasComponent<AuthorityLossImminent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entity))
+                        if (entityManager.HasComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entity))
                         {
-                            entityManager.RemoveComponent<AuthorityLossImminent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entity);
+                            entityManager.RemoveComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entity);
                         }
 
-                        entityManager.RemoveComponent<Authoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>());
+                        entityManager.RemoveComponent<Authoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>());
                         break;
                 }
             }
@@ -227,7 +227,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 //     .WithField(LoggingUtils.EntityId, entityId.Id)
                 //     .WithField("New Authority", newAuthority)
                 //     .WithField("Expected Old Authority", expectedOldAuthority)
-                //     .WithField("Component", "Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands")
+                //     .WithField("Component", "global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands")
                 // );
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsReactiveHandlers.cs
@@ -38,8 +38,8 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 {
                     All = new[]
                     {
-                        ComponentType.Create<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandSenders.Cmd>(),
-                        ComponentType.Create<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandResponders.Cmd>(),
+                        ComponentType.Create<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandSenders.Cmd>(),
+                        ComponentType.Create<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandResponders.Cmd>(),
                     },
                     Any = Array.Empty<ComponentType>(),
                     None = Array.Empty<ComponentType>(),
@@ -54,8 +54,8 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             {
                 Profiler.BeginSample("ComponentWithNoFieldsWithCommands");
                 var entityType = system.GetArchetypeChunkEntityType();
-                var senderTypeCmd = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandSenders.Cmd>(true);
-                var responderTypeCmd = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandResponders.Cmd>(true);
+                var senderTypeCmd = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandSenders.Cmd>(true);
+                var responderTypeCmd = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandResponders.Cmd>(true);
 
                 foreach (var chunk in chunkArray)
                 {
@@ -106,10 +106,10 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 All = Array.Empty<ComponentType>(),
                 Any = new ComponentType[]
                 {
-                    ComponentType.Create<ComponentAdded<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(),
-                    ComponentType.Create<ComponentRemoved<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReceivedUpdates>(),
-                    ComponentType.Create<AuthorityChanges<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(),
+                    ComponentType.Create<ComponentAdded<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(),
+                    ComponentType.Create<ComponentRemoved<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReceivedUpdates>(),
+                    ComponentType.Create<AuthorityChanges<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(),
                     ComponentType.Create<CommandRequests.Cmd>(),
                     ComponentType.Create<CommandResponses.Cmd>(),
                 },
@@ -120,10 +120,10 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 EntityCommandBuffer buffer)
             {
                 var entityType = system.GetArchetypeChunkEntityType();
-                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>();
-                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>();
-                var receivedUpdateType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReceivedUpdates>();
-                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>();
+                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>();
+                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>();
+                var receivedUpdateType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReceivedUpdates>();
+                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>();
 
                 var cmdRequestType = system.GetArchetypeChunkComponentType<CommandRequests.Cmd>();
                 var cmdResponseType = system.GetArchetypeChunkComponentType<CommandResponses.Cmd>();
@@ -138,12 +138,12 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                         var updateArray = chunk.GetNativeArray(receivedUpdateType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReceivedUpdates>(entities[i]);
+                            buffer.RemoveComponent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReceivedUpdates>(entities[i]);
                             var updateList = updateArray[i].Updates;
 
                             // Pool update lists to avoid excessive allocation
                             updateList.Clear();
-                            Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update.Pool.Push(updateList);
+                            global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update.Pool.Push(updateList);
 
                             ReferenceTypeProviders.UpdatesProvider.Free(updateArray[i].handle);
                         }
@@ -154,7 +154,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentAdded<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentAdded<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entities[i]);
                         }
                     }
 
@@ -163,7 +163,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentRemoved<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentRemoved<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entities[i]);
                         }
                     }
 
@@ -173,7 +173,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                         var authorityChangeArray = chunk.GetNativeArray(authorityChangeType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<AuthorityChanges<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entities[i]);
+                            buffer.RemoveComponent<AuthorityChanges<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entities[i]);
                             AuthorityChangesProvider.Free(authorityChangeArray[i].Handle);
                         }
                     }
@@ -208,7 +208,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             {
                 All = new ComponentType[]
                 {
-                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(),
+                    ComponentType.ReadOnly<AuthorityLossImminent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -218,7 +218,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             public override void AcknowledgeAuthorityLoss(NativeArray<ArchetypeChunk> chunkArray, ComponentSystemBase system,
                 ComponentUpdateSystem updateSystem)
             {
-                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>();
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>();
                 var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
 
                 foreach (var chunk in chunkArray)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsUpdateSender.cs
@@ -24,8 +24,8 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             {
                 All = new[]
                 {
-                    ComponentType.Create<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ComponentAuthority>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ComponentAuthority>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -41,7 +41,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 Profiler.BeginSample("ComponentWithNoFieldsWithCommands");
 
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>();
+                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>();
 
                 var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEvents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEvents.cs
@@ -120,61 +120,61 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
         public static class Serialization
         {
-            public static void SerializeComponent(Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static void SerializeComponent(global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
             }
 
-            public static void SerializeSnapshot(Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static void SerializeSnapshot(global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
             {
             }
 
-            public static Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
-                var component = new Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component();
+                var component = new global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component();
 
                 return component;
             }
 
-            public static Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
-                var update = new Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update();
+                var update = new global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update();
                 var obj = updateObj.GetFields();
 
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
+            public static global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
             {
-                var update = new Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update();
+                var update = new global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update();
                 var obj = data.GetFields();
 
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
             {
-                var component = new Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Snapshot();
+                var component = new global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Snapshot();
 
                 return component;
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component component)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component component)
             {
                 var obj = updateObj.GetFields();
 
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Snapshot snapshot)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Snapshot snapshot)
             {
                 var obj = updateObj.GetFields();
 
@@ -192,7 +192,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             internal uint handle;
             public global::System.Collections.Generic.List<Update> Updates
             {
-                get => Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+                get => global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsComponentDiffDeserializer.cs
@@ -18,7 +18,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                var update = global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
                 diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
                 var eventsObject = op.Update.SchemaData.Value.GetEvents();
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsEcsViewManager.cs
@@ -83,7 +83,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             {
                 workerSystem.TryGetEntity(entityId, out var entity);
 
-                var component = new Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component();
+                var component = new global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component();
 
                 component.MarkDataClean();
                 entityManager.AddSharedComponentData(entity, ComponentAuthority.NotAuthoritative);
@@ -95,7 +95,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 workerSystem.TryGetEntity(entityId, out var entity);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
-                entityManager.RemoveComponent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>(entity);
+                entityManager.RemoveComponent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>(entity);
             }
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsEvents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsEvents.cs
@@ -34,8 +34,8 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
                 public List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.Empty> Events
                 {
-                    get => Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReferenceTypeProviders.EvtProvider.Get(handle);
-                    internal set => Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReferenceTypeProviders.EvtProvider.Set(handle, value);
+                    get => global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReferenceTypeProviders.EvtProvider.Get(handle);
+                    internal set => global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReferenceTypeProviders.EvtProvider.Set(handle, value);
                 }
             }
 
@@ -49,8 +49,8 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
                 public List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.Empty> Events
                 {
-                    get => Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReferenceTypeProviders.EvtProvider.Get(handle);
-                    internal set => Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReferenceTypeProviders.EvtProvider.Set(handle, value);
+                    get => global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReferenceTypeProviders.EvtProvider.Get(handle);
+                    internal set => global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReferenceTypeProviders.EvtProvider.Set(handle, value);
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsProviders.cs
@@ -15,7 +15,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
         {
             public static class UpdatesProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -24,13 +24,13 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -40,7 +40,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsReactiveComponents.cs
@@ -28,9 +28,9 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     }
 
                     List<Update> updates;
-                    if (entityManager.HasComponent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReceivedUpdates>(entity))
+                    if (entityManager.HasComponent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReceivedUpdates>(entity))
                     {
-                        updates = entityManager.GetComponentData<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReceivedUpdates>(entity).Updates;
+                        updates = entityManager.GetComponentData<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReceivedUpdates>(entity).Updates;
                     }
                     else
                     {
@@ -49,7 +49,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public void Clean(World world)
             {
-                ComponentWithNoFieldsWithEvents.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
+                global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
             }
         }
 
@@ -214,7 +214,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public void Clean(World world)
             {
-                ComponentWithNoFieldsWithEvents.ReferenceTypeProviders.EvtProvider.CleanDataInWorld(world);
+                global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReferenceTypeProviders.EvtProvider.CleanDataInWorld(world);
             }
         }
 
@@ -228,7 +228,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 {
                     workerSystem.TryGetEntity(entityId, out var entity);
                     entityManager.AddComponent(entity,
-                        ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>());
+                        ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>());
                 }
 
                 for (int i = 0; i < authorityChanges.Count; ++i)
@@ -252,39 +252,39 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 switch (authority)
                 {
                     case Authority.Authoritative:
-                        if (!entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entity))
+                        if (!entityManager.HasComponent<NotAuthoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.Authoritative, Authority.NotAuthoritative, entityId);
                             return;
                         }
 
-                        entityManager.RemoveComponent<NotAuthoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>());
+                        entityManager.RemoveComponent<NotAuthoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>());
 
                         break;
                     case Authority.AuthorityLossImminent:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.AuthorityLossImminent, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>());
                         break;
                     case Authority.NotAuthoritative:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.NotAuthoritative, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        if (entityManager.HasComponent<AuthorityLossImminent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entity))
+                        if (entityManager.HasComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entity))
                         {
-                            entityManager.RemoveComponent<AuthorityLossImminent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entity);
+                            entityManager.RemoveComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entity);
                         }
 
-                        entityManager.RemoveComponent<Authoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>());
+                        entityManager.RemoveComponent<Authoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>());
                         break;
                 }
             }
@@ -297,7 +297,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 //     .WithField(LoggingUtils.EntityId, entityId.Id)
                 //     .WithField("New Authority", newAuthority)
                 //     .WithField("Expected Old Authority", expectedOldAuthority)
-                //     .WithField("Component", "Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents")
+                //     .WithField("Component", "global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents")
                 // );
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsReactiveHandlers.cs
@@ -73,10 +73,10 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 All = Array.Empty<ComponentType>(),
                 Any = new ComponentType[]
                 {
-                    ComponentType.Create<ComponentAdded<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(),
-                    ComponentType.Create<ComponentRemoved<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReceivedUpdates>(),
-                    ComponentType.Create<AuthorityChanges<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(),
+                    ComponentType.Create<ComponentAdded<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(),
+                    ComponentType.Create<ComponentRemoved<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReceivedUpdates>(),
+                    ComponentType.Create<AuthorityChanges<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(),
                     ComponentType.Create<ReceivedEvents.Evt>(),
                 },
                 None = Array.Empty<ComponentType>(),
@@ -86,10 +86,10 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 EntityCommandBuffer buffer)
             {
                 var entityType = system.GetArchetypeChunkEntityType();
-                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>();
-                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>();
-                var receivedUpdateType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReceivedUpdates>();
-                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>();
+                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>();
+                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>();
+                var receivedUpdateType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReceivedUpdates>();
+                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>();
                 var evtEventType = system.GetArchetypeChunkComponentType<ReceivedEvents.Evt>();
 
                 foreach (var chunk in chunkArray)
@@ -102,12 +102,12 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                         var updateArray = chunk.GetNativeArray(receivedUpdateType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReceivedUpdates>(entities[i]);
+                            buffer.RemoveComponent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReceivedUpdates>(entities[i]);
                             var updateList = updateArray[i].Updates;
 
                             // Pool update lists to avoid excessive allocation
                             updateList.Clear();
-                            Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update.Pool.Push(updateList);
+                            global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update.Pool.Push(updateList);
 
                             ReferenceTypeProviders.UpdatesProvider.Free(updateArray[i].handle);
                         }
@@ -118,7 +118,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentAdded<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentAdded<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entities[i]);
                         }
                     }
 
@@ -127,7 +127,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentRemoved<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentRemoved<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entities[i]);
                         }
                     }
 
@@ -137,7 +137,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                         var authorityChangeArray = chunk.GetNativeArray(authorityChangeType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<AuthorityChanges<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entities[i]);
+                            buffer.RemoveComponent<AuthorityChanges<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entities[i]);
                             AuthorityChangesProvider.Free(authorityChangeArray[i].Handle);
                         }
                     }
@@ -163,7 +163,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             {
                 All = new ComponentType[]
                 {
-                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(),
+                    ComponentType.ReadOnly<AuthorityLossImminent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -173,7 +173,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             public override void AcknowledgeAuthorityLoss(NativeArray<ArchetypeChunk> chunkArray, ComponentSystemBase system,
                 ComponentUpdateSystem updateSystem)
             {
-                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>();
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>();
                 var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
 
                 foreach (var chunk in chunkArray)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsUpdateSender.cs
@@ -24,8 +24,8 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             {
                 All = new[]
                 {
-                    ComponentType.Create<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ComponentAuthority>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ComponentAuthority>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -41,7 +41,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 Profiler.BeginSample("ComponentWithNoFieldsWithEvents");
 
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>();
+                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>();
 
                 var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponent.cs
@@ -287,7 +287,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
         public static class Serialization
         {
-            public static void SerializeComponent(Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static void SerializeComponent(global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component component, global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
                 {
                     obj.AddBool(1, component.BoolField);
@@ -332,7 +332,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 }
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component component, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
                 {
@@ -435,7 +435,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 }
             }
 
-            public static void SerializeUpdate(Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static void SerializeUpdate(global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update update, global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
                 var obj = updateObj.GetFields();
                 {
@@ -538,7 +538,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 }
             }
 
-            public static void SerializeSnapshot(Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static void SerializeSnapshot(global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Snapshot snapshot, global::Improbable.Worker.CInterop.SchemaObject obj)
             {
                 {
                     obj.AddBool(1, snapshot.BoolField);
@@ -583,9 +583,9 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 }
             }
 
-            public static Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
+            public static global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj, global::Unity.Entities.World world)
             {
-                var component = new Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component();
+                var component = new global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component();
 
                 {
                     component.BoolField = obj.GetBool(1);
@@ -642,9 +642,9 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 return component;
             }
 
-            public static Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
+            public static global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj)
             {
-                var update = new Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update();
+                var update = new global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update();
                 var obj = updateObj.GetFields();
 
                 var clearedFields = updateObj.GetClearedFields();
@@ -767,9 +767,9 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
+            public static global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update DeserializeUpdate(global::Improbable.Worker.CInterop.SchemaComponentData data)
             {
-                var update = new Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update();
+                var update = new global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update();
                 var obj = data.GetFields();
 
                 {
@@ -835,9 +835,9 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 return update;
             }
 
-            public static Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
+            public static global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Snapshot DeserializeSnapshot(global::Improbable.Worker.CInterop.SchemaObject obj)
             {
-                var component = new Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Snapshot();
+                var component = new global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Snapshot();
 
                 {
                     component.BoolField = obj.GetBool(1);
@@ -899,7 +899,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 return component;
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component component)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component component)
             {
                 var obj = updateObj.GetFields();
 
@@ -1022,7 +1022,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 }
             }
 
-            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Snapshot snapshot)
+            public static void ApplyUpdate(global::Improbable.Worker.CInterop.SchemaComponentUpdate updateObj, ref global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Snapshot snapshot)
             {
                 var obj = updateObj.GetFields();
 
@@ -1166,7 +1166,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             internal uint handle;
             public global::System.Collections.Generic.List<Update> Updates
             {
-                get => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+                get => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentCommandComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentCommandComponents.cs
@@ -15,19 +15,19 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             public struct FirstCommand : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Request> RequestsToSend
+                public List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Request> RequestsToSend
                 {
-                    get => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstCommandSenderProvider.Get(CommandListHandle);
-                    set => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstCommandSenderProvider.Set(CommandListHandle, value);
+                    get => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstCommandSenderProvider.Get(CommandListHandle);
+                    set => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstCommandSenderProvider.Set(CommandListHandle, value);
                 }
             }
             public struct SecondCommand : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Request> RequestsToSend
+                public List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Request> RequestsToSend
                 {
-                    get => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondCommandSenderProvider.Get(CommandListHandle);
-                    set => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondCommandSenderProvider.Set(CommandListHandle, value);
+                    get => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondCommandSenderProvider.Get(CommandListHandle);
+                    set => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondCommandSenderProvider.Set(CommandListHandle, value);
                 }
             }
         }
@@ -37,19 +37,19 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             public struct FirstCommand : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedRequest> Requests
+                public List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedRequest> Requests
                 {
-                    get => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstCommandRequestsProvider.Get(CommandListHandle);
-                    set => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstCommandRequestsProvider.Set(CommandListHandle, value);
+                    get => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstCommandRequestsProvider.Get(CommandListHandle);
+                    set => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstCommandRequestsProvider.Set(CommandListHandle, value);
                 }
             }
             public struct SecondCommand : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedRequest> Requests
+                public List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedRequest> Requests
                 {
-                    get => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondCommandRequestsProvider.Get(CommandListHandle);
-                    set => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondCommandRequestsProvider.Set(CommandListHandle, value);
+                    get => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondCommandRequestsProvider.Get(CommandListHandle);
+                    set => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondCommandRequestsProvider.Set(CommandListHandle, value);
                 }
             }
         }
@@ -59,19 +59,19 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             public struct FirstCommand : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Response> ResponsesToSend
+                public List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Response> ResponsesToSend
                 {
-                    get => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstCommandResponderProvider.Get(CommandListHandle);
-                    set => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstCommandResponderProvider.Set(CommandListHandle, value);
+                    get => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstCommandResponderProvider.Get(CommandListHandle);
+                    set => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstCommandResponderProvider.Set(CommandListHandle, value);
                 }
             }
             public struct SecondCommand : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Response> ResponsesToSend
+                public List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Response> ResponsesToSend
                 {
-                    get => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondCommandResponderProvider.Get(CommandListHandle);
-                    set => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondCommandResponderProvider.Set(CommandListHandle, value);
+                    get => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondCommandResponderProvider.Get(CommandListHandle);
+                    set => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondCommandResponderProvider.Set(CommandListHandle, value);
                 }
             }
         }
@@ -81,19 +81,19 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             public struct FirstCommand : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedResponse> Responses
+                public List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedResponse> Responses
                 {
-                    get => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstCommandResponsesProvider.Get(CommandListHandle);
-                    set => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstCommandResponsesProvider.Set(CommandListHandle, value);
+                    get => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstCommandResponsesProvider.Get(CommandListHandle);
+                    set => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstCommandResponsesProvider.Set(CommandListHandle, value);
                 }
             }
             public struct SecondCommand : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedResponse> Responses
+                public List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedResponse> Responses
                 {
-                    get => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondCommandResponsesProvider.Get(CommandListHandle);
-                    set => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondCommandResponsesProvider.Set(CommandListHandle, value);
+                    get => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondCommandResponsesProvider.Get(CommandListHandle);
+                    set => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondCommandResponsesProvider.Set(CommandListHandle, value);
                 }
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentCommandSenderReceiver.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentCommandSenderReceiver.cs
@@ -270,19 +270,19 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             IsValid = true;
         }
 
-        public void SendFirstCommandCommand(EntityId targetEntityId, global::Improbable.Gdk.Tests.NonblittableTypes.FirstCommandRequest request, Action<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedResponse> callback = null)
+        public void SendFirstCommandCommand(EntityId targetEntityId, global::Improbable.Gdk.Tests.NonblittableTypes.FirstCommandRequest request, Action<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedResponse> callback = null)
         {
             var commandRequest = new NonBlittableComponent.FirstCommand.Request(targetEntityId, request);
             SendFirstCommandCommand(commandRequest, callback);
         }
 
-        public void SendFirstCommandCommand(NonBlittableComponent.FirstCommand.Request request, Action<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedResponse> callback = null)
+        public void SendFirstCommandCommand(global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Request request, Action<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedResponse> callback = null)
         {
             int validCallbackEpoch = callbackEpoch;
             var requestId = commandSender.SendCommand(request, entity);
             if (callback != null)
             {
-                Action<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedResponse> wrappedCallback = response =>
+                Action<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedResponse> wrappedCallback = response =>
                 {
                     if (!this.IsValid || validCallbackEpoch != this.callbackEpoch)
                     {
@@ -294,19 +294,19 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 callbackSystem.RegisterCommandResponseCallback(requestId, wrappedCallback);
             }
         }
-        public void SendSecondCommandCommand(EntityId targetEntityId, global::Improbable.Gdk.Tests.NonblittableTypes.SecondCommandRequest request, Action<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedResponse> callback = null)
+        public void SendSecondCommandCommand(EntityId targetEntityId, global::Improbable.Gdk.Tests.NonblittableTypes.SecondCommandRequest request, Action<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedResponse> callback = null)
         {
             var commandRequest = new NonBlittableComponent.SecondCommand.Request(targetEntityId, request);
             SendSecondCommandCommand(commandRequest, callback);
         }
 
-        public void SendSecondCommandCommand(NonBlittableComponent.SecondCommand.Request request, Action<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedResponse> callback = null)
+        public void SendSecondCommandCommand(global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Request request, Action<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedResponse> callback = null)
         {
             int validCallbackEpoch = callbackEpoch;
             var requestId = commandSender.SendCommand(request, entity);
             if (callback != null)
             {
-                Action<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedResponse> wrappedCallback = response =>
+                Action<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedResponse> wrappedCallback = response =>
                 {
                     if (!this.IsValid || validCallbackEpoch != this.callbackEpoch)
                     {
@@ -333,15 +333,15 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
         private readonly CommandCallbackSystem callbackSystem;
         private readonly CommandSystem commandSystem;
 
-        private Dictionary<Action<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedRequest>, ulong> firstCommandCallbackToCallbackKey;
+        private Dictionary<Action<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedRequest>, ulong> firstCommandCallbackToCallbackKey;
 
-        public event Action<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedRequest> OnFirstCommandRequestReceived
+        public event Action<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedRequest> OnFirstCommandRequestReceived
         {
             add
             {
                 if (firstCommandCallbackToCallbackKey == null)
                 {
-                    firstCommandCallbackToCallbackKey = new Dictionary<Action<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedRequest>, ulong>();
+                    firstCommandCallbackToCallbackKey = new Dictionary<Action<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedRequest>, ulong>();
                 }
 
                 var key = callbackSystem.RegisterCommandRequestCallback(entityId, value);
@@ -358,15 +358,15 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 firstCommandCallbackToCallbackKey.Remove(value);
             }
         }
-        private Dictionary<Action<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedRequest>, ulong> secondCommandCallbackToCallbackKey;
+        private Dictionary<Action<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedRequest>, ulong> secondCommandCallbackToCallbackKey;
 
-        public event Action<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedRequest> OnSecondCommandRequestReceived
+        public event Action<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedRequest> OnSecondCommandRequestReceived
         {
             add
             {
                 if (secondCommandCallbackToCallbackKey == null)
                 {
-                    secondCommandCallbackToCallbackKey = new Dictionary<Action<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedRequest>, ulong>();
+                    secondCommandCallbackToCallbackKey = new Dictionary<Action<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedRequest>, ulong>();
                 }
 
                 var key = callbackSystem.RegisterCommandRequestCallback(entityId, value);
@@ -394,34 +394,34 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             IsValid = true;
         }
 
-        public void SendFirstCommandResponse(Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Response response)
+        public void SendFirstCommandResponse(global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Response response)
         {
             commandSystem.SendResponse(response);
         }
 
         public void SendFirstCommandResponse(long requestId, global::Improbable.Gdk.Tests.NonblittableTypes.FirstCommandResponse response)
         {
-            commandSystem.SendResponse(new Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Response(requestId, response));
+            commandSystem.SendResponse(new global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Response(requestId, response));
         }
 
         public void SendFirstCommandFailure(long requestId, string failureMessage)
         {
-            commandSystem.SendResponse(new Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Response(requestId, failureMessage));
+            commandSystem.SendResponse(new global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Response(requestId, failureMessage));
         }
 
-        public void SendSecondCommandResponse(Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Response response)
+        public void SendSecondCommandResponse(global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Response response)
         {
             commandSystem.SendResponse(response);
         }
 
         public void SendSecondCommandResponse(long requestId, global::Improbable.Gdk.Tests.NonblittableTypes.SecondCommandResponse response)
         {
-            commandSystem.SendResponse(new Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Response(requestId, response));
+            commandSystem.SendResponse(new global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Response(requestId, response));
         }
 
         public void SendSecondCommandFailure(long requestId, string failureMessage)
         {
-            commandSystem.SendResponse(new Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Response(requestId, failureMessage));
+            commandSystem.SendResponse(new global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Response(requestId, failureMessage));
         }
 
         public void RemoveAllCallbacks()

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentComponentDiffDeserializer.cs
@@ -18,7 +18,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                var update = global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
                 diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
                 var eventsObject = op.Update.SchemaData.Value.GetEvents();
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentEcsViewManager.cs
@@ -87,7 +87,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             {
                 workerSystem.TryGetEntity(entityId, out var entity);
 
-                var component = new Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component();
+                var component = new global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component();
 
                 component.stringFieldHandle = Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.StringFieldProvider.Allocate(world);
                 component.optionalFieldHandle = Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.OptionalFieldProvider.Allocate(world);
@@ -103,13 +103,13 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 workerSystem.TryGetEntity(entityId, out var entity);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
-                var data = entityManager.GetComponentData<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>(entity);
+                var data = entityManager.GetComponentData<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>(entity);
                 NonBlittableComponent.ReferenceTypeProviders.StringFieldProvider.Free(data.stringFieldHandle);
                 NonBlittableComponent.ReferenceTypeProviders.OptionalFieldProvider.Free(data.optionalFieldHandle);
                 NonBlittableComponent.ReferenceTypeProviders.ListFieldProvider.Free(data.listFieldHandle);
                 NonBlittableComponent.ReferenceTypeProviders.MapFieldProvider.Free(data.mapFieldHandle);
 
-                entityManager.RemoveComponent<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>(entity);
+                entityManager.RemoveComponent<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>(entity);
             }
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentEvents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentEvents.cs
@@ -47,8 +47,8 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
                 public List<global::Improbable.Gdk.Tests.NonblittableTypes.FirstEventPayload> Events
                 {
-                    get => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstEventProvider.Get(handle);
-                    internal set => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstEventProvider.Set(handle, value);
+                    get => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstEventProvider.Get(handle);
+                    internal set => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstEventProvider.Set(handle, value);
                 }
             }
 
@@ -58,8 +58,8 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
                 public List<global::Improbable.Gdk.Tests.NonblittableTypes.SecondEventPayload> Events
                 {
-                    get => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondEventProvider.Get(handle);
-                    internal set => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondEventProvider.Set(handle, value);
+                    get => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondEventProvider.Get(handle);
+                    internal set => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondEventProvider.Set(handle, value);
                 }
             }
 
@@ -73,8 +73,8 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
                 public List<global::Improbable.Gdk.Tests.NonblittableTypes.FirstEventPayload> Events
                 {
-                    get => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstEventProvider.Get(handle);
-                    internal set => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstEventProvider.Set(handle, value);
+                    get => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstEventProvider.Get(handle);
+                    internal set => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstEventProvider.Set(handle, value);
                 }
             }
 
@@ -84,8 +84,8 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
                 public List<global::Improbable.Gdk.Tests.NonblittableTypes.SecondEventPayload> Events
                 {
-                    get => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondEventProvider.Get(handle);
-                    internal set => Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondEventProvider.Set(handle, value);
+                    get => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondEventProvider.Get(handle);
+                    internal set => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondEventProvider.Set(handle, value);
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentProviders.cs
@@ -15,7 +15,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
         {
             public static class UpdatesProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -24,13 +24,13 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -40,7 +40,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {
@@ -482,7 +482,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             
             public static class FirstCommandSenderProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Request>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Request>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Request>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Request>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -491,13 +491,13 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Request>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Request>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Request> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Request> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -507,7 +507,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Request> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Request> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {
@@ -548,7 +548,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             
             public static class FirstCommandRequestsProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedRequest>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedRequest>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedRequest>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedRequest>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -557,13 +557,13 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedRequest>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedRequest>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedRequest> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedRequest> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -573,7 +573,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedRequest> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedRequest> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {
@@ -614,7 +614,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             
             public static class FirstCommandResponderProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Response>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Response>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Response>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Response>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -623,13 +623,13 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Response>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Response>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Response> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Response> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -639,7 +639,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Response> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Response> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {
@@ -680,7 +680,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             
             public static class FirstCommandResponsesProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedResponse>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedResponse>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedResponse>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedResponse>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -689,13 +689,13 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedResponse>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedResponse>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedResponse> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedResponse> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -705,7 +705,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedResponse> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.ReceivedResponse> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {
@@ -747,7 +747,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
             public static class SecondCommandSenderProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Request>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Request>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Request>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Request>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -756,13 +756,13 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Request>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Request>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Request> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Request> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -772,7 +772,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Request> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Request> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {
@@ -813,7 +813,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             
             public static class SecondCommandRequestsProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedRequest>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedRequest>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedRequest>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedRequest>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -822,13 +822,13 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedRequest>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedRequest>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedRequest> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedRequest> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -838,7 +838,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedRequest> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedRequest> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {
@@ -879,7 +879,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             
             public static class SecondCommandResponderProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Response>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Response>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Response>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Response>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -888,13 +888,13 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Response>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Response>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Response> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Response> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -904,7 +904,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Response> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Response> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {
@@ -945,7 +945,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             
             public static class SecondCommandResponsesProvider 
             {
-                private static readonly Dictionary<uint, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedResponse>> Storage = new Dictionary<uint, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedResponse>>();
+                private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedResponse>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedResponse>>();
                 private static readonly Dictionary<uint, global::Unity.Entities.World> WorldMapping = new Dictionary<uint, Unity.Entities.World>();
             
                 private static uint nextHandle = 0;
@@ -954,13 +954,13 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     var handle = GetNextHandle();
             
-                    Storage.Add(handle, default(List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedResponse>));
+                    Storage.Add(handle, default(List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedResponse>));
                     WorldMapping.Add(handle, world);
             
                     return handle;
                 }
             
-                public static List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedResponse> Get(uint handle)
+                public static List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedResponse> Get(uint handle)
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
@@ -970,7 +970,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     return value;
                 }
             
-                public static void Set(uint handle, List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedResponse> value)
+                public static void Set(uint handle, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.ReceivedResponse> value)
                 {
                     if (!Storage.ContainsKey(handle))
                     {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentReactiveCommandComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentReactiveCommandComponents.cs
@@ -30,13 +30,13 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     }
 
                     List<FirstCommand.ReceivedRequest> requests;
-                    if (entityManager.HasComponent<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandRequests.FirstCommand>(entity))
+                    if (entityManager.HasComponent<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandRequests.FirstCommand>(entity))
                     {
-                        requests = entityManager.GetComponentData<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandRequests.FirstCommand>(entity).Requests;
+                        requests = entityManager.GetComponentData<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandRequests.FirstCommand>(entity).Requests;
                     }
                     else
                     {
-                        var data = new Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandRequests.FirstCommand
+                        var data = new global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandRequests.FirstCommand
                         {
                             CommandListHandle = ReferenceTypeProviders.FirstCommandRequestsProvider.Allocate(world)
                         };
@@ -61,13 +61,13 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     }
 
                     List<FirstCommand.ReceivedResponse> responses;
-                    if (entityManager.HasComponent<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponses.FirstCommand>(response.SendingEntity))
+                    if (entityManager.HasComponent<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponses.FirstCommand>(response.SendingEntity))
                     {
-                        responses = entityManager.GetComponentData<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponses.FirstCommand>(response.SendingEntity).Responses;
+                        responses = entityManager.GetComponentData<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponses.FirstCommand>(response.SendingEntity).Responses;
                     }
                     else
                     {
-                        var data = new Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponses.FirstCommand
+                        var data = new global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponses.FirstCommand
                         {
                             CommandListHandle = ReferenceTypeProviders.FirstCommandResponsesProvider.Allocate(world)
                         };
@@ -99,16 +99,16 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     ? entityManager.GetComponentData<SpatialEntityId>(entity).EntityId
                     : new EntityId(0);
 
-                var commandSender = new Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandSenders.FirstCommand();
-                commandSender.CommandListHandle = Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstCommandSenderProvider.Allocate(world);
-                commandSender.RequestsToSend = new List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Request>();
+                var commandSender = new global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandSenders.FirstCommand();
+                commandSender.CommandListHandle = global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstCommandSenderProvider.Allocate(world);
+                commandSender.RequestsToSend = new List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Request>();
 
                 entityManager.AddComponentData(entity, commandSender);
 
-                var commandResponder = new Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponders.FirstCommand();
+                var commandResponder = new global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponders.FirstCommand();
                 commandResponder.CommandListHandle =
-                    Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstCommandResponderProvider.Allocate(world);
-                commandResponder.ResponsesToSend = new List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Response>();
+                    global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstCommandResponderProvider.Allocate(world);
+                commandResponder.ResponsesToSend = new List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.FirstCommand.Response>();
 
                 entityManager.AddComponentData(entity, commandResponder);
 
@@ -159,13 +159,13 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     }
 
                     List<SecondCommand.ReceivedRequest> requests;
-                    if (entityManager.HasComponent<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandRequests.SecondCommand>(entity))
+                    if (entityManager.HasComponent<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandRequests.SecondCommand>(entity))
                     {
-                        requests = entityManager.GetComponentData<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandRequests.SecondCommand>(entity).Requests;
+                        requests = entityManager.GetComponentData<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandRequests.SecondCommand>(entity).Requests;
                     }
                     else
                     {
-                        var data = new Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandRequests.SecondCommand
+                        var data = new global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandRequests.SecondCommand
                         {
                             CommandListHandle = ReferenceTypeProviders.SecondCommandRequestsProvider.Allocate(world)
                         };
@@ -190,13 +190,13 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     }
 
                     List<SecondCommand.ReceivedResponse> responses;
-                    if (entityManager.HasComponent<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponses.SecondCommand>(response.SendingEntity))
+                    if (entityManager.HasComponent<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponses.SecondCommand>(response.SendingEntity))
                     {
-                        responses = entityManager.GetComponentData<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponses.SecondCommand>(response.SendingEntity).Responses;
+                        responses = entityManager.GetComponentData<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponses.SecondCommand>(response.SendingEntity).Responses;
                     }
                     else
                     {
-                        var data = new Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponses.SecondCommand
+                        var data = new global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponses.SecondCommand
                         {
                             CommandListHandle = ReferenceTypeProviders.SecondCommandResponsesProvider.Allocate(world)
                         };
@@ -228,16 +228,16 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     ? entityManager.GetComponentData<SpatialEntityId>(entity).EntityId
                     : new EntityId(0);
 
-                var commandSender = new Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandSenders.SecondCommand();
-                commandSender.CommandListHandle = Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondCommandSenderProvider.Allocate(world);
-                commandSender.RequestsToSend = new List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Request>();
+                var commandSender = new global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandSenders.SecondCommand();
+                commandSender.CommandListHandle = global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondCommandSenderProvider.Allocate(world);
+                commandSender.RequestsToSend = new List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Request>();
 
                 entityManager.AddComponentData(entity, commandSender);
 
-                var commandResponder = new Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponders.SecondCommand();
+                var commandResponder = new global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponders.SecondCommand();
                 commandResponder.CommandListHandle =
-                    Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondCommandResponderProvider.Allocate(world);
-                commandResponder.ResponsesToSend = new List<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Response>();
+                    global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondCommandResponderProvider.Allocate(world);
+                commandResponder.ResponsesToSend = new List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.SecondCommand.Response>();
 
                 entityManager.AddComponentData(entity, commandResponder);
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentReactiveComponents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentReactiveComponents.cs
@@ -28,9 +28,9 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     }
 
                     List<Update> updates;
-                    if (entityManager.HasComponent<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReceivedUpdates>(entity))
+                    if (entityManager.HasComponent<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReceivedUpdates>(entity))
                     {
-                        updates = entityManager.GetComponentData<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReceivedUpdates>(entity).Updates;
+                        updates = entityManager.GetComponentData<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReceivedUpdates>(entity).Updates;
                     }
                     else
                     {
@@ -49,7 +49,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
             public void Clean(World world)
             {
-                NonBlittableComponent.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
+                global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
             }
         }
 
@@ -214,7 +214,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
             public void Clean(World world)
             {
-                NonBlittableComponent.ReferenceTypeProviders.FirstEventProvider.CleanDataInWorld(world);
+                global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.FirstEventProvider.CleanDataInWorld(world);
             }
         }
 
@@ -284,7 +284,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
             public void Clean(World world)
             {
-                NonBlittableComponent.ReferenceTypeProviders.SecondEventProvider.CleanDataInWorld(world);
+                global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.SecondEventProvider.CleanDataInWorld(world);
             }
         }
 
@@ -298,7 +298,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     workerSystem.TryGetEntity(entityId, out var entity);
                     entityManager.AddComponent(entity,
-                        ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>());
+                        ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>());
                 }
 
                 for (int i = 0; i < authorityChanges.Count; ++i)
@@ -322,39 +322,39 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 switch (authority)
                 {
                     case Authority.Authoritative:
-                        if (!entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entity))
+                        if (!entityManager.HasComponent<NotAuthoritative<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.Authoritative, Authority.NotAuthoritative, entityId);
                             return;
                         }
 
-                        entityManager.RemoveComponent<NotAuthoritative<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>());
+                        entityManager.RemoveComponent<NotAuthoritative<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>());
 
                         break;
                     case Authority.AuthorityLossImminent:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.AuthorityLossImminent, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>());
                         break;
                     case Authority.NotAuthoritative:
-                        if (!entityManager.HasComponent<Authoritative<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entity))
+                        if (!entityManager.HasComponent<Authoritative<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entity))
                         {
                             LogInvalidAuthorityTransition(Authority.NotAuthoritative, Authority.Authoritative, entityId);
                             return;
                         }
 
-                        if (entityManager.HasComponent<AuthorityLossImminent<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entity))
+                        if (entityManager.HasComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entity))
                         {
-                            entityManager.RemoveComponent<AuthorityLossImminent<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entity);
+                            entityManager.RemoveComponent<AuthorityLossImminent<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entity);
                         }
 
-                        entityManager.RemoveComponent<Authoritative<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entity);
-                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>());
+                        entityManager.RemoveComponent<Authoritative<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entity);
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>());
                         break;
                 }
             }
@@ -367,7 +367,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 //     .WithField(LoggingUtils.EntityId, entityId.Id)
                 //     .WithField("New Authority", newAuthority)
                 //     .WithField("Expected Old Authority", expectedOldAuthority)
-                //     .WithField("Component", "Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent")
+                //     .WithField("Component", "global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent")
                 // );
             }
         }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentReactiveHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentReactiveHandlers.cs
@@ -40,8 +40,8 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     All = new[]
                     {
-                        ComponentType.Create<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandSenders.FirstCommand>(),
-                        ComponentType.Create<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponders.FirstCommand>(),
+                        ComponentType.Create<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandSenders.FirstCommand>(),
+                        ComponentType.Create<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponders.FirstCommand>(),
                     },
                     Any = Array.Empty<ComponentType>(),
                     None = Array.Empty<ComponentType>(),
@@ -50,8 +50,8 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     All = new[]
                     {
-                        ComponentType.Create<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandSenders.SecondCommand>(),
-                        ComponentType.Create<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponders.SecondCommand>(),
+                        ComponentType.Create<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandSenders.SecondCommand>(),
+                        ComponentType.Create<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponders.SecondCommand>(),
                     },
                     Any = Array.Empty<ComponentType>(),
                     None = Array.Empty<ComponentType>(),
@@ -94,10 +94,10 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             {
                 Profiler.BeginSample("NonBlittableComponent");
                 var entityType = system.GetArchetypeChunkEntityType();
-                var senderTypeFirstCommand = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandSenders.FirstCommand>(true);
-                var responderTypeFirstCommand = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponders.FirstCommand>(true);
-                var senderTypeSecondCommand = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandSenders.SecondCommand>(true);
-                var responderTypeSecondCommand = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponders.SecondCommand>(true);
+                var senderTypeFirstCommand = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandSenders.FirstCommand>(true);
+                var responderTypeFirstCommand = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponders.FirstCommand>(true);
+                var senderTypeSecondCommand = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandSenders.SecondCommand>(true);
+                var responderTypeSecondCommand = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponders.SecondCommand>(true);
 
                 foreach (var chunk in chunkArray)
                 {
@@ -181,10 +181,10 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 All = Array.Empty<ComponentType>(),
                 Any = new ComponentType[]
                 {
-                    ComponentType.Create<ComponentAdded<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(),
-                    ComponentType.Create<ComponentRemoved<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReceivedUpdates>(),
-                    ComponentType.Create<AuthorityChanges<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(),
+                    ComponentType.Create<ComponentAdded<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(),
+                    ComponentType.Create<ComponentRemoved<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReceivedUpdates>(),
+                    ComponentType.Create<AuthorityChanges<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(),
                     ComponentType.Create<ReceivedEvents.FirstEvent>(),
                     ComponentType.Create<ReceivedEvents.SecondEvent>(),
                     ComponentType.Create<CommandRequests.FirstCommand>(),
@@ -199,10 +199,10 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 EntityCommandBuffer buffer)
             {
                 var entityType = system.GetArchetypeChunkEntityType();
-                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>();
-                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>();
-                var receivedUpdateType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReceivedUpdates>();
-                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>();
+                var componentAddedType = system.GetArchetypeChunkComponentType<ComponentAdded<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>();
+                var componentRemovedType = system.GetArchetypeChunkComponentType<ComponentRemoved<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>();
+                var receivedUpdateType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReceivedUpdates>();
+                var authorityChangeType = system.GetArchetypeChunkComponentType<AuthorityChanges<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>();
                 var firstEventEventType = system.GetArchetypeChunkComponentType<ReceivedEvents.FirstEvent>();
                 var secondEventEventType = system.GetArchetypeChunkComponentType<ReceivedEvents.SecondEvent>();
 
@@ -222,12 +222,12 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                         var updateArray = chunk.GetNativeArray(receivedUpdateType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReceivedUpdates>(entities[i]);
+                            buffer.RemoveComponent<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReceivedUpdates>(entities[i]);
                             var updateList = updateArray[i].Updates;
 
                             // Pool update lists to avoid excessive allocation
                             updateList.Clear();
-                            Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update.Pool.Push(updateList);
+                            global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update.Pool.Push(updateList);
 
                             ReferenceTypeProviders.UpdatesProvider.Free(updateArray[i].handle);
                         }
@@ -238,7 +238,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentAdded<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentAdded<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entities[i]);
                         }
                     }
 
@@ -247,7 +247,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     {
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<ComponentRemoved<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entities[i]);
+                            buffer.RemoveComponent<ComponentRemoved<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entities[i]);
                         }
                     }
 
@@ -257,7 +257,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                         var authorityChangeArray = chunk.GetNativeArray(authorityChangeType);
                         for (int i = 0; i < entities.Length; ++i)
                         {
-                            buffer.RemoveComponent<AuthorityChanges<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entities[i]);
+                            buffer.RemoveComponent<AuthorityChanges<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entities[i]);
                             AuthorityChangesProvider.Free(authorityChangeArray[i].Handle);
                         }
                     }
@@ -334,7 +334,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             {
                 All = new ComponentType[]
                 {
-                    ComponentType.ReadOnly<AuthorityLossImminent<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(),
+                    ComponentType.ReadOnly<AuthorityLossImminent<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -344,7 +344,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             public override void AcknowledgeAuthorityLoss(NativeArray<ArchetypeChunk> chunkArray, ComponentSystemBase system,
                 ComponentUpdateSystem updateSystem)
             {
-                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>();
+                var authorityLossType = system.GetArchetypeChunkComponentType<AuthorityLossImminent<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>();
                 var spatialEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>();
 
                 foreach (var chunk in chunkArray)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentUpdateSender.cs
@@ -24,8 +24,8 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             {
                 All = new[]
                 {
-                    ComponentType.Create<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>(),
-                    ComponentType.Create<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ComponentAuthority>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>(),
+                    ComponentType.Create<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ComponentAuthority>(),
                     ComponentType.ReadOnly<SpatialEntityId>()
                 },
                 Any = Array.Empty<ComponentType>(),
@@ -41,7 +41,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 Profiler.BeginSample("NonBlittableComponent");
 
                 var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>();
+                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>();
 
                 var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ComponentDiffDeserializerGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ComponentDiffDeserializerGenerator.tt
@@ -5,7 +5,7 @@
     var componentDetails = GetComponentDetails();
     var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
     var eventDetailsList = GetEventDetailsList();
-    var componentNamespace = qualifiedNamespace + "." + componentDetails.ComponentName;
+    var componentNamespace = "global::" + qualifiedNamespace + "." + componentDetails.ComponentName;
 #>
 <#= generatedHeader #>
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ComponentDiffDeserializerGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ComponentDiffDeserializerGenerator.tt
@@ -5,7 +5,7 @@
     var componentDetails = GetComponentDetails();
     var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
     var eventDetailsList = GetEventDetailsList();
-    var componentNamespace = "global::" + qualifiedNamespace + "." + componentDetails.ComponentName;
+    var componentNamespace = $"global::{qualifiedNamespace}.{componentDetails.ComponentName}";
 #>
 <#= generatedHeader #>
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ReactiveCommandComponentGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ReactiveCommandComponentGenerator.tt
@@ -4,6 +4,7 @@
     var componentDetails = GetComponentDetails();
     var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
     var commandDetailsList = GetCommandDetailsList();
+    var componentNamespace = "global::"  + qualifiedNamespace + "." + componentDetails.ComponentName;
 #>
 <#= generatedHeader #>
 
@@ -27,8 +28,8 @@ namespace <#= qualifiedNamespace #>
         var responseType = command.CommandName + ".Response";
         var receivedResponseType = command.CommandName + ".ReceivedResponse";
 
-        var commandResponseBufferType = $"{qualifiedNamespace}.{componentDetails.ComponentName}.CommandResponses.{command.CommandName}";
-        var commandRequestBufferType = $"{qualifiedNamespace}.{componentDetails.ComponentName}.CommandRequests.{command.CommandName}";
+        var commandResponseBufferType = $"{componentNamespace}.CommandResponses.{command.CommandName}";
+        var commandRequestBufferType = $"{componentNamespace}.CommandRequests.{command.CommandName}";
 #>
         public class <#= command.CommandName #>ReactiveCommandComponentManager : IReactiveCommandComponentManager
         {
@@ -113,16 +114,16 @@ namespace <#= qualifiedNamespace #>
                     ? entityManager.GetComponentData<SpatialEntityId>(entity).EntityId
                     : new EntityId(0);
 
-                var commandSender = new <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.CommandSenders.<#= command.CommandName #>();
-                commandSender.CommandListHandle = <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= command.CommandName #>SenderProvider.Allocate(world);
-                commandSender.RequestsToSend = new List<<#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.<#= command.CommandName #>.Request>();
+                var commandSender = new <#= componentNamespace #>.CommandSenders.<#= command.CommandName #>();
+                commandSender.CommandListHandle = <#= componentNamespace #>.ReferenceTypeProviders.<#= command.CommandName #>SenderProvider.Allocate(world);
+                commandSender.RequestsToSend = new List<<#= componentNamespace #>.<#= command.CommandName #>.Request>();
 
                 entityManager.AddComponentData(entity, commandSender);
 
-                var commandResponder = new <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.CommandResponders.<#= command.CommandName #>();
+                var commandResponder = new <#= componentNamespace #>.CommandResponders.<#= command.CommandName #>();
                 commandResponder.CommandListHandle =
-                    <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= command.CommandName #>ResponderProvider.Allocate(world);
-                commandResponder.ResponsesToSend = new List<<#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.<#= command.CommandName #>.Response>();
+                    <#= componentNamespace #>.ReferenceTypeProviders.<#= command.CommandName #>ResponderProvider.Allocate(world);
+                commandResponder.ResponsesToSend = new List<<#= componentNamespace #>.<#= command.CommandName #>.Response>();
 
                 entityManager.AddComponentData(entity, commandResponder);
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ReactiveCommandComponentGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ReactiveCommandComponentGenerator.tt
@@ -4,7 +4,7 @@
     var componentDetails = GetComponentDetails();
     var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
     var commandDetailsList = GetCommandDetailsList();
-    var componentNamespace = "global::"  + qualifiedNamespace + "." + componentDetails.ComponentName;
+    var componentNamespace = $"global::{qualifiedNamespace}.{componentDetails.ComponentName}";
 #>
 <#= generatedHeader #>
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ReactiveComponentGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ReactiveComponentGenerator.tt
@@ -4,7 +4,7 @@
     var componentDetails = GetComponentDetails();
     var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
     var eventDetailsList = GetEventDetailsList();
-    var componentNamespace = "global::" + qualifiedNamespace + "." + componentDetails.ComponentName;
+    var componentNamespace = $"global::{qualifiedNamespace}.{componentDetails.ComponentName}";
 #>
 <#= generatedHeader #>
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ReactiveComponentGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ReactiveComponentGenerator.tt
@@ -4,7 +4,7 @@
     var componentDetails = GetComponentDetails();
     var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
     var eventDetailsList = GetEventDetailsList();
-    var componentNamespace = qualifiedNamespace + "." + componentDetails.ComponentName;
+    var componentNamespace = "global::" + qualifiedNamespace + "." + componentDetails.ComponentName;
 #>
 <#= generatedHeader #>
 
@@ -55,7 +55,7 @@ namespace <#= qualifiedNamespace #>
 
             public void Clean(World world)
             {
-                <#= componentDetails.ComponentName #>.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
+                <#= componentNamespace #>.ReferenceTypeProviders.UpdatesProvider.CleanDataInWorld(world);
             }
         }
 
@@ -224,7 +224,7 @@ namespace <#= qualifiedNamespace #>
 
             public void Clean(World world)
             {
-                <#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= ev.EventName #>Provider.CleanDataInWorld(world);
+                <#= componentNamespace #>.ReferenceTypeProviders.<#= ev.EventName #>Provider.CleanDataInWorld(world);
             }
         }
 <# } #>

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityCommandComponentsGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityCommandComponentsGenerator.tt
@@ -4,7 +4,7 @@
     var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
     var componentDetails = GetComponentDetails();
     var commandDetailsList = GetCommandDetailsList();
-    var componentNamespace = "global::" + qualifiedNamespace + "." + componentDetails.ComponentName;
+    var componentNamespace = $"global::{qualifiedNamespace}.{componentDetails.ComponentName}";
 #>
 <#= generatedHeader #>
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityCommandComponentsGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityCommandComponentsGenerator.tt
@@ -4,6 +4,7 @@
     var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
     var componentDetails = GetComponentDetails();
     var commandDetailsList = GetCommandDetailsList();
+    var componentNamespace = "global::" + qualifiedNamespace + "." + componentDetails.ComponentName;
 #>
 <#= generatedHeader #>
 
@@ -21,10 +22,10 @@ namespace <#= qualifiedNamespace #>
             public struct <#= command.CommandName #> : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<<#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.<#= command.CommandName #>.Request> RequestsToSend
+                public List<global::<#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.<#= command.CommandName #>.Request> RequestsToSend
                 {
-                    get => <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= command.CommandName #>SenderProvider.Get(CommandListHandle);
-                    set => <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= command.CommandName #>SenderProvider.Set(CommandListHandle, value);
+                    get => global::<#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= command.CommandName #>SenderProvider.Get(CommandListHandle);
+                    set => global::<#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= command.CommandName #>SenderProvider.Set(CommandListHandle, value);
                 }
             }
 <# } #>
@@ -36,10 +37,10 @@ namespace <#= qualifiedNamespace #>
             public struct <#= command.CommandName #> : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<<#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.<#= command.CommandName #>.ReceivedRequest> Requests
+                public List<<#= componentNamespace #>.<#= command.CommandName #>.ReceivedRequest> Requests
                 {
-                    get => <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= command.CommandName #>RequestsProvider.Get(CommandListHandle);
-                    set => <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= command.CommandName #>RequestsProvider.Set(CommandListHandle, value);
+                    get => <#= componentNamespace #>.ReferenceTypeProviders.<#= command.CommandName #>RequestsProvider.Get(CommandListHandle);
+                    set => <#= componentNamespace #>.ReferenceTypeProviders.<#= command.CommandName #>RequestsProvider.Set(CommandListHandle, value);
                 }
             }
 <# } #>
@@ -51,10 +52,10 @@ namespace <#= qualifiedNamespace #>
             public struct <#= command.CommandName #> : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<<#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.<#= command.CommandName #>.Response> ResponsesToSend
+                public List<<#= componentNamespace #>.<#= command.CommandName #>.Response> ResponsesToSend
                 {
-                    get => <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= command.CommandName #>ResponderProvider.Get(CommandListHandle);
-                    set => <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= command.CommandName #>ResponderProvider.Set(CommandListHandle, value);
+                    get => <#= componentNamespace #>.ReferenceTypeProviders.<#= command.CommandName #>ResponderProvider.Get(CommandListHandle);
+                    set => <#= componentNamespace #>.ReferenceTypeProviders.<#= command.CommandName #>ResponderProvider.Set(CommandListHandle, value);
                 }
             }
 <# } #>
@@ -66,10 +67,10 @@ namespace <#= qualifiedNamespace #>
             public struct <#= command.CommandName #> : IComponentData
             {
                 internal uint CommandListHandle;
-                public List<<#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.<#= command.CommandName #>.ReceivedResponse> Responses
+                public List<<#= componentNamespace #>.<#= command.CommandName #>.ReceivedResponse> Responses
                 {
-                    get => <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= command.CommandName #>ResponsesProvider.Get(CommandListHandle);
-                    set => <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= command.CommandName #>ResponsesProvider.Set(CommandListHandle, value);
+                    get => <#= componentNamespace #>.ReferenceTypeProviders.<#= command.CommandName #>ResponsesProvider.Get(CommandListHandle);
+                    set => <#= componentNamespace #>.ReferenceTypeProviders.<#= command.CommandName #>ResponsesProvider.Set(CommandListHandle, value);
                 }
             }
 <# } #>

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityCommandSenderReceiverGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityCommandSenderReceiverGenerator.tt
@@ -4,6 +4,7 @@
     var componentDetails = GetComponentDetails();
     var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
     var commandDetailsList = GetCommandDetailsList();
+    var componentNamespace = "global::" + qualifiedNamespace + "." + componentDetails.ComponentName;
 #>
 <#= generatedHeader #>
 
@@ -276,7 +277,7 @@ namespace <#= qualifiedNamespace #>
         }
 
 <# foreach (var commandDetails in commandDetailsList) {
-    var receivedCommandResponseType = $"{qualifiedNamespace}.{componentDetails.ComponentName}.{commandDetails.CommandName}.ReceivedResponse";
+    var receivedCommandResponseType = $"{componentNamespace}.{commandDetails.CommandName}.ReceivedResponse";
     var commandRequest = $"{componentDetails.ComponentName}.{commandDetails.CommandName}.Request";
 #>
         public void Send<#= commandDetails.CommandName #>Command(EntityId targetEntityId, <#= commandDetails.FqnRequestType #> request, Action<<#= receivedCommandResponseType #>> callback = null)
@@ -285,13 +286,13 @@ namespace <#= qualifiedNamespace #>
             Send<#= commandDetails.CommandName #>Command(commandRequest, callback);
         }
 
-        public void Send<#= commandDetails.CommandName #>Command(<#= commandRequest #> request, Action<<#= receivedCommandResponseType #>> callback = null)
+        public void Send<#= commandDetails.CommandName #>Command(<#= componentNamespace #>.<#= commandDetails.CommandName #>.Request request, Action<<#= componentNamespace #>.<#= commandDetails.CommandName #>.ReceivedResponse> callback = null)
         {
             int validCallbackEpoch = callbackEpoch;
             var requestId = commandSender.SendCommand(request, entity);
             if (callback != null)
             {
-                Action<<#= receivedCommandResponseType #>> wrappedCallback = response =>
+                Action<<#= componentNamespace #>.<#= commandDetails.CommandName #>.ReceivedResponse> wrappedCallback = response =>
                 {
                     if (!this.IsValid || validCallbackEpoch != this.callbackEpoch)
                     {
@@ -320,17 +321,17 @@ namespace <#= qualifiedNamespace #>
         private readonly CommandSystem commandSystem;
 
 <# foreach (var commandDetails in commandDetailsList) {
-    var receivedCommandRequestType = $"{qualifiedNamespace}.{componentDetails.ComponentName}.{commandDetails.CommandName}.ReceivedRequest";
+    var receivedCommandRequestType = $"{componentNamespace}.{commandDetails.CommandName}.ReceivedRequest";
 #>
-        private Dictionary<Action<<#= receivedCommandRequestType #>>, ulong> <#= commandDetails.CamelCaseCommandName #>CallbackToCallbackKey;
+        private Dictionary<Action<<#= componentNamespace #>.<#= commandDetails.CommandName #>.ReceivedRequest>, ulong> <#= commandDetails.CamelCaseCommandName #>CallbackToCallbackKey;
 
-        public event Action<<#= receivedCommandRequestType #>> On<#= commandDetails.CommandName #>RequestReceived
+        public event Action<<#= componentNamespace #>.<#= commandDetails.CommandName #>.ReceivedRequest> On<#= commandDetails.CommandName #>RequestReceived
         {
             add
             {
                 if (<#= commandDetails.CamelCaseCommandName #>CallbackToCallbackKey == null)
                 {
-                    <#= commandDetails.CamelCaseCommandName #>CallbackToCallbackKey = new Dictionary<Action<<#= receivedCommandRequestType #>>, ulong>();
+                    <#= commandDetails.CamelCaseCommandName #>CallbackToCallbackKey = new Dictionary<Action<<#= componentNamespace #>.<#= commandDetails.CommandName #>.ReceivedRequest>, ulong>();
                 }
 
                 var key = callbackSystem.RegisterCommandRequestCallback(entityId, value);
@@ -359,29 +360,29 @@ namespace <#= qualifiedNamespace #>
             IsValid = true;
         }
 <# foreach (var commandDetails in commandDetailsList) {
-    var commandResponseType = $"{qualifiedNamespace}.{componentDetails.ComponentName}.{commandDetails.CommandName}.Response";
+    var commandResponseType = $"{componentNamespace}.{commandDetails.CommandName}.Response";
 #>
 
-        public void Send<#= commandDetails.CommandName #>Response(<#= commandResponseType #> response)
+        public void Send<#= commandDetails.CommandName #>Response(<#= componentNamespace #>.<#= commandDetails.CommandName #>.Response response)
         {
             commandSystem.SendResponse(response);
         }
 
         public void Send<#= commandDetails.CommandName #>Response(long requestId, <#= commandDetails.FqnResponseType #> response)
         {
-            commandSystem.SendResponse(new <#= commandResponseType #>(requestId, response));
+            commandSystem.SendResponse(new <#= componentNamespace #>.<#= commandDetails.CommandName #>.Response(requestId, response));
         }
 
         public void Send<#= commandDetails.CommandName #>Failure(long requestId, string failureMessage)
         {
-            commandSystem.SendResponse(new <#= commandResponseType #>(requestId, failureMessage));
+            commandSystem.SendResponse(new <#= componentNamespace #>.<#= commandDetails.CommandName #>.Response(requestId, failureMessage));
         }
 <# } #>
 
         public void RemoveAllCallbacks()
         {
 <# foreach (var commandDetails in commandDetailsList) {
-    var receivedCommandRequestType = $"{qualifiedNamespace}.{componentDetails.ComponentName}.{commandDetails.CommandName}.ReceivedRequest";
+    var receivedCommandRequestType = $"{componentNamespace}.{commandDetails.CommandName}.ReceivedRequest";
 #>
             if (<#= commandDetails.CamelCaseCommandName #>CallbackToCallbackKey != null)
             {

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityCommandSenderReceiverGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityCommandSenderReceiverGenerator.tt
@@ -4,7 +4,7 @@
     var componentDetails = GetComponentDetails();
     var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
     var commandDetailsList = GetCommandDetailsList();
-    var componentNamespace = "global::" + qualifiedNamespace + "." + componentDetails.ComponentName;
+    var componentNamespace = $"global::{qualifiedNamespace}.{componentDetails.ComponentName}";
 #>
 <#= generatedHeader #>
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
@@ -4,7 +4,7 @@
     var fieldDetailsList = GetFieldDetailsList();
     var componentDetails = GetComponentDetails();
     var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
-    var componentNamespace = qualifiedNamespace + "." + componentDetails.ComponentName;
+    var componentNamespace = "global::" + qualifiedNamespace + "." + componentDetails.ComponentName;
 #>
 <#= generatedHeader #>
 
@@ -374,7 +374,7 @@ var fieldDetails = fieldDetailsList[i]; #>
             internal uint handle;
             public global::System.Collections.Generic.List<Update> Updates
             {
-                get => <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.UpdatesProvider.Get(handle);
+                get => <#= componentNamespace #>.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
@@ -4,7 +4,7 @@
     var fieldDetailsList = GetFieldDetailsList();
     var componentDetails = GetComponentDetails();
     var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
-    var componentNamespace = "global::" + qualifiedNamespace + "." + componentDetails.ComponentName;
+    var componentNamespace = $"global::{qualifiedNamespace}.{componentDetails.ComponentName}";
 #>
 <#= generatedHeader #>
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentSenderGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentSenderGenerator.tt
@@ -4,7 +4,7 @@
     var componentDetails = GetComponentDetails();
     var fieldDetailsList = GetFieldDetailsList();
     var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
-    var componentNamespace = "global::" + qualifiedNamespace + "." + componentDetails.ComponentName;
+    var componentNamespace = $"global::{qualifiedNamespace}.{componentDetails.ComponentName}";
     var profilingStart = $"Profiler.BeginSample(\"{componentDetails.ComponentName}\");";
     var profilingEnd = "Profiler.EndSample();";
 #>

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentSenderGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentSenderGenerator.tt
@@ -4,7 +4,7 @@
     var componentDetails = GetComponentDetails();
     var fieldDetailsList = GetFieldDetailsList();
     var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
-    var componentNamespace = qualifiedNamespace + "." + componentDetails.ComponentName;
+    var componentNamespace = "global::" + qualifiedNamespace + "." + componentDetails.ComponentName;
     var profilingStart = $"Profiler.BeginSample(\"{componentDetails.ComponentName}\");";
     var profilingEnd = "Profiler.EndSample();";
 #>

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityEcsViewManagerGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityEcsViewManagerGenerator.tt
@@ -5,7 +5,7 @@
     var componentDetails = GetComponentDetails();
     var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
     var eventDetailsList = GetEventDetailsList();
-    var componentNamespace = qualifiedNamespace + "." + componentDetails.ComponentName;
+    var componentNamespace = "global::" + qualifiedNamespace + "." + componentDetails.ComponentName;
 #>
 <#= generatedHeader #>
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityEcsViewManagerGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityEcsViewManagerGenerator.tt
@@ -5,7 +5,7 @@
     var componentDetails = GetComponentDetails();
     var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
     var eventDetailsList = GetEventDetailsList();
-    var componentNamespace = "global::" + qualifiedNamespace + "." + componentDetails.ComponentName;
+    var componentNamespace = $"global::{qualifiedNamespace}.{componentDetails.ComponentName}";
 #>
 <#= generatedHeader #>
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityEventGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityEventGenerator.tt
@@ -4,7 +4,7 @@
     var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
     var componentDetails = GetComponentDetails();
     var eventDetailsList = GetEventDetailsList();
-    var componentNamespace = "global::" + qualifiedNamespace + "." + componentDetails.ComponentName;
+    var componentNamespace = $"global::{qualifiedNamespace}.{componentDetails.ComponentName}";
 #>
 <#= generatedHeader #>
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityEventGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityEventGenerator.tt
@@ -4,6 +4,7 @@
     var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
     var componentDetails = GetComponentDetails();
     var eventDetailsList = GetEventDetailsList();
+    var componentNamespace = "global::" + qualifiedNamespace + "." + componentDetails.ComponentName;
 #>
 <#= generatedHeader #>
 
@@ -42,8 +43,8 @@ namespace <#= qualifiedNamespace #>
 
                 public List<<#= eventDetails.FqnPayloadType #>> Events
                 {
-                    get => <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= eventDetails.EventName #>Provider.Get(handle);
-                    internal set => <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= eventDetails.EventName #>Provider.Set(handle, value);
+                    get => <#= componentNamespace #>.ReferenceTypeProviders.<#= eventDetails.EventName #>Provider.Get(handle);
+                    internal set => <#= componentNamespace #>.ReferenceTypeProviders.<#= eventDetails.EventName #>Provider.Set(handle, value);
                 }
             }
 
@@ -59,8 +60,8 @@ namespace <#= qualifiedNamespace #>
 
                 public List<<#= eventDetails.FqnPayloadType #>> Events
                 {
-                    get => <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= eventDetails.EventName #>Provider.Get(handle);
-                    internal set => <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= eventDetails.EventName #>Provider.Set(handle, value);
+                    get => <#= componentNamespace #>.ReferenceTypeProviders.<#= eventDetails.EventName #>Provider.Get(handle);
+                    internal set => <#= componentNamespace #>.ReferenceTypeProviders.<#= eventDetails.EventName #>Provider.Set(handle, value);
                 }
             }
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityReactiveComponentHandlersGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityReactiveComponentHandlersGenerator.tt
@@ -5,7 +5,7 @@
     var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
     var commandDetailsList = GetCommandDetailsList();
     var eventDetailsList = GetEventDetailsList();
-    var componentNamespace = "global::" + qualifiedNamespace + "." + componentDetails.ComponentName;
+    var componentNamespace = $"global::{qualifiedNamespace}.{componentDetails.ComponentName}";
     var profilingStart = $"Profiler.BeginSample(\"{componentDetails.ComponentName}\");";
     var profilingEnd = "Profiler.EndSample();";
 #>

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityReactiveComponentHandlersGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityReactiveComponentHandlersGenerator.tt
@@ -5,7 +5,7 @@
     var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
     var commandDetailsList = GetCommandDetailsList();
     var eventDetailsList = GetEventDetailsList();
-    var componentNamespace = qualifiedNamespace + "." + componentDetails.ComponentName;
+    var componentNamespace = "global::" + qualifiedNamespace + "." + componentDetails.ComponentName;
     var profilingStart = $"Profiler.BeginSample(\"{componentDetails.ComponentName}\");";
     var profilingEnd = "Profiler.EndSample();";
 #>
@@ -51,8 +51,8 @@ namespace <#= qualifiedNamespace #>
                 {
                     All = new[]
                     {
-                        ComponentType.Create<<#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.CommandSenders.<#= commandDetails.CommandName #>>(),
-                        ComponentType.Create<<#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.CommandResponders.<#= commandDetails.CommandName #>>(),
+                        ComponentType.Create<<#= componentNamespace #>.CommandSenders.<#= commandDetails.CommandName #>>(),
+                        ComponentType.Create<<#= componentNamespace #>.CommandResponders.<#= commandDetails.CommandName #>>(),
                     },
                     Any = Array.Empty<ComponentType>(),
                     None = Array.Empty<ComponentType>(),
@@ -103,8 +103,8 @@ namespace <#= qualifiedNamespace #>
 for (var i = 0; i < commandDetailsList.Count; i++) {
     var commandDetails = commandDetailsList[i];
     var commandName = commandDetails.CommandName;
-    var commandSenderType = $"{qualifiedNamespace}.{componentDetails.ComponentName}.CommandSenders.{commandName}";
-    var commandResponderType = $"{qualifiedNamespace}.{componentDetails.ComponentName}.CommandResponders.{commandName}";
+    var commandSenderType = $"{componentNamespace}.CommandSenders.{commandName}";
+    var commandResponderType = $"{componentNamespace}.CommandResponders.{commandName}";
 #>
                 var senderType<#= commandName #> = system.GetArchetypeChunkComponentType<<#= commandSenderType #>>(true);
                 var responderType<#= commandName #> = system.GetArchetypeChunkComponentType<<#= commandResponderType #>>(true);
@@ -117,8 +117,8 @@ for (var i = 0; i < commandDetailsList.Count; i++) {
 for (var i = 0; i < commandDetailsList.Count; i++) {
     var commandDetails = commandDetailsList[i];
     var commandName = commandDetails.CommandName;
-    var commandSenderType = $"{qualifiedNamespace}.{componentDetails.ComponentName}.CommandSenders.{commandName}";
-    var commandResponderType = $"{qualifiedNamespace}.{componentDetails.ComponentName}.CommandResponders.{commandName}";
+    var commandSenderType = $"{componentNamespace}.CommandSenders.{commandName}";
+    var commandResponderType = $"{componentNamespace}.CommandResponders.{commandName}";
 #>
                     if (chunk.Has(senderType<#= commandName #>))
                     {

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityReferenceTypeProviderGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityReferenceTypeProviderGenerator.tt
@@ -7,7 +7,7 @@
     var commandDetailsList = GetCommandDetailsList();
     var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
     var generator = new UnityReferenceTypeProviderContent();
-    var componentNamespace = qualifiedNamespace + "." + componentDetails.ComponentName;
+    var componentNamespace = "global::" + qualifiedNamespace + "." + componentDetails.ComponentName;
 #>
 <#= generatedHeader #>
 
@@ -34,10 +34,10 @@ namespace <#= qualifiedNamespace #>
             <#= CommonGeneratorUtils.IndentEveryNewline(generator.Generate(eventDetails.EventName, $"List<{eventDetails.FqnPayloadType}>"), 3) #>
 <# } #>
 <# foreach (var commandDetails in commandDetailsList) { #>
-            <#= CommonGeneratorUtils.IndentEveryNewline(generator.Generate($"{commandDetails.CommandName}Sender", $"List<{qualifiedNamespace}.{componentDetails.ComponentName}.{commandDetails.CommandName}.Request>"), 3) #>
-            <#= CommonGeneratorUtils.IndentEveryNewline(generator.Generate($"{commandDetails.CommandName}Requests", $"List<{qualifiedNamespace}.{componentDetails.ComponentName}.{commandDetails.CommandName}.ReceivedRequest>"), 3) #>
-            <#= CommonGeneratorUtils.IndentEveryNewline(generator.Generate($"{commandDetails.CommandName}Responder", $"List<{qualifiedNamespace}.{componentDetails.ComponentName}.{commandDetails.CommandName}.Response>"), 3) #>
-            <#= CommonGeneratorUtils.IndentEveryNewline(generator.Generate($"{commandDetails.CommandName}Responses", $"List<{qualifiedNamespace}.{componentDetails.ComponentName}.{commandDetails.CommandName}.ReceivedResponse>"), 3) #>
+            <#= CommonGeneratorUtils.IndentEveryNewline(generator.Generate($"{commandDetails.CommandName}Sender", $"List<{componentNamespace}.{commandDetails.CommandName}.Request>"), 3) #>
+            <#= CommonGeneratorUtils.IndentEveryNewline(generator.Generate($"{commandDetails.CommandName}Requests", $"List<{componentNamespace}.{commandDetails.CommandName}.ReceivedRequest>"), 3) #>
+            <#= CommonGeneratorUtils.IndentEveryNewline(generator.Generate($"{commandDetails.CommandName}Responder", $"List<{componentNamespace}.{commandDetails.CommandName}.Response>"), 3) #>
+            <#= CommonGeneratorUtils.IndentEveryNewline(generator.Generate($"{commandDetails.CommandName}Responses", $"List<{componentNamespace}.{commandDetails.CommandName}.ReceivedResponse>"), 3) #>
 
 <# } #>
         }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityReferenceTypeProviderGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityReferenceTypeProviderGenerator.tt
@@ -7,7 +7,7 @@
     var commandDetailsList = GetCommandDetailsList();
     var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
     var generator = new UnityReferenceTypeProviderContent();
-    var componentNamespace = "global::" + qualifiedNamespace + "." + componentDetails.ComponentName;
+    var componentNamespace = $"global::{qualifiedNamespace}.{componentDetails.ComponentName}";
 #>
 <#= generatedHeader #>
 


### PR DESCRIPTION
#### Description
e.g. 
```
package name;

component Name
{
    id = 200;
    float name = 1;
}
```

would lead to the code generator generating invalid code. Added `global::` to all the namespaces to make sure it knows which namespace to use.

This fixes most of the cases, however if we have a component and an event / command with the same name, this is not fixed. This will require fixes in a different place and will be done at a later point.

#### Tests
added test schema to the test project and tested it locally.

#### Documentation
no need

#### Primary reviewers
@jamiebrynes7 
