### PR TITLE
Fix event race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed a bug where if an entity received an event and was removed from your worker's view in the same ops list, the event would not be removed.
+
 ## `0.2.1` - 2019-04-15
 
 ### Breaking Changes

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionComponentDiffStorage.cs
@@ -81,6 +81,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 {
                     updateStorage.RemoveAll(update => update.EntityId.Id == entityId);
                     authorityChanges.RemoveAll(change => change.EntityId.Id == entityId);
+                    myEventEventStorage.RemoveAll(change => change.EntityId.Id == entityId);
                 }
 
                 if (!componentsAdded.Remove(id))

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentComponentDiffStorage.cs
@@ -91,6 +91,8 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     updateStorage.RemoveAll(update => update.EntityId.Id == entityId);
                     authorityChanges.RemoveAll(change => change.EntityId.Id == entityId);
+                    firstEventEventStorage.RemoveAll(change => change.EntityId.Id == entityId);
+                    secondEventEventStorage.RemoveAll(change => change.EntityId.Id == entityId);
                 }
 
                 if (!componentsAdded.Remove(id))

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsComponentDiffStorage.cs
@@ -81,6 +81,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 {
                     updateStorage.RemoveAll(update => update.EntityId.Id == entityId);
                     authorityChanges.RemoveAll(change => change.EntityId.Id == entityId);
+                    evtEventStorage.RemoveAll(change => change.EntityId.Id == entityId);
                 }
 
                 if (!componentsAdded.Remove(id))

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentComponentDiffStorage.cs
@@ -91,6 +91,8 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     updateStorage.RemoveAll(update => update.EntityId.Id == entityId);
                     authorityChanges.RemoveAll(change => change.EntityId.Id == entityId);
+                    firstEventEventStorage.RemoveAll(change => change.EntityId.Id == entityId);
+                    secondEventEventStorage.RemoveAll(change => change.EntityId.Id == entityId);
                 }
 
                 if (!componentsAdded.Remove(id))

--- a/test-project/Packages/manifest.json
+++ b/test-project/Packages/manifest.json
@@ -2,9 +2,9 @@
   "dependencies": {
     "com.improbable.gdk.buildsystem": "file:../../workers/unity/Packages/com.improbable.gdk.buildsystem",
     "com.improbable.gdk.core": "file:../../workers/unity/Packages/com.improbable.gdk.core",
+    "com.improbable.gdk.dependencytest": "file:com.improbable.gdk.dependencytest",
     "com.improbable.gdk.querybasedinteresthelper": "file:../../workers/unity/Packages/com.improbable.gdk.querybasedinteresthelper",
     "com.improbable.gdk.testutils": "file:../../workers/unity/Packages/com.improbable.gdk.testutils",
-    "com.improbable.gdk.dependencytest": "file:com.improbable.gdk.dependencytest",
     "com.improbable.gdk.tools": "file:../../workers/unity/Packages/com.improbable.gdk.tools"
   },
   "registry": "https://staging-packages.unity.com"

--- a/test-project/ProjectSettings/ProjectVersion.txt
+++ b/test-project/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2018.3.5f1
+m_EditorVersion: 2018.3.11f1

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ComponentDiffStorageGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ComponentDiffStorageGenerator.tt
@@ -101,6 +101,9 @@ namespace <#= qualifiedNamespace #>
                 {
                     updateStorage.RemoveAll(update => update.EntityId.Id == entityId);
                     authorityChanges.RemoveAll(change => change.EntityId.Id == entityId);
+<# foreach (var ev in eventDetailsList) { #>
+                    <#= ev.CamelCaseEventName #>EventStorage.RemoveAll(change => change.EntityId.Id == entityId);
+<# } #>
                 }
 
                 if (!componentsAdded.Remove(id))


### PR DESCRIPTION
#### Description
@jessicafalk discovered a race where if an entity was removed from your view in the same frame as you received an event, the event would not be cleared from the diff. This PR fixes that bug.

#### Tests
Ran codegen, observed the changes - satisfied it would properly clear the events.

#### Documentation
Changelog

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@jessicafalk @samiwh 
