### PR TITLE
Remove test exception from playground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Internal
+
+- Stopped throwing a `Test Exception` in playground.
+
 ## `0.2.4` - 2019-06-28
 
 ### Breaking Changes

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/CubeSpawnerInputBehaviour.cs
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/CubeSpawnerInputBehaviour.cs
@@ -25,7 +25,6 @@ namespace Playground.MonoBehaviours
             if (response.StatusCode != StatusCode.Success)
             {
                 logDispatcher.HandleLog(LogType.Error, new LogEvent($"Spawn error: {response.Message}"));
-                throw new Exception("Test Exception");
             }
         }
 


### PR DESCRIPTION
#### Description

- Stopped throwing `Test Exception` in playground

#### Tests

- can't see the exception anymore

#### Documentation

- [x] changelog

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
