### PR TITLE
add network and hardware specs

### DIFF
--- a/docs/fragments/machine-setup.md
+++ b/docs/fragments/machine-setup.md
@@ -12,7 +12,7 @@ Ensure your machine meets the minimum system requirements for Unity development.
 
 Refer to the [Unity system requirements](https://unity3d.com/unity/system-requirements) for further information about the minimum hardware requirements.
 
-### 3: Network settings
+### 3. Network settings
 
 To configure your network to work with SpatialOS, refer to the [SpatialOS network settings](https://docs.improbable.io/reference/latest/shared/setup/requirements#network-settings). 
 

--- a/docs/fragments/machine-setup.md
+++ b/docs/fragments/machine-setup.md
@@ -5,9 +5,18 @@ If you have not signed up before, you can do this [here](https://improbable.io/g
 
 If you have already signed up, make sure you are logged into [Improbable.io](https://improbable.io). If you are logged in, you should see your picture in the top right of this page; if you are not logged in, select __Sign in__ at the top of this page and follow the instructions.
 
-<br/>
 
-### 2. Install the GDK dependencies
+### 2: Hardware
+
+Ensure your machine meets the minimum system requirements for Unity development.
+
+Refer to the [Unity system requirements](https://unity3d.com/unity/system-requirements) for further information about the minimum hardware requirements.
+
+### 3: Network settings
+
+To configure your network to work with SpatialOS, refer to the [SpatialOS network settings](https://docs.improbable.io/reference/latest/shared/setup/requirements#network-settings). 
+
+### 4. Install the GDK dependencies
 
 <%(#Expandable title="Setup for Windows")%>
 

--- a/docs/fragments/machine-setup.md
+++ b/docs/fragments/machine-setup.md
@@ -6,7 +6,7 @@ If you have not signed up before, you can do this [here](https://improbable.io/g
 If you have already signed up, make sure you are logged into [Improbable.io](https://improbable.io). If you are logged in, you should see your picture in the top right of this page; if you are not logged in, select __Sign in__ at the top of this page and follow the instructions.
 
 
-### 2: Hardware
+### 2. Hardware
 
 Ensure your machine meets the minimum system requirements for Unity development.
 


### PR DESCRIPTION
#### Description
This change adds system requirements and network requirements to the Unity GDK setup docs. It's based on feedback that [customers](https://forums.improbable.io/t/cant-upload-to-cloud-and-failed-to-unzip-the-client/5246/8) don't always see these specifications in the current setup flow.

#### Tests
Rendered and linted in `improbadoc`.

![screencapture-localhost-8080-reference-1-0-machine-setup-2019-07-03-15_41_51](https://user-images.githubusercontent.com/19690292/60601095-6b7e8b80-9da9-11e9-8d60-c033a7aaa3c5.png)

#### Documentation
This is documentation dude.

I skipped a changelog entry as this is a small changes and has no applicability for existing users.
