### PR TITLE
Move runtime IP to EditorPref / DevAuthToken to PlayerPref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 ### Changed
 
 - Upgraded the project to be compatible with `2019.1.3f1`.
+- Moved Runtime IP from the `GdkToolsConfiguration.json` to an Editor Preference.
+- Moved Dev Auth Token to a PlayerPref.
+    - Added a setting in `GdkToolsConfiguration` to let users configure whether a DevAuthToken.txt should be generated or not.
+    - When launching Android cloud clients from the Editor, the DevAuthToken is now passed in as a command line argument.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@
 ### Changed
 
 - Upgraded the project to be compatible with `2019.1.3f1`.
-- Moved Runtime IP from the `GdkToolsConfiguration.json` to an Editor Preference.
-- Moved Dev Auth Token to a PlayerPref.
-    - Added a setting in `GdkToolsConfiguration` to let users configure whether a DevAuthToken.txt should be generated or not.
+- Moved Runtime IP from the `GdkToolsConfiguration.json` to the Editor Preferences.
+- Moved Dev Auth Token to the Player Preferences.
+    - Added a setting in `GdkToolsConfiguration` to let users configure whether a `DevAuthToken.txt` should be generated or not.
     - When launching Android cloud clients from the Editor, the DevAuthToken is now passed in as a command line argument.
 
 ### Fixed

--- a/workers/unity/Assets/Config/GdkToolsConfiguration.json
+++ b/workers/unity/Assets/Config/GdkToolsConfiguration.json
@@ -5,7 +5,6 @@
     ],
     "CodegenOutputDir": "Assets/Generated/Source",
     "DescriptorOutputDir": "../../build/assembly/schema",
-    "RuntimeIp": "",
     "DevAuthTokenDir": "Resources",
     "DevAuthTokenLifetimeDays": 30
 }

--- a/workers/unity/Assets/Config/GdkToolsConfiguration.json
+++ b/workers/unity/Assets/Config/GdkToolsConfiguration.json
@@ -6,5 +6,6 @@
     "CodegenOutputDir": "Assets/Generated/Source",
     "DescriptorOutputDir": "../../build/assembly/schema",
     "DevAuthTokenDir": "Resources",
-    "DevAuthTokenLifetimeDays": 30
+    "DevAuthTokenLifetimeDays": 30,
+    "SaveDevAuthTokenToFile": false
 }

--- a/workers/unity/Assets/Plugins.meta
+++ b/workers/unity/Assets/Plugins.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 0bfcc7b81e816e04aae6ed60da22adac
+guid: 561a7ccc11dec9642aaa85e3f9aad067
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs
@@ -25,6 +25,7 @@ namespace Improbable.Gdk.Core
         public const string LinkProtocol = "linkProtocol";
         public const string LocatorHost = "locatorHost";
         public const string LoginToken = "loginToken";
+        public const string DevAuthTokenKey = "devAuthTokenSecret";
         public const string PlayerIdentityToken = "playerIdentityToken";
         public const string ProjectName = "projectName";
         public const string ReceptionistHost = "receptionistHost";
@@ -36,7 +37,7 @@ namespace Improbable.Gdk.Core
     }
 
     /// <summary>
-    ///     Stores the configuration needed to connect via the Lcoator.
+    ///     Stores the configuration needed to connect via the Locator.
     /// </summary>
     public struct LocatorConfig
     {

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
@@ -254,16 +254,21 @@ namespace Improbable.Gdk.Core
         /// </summary>
         protected virtual string GetDevAuthToken()
         {
-            var textAsset = Resources.Load<TextAsset>("DevAuthToken");
-            if (textAsset != null)
+            if (!PlayerPrefs.HasKey(RuntimeConfigNames.DevAuthTokenKey))
             {
-                return textAsset.text.Trim();
+                var textAsset = Resources.Load<TextAsset>("DevAuthToken");
+                if (textAsset != null)
+                {
+                    PlayerPrefs.SetString(RuntimeConfigNames.DevAuthTokenKey, textAsset.text.Trim());
+                }
+                else
+                {
+                    throw new MissingReferenceException("Unable to find DevAuthToken.txt in the Resources folder. " +
+                        "You can generate one via SpatialOS > Generate Dev Authentication Token.");
+                }
             }
-            else
-            {
-                throw new MissingReferenceException("Unable to find DevAuthToken.txt in the Resources folder. " +
-                    "You can generate one via SpatialOS > Generate Dev Authentication Token.");
-            }
+
+            return PlayerPrefs.GetString(RuntimeConfigNames.DevAuthTokenKey);
         }
 
         /// <summary>

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
@@ -254,18 +254,20 @@ namespace Improbable.Gdk.Core
         /// </summary>
         protected virtual string GetDevAuthToken()
         {
-            if (!PlayerPrefs.HasKey(RuntimeConfigNames.DevAuthTokenKey))
+            if (PlayerPrefs.HasKey(RuntimeConfigNames.DevAuthTokenKey))
             {
-                var textAsset = Resources.Load<TextAsset>("DevAuthToken");
-                if (textAsset != null)
-                {
-                    PlayerPrefs.SetString(RuntimeConfigNames.DevAuthTokenKey, textAsset.text.Trim());
-                }
-                else
-                {
-                    throw new MissingReferenceException("Unable to find DevAuthToken.txt in the Resources folder. " +
-                        "You can generate one via SpatialOS > Generate Dev Authentication Token.");
-                }
+                return PlayerPrefs.GetString(RuntimeConfigNames.DevAuthTokenKey);
+            }
+
+            var textAsset = Resources.Load<TextAsset>("DevAuthToken");
+            if (textAsset != null)
+            {
+                PlayerPrefs.SetString(RuntimeConfigNames.DevAuthTokenKey, textAsset.text.Trim());
+            }
+            else
+            {
+                throw new MissingReferenceException("Unable to find DevAuthToken.txt in the Resources folder. " +
+                    "You can generate one via SpatialOS > Generate Dev Authentication Token.");
             }
 
             return PlayerPrefs.GetString(RuntimeConfigNames.DevAuthTokenKey);

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
@@ -16,7 +16,6 @@ namespace Improbable.Gdk.Mobile
         private const string MenuLaunchAndroidLocal = "/Android for local";
         private const string MenuLaunchAndroidCloud = "/Android for cloud";
 
-
         [MenuItem(MenuLaunchMobile + MenuLaunchAndroidLocal, false, 73)]
         private static void LaunchAndroidLocal()
         {
@@ -94,14 +93,14 @@ namespace Improbable.Gdk.Mobile
                     var gdkToolsConfig = GdkToolsConfiguration.GetOrCreateInstance();
 
                     // Return error if no DevAuthToken is set AND fails to generate new DevAuthToken.
-                    if (!EditorPrefs.HasKey(RuntimeConfigNames.DevAuthTokenKey) && !DevAuthTokenUtils.Generate())
+                    if (!PlayerPrefs.HasKey(RuntimeConfigNames.DevAuthTokenKey) && !DevAuthTokenUtils.Generate())
                     {
                         Debug.LogError("Failed to generate a Dev Auth Token to launch mobile client.");
                         return;
                     }
 
-                    // Returns error if DevAuthToken.txt does not exists AND fails to save new DevAuthToken.txt.
-                    // Ignores if GdkToolsConfiguration does not require DevAuthToken to be saved as text file
+                    // Prints a warning if DevAuthToken.txt does not exist, if GdkToolsConfiguration is configured
+                    // to save a DAT to file.
                     if (gdkToolsConfig.SaveDevAuthTokenToFile && !File.Exists(gdkToolsConfig.DevAuthTokenFilepath))
                     {
                         Debug.LogWarning("Launching Android client without a DevAuthToken.txt asset.");

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
@@ -99,13 +99,6 @@ namespace Improbable.Gdk.Mobile
                         return;
                     }
 
-                    // Prints a warning if DevAuthToken.txt does not exist, if GdkToolsConfiguration is configured
-                    // to save a DAT to file.
-                    if (gdkToolsConfig.SaveDevAuthTokenToFile && !File.Exists(gdkToolsConfig.DevAuthTokenFilepath))
-                    {
-                        Debug.LogWarning("Launching Android client without a DevAuthToken.txt asset.");
-                    }
-
                     arguments.Append($"+{RuntimeConfigNames.DevAuthTokenKey} {DevAuthTokenUtils.DevAuthToken} ");
                 }
 

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
@@ -90,6 +90,26 @@ namespace Improbable.Gdk.Mobile
                 else
                 {
                     arguments.Append($"+{RuntimeConfigNames.Environment} {RuntimeConfigDefaults.CloudEnvironment} ");
+
+                    var gdkToolsConfig = GdkToolsConfiguration.GetOrCreateInstance();
+
+                    // Return error if no DevAuthToken is set AND fails to generate new DevAuthToken.
+                    if (!EditorPrefs.HasKey(RuntimeConfigNames.DevAuthTokenKey) && !DevAuthTokenUtils.Generate())
+                    {
+                        Debug.LogError("Failed to generate a Dev Auth Token to launch mobile client.");
+                        return;
+                    }
+
+                    // Returns error if DevAuthToken.txt does not exists AND fails to save new DevAuthToken.txt.
+                    // Ignores if GdkToolsConfiguration does not require DevAuthToken to be saved as text file
+                    if (gdkToolsConfig.SaveDevAuthTokenToFile &&
+                        (!File.Exists(gdkToolsConfig.DevAuthTokenFilepath) || !DevAuthTokenUtils.SaveTokenToFile()))
+                    {
+                        Debug.LogError("Failed to save DevAuthToken.txt asset.");
+                        return;
+                    }
+
+                    arguments.Append($"+{RuntimeConfigNames.DevAuthTokenKey} {DevAuthTokenUtils.DevAuthToken}");
                 }
 
                 // Get chosen android package id and launch

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
@@ -102,11 +102,9 @@ namespace Improbable.Gdk.Mobile
 
                     // Returns error if DevAuthToken.txt does not exists AND fails to save new DevAuthToken.txt.
                     // Ignores if GdkToolsConfiguration does not require DevAuthToken to be saved as text file
-                    if (gdkToolsConfig.SaveDevAuthTokenToFile &&
-                        (!File.Exists(gdkToolsConfig.DevAuthTokenFilepath) || !DevAuthTokenUtils.SaveTokenToFile()))
+                    if (gdkToolsConfig.SaveDevAuthTokenToFile && !File.Exists(gdkToolsConfig.DevAuthTokenFilepath))
                     {
-                        Debug.LogError("Failed to save DevAuthToken.txt asset.");
-                        return;
+                        Debug.LogWarning("Launching Android client without a DevAuthToken.txt asset.");
                     }
 
                     arguments.Append($"+{RuntimeConfigNames.DevAuthTokenKey} {DevAuthTokenUtils.DevAuthToken}");

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Editor/LaunchMenu.cs
@@ -93,7 +93,7 @@ namespace Improbable.Gdk.Mobile
                     var gdkToolsConfig = GdkToolsConfiguration.GetOrCreateInstance();
 
                     // Return error if no DevAuthToken is set AND fails to generate new DevAuthToken.
-                    if (!PlayerPrefs.HasKey(RuntimeConfigNames.DevAuthTokenKey) && !DevAuthTokenUtils.Generate())
+                    if (!PlayerPrefs.HasKey(RuntimeConfigNames.DevAuthTokenKey) && !DevAuthTokenUtils.TryGenerate())
                     {
                         Debug.LogError("Failed to generate a Dev Auth Token to launch mobile client.");
                         return;
@@ -106,7 +106,7 @@ namespace Improbable.Gdk.Mobile
                         Debug.LogWarning("Launching Android client without a DevAuthToken.txt asset.");
                     }
 
-                    arguments.Append($"+{RuntimeConfigNames.DevAuthTokenKey} {DevAuthTokenUtils.DevAuthToken}");
+                    arguments.Append($"+{RuntimeConfigNames.DevAuthTokenKey} {DevAuthTokenUtils.DevAuthToken} ");
                 }
 
                 // Get chosen android package id and launch

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Improbable.Gdk.Mobile.asmdef
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Improbable.Gdk.Mobile.asmdef
@@ -6,5 +6,10 @@
     "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
-    "allowUnsafeCode": false
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
 }

--- a/workers/unity/Packages/com.improbable.gdk.mobile/Worker/DefaultMobileWorkerConnector.cs
+++ b/workers/unity/Packages/com.improbable.gdk.mobile/Worker/DefaultMobileWorkerConnector.cs
@@ -47,6 +47,12 @@ namespace Improbable.Gdk.Mobile
                 PlayerPrefs.DeleteKey(HostIpPlayerPrefsKey);
             }
 
+            var devAuthToken = CommandLineUtility.GetCommandLineValue(arguments, RuntimeConfigNames.DevAuthTokenKey, string.Empty);
+            if (!string.IsNullOrEmpty(devAuthToken))
+            {
+                PlayerPrefs.SetString(RuntimeConfigNames.DevAuthTokenKey, devAuthToken);
+            }
+
             PlayerPrefs.Save();
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/DevAuthTokenUtils.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/DevAuthTokenUtils.cs
@@ -69,7 +69,7 @@ namespace Improbable.Gdk.Tools
             return !gdkToolsConfiguration.SaveDevAuthTokenToFile || SaveTokenToFile();
         }
 
-        public static bool SaveTokenToFile()
+        private static bool SaveTokenToFile()
         {
             var gdkToolsConfiguration = GdkToolsConfiguration.GetOrCreateInstance();
             var devAuthTokenFullDir = gdkToolsConfiguration.DevAuthTokenFullDir;

--- a/workers/unity/Packages/com.improbable.gdk.tools/DevAuthTokenUtils.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/DevAuthTokenUtils.cs
@@ -83,8 +83,8 @@ namespace Improbable.Gdk.Tools
             if (!PlayerPrefs.HasKey(PlayerPrefDevAuthTokenKey))
             {
                 // Given we call SaveTokenToFile after successfully generating a Dev Auth Token,
-                // we should never see the following warning.
-                Debug.LogWarning("Cannot save Development Authentication Token, as it has not been generated.");
+                // we should never see the following error.
+                Debug.LogError("Cannot save Development Authentication Token, as it has not been generated.");
                 return false;
             }
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/DevAuthTokenUtils.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/DevAuthTokenUtils.cs
@@ -9,7 +9,7 @@ namespace Improbable.Gdk.Tools
 {
     public static class DevAuthTokenUtils
     {
-        public static string DevAuthToken => EditorPrefs.GetString(DevAuthTokenKey);
+        public static string DevAuthToken => PlayerPrefs.GetString(DevAuthTokenKey);
 
         private static string DevAuthTokenAssetPath =>
             Path.Combine("Assets", GdkToolsConfiguration.GetOrCreateInstance().DevAuthTokenDir, "DevAuthToken.txt");
@@ -64,7 +64,7 @@ namespace Improbable.Gdk.Tools
             }
 
             Debug.Log($"Saving token {devAuthToken} to Editor Preferences.");
-            EditorPrefs.SetString(DevAuthTokenKey, devAuthToken);
+            PlayerPrefs.SetString(DevAuthTokenKey, devAuthToken);
 
             return !gdkToolsConfiguration.SaveDevAuthTokenToFile || SaveTokenToFile();
         }
@@ -75,7 +75,7 @@ namespace Improbable.Gdk.Tools
             var devAuthTokenFullDir = gdkToolsConfiguration.DevAuthTokenFullDir;
             var devAuthTokenFilePath = gdkToolsConfiguration.DevAuthTokenFilepath;
 
-            if (!EditorPrefs.HasKey(DevAuthTokenKey))
+            if (!PlayerPrefs.HasKey(DevAuthTokenKey))
             {
                 // Given we call SaveTokenToFile after successfully generating a Dev Auth Token,
                 // we should never see the following warning.
@@ -83,7 +83,7 @@ namespace Improbable.Gdk.Tools
                 return false;
             }
 
-            var devAuthToken = EditorPrefs.GetString(DevAuthTokenKey);
+            var devAuthToken = PlayerPrefs.GetString(DevAuthTokenKey);
 
             if (!Directory.Exists(devAuthTokenFullDir))
             {
@@ -110,7 +110,7 @@ namespace Improbable.Gdk.Tools
         [MenuItem(DevAuthMenuPrefix + DevAuthMenuClearToken, false, MenuPriorities.ClearDevAuthToken)]
         private static void ClearToken()
         {
-            EditorPrefs.DeleteKey(DevAuthTokenKey);
+            PlayerPrefs.DeleteKey(DevAuthTokenKey);
             AssetDatabase.DeleteAsset(DevAuthTokenAssetPath);
             AssetDatabase.Refresh();
         }

--- a/workers/unity/Packages/com.improbable.gdk.tools/DevAuthTokenUtils.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/DevAuthTokenUtils.cs
@@ -51,10 +51,12 @@ namespace Improbable.Gdk.Tools
                 }
                 else
                 {
-                    throw new Exception(
-                        $@"{(deserializedMessage.TryGetValue(JsonErrorKey, out var errorMessage)
-                            ? errorMessage
-                            : string.Empty)}");
+                    if (deserializedMessage.TryGetValue(JsonErrorKey, out var errorMessage))
+                    {
+                        throw new Exception(errorMessage.ToString());
+                    }
+
+                    throw new Exception(string.Empty);
                 }
             }
             catch (Exception e)

--- a/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs
@@ -16,6 +16,7 @@ namespace Improbable.Gdk.Tools
         public string DescriptorOutputDir;
         public string DevAuthTokenDir;
         public int DevAuthTokenLifetimeDays;
+        public bool SaveDevAuthTokenToFile;
 
         internal string RuntimeIpEditorPrefKey = "RuntimeIp";
         public string RuntimeIp => EditorPrefs.GetString(RuntimeIpEditorPrefKey);
@@ -84,6 +85,11 @@ namespace Improbable.Gdk.Tools
             if (!string.IsNullOrEmpty(RuntimeIp) && !IPAddress.TryParse(RuntimeIp, out _))
             {
                 errors.Add($"Runtime IP \"{RuntimeIp}\" is not a valid IP address.");
+            }
+
+            if (!SaveDevAuthTokenToFile)
+            {
+                return errors;
             }
 
             if (string.IsNullOrEmpty(DevAuthTokenDir))

--- a/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using UnityEditor;
 using UnityEngine;
 
 namespace Improbable.Gdk.Tools
@@ -13,9 +14,11 @@ namespace Improbable.Gdk.Tools
         public List<string> SchemaSourceDirs = new List<string>();
         public string CodegenOutputDir;
         public string DescriptorOutputDir;
-        public string RuntimeIp;
         public string DevAuthTokenDir;
         public int DevAuthTokenLifetimeDays;
+
+        internal string RuntimeIpEditorPrefKey = "RuntimeIp";
+        public string RuntimeIp => EditorPrefs.GetString(RuntimeIpEditorPrefKey);
 
         public string DevAuthTokenFullDir => Path.Combine(Application.dataPath, DevAuthTokenDir);
         public string DevAuthTokenFilepath => Path.Combine(DevAuthTokenFullDir, "DevAuthToken.txt");
@@ -101,7 +104,6 @@ namespace Improbable.Gdk.Tools
             SchemaStdLibDir = DefaultValues.SchemaStdLibDir;
             CodegenOutputDir = DefaultValues.CodegenOutputDir;
             DescriptorOutputDir = DefaultValues.DescriptorOutputDir;
-            RuntimeIp = DefaultValues.RuntimeIp;
             DevAuthTokenDir = DefaultValues.DevAuthTokenDir;
             DevAuthTokenLifetimeDays = DefaultValues.DevAuthTokenLifetimeDays;
 
@@ -134,7 +136,6 @@ namespace Improbable.Gdk.Tools
             public const string CodegenOutputDir = "Assets/Generated/Source";
             public const string DescriptorOutputDir = "../../build/assembly/schema";
             public const string SchemaSourceDir = "../../schema";
-            public const string RuntimeIp = null;
             public const string DevAuthTokenDir = "Resources";
             public const int DevAuthTokenLifetimeDays = 30;
         }

--- a/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfiguration.cs
@@ -27,8 +27,6 @@ namespace Improbable.Gdk.Tools
 
         private static readonly string JsonFilePath = Path.GetFullPath("Assets/Config/GdkToolsConfiguration.json");
 
-        private static readonly string UnityProjectRoot = Path.Combine(Application.dataPath, "..");
-
         private GdkToolsConfiguration()
         {
             ResetToDefault();
@@ -70,7 +68,7 @@ namespace Improbable.Gdk.Tools
 
                 try
                 {
-                    var fullSchemaSourceDirPath = Path.Combine(UnityProjectRoot, schemaSourceDir);
+                    var fullSchemaSourceDirPath = Path.Combine(Application.dataPath, "..", schemaSourceDir);
                     if (!Directory.Exists(fullSchemaSourceDirPath))
                     {
                         errors.Add($"{fullSchemaSourceDirPath} cannot be found.");

--- a/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationWindow.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationWindow.cs
@@ -165,9 +165,12 @@ namespace Improbable.Gdk.Tools
                 toolsConfig.DevAuthTokenLifetimeDays =
                     EditorGUILayout.IntSlider(DevAuthTokenLifetimeLabel, toolsConfig.DevAuthTokenLifetimeDays, 1, 90);
 
-                toolsConfig.DevAuthTokenDir = EditorGUILayout.TextField(DevAuthTokenDirLabel, toolsConfig.DevAuthTokenDir);
-
-                GUILayout.Label($"Token filepath: {toolsConfig.DevAuthTokenFilepath}", EditorStyles.helpBox);
+                toolsConfig.SaveDevAuthTokenToFile = EditorGUILayout.Toggle("Save token to file", toolsConfig.SaveDevAuthTokenToFile);
+                using (new EditorGUI.DisabledScope(!toolsConfig.SaveDevAuthTokenToFile))
+                {
+                    toolsConfig.DevAuthTokenDir = EditorGUILayout.TextField(DevAuthTokenDirLabel, toolsConfig.DevAuthTokenDir);
+                    GUILayout.Label($"Token filepath: {toolsConfig.DevAuthTokenFilepath}", EditorStyles.helpBox);
+                }
             }
 
             EditorGUIUtility.labelWidth = previousWidth;

--- a/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationWindow.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationWindow.cs
@@ -154,7 +154,9 @@ namespace Improbable.Gdk.Tools
             GUILayout.Label(MobileSectionLabel, EditorStyles.boldLabel);
             using (new EditorGUI.IndentLevelScope())
             {
-                toolsConfig.RuntimeIp = EditorGUILayout.TextField(RuntimeIpLabel, toolsConfig.RuntimeIp);
+                EditorPrefs.SetString(
+                    toolsConfig.RuntimeIpEditorPrefKey,
+                    EditorGUILayout.TextField(RuntimeIpLabel, toolsConfig.RuntimeIp));
             }
 
             GUILayout.Label(DevAuthTokenSectionLabel, EditorStyles.boldLabel);

--- a/workers/unity/Packages/com.improbable.gdk.tools/MenuPriorities.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/MenuPriorities.cs
@@ -12,5 +12,6 @@ namespace Improbable.Gdk.Tools
 
         internal const int GdkToolsConfiguration = 201;
         internal const int GenerateDevAuthToken = 202;
+        internal const int ClearDevAuthToken = 204;
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.tools/MenuPriorities.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/MenuPriorities.cs
@@ -12,6 +12,6 @@ namespace Improbable.Gdk.Tools
 
         internal const int GdkToolsConfiguration = 201;
         internal const int GenerateDevAuthToken = 202;
-        internal const int ClearDevAuthToken = 204;
+        internal const int ClearDevAuthToken = 203;
     }
 }

--- a/workers/unity/ProjectSettings/EditorBuildSettings.asset
+++ b/workers/unity/ProjectSettings/EditorBuildSettings.asset
@@ -14,7 +14,4 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Playground/Scenes/MobileClientScene.unity
     guid: 82ccd0fd96a2ba24f88d0c7d01592f2e
-  - enabled: 1
-    path: Assets/Playground/Scenes/iOSClientScene.unity
-    guid: 424c4b2c090874512badc5e7ee757d5f
   m_configObjects: {}

--- a/workers/unity/ProjectSettings/GraphicsSettings.asset
+++ b/workers/unity/ProjectSettings/GraphicsSettings.asset
@@ -37,6 +37,7 @@ GraphicsSettings:
   - {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 17000, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 16000, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 16001, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}

--- a/workers/unity/ProjectSettings/ProjectSettings.asset
+++ b/workers/unity/ProjectSettings/ProjectSettings.asset
@@ -3,7 +3,7 @@
 --- !u!129 &1
 PlayerSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 15
+  serializedVersion: 16
   productGUID: 00d744d32a4452244a9a72cbda2f61ff
   AndroidProfiler: 0
   AndroidFilterTouchesWhenObscured: 0
@@ -125,7 +125,6 @@ PlayerSettings:
   m_HolographicPauseOnTrackingLoss: 1
   xboxOneDisableKinectGpuReservation: 0
   xboxOneEnable7thCore: 0
-  isWsaHolographicRemotingEnabled: 0
   vrSettings:
     cardboard:
       depthFormat: 0
@@ -140,10 +139,17 @@ PlayerSettings:
     hololens:
       depthFormat: 1
       depthBufferSharingEnabled: 0
+    lumin:
+      depthFormat: 0
+      frameTiming: 2
+      enableGLCache: 0
+      glCacheMaxBlobSize: 524288
+      glCacheMaxFileSize: 8388608
     oculus:
       sharedDepthBuffer: 0
       dashSupport: 0
     enable360StereoCapture: 0
+  isWsaHolographicRemotingEnabled: 0
   protectGraphicsMemory: 0
   enableFrameTimingStats: 0
   useHDRDisplay: 0
@@ -155,7 +161,7 @@ PlayerSettings:
   applicationIdentifier:
     Android: com.improbable.gdk
     Standalone: com.improbable.gdk
-    iOS: com.improbable.gdk
+    iPhone: com.improbable.gdk
     tvOS: com.improbable.gdk
   buildNumber: {}
   AndroidBundleVersionCode: 1
@@ -196,6 +202,10 @@ PlayerSettings:
   iPadHighResPortraitSplashScreen: {fileID: 0}
   iPadLandscapeSplashScreen: {fileID: 0}
   iPadHighResLandscapeSplashScreen: {fileID: 0}
+  iPhone65inPortraitSplashScreen: {fileID: 0}
+  iPhone65inLandscapeSplashScreen: {fileID: 0}
+  iPhone61inPortraitSplashScreen: {fileID: 0}
+  iPhone61inLandscapeSplashScreen: {fileID: 0}
   appleTVSplashScreen: {fileID: 0}
   appleTVSplashScreen2x: {fileID: 0}
   tvOSSmallIconLayers: []
@@ -247,7 +257,7 @@ PlayerSettings:
   AndroidTargetArchitectures: 5
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
-  AndroidKeystoreName: 
+  AndroidKeystoreName: '{inproject}: '
   AndroidKeyaliasName: 
   AndroidBuildApkPerCpuArchitecture: 0
   AndroidTVCompatibility: 1
@@ -255,6 +265,7 @@ PlayerSettings:
   AndroidEnableTango: 0
   androidEnableBanner: 1
   androidUseLowAccuracyLocation: 0
+  androidUseCustomKeystore: 0
   m_AndroidBanners:
   - width: 320
     height: 180
@@ -369,6 +380,7 @@ PlayerSettings:
   m_BuildTargetEnableVuforiaSettings: []
   openGLRequireES31: 0
   openGLRequireES31AEP: 0
+  openGLRequireES32: 0
   m_TemplateCustomTags: {}
   mobileMTRendering:
     Android: 1
@@ -552,6 +564,7 @@ PlayerSettings:
   ps4DownloadDataSize: 0
   ps4GarlicHeapSize: 2048
   ps4ProGarlicHeapSize: 2560
+  playerPrefsMaxSize: 32768
   ps4Passcode: frAQBc8Wsa1xVPfvJcrgRYwTiizs2trQ
   ps4pnSessions: 1
   ps4pnPresence: 1
@@ -599,6 +612,7 @@ PlayerSettings:
   webGLCompressionFormat: 1
   webGLLinkerTarget: 0
   webGLThreadsSupport: 0
+  webGLWasmStreaming: 0
   scriptingDefineSymbols:
     1: UNITY_POST_PROCESSING_STACK_V2;UNITY_DISABLE_AUTOMATIC_SYSTEM_BOOTSTRAP;DISABLE_REACTIVE_COMPONENTS
     4: UNITY_POST_PROCESSING_STACK_V2;UNITY_DISABLE_AUTOMATIC_SYSTEM_BOOTSTRAP;DISABLE_REACTIVE_COMPONENTS
@@ -618,13 +632,15 @@ PlayerSettings:
   scriptingBackend:
     Android: 0
     Standalone: 0
-    iOS: 1
+    iPhone: 1
   il2cppCompilerConfiguration: {}
   managedStrippingLevel: {}
   incrementalIl2cppBuild: {}
   allowUnsafeCode: 0
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1
+  gcIncremental: 0
+  gcWBarrierValidation: 0
   apiCompatibilityLevelPerPlatform: {}
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
@@ -655,7 +671,6 @@ PlayerSettings:
   metroFTAName: 
   metroFTAFileTypes: []
   metroProtocolName: 
-  metroCompilationOverrides: 1
   XboxOneProductId: 
   XboxOneUpdateKey: 
   XboxOneSandboxId: 
@@ -680,7 +695,7 @@ PlayerSettings:
   XboxOneAllowedProductIds: []
   XboxOnePersistentLocalStorageSize: 0
   XboxOneXTitleMemory: 8
-  xboxOneScriptCompiler: 0
+  xboxOneScriptCompiler: 1
   XboxOneOverrideIdentityName: 
   vrEditorSettings:
     daydream:
@@ -694,7 +709,7 @@ PlayerSettings:
     m_PortalFolderPath: 
   luminCert:
     m_CertPath: 
-    m_PrivateKeyPath: 
+    m_SignPackage: 1
   luminIsChannelApp: 0
   luminVersion:
     m_VersionCode: 1


### PR DESCRIPTION
#### Description

- move runtime ip to an editor pref
- move DAT to player pref
	- [this ties a DAT to a company/project_name](https://docs.unity3d.com/ScriptReference/PlayerPrefs.html)
	- only create DAT.txt if enabled in GdkToolsConfiguration
	- pass in DAT as argument when starting android client for cloud
	- if DAT argument passed in, player pref is set
	- if no DAT argument exists / previously set as player pref - read from DAT.txt and save to player prefs

#### Tests

- local launch works fine
- android cloud launch via editor works fine
- no DAT.txt generated unless specifically requested

#### Documentation

- [x] changelog
- [ ] update screenshots/docs where relevant

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
