### PR TITLE
Add `LinkedGameObjectMap` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added the `LinkedGameObjectMap` class for finding the `GameObject`(s) linked with a specified `EntityId`.
+- Added the `LinkedGameObjectMap` class for finding the `GameObject`(s) linked with a specified `EntityId`. [#1013](https://github.com/spatialos/gdk-for-unity/pull/1013)
     - This can be used with the `[Require]` annotation to inject it into your `MonoBehaviours` provided you are using the `GameObjectCreation` feature module. For example: `[Require] private LinkedGameObjectMap gameObjectMap;`
 
 ### Internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Added the `LinkedGameObjectMap` class for finding the `GameObject`(s) linked with a specified `EntityId`.
-    - This can be used with the `[Require]` annotation to inject it into your `MonoBehaviours` provided you are using the `GameObjectCreation` feature module.
+    - This can be used with the `[Require]` annotation to inject it into your `MonoBehaviours` provided you are using the `GameObjectCreation` feature module. For example: `[Require] private LinkedGameObjectMap gameObjectMap;`
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- Added the `LinkedGameObjectMap` class for finding the `GameObject`(s) linked with a specified `EntityId`.
+    - This can be used with the `[Require]` annotation to inject it into your `MonoBehaviours` provided you are using the `GameObjectCreation` feature module.
+
 ### Internal
 
 - Stopped throwing a `Test Exception` in playground.

--- a/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntityGameObjectLinker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/EntityGameObjectLinker.cs
@@ -15,7 +15,7 @@ namespace Improbable.Gdk.Subscriptions
         private readonly EntityManager entityManager;
         private readonly World world;
 
-        private readonly Dictionary<EntityId, List<GameObject>> entityIdToGameObjects =
+        internal readonly Dictionary<EntityId, List<GameObject>> EntityIdToGameObjects =
             new Dictionary<EntityId, List<GameObject>>();
 
         private readonly Dictionary<GameObject, List<RequiredSubscriptionsInjector>> gameObjectToInjectors =
@@ -66,10 +66,10 @@ namespace Improbable.Gdk.Subscriptions
                     $"GameObject is already linked to the entity with ID {linkedComponent.EntityId}");
             }
 
-            if (!entityIdToGameObjects.TryGetValue(entityId, out var linkedGameObjects))
+            if (!EntityIdToGameObjects.TryGetValue(entityId, out var linkedGameObjects))
             {
                 linkedGameObjects = new List<GameObject>();
-                entityIdToGameObjects.Add(entityId, linkedGameObjects);
+                EntityIdToGameObjects.Add(entityId, linkedGameObjects);
             }
 
             linkedGameObjects.Add(gameObject);
@@ -116,7 +116,7 @@ namespace Improbable.Gdk.Subscriptions
                 throw new ArgumentException($"Can not unlink null GameObject from entity {entityId}");
             }
 
-            if (!entityIdToGameObjects.TryGetValue(entityId, out var gameObjectSet) ||
+            if (!EntityIdToGameObjects.TryGetValue(entityId, out var gameObjectSet) ||
                 !gameObjectSet.Contains(gameObject))
             {
                 throw new ArgumentException(
@@ -155,13 +155,13 @@ namespace Improbable.Gdk.Subscriptions
             gameObjectSet.Remove(gameObject);
             if (gameObjectSet.Count == 0)
             {
-                entityIdToGameObjects.Remove(entityId);
+                EntityIdToGameObjects.Remove(entityId);
             }
         }
 
         public void UnlinkAllGameObjects()
         {
-            var ids = entityIdToGameObjects.Keys.ToArray();
+            var ids = EntityIdToGameObjects.Keys.ToArray();
             foreach (var id in ids)
             {
                 UnlinkAllGameObjectsFromEntityId(id);
@@ -170,7 +170,7 @@ namespace Improbable.Gdk.Subscriptions
 
         public void UnlinkAllGameObjectsFromEntityId(EntityId entityId)
         {
-            if (!entityIdToGameObjects.TryGetValue(entityId, out var gameObjectSet))
+            if (!EntityIdToGameObjects.TryGetValue(entityId, out var gameObjectSet))
             {
                 return;
             }

--- a/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/LinkedGameObjectMap.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/LinkedGameObjectMap.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using Improbable.Gdk.Core;
+using UnityEngine;
+
+namespace Improbable.Gdk.Subscriptions
+{
+    /// <summary>
+    ///     Represents the mapping between SpatiaLOS entity IDs and linked GameObjects.
+    /// </summary>
+    public class LinkedGameObjectMap
+    {
+        private EntityGameObjectLinker linker;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="LinkedGameObjectMap"/> class backed with the data from
+        ///     the specified <see cref="EntityGameObjectLinker"/>.
+        /// </summary>
+        /// <param name="linker">The linker which contains the backing data for this map.</param>
+        public LinkedGameObjectMap(EntityGameObjectLinker linker)
+        {
+            this.linker = linker;
+        }
+
+        /// <summary>
+        ///     Gets the GameObjects that are linked to a given SpatialOS entity ID.
+        /// </summary>
+        /// <param name="entityId">The entity ID to get GameObjects for.</param>
+        /// <returns>A readonly list of the linked GameObjects or null if there are none linked.</returns>
+        public IReadOnlyList<GameObject> GetLinkedGameObjects(EntityId entityId)
+        {
+            return linker.EntityIdToGameObjects.TryGetValue(entityId, out var goList) ? goList.AsReadOnly() : null;
+        }
+
+        /// <summary>
+        ///     Tries to get the GameObjects that are linked to a given SpatialOS entity ID.
+        /// </summary>
+        /// <param name="entityId">The entity ID to get GameObjects for.</param>
+        /// <param name="linkedGameObjects">
+        ///     When this method returns, contains the GameObjects linked to the specified <see cref="EntityId"/>,
+        ///     if any are linked; otherwise, null. This parameter is passed uninitialized.
+        /// </param>
+        /// <returns>True, if there are any GameObjects linked to the <see cref="EntityId"/>; otherwise false</returns>
+        public bool TryGetLinkedGameObjects(EntityId entityId, out IReadOnlyList<GameObject> linkedGameObjects)
+        {
+            linkedGameObjects = GetLinkedGameObjects(entityId);
+            return linkedGameObjects != null;
+        }
+    }
+
+
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/LinkedGameObjectMap.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/LinkedGameObjectMap.cs
@@ -5,11 +5,11 @@ using UnityEngine;
 namespace Improbable.Gdk.Subscriptions
 {
     /// <summary>
-    ///     Represents the mapping between SpatiaLOS entity IDs and linked GameObjects.
+    ///     Represents the mapping between SpatialOS entity IDs and linked GameObjects.
     /// </summary>
     public class LinkedGameObjectMap
     {
-        private EntityGameObjectLinker linker;
+        private readonly EntityGameObjectLinker linker;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="LinkedGameObjectMap"/> class backed with the data from
@@ -46,6 +46,4 @@ namespace Improbable.Gdk.Subscriptions
             return linkedGameObjects != null;
         }
     }
-
-
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/LinkedGameObjectMap.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Subscriptions/LinkedGameObjectMap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c1f4bb3747776c1408a37a1b683f58c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectInitializationSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectInitializationSystem.cs
@@ -14,11 +14,11 @@ namespace Improbable.Gdk.GameObjectCreation
     [UpdateInGroup(typeof(GameObjectInitializationGroup))]
     internal class GameObjectInitializationSystem : ComponentSystem
     {
+        internal EntityGameObjectLinker Linker;
+
         private readonly IEntityGameObjectCreator gameObjectCreator;
 
         private readonly GameObject workerGameObject;
-
-        private EntityGameObjectLinker linker;
 
         private EntitySystem entitySystem;
         private WorkerSystem workerSystem;
@@ -36,17 +36,17 @@ namespace Improbable.Gdk.GameObjectCreation
             entitySystem = World.GetExistingSystem<EntitySystem>();
             workerSystem = World.GetExistingSystem<WorkerSystem>();
 
-            linker = new EntityGameObjectLinker(World);
+            Linker = new EntityGameObjectLinker(World);
 
             if (workerGameObject != null)
             {
-                linker.LinkGameObjectToSpatialOSEntity(new EntityId(0), workerGameObject);
+                Linker.LinkGameObjectToSpatialOSEntity(new EntityId(0), workerGameObject);
             }
         }
 
         protected override void OnDestroy()
         {
-            linker.UnlinkAllGameObjects();
+            Linker.UnlinkAllGameObjects();
 
             foreach (var entityId in entitySystem.GetEntitiesInView())
             {
@@ -61,16 +61,16 @@ namespace Improbable.Gdk.GameObjectCreation
             foreach (var entityId in entitySystem.GetEntitiesAdded())
             {
                 workerSystem.TryGetEntity(entityId, out var entity);
-                gameObjectCreator.OnEntityCreated(new SpatialOSEntity(entity, EntityManager), linker);
+                gameObjectCreator.OnEntityCreated(new SpatialOSEntity(entity, EntityManager), Linker);
             }
 
             var removedEntities = entitySystem.GetEntitiesRemoved();
             foreach (var entityId in removedEntities)
             {
-                linker.UnlinkAllGameObjectsFromEntityId(entityId);
+                Linker.UnlinkAllGameObjectsFromEntityId(entityId);
             }
 
-            linker.FlushCommandBuffer();
+            Linker.FlushCommandBuffer();
 
             foreach (var entityId in removedEntities)
             {

--- a/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/LinkedGameObjectMapSubscriptionManager.cs
+++ b/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/LinkedGameObjectMapSubscriptionManager.cs
@@ -1,0 +1,42 @@
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Subscriptions;
+using Unity.Entities;
+
+namespace Improbable.Gdk.GameObjectCreation
+{
+    [AutoRegisterSubscriptionManager]
+    internal class LinkedGameObjectMapSubscriptionManager : SubscriptionManager<LinkedGameObjectMap>
+    {
+        private readonly World world;
+        private Subscription<LinkedGameObjectMap> linkedGameObjectMapSubscription;
+
+        public LinkedGameObjectMapSubscriptionManager(World world)
+        {
+            this.world = world;
+        }
+
+        public override Subscription<LinkedGameObjectMap> Subscribe(EntityId entityId)
+        {
+            if (linkedGameObjectMapSubscription == null)
+            {
+                linkedGameObjectMapSubscription = new Subscription<LinkedGameObjectMap>(this, new EntityId(0));
+
+                var goSystem = world.GetExistingSystem<GameObjectInitializationSystem>();
+                if (goSystem != null)
+                {
+                    linkedGameObjectMapSubscription.SetAvailable(new LinkedGameObjectMap(goSystem.Linker));
+                }
+            }
+
+            return linkedGameObjectMapSubscription;
+        }
+
+        public override void Cancel(ISubscription subscription)
+        {
+        }
+
+        public override void ResetValue(ISubscription subscription)
+        {
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/LinkedGameObjectMapSubscriptionManager.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/LinkedGameObjectMapSubscriptionManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0a695143c3c71e24ea65cd8095350fb3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/Tests.meta
+++ b/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e78665e68bb8b86439407a3f4048f2ec
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/Tests/Editmode.meta
+++ b/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/Tests/Editmode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 337bb9b19a2826d4b8101da1bfe599be
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/Tests/Editmode/Improbable.Gdk.GameObjectCreation.EditmodeTests.asmdef
+++ b/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/Tests/Editmode/Improbable.Gdk.GameObjectCreation.EditmodeTests.asmdef
@@ -1,0 +1,22 @@
+{
+    "name": "Improbable.Gdk.GameObjectCreation.EditmodeTests",
+    "references": [
+        "GUID:0603bcb6cd766ea40a053a38fff8a84b",
+        "GUID:edb3612c44ad0d24988d387581fd5fbe",
+        "GUID:6e87be7cacbd7264c9a5b9efc59a4030",
+        "GUID:734d92eba21c94caba915361bd5ac177"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
+}

--- a/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/Tests/Editmode/Improbable.Gdk.GameObjectCreation.EditmodeTests.asmdef.meta
+++ b/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/Tests/Editmode/Improbable.Gdk.GameObjectCreation.EditmodeTests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e67b112f63be27045991e75c4b916959
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/Tests/Editmode/LinkedGameObjectMapSubscriptionTests.cs
+++ b/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/Tests/Editmode/LinkedGameObjectMapSubscriptionTests.cs
@@ -1,0 +1,29 @@
+﻿using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.EditmodeTests.Subscriptions;
+using Improbable.Gdk.Subscriptions;
+using NUnit.Framework;
+
+namespace Improbable.Gdk.GameObjectCreation.EditmodeTests
+{
+    public class LinkedGameObjectMapSubscriptionTests : SubscriptionTestBase
+    {
+        private EntityId entityId = new EntityId(100);
+
+        [Test]
+        public void Subscribe_to_LinkedGameObjectMap_should_not_be_available_if_GameObjectCreation_systems_are_not_present()
+        {
+            var goMapSubscription = SubscriptionSystem.Subscribe<LinkedGameObjectMap>(entityId);
+            Assert.IsFalse(goMapSubscription.HasValue);
+        }
+
+        [Test]
+        public void Subscribe_to_LinkedGameObjectMap_should_be_available_if_GameObjectCreation_systems_are_added()
+        {
+            GameObjectCreationHelper.EnableStandardGameObjectCreation(World, new MockGameObjectCreator());
+
+            var goMapSubscription = SubscriptionSystem.Subscribe<LinkedGameObjectMap>(entityId);
+            Assert.IsTrue(goMapSubscription.HasValue);
+            Assert.IsNotNull(goMapSubscription.Value);
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/Tests/Editmode/LinkedGameObjectMapSubscriptionTests.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/Tests/Editmode/LinkedGameObjectMapSubscriptionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e5ae5fe5ab171ae4e8efdefcc8c2c7b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/Tests/Editmode/MockGameObjectCreator.cs
+++ b/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/Tests/Editmode/MockGameObjectCreator.cs
@@ -1,0 +1,18 @@
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Subscriptions;
+
+namespace Improbable.Gdk.GameObjectCreation.EditmodeTests
+{
+    public class MockGameObjectCreator : IEntityGameObjectCreator
+    {
+        public void OnEntityCreated(SpatialOSEntity entity, EntityGameObjectLinker linker)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void OnEntityRemoved(EntityId entityId)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/Tests/Editmode/MockGameObjectCreator.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/Tests/Editmode/MockGameObjectCreator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9b625b182f162674e8b4a43c0159d41e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#### Description
Added an API to expose the `EntityId -> [GameObject]` relationship. This is wrapped in an object to ensure that we expose a list which is readonly (we really don't want users to mutate the underlying data). 

Also added a subscription manager for this (only in the GameObjectCreation module as the linker actually lives in a system here!) and added tests for this. 

**Commits are ordered and logical!**

#### Tests
Added some tests for the subscription fulfillment. 

#### Documentation
- [x] Changelog
