### PR TITLE
Fix PlayerLoop breaking on disconnected worker

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Utility/PlayerLoopUtils.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Utility/PlayerLoopUtils.cs
@@ -218,7 +218,7 @@ namespace Improbable.Gdk.Core
                         return targetSystem.World != world;
                     }
 
-                    return false;
+                    return true;
                 }).ToArray();
             }
 


### PR DESCRIPTION
#### Description
No longer remove all non-ecs function calls from the PlayerLoop when a worker disconnects.
Oops

#### Tests
Tested locally and on the cloud, SimulatedPlayers can safely disconnect again.