### PR TITLE
Load dev token asset by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .vs/
 .gradle/
 .DS_Store
+DevAuthToken.txt*
 
 #Unity Engine Gitignore (https://github.com/github/gitignore/blob/master/Unity.gitignore)
 workers/unity/[Ll]ibrary/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
     - Pulled out the `UiStateManager` from the `BuildConfigEditor` into this assembly and made it public.
 - Exceptions thrown in user-code callbacks no longer cause other callbacks scheduled for that frame to not fire. Instead, the exceptions are caught and logged with Debug.LogException.
 - Upgraded the Worker SDK version to `13.7.1`.
-- The Development Authentication Token will by default be loaded searching for a `DevAuthToken.txt` asset in any of your Resources folder.
+- Updated the default method of loading a Development Authentication Token to search for a `DevAuthToken.txt` asset at the root of any `Resources` folder.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@
     - Pulled out the `UiStateManager` from the `BuildConfigEditor` into this assembly and made it public.
 - Exceptions thrown in user-code callbacks no longer cause other callbacks scheduled for that frame to not fire. Instead, the exceptions are caught and logged with Debug.LogException.
 - Upgraded the Worker SDK version to `13.7.1`.
+- The Development Authentication Token will by default be loaded searching for a `DevAuthToken.txt` asset in any of your Resources folder.
 
 ### Fixed
 
 - Fixed a bug where if an entity received an event and was removed from your worker's view in the same ops list, the event would not be removed.
+- Fixed a bug where clicking on `SpatialOS` > `Generate Dev Authentication Token` would not always refresh the asset database correctly.
 
 ## `0.2.1` - 2019-04-15
 

--- a/workers/unity/Assets/.gitignore
+++ b/workers/unity/Assets/.gitignore
@@ -1,1 +1,0 @@
-DevAuthToken.txt*

--- a/workers/unity/Assets/Playground/Scripts/UI/ConnectionScreenController.cs
+++ b/workers/unity/Assets/Playground/Scripts/UI/ConnectionScreenController.cs
@@ -57,7 +57,7 @@ namespace Playground
         {
             UnityObjectDestroyer.Destroy(worker);
             errorMessage.text =
-                $"Connection failed. Please check the IP address entered.\nSpatialOS error message:\n{connectionError}";
+                $"Connection failed.\nSpatialOS error message:\n{connectionError}";
         }
 
         public void OnDisconnected(string disconnectReason)

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
@@ -31,11 +31,6 @@ namespace Improbable.Gdk.Core
         /// </remarks>
         public Worker Worker;
 
-        /// <summary>
-        ///    The token needed to connect via the development authentication flow.
-        /// </summary>
-        protected string DevelopmentAuthToken;
-
         private List<Action<Worker>> workerConnectedCallbacks = new List<Action<Worker>>();
 
         /// <summary>
@@ -228,16 +223,16 @@ namespace Improbable.Gdk.Core
         /// <summary>
         /// Loads the development authentication token and stores it in the DevelopmentAuthToken field.
         /// </summary>
-        protected virtual void LoadDevAuthToken()
+        protected virtual string GetDevAuthToken()
         {
             var textAsset = Resources.Load<TextAsset>("DevAuthToken");
             if (textAsset != null)
             {
-                DevelopmentAuthToken = textAsset.text.Trim();
+                return textAsset.text.Trim();
             }
             else
             {
-                Debug.LogWarning("Unable to find DevAuthToken.txt in the Resources folder.");
+                throw new MissingReferenceException("Unable to find DevAuthToken.txt in the Resources folder.");
             }
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
@@ -186,6 +186,32 @@ namespace Improbable.Gdk.Core
         protected abstract AlphaLocatorConfig GetAlphaLocatorConfig(string workerType);
 
         /// <summary>
+        /// Retrieves the configuration needed to connect via the Alpha Locator service using the development authentication flow.
+        /// </summary>
+        /// <returns>A <see cref="AlphaLocatorConfig"/> object.</returns>
+        protected AlphaLocatorConfig GetAlphaLocatorConfigViaDevAuthFlow(string workerType)
+        {
+            var token = GetDevAuthToken();
+            var pit = GetDevelopmentPlayerIdentityToken(token, GetPlayerId(), GetDisplayName());
+            var loginTokenDetails = GetDevelopmentLoginTokens(workerType, pit);
+            var loginToken = SelectLoginToken(loginTokenDetails);
+
+            return new AlphaLocatorConfig
+            {
+                LocatorHost = RuntimeConfigDefaults.LocatorHost,
+                LocatorParameters = new Improbable.Worker.CInterop.Alpha.LocatorParameters
+                {
+                    PlayerIdentity = new PlayerIdentityCredentials
+                    {
+                        PlayerIdentityToken = pit,
+                        LoginToken = loginToken,
+                    },
+                    UseInsecureConnection = false,
+                }
+            };
+        }
+
+        /// <summary>
         /// Retrieves the configuration needed to connect via the Receptionist service.
         /// </summary>
         /// <param name="workerType">The type of worker you want to connect.</param>

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
@@ -232,7 +232,8 @@ namespace Improbable.Gdk.Core
             }
             else
             {
-                throw new MissingReferenceException("Unable to find DevAuthToken.txt in the Resources folder.");
+                throw new MissingReferenceException("Unable to find DevAuthToken.txt in the Resources folder. " +
+                    "You can generate one via SpatialOS > Generate Dev Authentication Token.");
             }
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
@@ -31,7 +31,10 @@ namespace Improbable.Gdk.Core
         /// </remarks>
         public Worker Worker;
 
-        [SerializeField] protected string DevelopmentAuthToken;
+        /// <summary>
+        ///    The token needed to connect via the development authentication flow.
+        /// </summary>
+        protected string DevelopmentAuthToken;
 
         private List<Action<Worker>> workerConnectedCallbacks = new List<Action<Worker>>();
 
@@ -220,6 +223,22 @@ namespace Improbable.Gdk.Core
         protected virtual string SelectDeploymentName(DeploymentList deployments)
         {
             return null;
+        }
+
+        /// <summary>
+        /// Loads the development authentication token and stores it in the DevelopmentAuthToken field.
+        /// </summary>
+        protected virtual void LoadDevAuthToken()
+        {
+            var textAsset = Resources.Load<TextAsset>("DevAuthToken");
+            if (textAsset != null)
+            {
+                DevelopmentAuthToken = textAsset.text.Trim();
+            }
+            else
+            {
+                Debug.LogWarning("Unable to find DevAuthToken.txt in the Resources folder.");
+            }
         }
 
         /// <summary>

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs
@@ -50,6 +50,7 @@ namespace Improbable.Gdk.Mobile
 
         protected override AlphaLocatorConfig GetAlphaLocatorConfig(string workerType)
         {
+            LoadDevAuthToken();
             var pit = GetDevelopmentPlayerIdentityToken(DevelopmentAuthToken, GetPlayerId(), GetDisplayName());
             var loginTokenDetails = GetDevelopmentLoginTokens(workerType, pit);
             var loginToken = SelectLoginToken(loginTokenDetails);

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs
@@ -50,24 +50,7 @@ namespace Improbable.Gdk.Mobile
 
         protected override AlphaLocatorConfig GetAlphaLocatorConfig(string workerType)
         {
-            var token = GetDevAuthToken();
-            var pit = GetDevelopmentPlayerIdentityToken(token, GetPlayerId(), GetDisplayName());
-            var loginTokenDetails = GetDevelopmentLoginTokens(workerType, pit);
-            var loginToken = SelectLoginToken(loginTokenDetails);
-
-            return new AlphaLocatorConfig
-            {
-                LocatorHost = RuntimeConfigDefaults.LocatorHost,
-                LocatorParameters = new Worker.CInterop.Alpha.LocatorParameters
-                {
-                    PlayerIdentity = new PlayerIdentityCredentials
-                    {
-                        PlayerIdentityToken = pit,
-                        LoginToken = loginToken,
-                    },
-                    UseInsecureConnection = false,
-                }
-            };
+            return GetAlphaLocatorConfigViaDevAuthFlow(workerType);
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Worker/MobileWorkerConnector.cs
@@ -50,8 +50,8 @@ namespace Improbable.Gdk.Mobile
 
         protected override AlphaLocatorConfig GetAlphaLocatorConfig(string workerType)
         {
-            LoadDevAuthToken();
-            var pit = GetDevelopmentPlayerIdentityToken(DevelopmentAuthToken, GetPlayerId(), GetDisplayName());
+            var token = GetDevAuthToken();
+            var pit = GetDevelopmentPlayerIdentityToken(token, GetPlayerId(), GetDisplayName());
             var loginTokenDetails = GetDevelopmentLoginTokens(workerType, pit);
             var loginToken = SelectLoginToken(loginTokenDetails);
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/DevAuthTokenUtils.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/DevAuthTokenUtils.cs
@@ -61,6 +61,8 @@ namespace Improbable.Gdk.Tools
             }
 
             Debug.Log($"Saving token {devAuthToken} to {devAuthTokenFilePath}.");
+            AssetDatabase.ImportAsset(devAuthTokenFilePath, ImportAssetOptions.ForceUpdate);
+            AssetDatabase.Refresh();
         }
     }
 }


### PR DESCRIPTION
#### Description
Instead of having to enter the dev auth token into an inspector field, we should load an asset when needed.
Need to update the other projects as well.

#### Tests
tested locally and in cloud.

#### Documentation
will be updated soonish
