### PR TITLE
Hotfix - Received Updates should be a reactive component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,39 +4,39 @@
 
 ### Breaking Changes
 
-- Schema from packages are no longer copied into the root `schema` directory.
+- Schema from packages are no longer copied into the root `schema` directory. [#953](https://github.com/spatialos/gdk-for-unity/pull/953)
     - Renamed the `Schema` directory within packages to `.schema`, to avoid generating unecessary `.meta` files.
     - Update feature module schema to the correct namespaces and folders within `.schema`.
     - If you use schema that imports from GDK packages, you will need to change how you import GDK schema.
         - Schema file Y in package `improbable.gdk.X` is imported using `import "improbable/gdk/X/Y.schema"`.
         - For example, `import "from_gdk_packages/com.improbable.gdk.core/common.schema";` now becomes `import "improbable/gdk/core/common.schema";`.
-- Upgraded the Unity Entities package to `preview.33` from `preview.21`.
+- Upgraded the Unity Entities package to `preview.33` from `preview.21`. [#963](https://github.com/spatialos/gdk-for-unity/pull/963), [#966](https://github.com/spatialos/gdk-for-unity/pull/966), [#967](https://github.com/spatialos/gdk-for-unity/pull/967)
     - See the Unity Entities package [changelog](https://docs.unity3d.com/Packages/com.unity.entities@0.0/changelog/CHANGELOG.html) for more information.
     - This has removed several APIs such as `[Inject]` and `ComponentDataArray`.
     - If you use generic `IComponentData` types, you must explicitly register them. Please view Unity's example on `RegisterGenericComponentType` in the changelog linked above.
     - System groups API has changed, systems without a group are automatically added to the `SimulationSystemGroup` which runs on `Update`.
         - The Unity Editor will print helpful warnings if any systems are not grouped properly.
-- Removed `BlittableBool`, as `bool` is now blittable.
-- Fixed a bug where the generated `ReceivedUpdates` component was not correctly wrapped in the `DISABLED_REACTIVE_COMPONENTS` define. 
+- Removed `BlittableBool`, as `bool` is now blittable. [#965](https://github.com/spatialos/gdk-for-unity/pull/965)
+- Fixed a bug where the generated `ReceivedUpdates` component was not correctly wrapped in the `DISABLED_REACTIVE_COMPONENTS` define. [#971](https://github.com/spatialos/gdk-for-unity/pull/971)
     - This means that if you have `DISABLE_REACTIVE_COMPONENTS` set, the `ReceivedUpdates` types will no longer be available.
 
 ### Changed
 
-- Upgraded the project to be compatible with `2019.1.3f1`.
-- Moved Runtime IP from the `GdkToolsConfiguration.json` to the Editor Preferences.
-- Moved Dev Auth Token to the Player Preferences.
+- Upgraded the project to be compatible with `2019.1.3f1`. [#951](https://github.com/spatialos/gdk-for-unity/pull/951)
+- Moved Runtime IP from the `GdkToolsConfiguration.json` to the Editor Preferences. [#961](https://github.com/spatialos/gdk-for-unity/pull/961)
+- Moved Dev Auth Token to the Player Preferences. [#961](https://github.com/spatialos/gdk-for-unity/pull/961)
     - Added a setting in `GdkToolsConfiguration` to let users configure whether a `DevAuthToken.txt` should be generated or not.
     - When launching Android cloud clients from the Editor, the DevAuthToken is now passed in as a command line argument.
-- The schema descriptor is no longer deleted when you select `SpatialOS > Clean all workers` from the Unity Editor.
+- The schema descriptor is no longer deleted when you select `SpatialOS > Clean all workers` from the Unity Editor. [#969](https://github.com/spatialos/gdk-for-unity/pull/969)
 
 ### Fixed
 
-- Fixed a bug where a worker's `World` could get disposed multiple times if you stopped the application inside the Editor while the worker is being created.
+- Fixed a bug where a worker's `World` could get disposed multiple times if you stopped the application inside the Editor while the worker is being created. [#952](https://github.com/spatialos/gdk-for-unity/pull/952)
 
 ### Internal
 
-- Removed the workaround for a schema component update bug (WRK-1031).
-- All playground launch configuration files now use the `w2_r0500_e5` template instead of the `small` template which was deprecated.
+- Removed the workaround for a schema component update bug (WRK-1031). [#962](https://github.com/spatialos/gdk-for-unity/pull/962)
+- All playground launch configuration files now use the `w2_r0500_e5` template instead of the `small` template which was deprecated. [#968](https://github.com/spatialos/gdk-for-unity/pull/968)
 
 ## `0.2.2` - 2019-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
     - System groups API has changed, systems without a group are automatically added to the `SimulationSystemGroup` which runs on `Update`.
         - The Unity Editor will print helpful warnings if any systems are not grouped properly.
 - Removed `BlittableBool`, as `bool` is now blittable.
+- Fixed a bug where the generated `ReceivedUpdates` component was not correctly wrapped in the `DISABLED_REACTIVE_COMPONENTS` define. 
+    - This means that if you have `DISABLE_REACTIVE_COMPONENTS` set, the `ReceivedUpdates` types will no longer be available.
 
 ### Changed
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKey.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKey.cs
@@ -3501,7 +3501,6 @@ namespace Improbable.Gdk.Tests
         }
 
 #if !DISABLE_REACTIVE_COMPONENTS
-
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKey.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKey.cs
@@ -3500,6 +3500,8 @@ namespace Improbable.Gdk.Tests
             public Option<global::System.Collections.Generic.Dictionary<global::Improbable.Gdk.Tests.SomeEnum,string>> Field18;
         }
 
+#if !DISABLE_REACTIVE_COMPONENTS
+
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;
@@ -3508,6 +3510,7 @@ namespace Improbable.Gdk.Tests
                 get => global::Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
+#endif
 
         internal class ExhaustiveMapKeyDynamic : IDynamicInvokable
         {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyProviders.cs
@@ -13,6 +13,7 @@ namespace Improbable.Gdk.Tests
     {
         internal static class ReferenceTypeProviders
         {
+#if !DISABLE_REACTIVE_COMPONENTS
             public static class UpdatesProvider 
             {
                 private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.ExhaustiveMapKey.Update>>();
@@ -79,6 +80,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
             
+#endif
 
             public static class Field1Provider 
             {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValue.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValue.cs
@@ -3500,6 +3500,8 @@ namespace Improbable.Gdk.Tests
             public Option<global::System.Collections.Generic.Dictionary<string,global::Improbable.Gdk.Tests.SomeEnum>> Field18;
         }
 
+#if !DISABLE_REACTIVE_COMPONENTS
+
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;
@@ -3508,6 +3510,7 @@ namespace Improbable.Gdk.Tests
                 get => global::Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
+#endif
 
         internal class ExhaustiveMapValueDynamic : IDynamicInvokable
         {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValue.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValue.cs
@@ -3501,7 +3501,6 @@ namespace Improbable.Gdk.Tests
         }
 
 #if !DISABLE_REACTIVE_COMPONENTS
-
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueProviders.cs
@@ -13,6 +13,7 @@ namespace Improbable.Gdk.Tests
     {
         internal static class ReferenceTypeProviders
         {
+#if !DISABLE_REACTIVE_COMPONENTS
             public static class UpdatesProvider 
             {
                 private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.ExhaustiveMapValue.Update>>();
@@ -79,6 +80,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
             
+#endif
 
             public static class Field1Provider 
             {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptional.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptional.cs
@@ -2906,6 +2906,8 @@ namespace Improbable.Gdk.Tests
             public Option<global::Improbable.Gdk.Tests.SomeEnum?> Field18;
         }
 
+#if !DISABLE_REACTIVE_COMPONENTS
+
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;
@@ -2914,6 +2916,7 @@ namespace Improbable.Gdk.Tests
                 get => global::Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
+#endif
 
         internal class ExhaustiveOptionalDynamic : IDynamicInvokable
         {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptional.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptional.cs
@@ -2907,7 +2907,6 @@ namespace Improbable.Gdk.Tests
         }
 
 #if !DISABLE_REACTIVE_COMPONENTS
-
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalProviders.cs
@@ -13,6 +13,7 @@ namespace Improbable.Gdk.Tests
     {
         internal static class ReferenceTypeProviders
         {
+#if !DISABLE_REACTIVE_COMPONENTS
             public static class UpdatesProvider 
             {
                 private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.ExhaustiveOptional.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.ExhaustiveOptional.Update>>();
@@ -79,6 +80,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
             
+#endif
 
             public static class Field1Provider 
             {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeated.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeated.cs
@@ -3105,7 +3105,6 @@ namespace Improbable.Gdk.Tests
         }
 
 #if !DISABLE_REACTIVE_COMPONENTS
-
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeated.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeated.cs
@@ -3104,6 +3104,8 @@ namespace Improbable.Gdk.Tests
             public Option<global::System.Collections.Generic.List<global::Improbable.Gdk.Tests.SomeEnum>> Field18;
         }
 
+#if !DISABLE_REACTIVE_COMPONENTS
+
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;
@@ -3112,6 +3114,7 @@ namespace Improbable.Gdk.Tests
                 get => global::Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
+#endif
 
         internal class ExhaustiveRepeatedDynamic : IDynamicInvokable
         {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedProviders.cs
@@ -13,6 +13,7 @@ namespace Improbable.Gdk.Tests
     {
         internal static class ReferenceTypeProviders
         {
+#if !DISABLE_REACTIVE_COMPONENTS
             public static class UpdatesProvider 
             {
                 private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.ExhaustiveRepeated.Update>>();
@@ -79,6 +80,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
             
+#endif
 
             public static class Field1Provider 
             {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingular.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingular.cs
@@ -1516,6 +1516,8 @@ namespace Improbable.Gdk.Tests
             public Option<global::Improbable.Gdk.Tests.SomeEnum> Field18;
         }
 
+#if !DISABLE_REACTIVE_COMPONENTS
+
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;
@@ -1524,6 +1526,7 @@ namespace Improbable.Gdk.Tests
                 get => global::Improbable.Gdk.Tests.ExhaustiveSingular.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
+#endif
 
         internal class ExhaustiveSingularDynamic : IDynamicInvokable
         {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingular.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingular.cs
@@ -1517,7 +1517,6 @@ namespace Improbable.Gdk.Tests
         }
 
 #if !DISABLE_REACTIVE_COMPONENTS
-
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularProviders.cs
@@ -13,6 +13,7 @@ namespace Improbable.Gdk.Tests
     {
         internal static class ReferenceTypeProviders
         {
+#if !DISABLE_REACTIVE_COMPONENTS
             public static class UpdatesProvider 
             {
                 private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.ExhaustiveSingular.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.ExhaustiveSingular.Update>>();
@@ -79,6 +80,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
             
+#endif
 
             public static class Field3Provider 
             {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponent.cs
@@ -291,6 +291,8 @@ namespace Improbable.Gdk.Tests
             public Option<global::Improbable.Gdk.Tests.TypeName> NestedType;
         }
 
+#if !DISABLE_REACTIVE_COMPONENTS
+
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;
@@ -299,6 +301,7 @@ namespace Improbable.Gdk.Tests
                 get => global::Improbable.Gdk.Tests.NestedComponent.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
+#endif
 
         internal class NestedComponentDynamic : IDynamicInvokable
         {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponent.cs
@@ -292,7 +292,6 @@ namespace Improbable.Gdk.Tests
         }
 
 #if !DISABLE_REACTIVE_COMPONENTS
-
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentProviders.cs
@@ -13,6 +13,7 @@ namespace Improbable.Gdk.Tests
     {
         internal static class ReferenceTypeProviders
         {
+#if !DISABLE_REACTIVE_COMPONENTS
             public static class UpdatesProvider 
             {
                 private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.NestedComponent.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.NestedComponent.Update>>();
@@ -79,6 +80,7 @@ namespace Improbable.Gdk.Tests
                 }
             }
             
+#endif
 
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/Connection.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/Connection.cs
@@ -291,6 +291,8 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
             public Option<int> Value;
         }
 
+#if !DISABLE_REACTIVE_COMPONENTS
+
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;
@@ -299,6 +301,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 get => global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
+#endif
 
         internal class ConnectionDynamic : IDynamicInvokable
         {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/Connection.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/Connection.cs
@@ -292,7 +292,6 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
         }
 
 #if !DISABLE_REACTIVE_COMPONENTS
-
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionProviders.cs
@@ -13,6 +13,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
     {
         internal static class ReferenceTypeProviders
         {
+#if !DISABLE_REACTIVE_COMPONENTS
             public static class UpdatesProvider 
             {
                 private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update>>();
@@ -79,6 +80,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 }
             }
             
+#endif
 
             public static class MyEventProvider 
             {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponent.cs
@@ -576,7 +576,6 @@ namespace Improbable.Gdk.Tests.BlittableTypes
         }
 
 #if !DISABLE_REACTIVE_COMPONENTS
-
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponent.cs
@@ -575,6 +575,8 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             public Option<double> DoubleField;
         }
 
+#if !DISABLE_REACTIVE_COMPONENTS
+
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;
@@ -583,6 +585,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 get => global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
+#endif
 
         internal class BlittableComponentDynamic : IDynamicInvokable
         {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentProviders.cs
@@ -13,6 +13,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
     {
         internal static class ReferenceTypeProviders
         {
+#if !DISABLE_REACTIVE_COMPONENTS
             public static class UpdatesProvider 
             {
                 private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update>>();
@@ -79,6 +80,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 }
             }
             
+#endif
 
             public static class FirstEventProvider 
             {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFields.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFields.cs
@@ -188,7 +188,6 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
         }
 
 #if !DISABLE_REACTIVE_COMPONENTS
-
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFields.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFields.cs
@@ -187,6 +187,8 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
         }
 
+#if !DISABLE_REACTIVE_COMPONENTS
+
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;
@@ -195,6 +197,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 get => global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
+#endif
 
         internal class ComponentWithNoFieldsDynamic : IDynamicInvokable
         {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsProviders.cs
@@ -13,6 +13,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
     {
         internal static class ReferenceTypeProviders
         {
+#if !DISABLE_REACTIVE_COMPONENTS
             public static class UpdatesProvider 
             {
                 private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update>>();
@@ -79,6 +80,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
             
+#endif
 
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommands.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommands.cs
@@ -188,7 +188,6 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
         }
 
 #if !DISABLE_REACTIVE_COMPONENTS
-
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommands.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommands.cs
@@ -187,6 +187,8 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
         }
 
+#if !DISABLE_REACTIVE_COMPONENTS
+
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;
@@ -195,6 +197,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 get => global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
+#endif
 
         internal class ComponentWithNoFieldsWithCommandsDynamic : IDynamicInvokable
         {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsProviders.cs
@@ -13,6 +13,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
     {
         internal static class ReferenceTypeProviders
         {
+#if !DISABLE_REACTIVE_COMPONENTS
             public static class UpdatesProvider 
             {
                 private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update>>();
@@ -79,6 +80,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
             
+#endif
 
             public static class CmdSenderProvider 
             {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEvents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEvents.cs
@@ -188,7 +188,6 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
         }
 
 #if !DISABLE_REACTIVE_COMPONENTS
-
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEvents.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEvents.cs
@@ -187,6 +187,8 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
         }
 
+#if !DISABLE_REACTIVE_COMPONENTS
+
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;
@@ -195,6 +197,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 get => global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
+#endif
 
         internal class ComponentWithNoFieldsWithEventsDynamic : IDynamicInvokable
         {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsProviders.cs
@@ -13,6 +13,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
     {
         internal static class ReferenceTypeProviders
         {
+#if !DISABLE_REACTIVE_COMPONENTS
             public static class UpdatesProvider 
             {
                 private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update>>();
@@ -79,6 +80,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
             
+#endif
 
             public static class EvtProvider 
             {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponent.cs
@@ -1161,6 +1161,8 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             public Option<global::System.Collections.Generic.Dictionary<int,string>> MapField;
         }
 
+#if !DISABLE_REACTIVE_COMPONENTS
+
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;
@@ -1169,6 +1171,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 get => global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
+#endif
 
         internal class NonBlittableComponentDynamic : IDynamicInvokable
         {

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponent.cs
@@ -1162,7 +1162,6 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
         }
 
 #if !DISABLE_REACTIVE_COMPONENTS
-
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentProviders.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentProviders.cs
@@ -13,6 +13,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
     {
         internal static class ReferenceTypeProviders
         {
+#if !DISABLE_REACTIVE_COMPONENTS
             public static class UpdatesProvider 
             {
                 private static readonly Dictionary<uint, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update>> Storage = new Dictionary<uint, List<global::Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update>>();
@@ -79,6 +80,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 }
             }
             
+#endif
 
             public static class StringFieldProvider 
             {

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
@@ -369,6 +369,8 @@ var fieldDetails = fieldDetailsList[i]; #>
 <# } #>
         }
 
+#if !DISABLE_REACTIVE_COMPONENTS
+
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;
@@ -377,6 +379,7 @@ var fieldDetails = fieldDetailsList[i]; #>
                 get => <#= componentNamespace #>.ReferenceTypeProviders.UpdatesProvider.Get(handle);
             }
         }
+#endif
 
         internal class <#= componentDetails.ComponentName  #>Dynamic : IDynamicInvokable
         {

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
@@ -370,7 +370,6 @@ var fieldDetails = fieldDetailsList[i]; #>
         }
 
 #if !DISABLE_REACTIVE_COMPONENTS
-
         public struct ReceivedUpdates : IComponentData
         {
             internal uint handle;

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityReferenceTypeProviderGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityReferenceTypeProviderGenerator.tt
@@ -22,7 +22,9 @@ namespace <#= qualifiedNamespace #>
     {
         internal static class ReferenceTypeProviders
         {
+#if !DISABLE_REACTIVE_COMPONENTS
             <#= CommonGeneratorUtils.IndentEveryNewline(generator.Generate("Updates", $"List<{componentNamespace}.Update>"), 3) #>
+#endif
 
 <# foreach (var fieldDetails in fieldDetailsList) { #>
 <# if (!fieldDetails.IsBlittable) { #>


### PR DESCRIPTION
#### Description
Wasn't correctly wrapped in the `DISABLE_REACTIVE_COMPONENTS` define. The type would exist but never contain any updates.

#### Tests
Generated code - verified it was compiled out

#### Documentation
Changelog - breaking change.

#### Primary reviewers

