### PR TITLE
Update Deployments docs

### DIFF
--- a/docs/reference/concepts/deployments.md
+++ b/docs/reference/concepts/deployments.md
@@ -16,7 +16,7 @@ Before you launch a deployment, you need to ensure that it is configured correct
 
 ### Launch configuration
 
-The launch configuration file specifies the parameters of your game world as well as your load balancing configuration. The load balancing configuration determines the worker instances that the SpatialOS Runtime will start.
+The launch configuration file specifies the parameters of your game world as well as your load balancing configuration. The load balancing configuration determines the worker-instances that the SpatialOS Runtime starts and how they are balanced across your game world.
 
 For more information, see the [comprehensive launch configuration documentation](https://docs.improbable.io/reference/latest/shared/project-layout/launch-config#launch-configuration-file).
 
@@ -37,6 +37,8 @@ To start a local deployment, in your Unity Editor, select **SpatialOS** > **Loca
 This starts a local version of the SpatialOS Runtime on your development machine together with all server-workers specified in the launch configuration you used.
 
 <%(Callout message="Its done when you see the following message in the console window which opens:<br/><br/>```SpatialOS ready. Access the Inspector at https://localhost:21000/inspector```")%>
+
+> **Note:** You can only have one instance of a local deployment running at any given time.
 
 ### Start a standalone client worker
 

--- a/docs/reference/concepts/deployments.md
+++ b/docs/reference/concepts/deployments.md
@@ -1,81 +1,37 @@
 <%(TOC)%>
 
-# Deploy your game
+# Deployments
 
-When you want to try out your game, you need to run a deployment of the game. This means launching SpatialOS itself. SpatialOS sets up the game world and optionally starts up the server-workers needed to run the game world. Once the deployment is running, you can connect clients to it in order to play the game. You can run a deployment on your development machine (a "local deployment") or in the cloud (a "cloud deployment").
+When you want to try out your game, you need to run a deployment of the game. This means launching SpatialOS itself. SpatialOS sets up the game world and optionally starts up the server-workers needed to run the game world. 
 
-Before you deploy your game, you need to build its workers; see documentation on [building workers]({{urlRoot}}/projects/myo/build).
+Once the deployment is running, you can connect clients to it in order to play the game. 
+
+You can run a deployment on your development machine (a "local deployment") or in the cloud (a "cloud deployment").
+
+Before you deploy your game, you need to build its workers; see documentation on [building workers]({{urlRoot}}/modules/build-system/editor-menu).
 
 ## Configuring your deployment
 
-To ensure the SpatialOS Runtime starts [server-workers](https://docs.improbable.io/reference/latest/shared/concepts/workers-load-balancing#server-workers) correctly, you need to ensure the launch configuration file has the worker set up correctly. See the [Worker launch configuration](https://docs.improbable.io/reference/latest/shared/worker-configuration/launch-configuration#worker-launch-configuration) in the SpatialOS documentation for guidance on how to define the worker launch configurations for both server-workers and client-workers.
+To ensure the SpatialOS Runtime starts your [server-workers](https://docs.improbable.io/reference/latest/shared/concepts/workers-load-balancing#server-workers) correctly, you need to ensure the launch configuration file has the worker set up correctly.
+
+ See the [Worker launch configuration](https://docs.improbable.io/reference/latest/shared/worker-configuration/launch-configuration#worker-launch-configuration) in the SpatialOS documentation for guidance on how to define the worker launch configurations for both server-workers and client-workers.
 
 ## Local deployment
 
-To start a local deployment, either:
-
-* In your Unity Editor, from the menu select **SpatialOS** > **Local Launch**. (This runs the default launch configuration.)
-
-    or
-* Open a terminal window and from the root of your game project directory run `spatial local launch` via the [`spatial` CLI](https://docs.improbable.io/reference/latest/shared/glossary#the-spatial-command-line-tool-cli).
-
-(See the [SpatialOS documentation](https://docs.improbable.io/reference/latest/shared/spatial-cli/spatial-local-launch) for details of the launch configurations.)
+To start a local deployment, in your Unity Editor, from the menu select **SpatialOS** > **Local Launch**.
 
 This starts a local version of the SpatialOS Runtime on your development machine together with all server-workers specified in the launch configuration you used.
 
-It’s done when you see the following message in the terminal: `SpatialOS ready. Access the Inspector at http://localhost:21000/inspector`.
+<%(Callout message="Its done when you see the following message in the console window which opens:<br/><br/>```SpatialOS ready. Access the Inspector at https://localhost:21000/inspector```")%>
 
-To start your client-workers, from a terminal window, in any directory, run `spatial local worker launch <YourExternalWorker> <YourLaunchConfig>`, replacing the `<example-content>` with names relevant to your game. Use the [Inspector](https://docs.improbable.io/reference/latest/shared/operate/inspector) to look at the current state of your game world.
+### Start a standalone client worker
+
+The GDK provides tooling for starting client workers from the Unity Editor. 
+
+First, ensure that have built the worker by selecting **SpatialOS** > **Build for local** > **UnityClient**. This may take a few minutes depending on the size of your Unity project.
+
+Then, in your Unity Editor, from the menu select **SpatialOS** > **Launch standalone client**.
 
 ## Cloud deployment
 
-Follow this section to start a cloud deployment.
-
-### Setup the SpatialOS project name
-
-You are allocated an empty SpatialOS project in the cloud when you sign up to SpatialOS; you use this to deploy your game, but to do this you need to tell the GDK the name of your allocated SpatialOS project so it knows where to deploy your game to.
-
-1. Open the `spatialos.json` file in the root folder of your game.
-1. Change the `name` field so it matches the name of your SpatialOS project. You can find this in the SpatialOS [Console](https://console.improbable.io). It’ll be something like `beta_someword_anotherword_000`.
-
-### Build and upload the game assembly
-
-The assembly includes executable files for the client-workers and server-workers, as well as the assets both types of workers use. (The assets might be the models and textures that the client-servers - that is, the game executable code - use to visualise the game.)
-
-  1. To build an assembly; in your Unity Editor, select **SpatialOS** > **Build all workers for cloud**.
-  1. To upload an assembly; open a terminal and navigate to the directory your game is in (the repository you’ve cloned). Run `spatial cloud upload <assembly name>`. The `<assembly name>` is a label you create so you can identify this assembly in the next step - for example you could call it `MyGDKAssembly`.
-
-  > **It’s finished uploading when:** You see a successful upload report printed in your terminal output, and your automatically opens [https://console.improbable.io](https://console.improbable.io) displaying the deployment.
-
-### Launch a cloud deployment
-
-1. Launch a cloud deployment
-
-   * In the same terminal window, run `spatial cloud launch <assembly name> cloud_launch.json <deployment name> --snapshot=snapshots/default.snapshot`
-   * This command defaults to deploying to clusters located in the US. If you’re in Europe, add the `--cluster_region=eu` flag for lower latency.
-   * It’s done when you see `Deployment launched successfully` printed in your terminal output. This might take a couple of minutes.
-
-**About the `spatial cloud launch` command**   
-`spatial cloud launch` deploys a project to the cloud. Its full syntax is:
-
-```
-spatial cloud launch <assembly name> <launch configuration> <deployment name> --snapshot=<snapshot file>
-```
-
-where:
-
-  * `<assembly name>` identifies the worker assemblies to use. The name needs to conform to the following regex: `[a-zA-Z0-9_.-]{5,64}`
-  * `<launch configuration>` is the configuration file for the deployment. This project includes `default_launch.json`, which is intended for use with local deployments, and `cloud_launch.json`, which is for cloud deployments.
-  * `<deployment name>` is a name of your choice, which is used to identify the deployment. The name needs to conform to the following regex: `[a-z0-9_]{2,32}`
-  * `<snapshot file>` is the snapshot of the world you want to start from. See this [documentation]({{urlRoot}}/reference/concepts/snapshots) for further information.
-
-### Launch the game client
-
-  1. Open the SpatialOS [Console](https://console.improbable.io/projects). You’ll see the project and the deployment you just created.
-  1. In the SpatialOS Console, select the deployment’s name to open the overview page.
-  1. Select **Launch**.
-
-  > You can ignore the prompt to install the Launcher, as it’s installed as part of the SpatialOS Installer.
-
-  1. To get links to share the game with others, select **Share**.
-  1. Once you’ve finished playing, select **Stop** in the Console.
+Check out our [Deployment Launcher feature module]({{urlRoot}}/modules/deployment-launcher/overview) for details on launching a cloud deployment.

--- a/docs/reference/concepts/deployments.md
+++ b/docs/reference/concepts/deployments.md
@@ -2,13 +2,13 @@
 
 # Deployments
 
+<%(Callout type="warn" message="Before you deploy your game, you need to build its workers. See the documentation on [building workers]({{urlRoot}}/modules/build-system/editor-menu).")%>
+
 When you want to try out your game, you need to run a deployment of the game. This means launching SpatialOS itself. SpatialOS sets up the game world and optionally starts up the server-workers needed to run the game world.
 
 Once the deployment is running, you can connect clients to it in order to play your game.
 
 You can run a deployment on your development machine (a "local deployment") or in the cloud (a "cloud deployment").
-
-Before you deploy your game, you need to build its workers. See the documentation on [building workers]({{urlRoot}}/modules/build-system/editor-menu).
 
 ## Configuring your deployment
 

--- a/docs/reference/concepts/deployments.md
+++ b/docs/reference/concepts/deployments.md
@@ -16,7 +16,7 @@ Before you launch a deployment, you need to ensure that it is configured correct
 
 ### Launch configuration
 
-The launch configuration file specifics the parameters of your game world as well as your load balancing configuration. The load balancing configuration determines the worker instances that the SpatialOS Runtime will start.
+The launch configuration file specifies the parameters of your game world as well as your load balancing configuration. The load balancing configuration determines the worker instances that the SpatialOS Runtime will start.
 
 For more information, see the [comprehensive launch configuration documentation](https://docs.improbable.io/reference/latest/shared/project-layout/launch-config#launch-configuration-file).
 
@@ -24,11 +24,11 @@ For more information, see the [comprehensive launch configuration documentation]
 
 ### Worker configuration
 
-The worker configuration file specifics the parameters of a specific worker-type as well as describing how the SpatialOS Runtime should start them. 
+The worker configuration file specifies the parameters of a specific worker-type as well as describing how the SpatialOS Runtime should start them. 
 
 For more information, see the [comprehensive worker configuration documentation](https://docs.improbable.io/reference/latest/shared/project-layout/introduction#configuration-file).
 
-> **Note:** The `build` section of the worker configuration files are **not** used in the GDK for Unity.
+> **Note:** The `build` section of the worker configuration files are **not** used by the GDK for Unity.
 
 ## Local deployment
 

--- a/docs/reference/concepts/deployments.md
+++ b/docs/reference/concepts/deployments.md
@@ -34,19 +34,19 @@ For more information, see the [comprehensive worker configuration documentation]
 
 To start a local deployment, in your Unity Editor, select **SpatialOS** > **Local Launch**.
 
-This starts a local version of the SpatialOS Runtime on your development machine together with all server-workers specified in the launch configuration you used.
+This starts a local version of the SpatialOS Runtime on your development machine together with all server-workers specified in the launch configuration you selected.
 
 <%(Callout message="Its done when you see the following message in the console window which opens:<br/><br/>```SpatialOS ready. Access the Inspector at https://localhost:21000/inspector```")%>
 
-> **Note:** You can only have one instance of a local deployment running at any given time.
+> **Note:** You can only have one instance of a local deployment running at any given time. If you already have one instance running, you may see an error like: `listen tcp :22000: bind: Only one usage of each socket address (protocol/network address/port) is normally permitted.`
 
 ### Start a standalone client worker
 
-The GDK provides tooling for starting client workers from the Unity Editor. 
+The GDK provides tooling for starting client workers from the Unity Editor.
 
 First, ensure that you have built the worker by selecting **SpatialOS** > **Build for local** > **UnityClient**. This may take a few minutes depending on the size of your Unity project.
 
-Then, in your Unity Editor,  select **SpatialOS** > **Launch standalone client**.
+Then, select **SpatialOS** > **Launch standalone client** to launch the built out client.
 
 ## Cloud deployment
 

--- a/docs/reference/concepts/deployments.md
+++ b/docs/reference/concepts/deployments.md
@@ -8,7 +8,7 @@ Once the deployment is running, you can connect clients to it in order to play t
 
 You can run a deployment on your development machine (a "local deployment") or in the cloud (a "cloud deployment").
 
-Before you deploy your game, you need to build its workers; see documentation on [building workers]({{urlRoot}}/modules/build-system/editor-menu).
+Before you deploy your game, you need to build its workers; see the documentation on [building workers]({{urlRoot}}/modules/build-system/editor-menu).
 
 ## Configuring your deployment
 
@@ -18,7 +18,7 @@ To ensure the SpatialOS Runtime starts your [server-workers](https://docs.improb
 
 ## Local deployment
 
-To start a local deployment, in your Unity Editor, from the menu select **SpatialOS** > **Local Launch**.
+To start a local deployment, in your Unity Editor, select **SpatialOS** > **Local Launch**.
 
 This starts a local version of the SpatialOS Runtime on your development machine together with all server-workers specified in the launch configuration you used.
 
@@ -28,9 +28,9 @@ This starts a local version of the SpatialOS Runtime on your development machine
 
 The GDK provides tooling for starting client workers from the Unity Editor. 
 
-First, ensure that have built the worker by selecting **SpatialOS** > **Build for local** > **UnityClient**. This may take a few minutes depending on the size of your Unity project.
+First, ensure that you have built the worker by selecting **SpatialOS** > **Build for local** > **UnityClient**. This may take a few minutes depending on the size of your Unity project.
 
-Then, in your Unity Editor, from the menu select **SpatialOS** > **Launch standalone client**.
+Then, in your Unity Editor,  select **SpatialOS** > **Launch standalone client**.
 
 ## Cloud deployment
 

--- a/docs/reference/concepts/deployments.md
+++ b/docs/reference/concepts/deployments.md
@@ -2,19 +2,33 @@
 
 # Deployments
 
-When you want to try out your game, you need to run a deployment of the game. This means launching SpatialOS itself. SpatialOS sets up the game world and optionally starts up the server-workers needed to run the game world. 
+When you want to try out your game, you need to run a deployment of the game. This means launching SpatialOS itself. SpatialOS sets up the game world and optionally starts up the server-workers needed to run the game world.
 
-Once the deployment is running, you can connect clients to it in order to play the game. 
+Once the deployment is running, you can connect clients to it in order to play your game.
 
 You can run a deployment on your development machine (a "local deployment") or in the cloud (a "cloud deployment").
 
-Before you deploy your game, you need to build its workers; see the documentation on [building workers]({{urlRoot}}/modules/build-system/editor-menu).
+Before you deploy your game, you need to build its workers. See the documentation on [building workers]({{urlRoot}}/modules/build-system/editor-menu).
 
 ## Configuring your deployment
 
-To ensure the SpatialOS Runtime starts your [server-workers](https://docs.improbable.io/reference/latest/shared/concepts/workers-load-balancing#server-workers) correctly, you need to ensure the launch configuration file has the worker set up correctly.
+Before you launch a deployment, you need to ensure that it is configured correctly. There are two parts to configuring a deployment: the launch configuration and the worker configurations.
 
- See the [Worker launch configuration](https://docs.improbable.io/reference/latest/shared/worker-configuration/launch-configuration#worker-launch-configuration) in the SpatialOS documentation for guidance on how to define the worker launch configurations for both server-workers and client-workers.
+### Launch configuration
+
+The launch configuration file specifics the parameters of your game world as well as your load balancing configuration. The load balancing configuration determines the worker instances that the SpatialOS Runtime will start.
+
+For more information, see the [comprehensive launch configuration documentation](https://docs.improbable.io/reference/latest/shared/project-layout/launch-config#launch-configuration-file).
+
+> **Note:** If the SpatialOS Runtime fails to start a worker in a deployment that you were expecting, double check that your load balancing configuration is correct.
+
+### Worker configuration
+
+The worker configuration file specifics the parameters of a specific worker-type as well as describing how the SpatialOS Runtime should start them. 
+
+For more information, see the [comprehensive worker configuration documentation](https://docs.improbable.io/reference/latest/shared/project-layout/introduction#configuration-file).
+
+> **Note:** The `build` section of the worker configuration files are **not** used in the GDK for Unity.
 
 ## Local deployment
 


### PR DESCRIPTION
#### Description
Tidied up and updated deployment documentation. Removed CLI usage instructions and directed users to the deployment launcher feature module for cloud deployment instructions.

#### Tests
Improbadoc local serve.
