### PR TITLE
Fix code generation path escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed a bug where invalid characters in your PATH elements would throw exceptions and break code generation. [#986](https://github.com/spatialos/gdk-for-unity/pull/986)
 - Fixed a regression in the `SetKinematicFromAuthoritySystem` that failed to toggle a rigidbody's kinematic state on `TransformInternal` authority changes. [#988](https://github.com/spatialos/gdk-for-unity/pull/988)
+- Fixed a regression in the code generator where spaces in your path would cause code generation failures. [#991](https://github.com/spatialos/gdk-for-unity/pull/991)
 
 ## `0.2.3` - 2019-06-12
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/CodeGenerator.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/CodeGenerator.cs
@@ -69,7 +69,7 @@ namespace Improbable.Gdk.CodeGenerator
 
         private string GenerateBundle()
         {
-            var inputPaths = options.SchemaInputDirs.Select(dir => $"--schema_path={dir}");
+            var inputPaths = options.SchemaInputDirs.Select(dir => $"--schema_path=\"{dir}\"");
 
             SystemTools.EnsureDirectoryEmpty(options.JsonDirectory);
 
@@ -80,8 +80,8 @@ namespace Improbable.Gdk.CodeGenerator
             var arguments = new[]
             {
                 "--load_all_schema_on_schema_path",
-                $@"--bundle_json_out={bundlePath}",
-                $@"--descriptor_set_out={descriptorPath}"
+                $"--bundle_json_out=\"{bundlePath}\"",
+                $"--descriptor_set_out=\"{descriptorPath}\""
             }.Union(inputPaths).ToList();
 
             SystemTools.RunRedirected(options.SchemaCompilerPath, arguments);


### PR DESCRIPTION
#### Description
See title. There were a few un-escaped paths.

Changelog incoming
