### PR TITLE
UTY-2061: Exclude schema directory when cleaning workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Moved Dev Auth Token to the Player Preferences.
     - Added a setting in `GdkToolsConfiguration` to let users configure whether a `DevAuthToken.txt` should be generated or not.
     - When launching Android cloud clients from the Editor, the DevAuthToken is now passed in as a command line argument.
+- The schema descriptor is no longer deleted when you select `SpatialOS > Clean all workers` from the Unity Editor.
 
 ### Fixed
 

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/EditorPaths.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/Util/EditorPaths.cs
@@ -11,10 +11,16 @@ namespace Improbable.Gdk.BuildSystem
     /// </remarks>
     public static class EditorPaths
     {
+        /// <summary>
+        ///     The path to the Unity project build directory that worker build artifacts are placed into.
+        /// </summary>
         public static readonly string BuildScratchDirectory =
             Path.GetFullPath(Path.Combine(Application.dataPath, "..", "build", "worker"));
 
-        public static readonly string AssetDatabaseDirectory =
+        /// <summary>
+        ///     The path to the SpatialOS assembly directory where SpatialOS assembly artifacts are placed.
+        /// </summary>
+        public static readonly string SpatialAssemblyDirectory =
             Path.Combine(Application.dataPath, "..", "..", "..", "build", "assembly");
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
+++ b/workers/unity/Packages/com.improbable.gdk.buildsystem/WorkerBuilder.cs
@@ -15,11 +15,11 @@ namespace Improbable.Gdk.BuildSystem
     public static class WorkerBuilder
     {
         private static readonly string PlayerBuildDirectory =
-            Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), EditorPaths.AssetDatabaseDirectory,
+            Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), EditorPaths.SpatialAssemblyDirectory,
                 "worker"));
 
-        private static readonly string AssetDatabaseDirectory =
-            Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), EditorPaths.AssetDatabaseDirectory));
+        private static readonly string SpatialAssemblyDirectory =
+            Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), EditorPaths.SpatialAssemblyDirectory));
 
         private const string BuildWorkerTypes = "buildWorkerTypes";
 
@@ -217,9 +217,18 @@ namespace Improbable.Gdk.BuildSystem
 
         public static void Clean()
         {
-            if (Directory.Exists(AssetDatabaseDirectory))
+            // Delete all but the schema directory where the schema descriptor is placed.
+            if (Directory.Exists(SpatialAssemblyDirectory))
             {
-                Directory.Delete(AssetDatabaseDirectory, true);
+                var children = new DirectoryInfo(SpatialAssemblyDirectory).GetDirectories();
+
+                foreach (var child in children)
+                {
+                    if (child.Name != "schema")
+                    {
+                        Directory.Delete(child.FullName, true);
+                    }
+                }
             }
 
             if (Directory.Exists(EditorPaths.BuildScratchDirectory))


### PR DESCRIPTION
#### Description
Selecting `SpatialOS > Clean all workers` now only removes worker-related artifacts (configurations + assemblies). The `schema.descriptor` is preserved. 

#### Tests

Built + cleaned - checked state of the directory.

#### Documentation

Added a changelog

