### PR TITLE
Safe Callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,13 @@
 - Added a `Improbable.Gdk.Core.Editor` asmdef.
     - Moved `SingletonScriptableObject<T>` from the build system feature module into this assembly and made it public.
     - Pulled out the `UiStateManager` from the `BuildConfigEditor` into this assembly and made it public.
+- Exceptions thrown in user-code callbacks no longer cause other callbacks scheduled for that frame to not fire. Instead, the exceptions are caught and logged with Debug.LogException.
 
 ### Fixed
 
 - Fixed a bug where if an entity received an event and was removed from your worker's view in the same ops list, the event would not be removed.
 
 ## `0.2.1` - 2019-04-15
-
-### Changed
-
-- Exceptions thrown in user-code callbacks no longer cause other callbacks scheduled for that frame to not fire. Instead, the exceptions are caught and logged with Debug.LogException.
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Changed
 
-- Exceptions in callbacks now no longer break the system that called it, but get logged instead.
+- Exceptions thrown in user-code callbacks no longer cause other callbacks scheduled for that frame to not fire. Instead, the exceptions are caught and logged with Debug.LogException.
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ## `0.2.1` - 2019-04-15
 
+### Changed
+
+- Exceptions in callbacks now no longer break the system that called it, but get logged instead.
+
 ### Breaking Changes
 
 - Removed `clientAccess` from the `AddPlayerLifecycleComponents` signature. We now construct the client access attribute within the helper.

--- a/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace Improbable.Gdk.Subscriptions
 {
@@ -53,17 +54,19 @@ namespace Improbable.Gdk.Subscriptions
         {
             isInInvoke = true;
 
-            try
+            for (var i = 0; i < callbacks.Count; i++)
             {
-                for (var i = 0; i < callbacks.Count; i++)
+                try
                 {
                     callbacks[i].Invoke(op);
                 }
+                catch (Exception e)
+                {
+                    Debug.LogException(e);
+                }
             }
-            finally
-            {
-                isInInvoke = false;
-            }
+
+            isInInvoke = false;
 
             FlushDeferredOperations();
         }
@@ -72,17 +75,19 @@ namespace Improbable.Gdk.Subscriptions
         {
             isInInvoke = true;
 
-            try
+            for (var i = callbacks.Count - 1; i >= 0; i--)
             {
-                for (var i = callbacks.Count - 1; i >= 0; i--)
+                try
                 {
                     callbacks[i].Invoke(op);
                 }
+                catch (Exception e)
+                {
+                    Debug.LogException(e);
+                }
             }
-            finally
-            {
-                isInInvoke = false;
-            }
+
+            isInInvoke = false;
 
             FlushDeferredOperations();
         }
@@ -124,10 +129,10 @@ namespace Improbable.Gdk.Subscriptions
             public readonly ulong Key;
             private readonly Action<T> action;
 
-            public WrappedCallback(ulong key, Action<T> action)
+            public WrappedCallback(ulong key, Action<T> callback)
             {
                 Key = key;
-                this.action = action;
+                action = callback;
             }
 
             public void Invoke(T arg)

--- a/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Callbacks.cs
@@ -5,13 +5,13 @@ namespace Improbable.Gdk.Subscriptions
 {
     internal class Callbacks<T>
     {
-        private List<WrappedCallback> callbacks = new List<WrappedCallback>();
-        private HashSet<ulong> currentKeys = new HashSet<ulong>();
+        private readonly List<WrappedCallback> callbacks = new List<WrappedCallback>();
+        private readonly HashSet<ulong> currentKeys = new HashSet<ulong>();
 
         // These can be lists as we expect the number of callbacks added/removed during invocation of other callbacks
         // to be low.
-        private List<ulong> toRemove = new List<ulong>();
-        private List<WrappedCallback> toAdd = new List<WrappedCallback>();
+        private readonly List<ulong> toRemove = new List<ulong>();
+        private readonly List<WrappedCallback> toAdd = new List<WrappedCallback>();
 
         private bool isInInvoke = false;
 
@@ -46,7 +46,7 @@ namespace Improbable.Gdk.Subscriptions
             }
 
             currentKeys.Remove(key);
-            return callbacks.RemoveAll(callback => callback.Key == key) == 1;
+            return callbacks.Remove(new WrappedCallback(key, default));
         }
 
         public void InvokeAll(T op)
@@ -55,9 +55,9 @@ namespace Improbable.Gdk.Subscriptions
 
             try
             {
-                for (int i = 0; i < callbacks.Count; i++)
+                for (var i = 0; i < callbacks.Count; i++)
                 {
-                    callbacks[i].Action(op);
+                    callbacks[i].Invoke(op);
                 }
             }
             finally
@@ -74,9 +74,9 @@ namespace Improbable.Gdk.Subscriptions
 
             try
             {
-                for (int i = callbacks.Count - 1; i >= 0; i--)
+                for (var i = callbacks.Count - 1; i >= 0; i--)
                 {
-                    callbacks[i].Action(op);
+                    callbacks[i].Invoke(op);
                 }
             }
             finally
@@ -89,31 +89,65 @@ namespace Improbable.Gdk.Subscriptions
 
         private void FlushDeferredOperations()
         {
-            callbacks.RemoveAll(callback => toRemove.Contains(callback.Key));
-
-            foreach (var key in toRemove)
+            if (toRemove.Count > 0)
             {
-                currentKeys.Remove(key);
+                for (var i = callbacks.Count - 1; i >= 0; i--)
+                {
+                    if (toRemove.Contains(callbacks[i].Key))
+                    {
+                        callbacks.RemoveAt(i);
+                    }
+                }
+
+                foreach (var key in toRemove)
+                {
+                    currentKeys.Remove(key);
+                }
+
+                toRemove.Clear();
             }
 
-            foreach (var callback in toAdd)
+            if (toAdd.Count > 0)
             {
-                callbacks.Add(callback);
-            }
+                foreach (var callback in toAdd)
+                {
+                    callbacks.Add(callback);
+                    currentKeys.Add(callback.Key);
+                }
 
-            toRemove.Clear();
-            toAdd.Clear();
+                toAdd.Clear();
+            }
         }
 
-        private struct WrappedCallback
+        private struct WrappedCallback : IEquatable<WrappedCallback>
         {
-            public ulong Key;
-            public Action<T> Action;
+            public readonly ulong Key;
+            private readonly Action<T> action;
 
             public WrappedCallback(ulong key, Action<T> action)
             {
                 Key = key;
-                Action = action;
+                this.action = action;
+            }
+
+            public void Invoke(T arg)
+            {
+                action(arg);
+            }
+
+            public bool Equals(WrappedCallback other)
+            {
+                return Key == other.Key;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is WrappedCallback other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                return Key.GetHashCode();
             }
         }
     }
@@ -184,10 +218,7 @@ namespace Improbable.Gdk.Subscriptions
 
         public void RemoveAllCallbacksForIndex(long index)
         {
-            if (callbacks.ContainsKey(index))
-            {
-                callbacks.Remove(index);
-            }
+            callbacks.Remove(index);
         }
 
         public bool Remove(ulong callbackKey)
@@ -205,17 +236,17 @@ namespace Improbable.Gdk.Subscriptions
 
         public void InvokeAll(long index, T op)
         {
-            if (callbacks.ContainsKey(index))
+            if (callbacks.TryGetValue(index, out var callback))
             {
-                callbacks[index].InvokeAll(op);
+                callback.InvokeAll(op);
             }
         }
 
         public void InvokeAllReverse(long index, T op)
         {
-            if (callbacks.ContainsKey(index))
+            if (callbacks.TryGetValue(index, out var callback))
             {
-                callbacks[index].InvokeAllReverse(op);
+                callback.InvokeAllReverse(op);
             }
         }
     }


### PR DESCRIPTION
#### Description
Make callbacks resistant against exceptions in our users code.
Currently this uses Debug.LogException, however this should at some point move to a logging framework for Core.
As a drive-by, remove all closures from Callbacks functions.

Draft until 0.2.1 is released

#### Tests
Ran Playground (will run FPS)

#### Documentation
Changelog

#### Primary reviewers
@jamiebrynes7 
