### PR TITLE
Disable premerge for docs branches

### DIFF
--- a/.buildkite/premerge.definition.yaml
+++ b/.buildkite/premerge.definition.yaml
@@ -1,6 +1,6 @@
 ---
 agent_queue_id: trigger-pipelines
-description: Unity GDK pre-merge CI pipeline.
+description: GDK for Unity pre-merge CI pipeline.
 github:
   branch_configuration: []
   default_branch: develop

--- a/.buildkite/premerge.definition.yaml
+++ b/.buildkite/premerge.definition.yaml
@@ -4,7 +4,10 @@ description: Unity GDK pre-merge CI pipeline.
 github:
   branch_configuration: []
   default_branch: develop
-  pull_request_branch_filter_configuration: []
+  pull_request_branch_filter_configuration:
+    - "!docs/*"
+    - "!docs-next"
+    - "!docs-current"
 teams:
 # TODO: normalise team names between orgs otherwise pipelines cannot coexist
 - name: Everyone

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -61,7 +61,7 @@ steps:
       BUILD_TARGET_FILTER: "android"
       SCRIPTING_BACKEND: "mono"
 
-  - label: "build iOS"
+  - label: "build :ios:"
     command: bash -c .shared-ci/scripts/build-worker.sh
     <<: *common
     artifact_paths:

--- a/.buildkite/release-qa.steps.yaml
+++ b/.buildkite/release-qa.steps.yaml
@@ -47,7 +47,7 @@ steps:
       BUILD_TARGET_FILTER: "android"
       SCRIPTING_BACKEND: "mono"
 
-  - label: "build iOS"
+  - label: "build :ios:"
     command: bash -c .shared-ci/scripts/build-worker.sh
     <<: *common
     artifact_paths:


### PR DESCRIPTION
### Description

- update pipeline name to match others
- disable premerge for docs branches
- add ios emoji to buildkite step

#### Tests

- doesn't build anything for this commit https://github.com/spatialos/gdk-for-unity/commit/efa9903c8bcd3bce29ccdd3e27d2a001f6ed1f4a
![image](https://user-images.githubusercontent.com/10051819/61121713-c8f49580-a497-11e9-9fee-d25b9cec1ffc.png)

- ios emoji shows up 🎉 
![image](https://user-images.githubusercontent.com/10051819/61121694-bf6b2d80-a497-11e9-8a2e-4cba1ff42fe6.png)

#### Documentation

n/a

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
