### PR TITLE
Remove obsolete manager functions

### DIFF
--- a/workers/unity/Assets/Playground/Scripts/Camera/FollowCameraSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Camera/FollowCameraSystem.cs
@@ -29,9 +29,9 @@ namespace Playground
 
         private EntityQuery group;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             group = GetEntityQuery(
                 ComponentType.ReadWrite<CameraInput>(),

--- a/workers/unity/Assets/Playground/Scripts/Camera/InitCameraSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Camera/InitCameraSystem.cs
@@ -10,9 +10,9 @@ namespace Playground
         private ComponentUpdateSystem componentUpdateSystem;
         private EntityQuery inputGroup;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             componentUpdateSystem = World.GetExistingSystem<ComponentUpdateSystem>();
 
@@ -43,9 +43,11 @@ namespace Playground
             });
         }
 
-        protected override void OnDestroyManager()
+        protected override void OnDestroy()
         {
             Cursor.lockState = CursorLockMode.None;
+
+            base.OnDestroy();
         }
     }
 }

--- a/workers/unity/Assets/Playground/Scripts/Cubes/CollisionProcessSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Cubes/CollisionProcessSystem.cs
@@ -18,9 +18,9 @@ namespace Playground
         private EntityQuery collisionGroup;
         private CommandSystem commandSystem;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             commandSystem = World.GetExistingSystem<CommandSystem>();
 

--- a/workers/unity/Assets/Playground/Scripts/Cubes/CubeMovementSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Cubes/CubeMovementSystem.cs
@@ -12,9 +12,9 @@ namespace Playground
 
         private Vector3 origin;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             origin = World.GetExistingSystem<WorkerSystem>().Origin;
 

--- a/workers/unity/Assets/Playground/Scripts/Cubes/ProcessColorChangeSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Cubes/ProcessColorChangeSystem.cs
@@ -13,9 +13,9 @@ namespace Playground
 
         private Dictionary<Color, MaterialPropertyBlock> materialPropertyBlocks;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             updateSystem = World.GetExistingSystem<ComponentUpdateSystem>();
             workerSystem = World.GetExistingSystem<WorkerSystem>();

--- a/workers/unity/Assets/Playground/Scripts/Cubes/TriggerColorChangeSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Cubes/TriggerColorChangeSystem.cs
@@ -15,9 +15,9 @@ namespace Playground
         private int colorIndex;
         private float nextColorChange;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             updateSystem = World.GetExistingSystem<ComponentUpdateSystem>();
 

--- a/workers/unity/Assets/Playground/Scripts/DisconnectSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/DisconnectSystem.cs
@@ -9,9 +9,9 @@ namespace Playground
     {
         private EntityQuery group;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             group = GetEntityQuery(
                 ComponentType.ReadOnly<OnDisconnected>(),

--- a/workers/unity/Assets/Playground/Scripts/Metrics/MetricSendSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Metrics/MetricSendSystem.cs
@@ -28,9 +28,9 @@ namespace Playground
 
         private static readonly Metrics WorkerMetrics = new Metrics();
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             worker = World.GetExistingSystem<WorkerSystem>();
 

--- a/workers/unity/Assets/Playground/Scripts/Player/LocalPlayerInputSync.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/LocalPlayerInputSync.cs
@@ -12,9 +12,9 @@ namespace Playground
 
         private EntityQuery inputGroup;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             inputGroup = GetEntityQuery(
                 ComponentType.ReadWrite<PlayerInput.Component>(),

--- a/workers/unity/Assets/Playground/Scripts/Player/MoveLocalPlayerSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/MoveLocalPlayerSystem.cs
@@ -28,9 +28,9 @@ namespace Playground
 
         private const float SpeedSmoothTime = 0.1f;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             newPlayerGroup = GetEntityQuery(
                 ComponentType.ReadOnly<PlayerInput.Component>(),

--- a/workers/unity/Assets/Playground/Scripts/Player/PlayerCommandsSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/PlayerCommandsSystem.cs
@@ -25,9 +25,9 @@ namespace Playground
         private CommandSystem commandSystem;
         private EntityQuery launchGroup;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             commandSystem = World.GetExistingSystem<CommandSystem>();
             launchGroup = GetEntityQuery(

--- a/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
@@ -13,9 +13,9 @@ namespace Playground
         private CommandSystem commandSystem;
         private WorkerSystem workerSystem;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             commandSystem = World.GetExistingSystem<CommandSystem>();
             workerSystem = World.GetExistingSystem<WorkerSystem>();

--- a/workers/unity/Assets/Playground/Scripts/Player/ProcessRechargeSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/ProcessRechargeSystem.cs
@@ -13,9 +13,9 @@ namespace Playground
     {
         private EntityQuery group;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             group = GetEntityQuery(
                 ComponentType.ReadWrite<Launcher.Component>(),

--- a/workers/unity/Assets/Playground/Scripts/Player/ProcessScoresSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/ProcessScoresSystem.cs
@@ -9,9 +9,9 @@ namespace Playground
         private CommandSystem commandSystem;
         private WorkerSystem workerSystem;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             commandSystem = World.GetExistingSystem<CommandSystem>();
             workerSystem = World.GetExistingSystem<WorkerSystem>();

--- a/workers/unity/Assets/Playground/Scripts/UI/InitUISystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/UI/InitUISystem.cs
@@ -11,9 +11,9 @@ namespace Playground
         private ComponentUpdateSystem componentUpdateSystem;
         private EntityQuery uiInitGroup;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             componentUpdateSystem = World.GetExistingSystem<ComponentUpdateSystem>();
             uiInitGroup = GetEntityQuery(
@@ -47,12 +47,14 @@ namespace Playground
                 });
         }
 
-        protected override void OnDestroyManager()
+        protected override void OnDestroy()
         {
             if (UIComponent.Main != null)
             {
                 UnityObjectDestroyer.Destroy(UIComponent.Main.gameObject);
             }
+
+            base.OnDestroy();
         }
     }
 }

--- a/workers/unity/Assets/Playground/Scripts/UI/UpdateUISystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/UI/UpdateUISystem.cs
@@ -12,9 +12,9 @@ namespace Playground
         private EntityQuery launcherGroup;
         private EntityQuery scoreGroup;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             componentUpdateSystem = World.GetExistingSystem<ComponentUpdateSystem>();
             launcherGroup = GetEntityQuery(

--- a/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/AcknowledgeAuthorityLossSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/AcknowledgeAuthorityLossSystem.cs
@@ -24,19 +24,19 @@ namespace Improbable.Gdk.ReactiveComponents
 
         private ComponentUpdateSystem updateSystem;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
             updateSystem = World.GetExistingSystem<ComponentUpdateSystem>();
             GenerateComponentGroups();
             chunkArrayCache = new NativeArray<ArchetypeChunk>[authorityLossDetails.Count];
             gatheringJobs = new NativeArray<JobHandle>(authorityLossDetails.Count, Allocator.Persistent);
         }
 
-        protected override void OnDestroyManager()
+        protected override void OnDestroy()
         {
-            base.OnDestroyManager();
             gatheringJobs.Dispose();
+            base.OnDestroy();
         }
 
         private void GenerateComponentGroups()

--- a/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/CleanReactiveComponentsSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/CleanReactiveComponentsSystem.cs
@@ -20,18 +20,18 @@ namespace Improbable.Gdk.ReactiveComponents
         private NativeArray<ArchetypeChunk>[] chunkArrayCache;
         private NativeArray<JobHandle> gatheringJobs;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
             GenerateComponentGroups();
             chunkArrayCache = new NativeArray<ArchetypeChunk>[componentCleanups.Count];
             gatheringJobs = new NativeArray<JobHandle>(componentCleanups.Count, Allocator.Persistent);
         }
 
-        protected override void OnDestroyManager()
+        protected override void OnDestroy()
         {
-            base.OnDestroyManager();
             gatheringJobs.Dispose();
+            base.OnDestroy();
         }
 
         private void GenerateComponentGroups()

--- a/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/CommandSenderComponentSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/CommandSenderComponentSystem.cs
@@ -16,9 +16,9 @@ namespace Improbable.Gdk.ReactiveComponents
         private WorkerSystem workerSystem;
         private EntitySystem entitySystem;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             workerSystem = World.GetExistingSystem<WorkerSystem>();
             entitySystem = World.GetExistingSystem<EntitySystem>();
@@ -33,14 +33,14 @@ namespace Improbable.Gdk.ReactiveComponents
             }
         }
 
-        protected override void OnDestroyManager()
+        protected override void OnDestroy()
         {
             foreach (var manager in managers)
             {
                 manager.Clean(World);
             }
 
-            base.OnDestroyManager();
+            base.OnDestroy();
         }
 
         protected override void OnUpdate()

--- a/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveCommandComponentSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveCommandComponentSystem.cs
@@ -17,9 +17,9 @@ namespace Improbable.Gdk.ReactiveComponents
         private CommandSystem commandSystem;
         private WorkerSystem workerSystem;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             entityManager = World.EntityManager;
             commandSystem = World.GetExistingSystem<CommandSystem>();
@@ -32,14 +32,14 @@ namespace Improbable.Gdk.ReactiveComponents
             }
         }
 
-        protected override void OnDestroyManager()
+        protected override void OnDestroy()
         {
             foreach (var manager in managers)
             {
                 manager.Clean(World);
             }
 
-            base.OnDestroyManager();
+            base.OnDestroy();
         }
 
         protected override void OnUpdate()

--- a/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveComponentSendSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveComponentSendSystem.cs
@@ -23,9 +23,9 @@ namespace Improbable.Gdk.ReactiveComponents
 
         private IConnectionHandler connection;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             connection = World.GetExistingSystem<WorkerSystem>().ConnectionHandler;
 
@@ -34,10 +34,10 @@ namespace Improbable.Gdk.ReactiveComponents
             gatheringJobs = new NativeArray<JobHandle>(componentReplicators.Count * 2, Allocator.Persistent);
         }
 
-        protected override void OnDestroyManager()
+        protected override void OnDestroy()
         {
-            base.OnDestroyManager();
             gatheringJobs.Dispose();
+            base.OnDestroy();
         }
 
         protected override void OnUpdate()

--- a/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveComponentSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/ReactiveComponentSystem.cs
@@ -17,9 +17,9 @@ namespace Improbable.Gdk.ReactiveComponents
         private ComponentUpdateSystem updateSystem;
         private WorkerSystem workerSystem;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             entityManager = World.EntityManager;
             updateSystem = World.GetExistingSystem<ComponentUpdateSystem>();
@@ -32,14 +32,14 @@ namespace Improbable.Gdk.ReactiveComponents
             }
         }
 
-        protected override void OnDestroyManager()
+        protected override void OnDestroy()
         {
             foreach (var manager in managers)
             {
                 manager.Clean(World);
             }
 
-            base.OnDestroyManager();
+            base.OnDestroy();
         }
 
         protected override void OnUpdate()

--- a/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/WorldCommandsCleanSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/WorldCommandsCleanSystem.cs
@@ -29,9 +29,9 @@ namespace Improbable.Gdk.ReactiveComponents
 
         private EntityQuery worldCommandResponseGroup;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
             worldCommandResponseGroup = GetEntityQuery(worldCommandResponseQuery);
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/WorldCommandsSendSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/ReactiveComponents/Systems/WorldCommandsSendSystem.cs
@@ -32,9 +32,9 @@ namespace Improbable.Gdk.ReactiveComponents
         private CommandSystem commandSystem;
         private EntityQuery group;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
             connection = World.GetExistingSystem<WorkerSystem>().ConnectionHandler;
             commandSystem = World.GetExistingSystem<CommandSystem>();
             group = GetEntityQuery(worldCommandSendersQuery);

--- a/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/CommandCallbackSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/CommandCallbackSystem.cs
@@ -65,9 +65,9 @@ namespace Improbable.Gdk.Subscriptions
             callbackManagers.InvokeCallbacks();
         }
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
             Enabled = false;
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentCallbackSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentCallbackSystem.cs
@@ -86,9 +86,9 @@ namespace Improbable.Gdk.Subscriptions
             authorityCallbackManagers.InvokeLossImminentCallbacks();
         }
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
             Enabled = false;
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentConstraintsCallbackSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/ComponentConstraintsCallbackSystem.cs
@@ -110,9 +110,9 @@ namespace Improbable.Gdk.Subscriptions
             authority.InvokeCallbacks();
         }
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             entityAdded = new EntityAddedCallbackManager(World);
             Enabled = false;

--- a/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/RequireLifecycleSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/RequireLifecycleSystem.cs
@@ -28,9 +28,9 @@ namespace Improbable.Gdk.Subscriptions
             behavioursToEnable.Remove(behaviour);
         }
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             commandCallbackSystem = World.GetExistingSystem<CommandCallbackSystem>();
             componentCallbackSystem = World.GetExistingSystem<ComponentCallbackSystem>();

--- a/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/SubscriptionSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/SubscriptionSystem.cs
@@ -42,9 +42,9 @@ namespace Improbable.Gdk.Subscriptions
             return manager.SubscribeTypeErased(entity);
         }
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
             Enabled = false;
 
             AutoRegisterManagers();

--- a/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/WorkerFlagCallbackSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/Systems/WorkerFlagCallbackSystem.cs
@@ -8,9 +8,9 @@ namespace Improbable.Gdk.Subscriptions
     {
         private WorkerFlagCallbackManager manager;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
             Enabled = false;
 
             manager = new WorkerFlagCallbackManager(World);

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanTemporaryComponentsSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanTemporaryComponentsSystem.cs
@@ -15,9 +15,9 @@ namespace Improbable.Gdk.Core
         private readonly List<(EntityQuery, ComponentType)> componentGroupsToRemove =
             new List<(EntityQuery, ComponentType)>();
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             // Find all components with the RemoveAtEndOfTick attribute
             foreach (var type in ReflectionUtility.GetNonAbstractTypes(typeof(IComponentData),

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/CommandSystem.cs
@@ -51,10 +51,11 @@ namespace Improbable.Gdk.Core
             return manager.GetResponse(requestId);
         }
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            worker = World.GetExistingSystem<WorkerSystem>();
+            base.OnCreate();
 
+            worker = World.GetExistingSystem<WorkerSystem>();
             Enabled = false;
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentSendSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentSendSystem.cs
@@ -26,9 +26,9 @@ namespace Improbable.Gdk.Core
 
         private IConnectionHandler connection;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             connection = World.GetExistingSystem<WorkerSystem>().ConnectionHandler;
 
@@ -37,10 +37,10 @@ namespace Improbable.Gdk.Core
             gatheringJobs = new NativeArray<JobHandle>(componentReplicators.Count, Allocator.Persistent);
         }
 
-        protected override void OnDestroyManager()
+        protected override void OnDestroy()
         {
-            base.OnDestroyManager();
             gatheringJobs.Dispose();
+            base.OnDestroy();
         }
 
         public bool TryRegisterCustomReplicationSystem(uint componentId)

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/ComponentUpdateSystem.cs
@@ -92,9 +92,9 @@ namespace Improbable.Gdk.Core
             return worker.View.HasComponent(entityId, componentId);
         }
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             worker = World.GetExistingSystem<WorkerSystem>();
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/CustomSpatialOSSendSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/CustomSpatialOSSendSystem.cs
@@ -23,9 +23,9 @@ namespace Improbable.Gdk.Core
 
         private ComponentSendSystem componentSendSystem;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             WorkerSystem = World.GetExistingSystem<WorkerSystem>();
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/EcsViewSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/EcsViewSystem.cs
@@ -50,9 +50,9 @@ namespace Improbable.Gdk.Core
             }
         }
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             worker = World.GetExistingSystem<WorkerSystem>();
 
@@ -68,14 +68,14 @@ namespace Improbable.Gdk.Core
             Enabled = false;
         }
 
-        protected override void OnDestroyManager()
+        protected override void OnDestroy()
         {
             foreach (var manager in managers)
             {
                 manager.Clean(World);
             }
 
-            base.OnDestroyManager();
+            base.OnDestroy();
         }
 
         protected override void OnUpdate()

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/EntitySystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/EntitySystem.cs
@@ -46,9 +46,9 @@ namespace Improbable.Gdk.Core
             }
         }
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             workerSystem = World.GetExistingSystem<WorkerSystem>();
         }

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
@@ -18,9 +18,9 @@ namespace Improbable.Gdk.Core
 
         private View view;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             worker = World.GetExistingSystem<WorkerSystem>();
             ecsViewSystem = World.GetOrCreateSystem<EcsViewSystem>();

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSSendSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSSendSystem.cs
@@ -9,9 +9,9 @@ namespace Improbable.Gdk.Core
     {
         private WorkerSystem worker;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             worker = World.GetExistingSystem<WorkerSystem>();
         }

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerDisconnectCallbackSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerDisconnectCallbackSystem.cs
@@ -17,9 +17,9 @@ namespace Improbable.Gdk.Core
         private WorkerSystem worker;
         private EntityQuery group;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             group = GetEntityQuery(
                 ComponentType.ReadOnly<OnDisconnected>(),

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/WorkerSystem.cs
@@ -89,19 +89,19 @@ namespace Improbable.Gdk.Core
             MessagesToSend = ConnectionHandler.GetMessagesToSendContainer();
         }
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
             var entityManager = World.EntityManager;
             WorkerEntity = entityManager.CreateEntity(typeof(OnConnected), typeof(WorkerEntityTag));
             EntityIdToEntity.Add(new EntityId(0), WorkerEntity);
             Enabled = false;
         }
 
-        protected override void OnDestroyManager()
+        protected override void OnDestroy()
         {
             ConnectionHandler.Dispose();
-            base.OnDestroyManager();
+            base.OnDestroy();
         }
 
         protected override void OnUpdate()

--- a/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectInitializationSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectInitializationSystem.cs
@@ -29,9 +29,9 @@ namespace Improbable.Gdk.GameObjectCreation
             this.workerGameObject = workerGameObject;
         }
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             entitySystem = World.GetExistingSystem<EntitySystem>();
             workerSystem = World.GetExistingSystem<WorkerSystem>();
@@ -44,7 +44,7 @@ namespace Improbable.Gdk.GameObjectCreation
             }
         }
 
-        protected override void OnDestroyManager()
+        protected override void OnDestroy()
         {
             linker.UnlinkAllGameObjects();
 
@@ -53,7 +53,7 @@ namespace Improbable.Gdk.GameObjectCreation
                 gameObjectCreator.OnEntityRemoved(entityId);
             }
 
-            base.OnDestroyManager();
+            base.OnDestroy();
         }
 
         protected override void OnUpdate()

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/HandleCreatePlayerRequestSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/HandleCreatePlayerRequestSystem.cs
@@ -12,9 +12,9 @@ namespace Improbable.Gdk.PlayerLifecycle
     {
         private CommandSystem commandSystem;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
             commandSystem = World.GetExistingSystem<CommandSystem>();
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/SendCreatePlayerRequestSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/SendCreatePlayerRequestSystem.cs
@@ -39,9 +39,9 @@ namespace Improbable.Gdk.PlayerLifecycle
             ResultType = new SnapshotResultType()
         };
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             workerSystem = World.GetExistingSystem<WorkerSystem>();
             commandSystem = World.GetExistingSystem<CommandSystem>();

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatRequestSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatRequestSystem.cs
@@ -11,9 +11,9 @@ namespace Improbable.Gdk.PlayerLifecycle
     {
         private CommandSystem commandSystem;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             commandSystem = World.GetExistingSystem<CommandSystem>();
         }

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatResponseSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatResponseSystem.cs
@@ -20,9 +20,9 @@ namespace Improbable.Gdk.PlayerLifecycle
         private readonly Dictionary<(EntityId, Entity), bool> respondedCache =
             new Dictionary<(EntityId, Entity), bool>();
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             workerSystem = World.GetExistingSystem<WorkerSystem>();
             commandSystem = World.GetExistingSystem<CommandSystem>();

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/PlayerHeartbeatInitializationSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/PlayerHeartbeatInitializationSystem.cs
@@ -13,9 +13,9 @@ namespace Improbable.Gdk.PlayerLifecycle
     {
         private EntityQuery initializerGroup;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             var initializerQuery = new EntityQueryDesc
             {

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/SendPlayerHeartbeatRequestSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/SendPlayerHeartbeatRequestSystem.cs
@@ -13,9 +13,9 @@ namespace Improbable.Gdk.PlayerLifecycle
         private EntityQuery group;
         private CommandSystem commandSystem;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             group = GetEntityQuery(
                 ComponentType.ReadOnly<PlayerHeartbeatServer.ComponentAuthority>(),

--- a/workers/unity/Packages/com.improbable.gdk.testutils/Tests/Editmode/HybridGdkSystemTestBaseTests.cs
+++ b/workers/unity/Packages/com.improbable.gdk.testutils/Tests/Editmode/HybridGdkSystemTestBaseTests.cs
@@ -17,9 +17,9 @@ namespace Improbable.Gdk.TestUtils.EditmodeTests
         {
             private EntityQuery testGroup;
 
-            protected override void OnCreateManager()
+            protected override void OnCreate()
             {
-                base.OnCreateManager();
+                base.OnCreate();
 
                 testGroup = GetEntityQuery(
                     ComponentType.ReadWrite<Rigidbody>(),

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/ResetForAuthorityGainedSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/ResetForAuthorityGainedSystem.cs
@@ -15,9 +15,9 @@ namespace Improbable.Gdk.TransformSynchronization
         private EntityQuery rigidbodyGroup;
         private EntityQuery transformGroup;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             worker = World.GetExistingSystem<WorkerSystem>();
             updateSystem = World.GetExistingSystem<ComponentUpdateSystem>();

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TickSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TickSystem.cs
@@ -9,9 +9,9 @@ namespace Improbable.Gdk.TransformSynchronization
     {
         private EntityQuery transformGroup;
 
-        protected override void OnCreateManager()
+        protected override void OnCreate()
         {
-            base.OnCreateManager();
+            base.OnCreate();
 
             transformGroup = GetEntityQuery(
                 ComponentType.ReadWrite<TicksSinceLastTransformUpdate>(),


### PR DESCRIPTION
#### Description
Missed replacement of some obsolete function names.
Replaced `OnCreateManager` and `OnDestroyManager` with `OnCreate` and `OnDestroy`
