### PR TITLE
Remove workaround for a schema component update bug (WRK-1031).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 ### Fixed
 
 - Fixed a bug where a worker's `World` could get disposed multiple times if you stopped the application inside the Editor while the worker is being created.
-- Fixed a bug when uploading assemblies with the deployment launcher window, by adding the `--enable_pre_upload_check=false` argument.
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 
 - Fixed a bug where a worker's `World` could get disposed multiple times if you stopped the application inside the Editor while the worker is being created.
 
+### Internal
+
+- Removed the workaround for a schema component update bug (WRK-1031).
+
 ## `0.2.2` - 2019-05-15
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Fixed
 
 - Fixed a bug where a worker's `World` could get disposed multiple times if you stopped the application inside the Editor while the worker is being created.
+- Fixed a bug when uploading assemblies with the deployment launcher window, by adding the `--enable_pre_upload_check=false` argument.
 
 ### Internal
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyComponentDiffDeserializer.cs
@@ -46,8 +46,6 @@ namespace Improbable.Gdk.Tests
                 {
                     ref readonly var update = ref updates[i];
                     var schemaUpdate = new SchemaComponentUpdate(ComponentId);
-                    // TODO: UTY-1858 - remove this workaround.
-                    schemaUpdate.GetEvents();
                     var componentUpdate = new ComponentUpdate(schemaUpdate);
                     Serialization.SerializeUpdate(update.Update, schemaUpdate);
                     serializedMessages.AddComponentUpdate(componentUpdate, update.EntityId.Id);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueComponentDiffDeserializer.cs
@@ -46,8 +46,6 @@ namespace Improbable.Gdk.Tests
                 {
                     ref readonly var update = ref updates[i];
                     var schemaUpdate = new SchemaComponentUpdate(ComponentId);
-                    // TODO: UTY-1858 - remove this workaround.
-                    schemaUpdate.GetEvents();
                     var componentUpdate = new ComponentUpdate(schemaUpdate);
                     Serialization.SerializeUpdate(update.Update, schemaUpdate);
                     serializedMessages.AddComponentUpdate(componentUpdate, update.EntityId.Id);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalComponentDiffDeserializer.cs
@@ -46,8 +46,6 @@ namespace Improbable.Gdk.Tests
                 {
                     ref readonly var update = ref updates[i];
                     var schemaUpdate = new SchemaComponentUpdate(ComponentId);
-                    // TODO: UTY-1858 - remove this workaround.
-                    schemaUpdate.GetEvents();
                     var componentUpdate = new ComponentUpdate(schemaUpdate);
                     Serialization.SerializeUpdate(update.Update, schemaUpdate);
                     serializedMessages.AddComponentUpdate(componentUpdate, update.EntityId.Id);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedComponentDiffDeserializer.cs
@@ -46,8 +46,6 @@ namespace Improbable.Gdk.Tests
                 {
                     ref readonly var update = ref updates[i];
                     var schemaUpdate = new SchemaComponentUpdate(ComponentId);
-                    // TODO: UTY-1858 - remove this workaround.
-                    schemaUpdate.GetEvents();
                     var componentUpdate = new ComponentUpdate(schemaUpdate);
                     Serialization.SerializeUpdate(update.Update, schemaUpdate);
                     serializedMessages.AddComponentUpdate(componentUpdate, update.EntityId.Id);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularComponentDiffDeserializer.cs
@@ -46,8 +46,6 @@ namespace Improbable.Gdk.Tests
                 {
                     ref readonly var update = ref updates[i];
                     var schemaUpdate = new SchemaComponentUpdate(ComponentId);
-                    // TODO: UTY-1858 - remove this workaround.
-                    schemaUpdate.GetEvents();
                     var componentUpdate = new ComponentUpdate(schemaUpdate);
                     Serialization.SerializeUpdate(update.Update, schemaUpdate);
                     serializedMessages.AddComponentUpdate(componentUpdate, update.EntityId.Id);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentComponentDiffDeserializer.cs
@@ -46,8 +46,6 @@ namespace Improbable.Gdk.Tests
                 {
                     ref readonly var update = ref updates[i];
                     var schemaUpdate = new SchemaComponentUpdate(ComponentId);
-                    // TODO: UTY-1858 - remove this workaround.
-                    schemaUpdate.GetEvents();
                     var componentUpdate = new ComponentUpdate(schemaUpdate);
                     Serialization.SerializeUpdate(update.Update, schemaUpdate);
                     serializedMessages.AddComponentUpdate(componentUpdate, update.EntityId.Id);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionComponentDiffDeserializer.cs
@@ -60,8 +60,6 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 {
                     ref readonly var update = ref updates[i];
                     var schemaUpdate = new SchemaComponentUpdate(ComponentId);
-                    // TODO: UTY-1858 - remove this workaround.
-                    schemaUpdate.GetEvents();
                     var componentUpdate = new ComponentUpdate(schemaUpdate);
                     Serialization.SerializeUpdate(update.Update, schemaUpdate);
                     serializedMessages.AddComponentUpdate(componentUpdate, update.EntityId.Id);
@@ -75,8 +73,6 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                     {
                         ref readonly var ev = ref events[i];
                         var schemaUpdate = new SchemaComponentUpdate(ComponentId);
-                        // TODO: UTY-1858 - remove this workaround.
-                        schemaUpdate.GetFields();
                         var componentUpdate = new ComponentUpdate(schemaUpdate);
                         var obj = schemaUpdate.GetEvents().AddObject(1);
                         global::Improbable.Gdk.Tests.AlternateSchemaSyntax.RandomDataType.Serialization.Serialize(ev.Event.Payload, obj);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentComponentDiffDeserializer.cs
@@ -73,8 +73,6 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 {
                     ref readonly var update = ref updates[i];
                     var schemaUpdate = new SchemaComponentUpdate(ComponentId);
-                    // TODO: UTY-1858 - remove this workaround.
-                    schemaUpdate.GetEvents();
                     var componentUpdate = new ComponentUpdate(schemaUpdate);
                     Serialization.SerializeUpdate(update.Update, schemaUpdate);
                     serializedMessages.AddComponentUpdate(componentUpdate, update.EntityId.Id);
@@ -88,8 +86,6 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     {
                         ref readonly var ev = ref events[i];
                         var schemaUpdate = new SchemaComponentUpdate(ComponentId);
-                        // TODO: UTY-1858 - remove this workaround.
-                        schemaUpdate.GetFields();
                         var componentUpdate = new ComponentUpdate(schemaUpdate);
                         var obj = schemaUpdate.GetEvents().AddObject(1);
                         global::Improbable.Gdk.Tests.BlittableTypes.FirstEventPayload.Serialization.Serialize(ev.Event.Payload, obj);
@@ -105,8 +101,6 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     {
                         ref readonly var ev = ref events[i];
                         var schemaUpdate = new SchemaComponentUpdate(ComponentId);
-                        // TODO: UTY-1858 - remove this workaround.
-                        schemaUpdate.GetFields();
                         var componentUpdate = new ComponentUpdate(schemaUpdate);
                         var obj = schemaUpdate.GetEvents().AddObject(2);
                         global::Improbable.Gdk.Tests.BlittableTypes.SecondEventPayload.Serialization.Serialize(ev.Event.Payload, obj);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsComponentDiffDeserializer.cs
@@ -46,8 +46,6 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 {
                     ref readonly var update = ref updates[i];
                     var schemaUpdate = new SchemaComponentUpdate(ComponentId);
-                    // TODO: UTY-1858 - remove this workaround.
-                    schemaUpdate.GetEvents();
                     var componentUpdate = new ComponentUpdate(schemaUpdate);
                     Serialization.SerializeUpdate(update.Update, schemaUpdate);
                     serializedMessages.AddComponentUpdate(componentUpdate, update.EntityId.Id);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsComponentDiffDeserializer.cs
@@ -46,8 +46,6 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 {
                     ref readonly var update = ref updates[i];
                     var schemaUpdate = new SchemaComponentUpdate(ComponentId);
-                    // TODO: UTY-1858 - remove this workaround.
-                    schemaUpdate.GetEvents();
                     var componentUpdate = new ComponentUpdate(schemaUpdate);
                     Serialization.SerializeUpdate(update.Update, schemaUpdate);
                     serializedMessages.AddComponentUpdate(componentUpdate, update.EntityId.Id);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsComponentDiffDeserializer.cs
@@ -60,8 +60,6 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 {
                     ref readonly var update = ref updates[i];
                     var schemaUpdate = new SchemaComponentUpdate(ComponentId);
-                    // TODO: UTY-1858 - remove this workaround.
-                    schemaUpdate.GetEvents();
                     var componentUpdate = new ComponentUpdate(schemaUpdate);
                     Serialization.SerializeUpdate(update.Update, schemaUpdate);
                     serializedMessages.AddComponentUpdate(componentUpdate, update.EntityId.Id);
@@ -75,8 +73,6 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     {
                         ref readonly var ev = ref events[i];
                         var schemaUpdate = new SchemaComponentUpdate(ComponentId);
-                        // TODO: UTY-1858 - remove this workaround.
-                        schemaUpdate.GetFields();
                         var componentUpdate = new ComponentUpdate(schemaUpdate);
                         var obj = schemaUpdate.GetEvents().AddObject(1);
                         global::Improbable.Gdk.Tests.ComponentsWithNoFields.Empty.Serialization.Serialize(ev.Event.Payload, obj);

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentComponentDiffDeserializer.cs
@@ -73,8 +73,6 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 {
                     ref readonly var update = ref updates[i];
                     var schemaUpdate = new SchemaComponentUpdate(ComponentId);
-                    // TODO: UTY-1858 - remove this workaround.
-                    schemaUpdate.GetEvents();
                     var componentUpdate = new ComponentUpdate(schemaUpdate);
                     Serialization.SerializeUpdate(update.Update, schemaUpdate);
                     serializedMessages.AddComponentUpdate(componentUpdate, update.EntityId.Id);
@@ -88,8 +86,6 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     {
                         ref readonly var ev = ref events[i];
                         var schemaUpdate = new SchemaComponentUpdate(ComponentId);
-                        // TODO: UTY-1858 - remove this workaround.
-                        schemaUpdate.GetFields();
                         var componentUpdate = new ComponentUpdate(schemaUpdate);
                         var obj = schemaUpdate.GetEvents().AddObject(1);
                         global::Improbable.Gdk.Tests.NonblittableTypes.FirstEventPayload.Serialization.Serialize(ev.Event.Payload, obj);
@@ -105,8 +101,6 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     {
                         ref readonly var ev = ref events[i];
                         var schemaUpdate = new SchemaComponentUpdate(ComponentId);
-                        // TODO: UTY-1858 - remove this workaround.
-                        schemaUpdate.GetFields();
                         var componentUpdate = new ComponentUpdate(schemaUpdate);
                         var obj = schemaUpdate.GetEvents().AddObject(2);
                         global::Improbable.Gdk.Tests.NonblittableTypes.SecondEventPayload.Serialization.Serialize(ev.Event.Payload, obj);

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Assembly.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Assembly.cs
@@ -19,7 +19,8 @@ namespace Improbable.Gdk.DeploymentLauncher.Commands
                 config.AssemblyName,
                 "--project_name",
                 config.ProjectName,
-                "--json_output"
+                "--json_output",
+                "--enable_pre_upload_check=false"
             };
 
             if (config.ShouldForceUpload)

--- a/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Assembly.cs
+++ b/workers/unity/Packages/com.improbable.gdk.deploymentlauncher/Commands/Assembly.cs
@@ -20,7 +20,7 @@ namespace Improbable.Gdk.DeploymentLauncher.Commands
                 "--project_name",
                 config.ProjectName,
                 "--json_output",
-                "--enable_pre_upload_check=false"
+                "--enable_pre_upload_check=false",
             };
 
             if (config.ShouldForceUpload)

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ComponentDiffDeserializerGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/ComponentDiffDeserializerGenerator.tt
@@ -73,8 +73,6 @@ namespace <#= qualifiedNamespace #>
                 {
                     ref readonly var update = ref updates[i];
                     var schemaUpdate = new SchemaComponentUpdate(ComponentId);
-                    // TODO: UTY-1858 - remove this workaround.
-                    schemaUpdate.GetEvents();
                     var componentUpdate = new ComponentUpdate(schemaUpdate);
                     Serialization.SerializeUpdate(update.Update, schemaUpdate);
                     serializedMessages.AddComponentUpdate(componentUpdate, update.EntityId.Id);
@@ -92,8 +90,6 @@ namespace <#= qualifiedNamespace #>
                     {
                         ref readonly var ev = ref events[i];
                         var schemaUpdate = new SchemaComponentUpdate(ComponentId);
-                        // TODO: UTY-1858 - remove this workaround.
-                        schemaUpdate.GetFields();
                         var componentUpdate = new ComponentUpdate(schemaUpdate);
                         var obj = schemaUpdate.GetEvents().AddObject(<#= ev.EventIndex #>);
                         <#= ev.FqnPayloadType #>.Serialization.Serialize(ev.Event.Payload, obj);


### PR DESCRIPTION
#### Description

Removed the workaround for a schema component update bug (WRK-1031).

consider reading 1st and 3rd commit (2nd commit is generated code)

includes drive-by deployment launcher fix for uploading assemblies

#### Tests

- [x] local launch
- [x] cloud launch
- [x] premerge
- [x] release qa

#### Documentation

internal changelog entry

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
