### PR TITLE
Stop linux schema compiler overriding mac one

### DIFF
--- a/init.ps1
+++ b/init.ps1
@@ -28,7 +28,6 @@ UpdatePackage schema standard_library "$SdkPath/.schema"
 
 UpdatePackage tools schema_compiler-x86_64-win32 "$SdkPath/.schema_compiler"
 UpdatePackage tools schema_compiler-x86_64-macos "$SdkPath/.schema_compiler"
-UpdatePackage tools schema_compiler-x86_64-linux "$SdkPath/.schema_compiler"
 
 #Update Mobile SDK
 UpdatePackage worker_sdk core-static-fullylinked-arm-ios "$SdkMobilePath/Plugins/Improbable/Core/iOS/arm" "CoreSdkStatic.lib;libCoreSdkStatic.a.pic"

--- a/init.sh
+++ b/init.sh
@@ -33,7 +33,6 @@ update_package schema standard_library "${SDK_PATH}/.schema"
 
 update_package tools schema_compiler-x86_64-win32 "${SDK_PATH}/.schema_compiler"
 update_package tools schema_compiler-x86_64-macos "${SDK_PATH}/.schema_compiler"
-update_package tools schema_compiler-x86_64-linux "${SDK_PATH}/.schema_compiler"
 
 #Update Mobile SDK
 update_package worker_sdk core-static-fullylinked-arm-ios "${SDK_MOBILE_PATH}/Plugins/Improbable/Core/iOS/arm" "CoreSdkStatic.lib;libCoreSdkStatic.a.pic"


### PR DESCRIPTION
#### Description

- stop linux schema compiler overriding mac one

#### Tests

- actually opens without errors on mac

#### Documentation

- n/a

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
