### PR TITLE
Fix Worker Entity + GameObject Link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Fixed a bug where if an entity received an event and was removed from your worker's view in the same ops list, the event would not be removed.
 - Fixed a bug where clicking on `SpatialOS` > `Generate Dev Authentication Token` would not always refresh the asset database correctly.
+- Fixed a bug where requireables on a GameObject linked to the worker entity were not injected properly.
 
 ## `0.2.1` - 2019-04-15
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs
@@ -94,6 +94,7 @@ namespace Improbable.Gdk.Core
             base.OnCreateManager();
             var entityManager = World.GetOrCreateManager<EntityManager>();
             WorkerEntity = entityManager.CreateEntity(typeof(OnConnected), typeof(WorkerEntityTag));
+            EntityIdToEntity.Add(new EntityId(0), WorkerEntity);
             Enabled = false;
         }
 


### PR DESCRIPTION
#### Description
This PR fixes a bug where subscriptions wouldn't be fulfilled on the worker GameObject since it would never exist in the `EntityIdToEntity` map. 

#### Tests
Tested by Jose, who found the bug.

#### Documentation
**Did you remember a changelog entry?**
Yes

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
