### PR TITLE
Fix SetKinematicFromAuthoritySystem regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 
 - Fixed a bug where invalid characters in your PATH elements would throw exceptions and break code generation. [#986](https://github.com/spatialos/gdk-for-unity/pull/986)
-- Fixed a regression in the `SetKinematicFromAuthoritySystem` that failed to toggle a rigidbody's kinematic state on `TransformInternal` authority changes. [#988](https://github.com/spatialos/gdk-for-unity/pull/987)
+- Fixed a regression in the `SetKinematicFromAuthoritySystem` that failed to toggle a rigidbody's kinematic state on `TransformInternal` authority changes. [#988](https://github.com/spatialos/gdk-for-unity/pull/988)
 
 ## `0.2.3` - 2019-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 ### Breaking Changes
 
-- The constructor for the `ForwardingDispatcher` now accepts a `UnityEngine.LogType` instead of `Improbable.Worker.CInterop.LogLevel` as its parameter. [#987](https://github.com/spatialos/gdk-for-unity/pull/987) 
+- The constructor for the `ForwardingDispatcher` now accepts a `UnityEngine.LogType` instead of `Improbable.Worker.CInterop.LogLevel` as its parameter. [#987](https://github.com/spatialos/gdk-for-unity/pull/987)
 
 ### Fixed
 
 - Fixed a bug where invalid characters in your PATH elements would throw exceptions and break code generation. [#986](https://github.com/spatialos/gdk-for-unity/pull/986)
+- Fixed a regression in the `SetKinematicFromAuthoritySystem` that failed to toggle a rigidbody's kinematic state on `TransformInternal` authority changes. [#988](https://github.com/spatialos/gdk-for-unity/pull/987)
 
 ## `0.2.3` - 2019-06-12
 

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/SetKinematicFromAuthoritySystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/SetKinematicFromAuthoritySystem.cs
@@ -60,7 +60,7 @@ namespace Improbable.Gdk.TransformSynchronization
 
         private void UpdateAuthChangeGroup()
         {
-            Entities.With(newEntityGroup).ForEach(
+            Entities.With(authChangeGroup).ForEach(
                 (Rigidbody rigidbody, ref KinematicStateWhenAuth kinematicStateWhenAuth, ref SpatialEntityId spatialEntityId) =>
                 {
                     var changes = updateSystem.GetAuthorityChangesReceived(spatialEntityId.EntityId,


### PR DESCRIPTION
#### Description

- Fixed a regression in the `SetKinematicFromAuthoritySystem` that failed to toggle a rigidbody's kinematic state on `TransformInternal` authority changes.

#### Tests

- playground doesn't break
- it matches the implementation pre-0.2.2

#### Documentation

changelog included

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
