### PR TITLE
Exit docs release if not on docs-current

### DIFF
--- a/ci/tag-docs.sh
+++ b/ci/tag-docs.sh
@@ -30,6 +30,7 @@ fi
 
 if [[ "${BUILDKITE_BRANCH}" != "docs-current" && "${DOCS_TARGET}" == "production" ]]; then
     echo "Docs may only be published to production from docs-current."
+    buildkite-agent annotate "Docs may only be published to production from docs-current." --style 'error' --context 'ctx-error'
     exit 1
 fi
 

--- a/ci/tag-docs.sh
+++ b/ci/tag-docs.sh
@@ -30,6 +30,7 @@ fi
 
 if [[ "${BUILDKITE_BRANCH}" != "docs-current" && "${DOCS_TARGET}" == "production" ]]; then
     echo "Docs may only be published to production from docs-current."
+    exit 1
 fi
 
 setup_improbadoc


### PR DESCRIPTION
#### Description

Actually exit if we're trying to tag prod when not on `docs-current`

#### Tests

- [x] exits if we try to release this branch to prod

#### Documentation

n/a

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
