### PR TITLE
Use Unity logger types in ForwardingDispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- The constructor for the `ForwardingDispatcher` now accepts a `UnityEngine.LogType` instead of `Improbable.Worker.CInterop.LogLevel` as its parameter. [#987](https://github.com/spatialos/gdk-for-unity/pull/987) 
+
 ### Fixed
 
 - Fixed a bug where invalid characters in your PATH elements would throw exceptions and break code generation. [#986](https://github.com/spatialos/gdk-for-unity/pull/986)

--- a/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs
@@ -30,9 +30,9 @@ namespace Improbable.Gdk.Core
         ///     Constructor for the Forwarding Dispatcher
         /// </summary>
         /// <param name="minimumLogLevel">The minimum log level to forward logs to the SpatialOS runtime.</param>
-        public ForwardingDispatcher(LogLevel minimumLogLevel = LogLevel.Warn)
+        public ForwardingDispatcher(LogType minimumLogLevel = LogType.Warning)
         {
-            this.minimumLogLevel = minimumLogLevel;
+            this.minimumLogLevel = LogTypeMapping[minimumLogLevel];
             Application.logMessageReceived += LogCallback;
         }
 


### PR DESCRIPTION
#### Description

Pretty quick fix - use Unity's `LogType` instead of the C#IO's `LogLevel`. Requested in #753 

(This was cherry-picked out of #844 where I driveby fixed in a few days ago).

#### Tests

Ran the game - logging still worked. 

#### Documentation

Changelog + closes known issue.
