### PR TITLE
UTY-2058: Update launch config templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 ### Internal
 
 - Removed the workaround for a schema component update bug (WRK-1031).
+- All playground launch configuration files now use the `w2_r0500_e5` template instead of the `small` template which was deprecated.
 
 ## `0.2.2` - 2019-05-15
 

--- a/cloud_launch.json
+++ b/cloud_launch.json
@@ -1,5 +1,5 @@
 {
-  "template": "small",
+  "template": "w2_r0500_e5",
   "world": {
     "chunkEdgeLengthMeters": 5,
     "snapshots": {

--- a/default_launch.json
+++ b/default_launch.json
@@ -1,5 +1,5 @@
 {
-  "template": "small",
+  "template": "w2_r0500_e5",
   "world": {
     "chunkEdgeLengthMeters": 5,
     "snapshots": {


### PR DESCRIPTION
#### Description
`small` -> `w2_r0500_e5` 

#### Tests
Will run the release QA pipeline.

#### Documentation
Release note - internal.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
