### PR TITLE
Add user friendly error when failing to find build config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added support for Windows x86 builds.
+- Added a user-friendly error message when the build system fails to find a SpatialOS Build Configuration instance.
 
 ### Changed
 

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
@@ -114,7 +114,7 @@ namespace Improbable.Gdk.BuildSystem
             if (BuildConfig.GetInstance() == null)
             {
                 const string errorMessage =
-                    "Could not find an instance of the SpatialOS Build Configuration.\n\nPlease create one via Assets > Create > SpatialOS > SpatialOS Build Configuration.\n\nIf you already have an instance of the SpatialOS Build Configuration in your project, please open it in the Unity Inspector to force the asset to load and retry.";
+                    "Could not find an instance of the SpatialOS Build Configuration.\n\nPlease create one via Assets > Create > SpatialOS > SpatialOS Build Configuration.\n\nIf you already have an instance of the SpatialOS Build Configuration in your project, please open it in the Unity Inspector to force the asset to load and retry the build.";
 
                 if (Application.isEditor)
                 {
@@ -122,7 +122,7 @@ namespace Improbable.Gdk.BuildSystem
                     {
                         EditorUtility.DisplayDialog("Could not find SpatialOS Build Configuration",
                             errorMessage,
-                            "Okay");
+                            "OK");
                     };
                 }
 

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
@@ -111,6 +111,25 @@ namespace Improbable.Gdk.BuildSystem
             var activeBuildTarget = EditorUserBuildSettings.activeBuildTarget;
             var activeBuildTargetGroup = BuildPipeline.GetBuildTargetGroup(activeBuildTarget);
 
+            if (BuildConfig.GetInstance() == null)
+            {
+                const string errorMessage =
+                    "Could not find an instance of the SpatialOS Build Configuration.\n\nPlease create one via Assets > Create > SpatialOS > SpatialOS Build Configuration.\n\nIf you already have an instance of the SpatialOS Build Configuration in your project, please open it in the Unity Inspector to force the asset to load and retry.";
+
+                if (Application.isEditor)
+                {
+                    EditorApplication.delayCall += () =>
+                    {
+                        EditorUtility.DisplayDialog("Could not find SpatialOS Build Configuration",
+                            errorMessage,
+                            "Okay");
+                    };
+                }
+
+                Debug.LogError(errorMessage);
+                return false;
+            }
+
             try
             {
                 LocalLaunch.BuildConfig();


### PR DESCRIPTION
#### Description
Before building workers, we check whether we can find a SpatialOS Build Configuration instance. If not we:
- Display a popup if we are in the Editor.
- Log an error to the terminal.
- Terminate the build.

This is _instead_ of the user getting a null ref exception thrown somewhere inside the build process.

#### Tests
Deleted the asset. Tried to build. Saw popup + error in the terminal.

#### Documentation
Changelog.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
