### PR TITLE
Make DeferredDisposeWorker protected

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerConnector.cs
@@ -411,7 +411,7 @@ namespace Improbable.Gdk.Core
             StartCoroutine(DeferredDisposeWorker());
         }
 
-        private IEnumerator DeferredDisposeWorker()
+        protected IEnumerator DeferredDisposeWorker()
         {
             // Remove the world from the loop early, to avoid errors during the delay frame
             RemoveFromPlayerLoop();


### PR DESCRIPTION
#### Description
because we need to use it in the client-worker. see https://github.com/spatialos/gdk-for-unity-fps-starter-project/pull/200