### PR TITLE
Adding check for valid entity

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntityGameObjectLinker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntityGameObjectLinker.cs
@@ -125,7 +125,7 @@ namespace Improbable.Gdk.Subscriptions
 
             var injectors = gameObjectToInjectors[gameObject];
 
-            if (workerSystem.TryGetEntity(entityId, out var entity))
+            if (entityId.IsValid() && workerSystem.TryGetEntity(entityId, out var entity))
             {
                 foreach (var componentType in gameObjectToComponentsAdded[gameObject])
                 {


### PR DESCRIPTION
#### Description
Adding check for valid entity as it will otherwise try to remove the components from the gameobject that is linked to the worker entity as well.

#### Tests
ran it, no crashes anymore upon exiting the application
