### PR TITLE
Fixed world being disposed multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Fixed a bug where the `World` would get disposed multiple times, if you stopped the application inside the Editor while the worker still gets created.
+- Fixed a bug where a worker's `World` could get disposed multiple times if you stopped the application inside the Editor while the worker is being created.
 
 ## `0.2.2` - 2019-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Upgraded the project to be compatible with `2019.1.3f1`.
 
+### Fixed
+
+- Fixed a bug where the `World` would get disposed multiple times, if you stopped the application inside the Editor while the worker still gets created.
+
 ## `0.2.2` - 2019-05-15
 
 ### Breaking Changes

--- a/workers/unity/Packages/com.improbable.gdk.core/Utility/TaskUtility.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Utility/TaskUtility.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Improbable.Gdk.Core
+{
+    public static class TaskUtility
+    {
+        public static async Task<T> WithCancellation<T>(this Task<T> task, CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            using (cancellationToken.Register(s => ((TaskCompletionSource<bool>) s).TrySetResult(true), tcs))
+            {
+                if (task != await Task.WhenAny(task, tcs.Task))
+                {
+                    throw new OperationCanceledException(cancellationToken);
+                }
+            }
+
+            return task.Result;
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Utility/TaskUtility.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Utility/TaskUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b34cad4b6a4ea404095791bef7da86c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs
@@ -121,7 +121,7 @@ namespace Improbable.Gdk.Core
         ///     Connects to the SpatialOS Runtime via the Receptionist service and creates a <see cref="Worker" /> object
         ///     asynchronously.
         /// </summary>
-        /// <param name="config">
+        /// <param name="parameters">
         ///     The <see cref="ReceptionistConfig" /> object stores the configuration needed to connect via the
         ///     Receptionist Service.
         /// </param>
@@ -133,12 +133,12 @@ namespace Improbable.Gdk.Core
         ///     <see cref="Worker" /> object upon connecting successfully.
         /// </returns>
         public static async Task<Worker> CreateWorkerAsync(
-            ReceptionistConfig config,
+            ReceptionistConfig parameters,
             ConnectionParameters connectionParameters,
             ILogDispatcher logger, Vector3 origin)
         {
             using (var connectionFuture =
-                Connection.ConnectAsync(config.ReceptionistHost, config.ReceptionistPort, config.WorkerId,
+                Connection.ConnectAsync(parameters.ReceptionistHost, parameters.ReceptionistPort, parameters.WorkerId,
                     connectionParameters))
             {
                 return await TryToConnectAsync(connectionFuture, connectionParameters.WorkerType, logger, origin);
@@ -149,7 +149,7 @@ namespace Improbable.Gdk.Core
         ///     Connects to the SpatialOS Runtime via the Locator service and creates a <see cref="Worker" /> object
         ///     asynchronously.
         /// </summary>
-        /// <param name="config">
+        /// <param name="parameters">
         ///     The <see cref="LocatorConfig" /> object stores the configuration needed to connect via the
         ///     Receptionist Service.
         /// </param>
@@ -187,7 +187,7 @@ namespace Improbable.Gdk.Core
         ///     Connects to the SpatialOS Runtime via the Alpha Locator service and creates a <see cref="Worker" /> object
         ///     asynchronously.
         /// </summary>
-        /// <param name="config">
+        /// <param name="parameters">
         ///     The <see cref="AlphaLocatorConfig" /> object stores the configuration needed to connect via the
         ///     Receptionist Service.
         /// </param>
@@ -268,7 +268,12 @@ namespace Improbable.Gdk.Core
 
         public void Dispose()
         {
-            World?.Dispose();
+
+            if (World != null && World.IsCreated)
+            {
+                World?.Dispose();
+            }
+
             World = null;
             LogDispatcher?.Dispose();
             LogDispatcher = null;

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs
@@ -97,12 +97,14 @@ namespace Improbable.Gdk.Core
             ILogDispatcher logger,
             Vector3 origin)
         {
-            var tokenSource = new CancellationTokenSource();
-            Action cancelTask = delegate { tokenSource?.Cancel(); };
-            Application.quitting += cancelTask;
-            var connection = await Task.Run(() => connectionFuture.Get()).WithCancellation(tokenSource.Token);
-            Application.quitting -= cancelTask;
-            tokenSource.Dispose();
+            Connection connection;
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                Action cancelTask = delegate { tokenSource?.Cancel(); };
+                Application.quitting += cancelTask;
+                connection = await Task.Run(() => connectionFuture.Get()).WithCancellation(tokenSource.Token);
+                Application.quitting -= cancelTask;
+            }
 
             // A check is needed for the case that play mode is exited before the connection can complete.
             if (!Application.isPlaying)

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs
@@ -268,7 +268,6 @@ namespace Improbable.Gdk.Core
 
         public void Dispose()
         {
-
             if (World != null && World.IsCreated)
             {
                 World?.Dispose();

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/Worker.cs
@@ -270,7 +270,7 @@ namespace Improbable.Gdk.Core
         {
             if (World != null && World.IsCreated)
             {
-                World?.Dispose();
+                World.Dispose();
             }
 
             World = null;

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
@@ -118,6 +118,8 @@ namespace Improbable.Gdk.Core
                 if (!Application.isPlaying)
                 {
                     Dispose();
+                    throw new ConnectionFailedException("Editor application stopped",
+                        ConnectionErrorReason.EditorApplicationStopped);
                 }
 
                 HandleWorkerConnectionEstablished();
@@ -405,7 +407,7 @@ namespace Improbable.Gdk.Core
         {
             Worker?.Dispose();
             Worker = null;
-            Destroy(this);
+            UnityObjectDestroyer.Destroy(this);
         }
     }
 }


### PR DESCRIPTION
#### Description
fix for [UTY-1870](https://improbableio.atlassian.net/browse/UTY-1870)

Unity seems to dispose the World as well whenever you stop your editor application, so we need to check first before we dispose of the World to ensure we are not trying to dispose it multiple times.

Also did a quick rename of a parameter to ensure that code and XML documentation are consistent.

#### Tests
ran it in the editor, now it only throws the `Editor application stopped` error instead of a `World is already disposed' and a connection error.
