### PR TITLE
Add `SpatialOSEntity.TryGetComponent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Added a `TryGetComponent<T>(out T component);` method to the `SpatialOSEntity` struct. This can help reduce boilerplate when writing custom `IEntityGameObjectCreator` implementations.
+
 ## `0.2.5` - 2019-07-18
 
 ### Breaking Changes

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -1,5 +1,35 @@
 # Upgrade Guide
 
+## From `0.2.5` to `0.2.6`
+
+### General changes
+
+#### `SpatialOSEntity.TryGetComponent<T>(out T component)`
+
+Where previously, you may have had code like:
+
+```csharp
+SpatialOSEntity entity; // Assume constructed correctly.
+
+if (!entity.HasComponent<MyComponent>())
+{
+    return;
+}
+
+var myComponent = entity.GetComponent<MyComponent>();
+```
+
+You may now write:
+
+```csharp
+SpatialOSEntity entity; // Assume constructed correctly.
+
+if (!entity.TryGetComponent<MyComponent>(out var myComponent))
+{
+    return;
+}
+```
+
 ## From `0.2.4` to `0.2.5`
 
 ### NPM Packages

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/SpatialOSEntity.cs
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/SpatialOSEntity.cs
@@ -20,14 +20,41 @@ namespace Improbable.Gdk.GameObjectCreation
             SpatialOSEntityId = entityManager.GetComponentData<SpatialEntityId>(entity).EntityId;
         }
 
+        /// <summary>
+        ///     Checks if this entity has a component of type <see cref="T"/>
+        /// </summary>
+        /// <typeparam name="T">The SpatialOS component.</typeparam>
+        /// <returns>True, if the entity has the component; false otherwise.</returns>
         public bool HasComponent<T>() where T : struct, ISpatialComponentData, IComponentData
         {
             return entityManager.HasComponent<T>(entity);
         }
 
+        /// <summary>
+        ///     Gets a component of type <see cref="T"/> attached to this entity.
+        /// </summary>
+        /// <typeparam name="T">The SpatialOS component.</typeparam>
+        /// <returns>The component <see cref="T"/> attached to this entity.</returns>
+        /// <exception cref="System.ArgumentException">Thrown if the component <see cref="T"/> is not attached to this entity.</exception>
         public T GetComponent<T>() where T : struct, ISpatialComponentData, IComponentData
         {
             return entityManager.GetComponentData<T>(entity);
+        }
+
+        /// <summary>
+        ///     Attempts to get a component of type <see cref="T"/> attached to this entity.
+        /// </summary>
+        /// <param name="component">
+        ///     When this method returns, this will be the component attached to this entity if it exists;
+        ///     default constructed otherwise.
+        /// </param>
+        /// <typeparam name="T">The SpatialOS component.</typeparam>
+        /// <returns>True, if the entity has the component; false otherwise.</returns>
+        public bool TryGetComponent<T>(out T component) where T : struct, ISpatialComponentData, IComponentData
+        {
+            var has = HasComponent<T>();
+            component = has ? GetComponent<T>() : default(T);
+            return has;
         }
     }
 }


### PR DESCRIPTION
#### Description
Upstreamed from dog-fooding project. This helps cut down on boilerplate in `IEntityGameObjectCreator` implementations.

Also did a driveby refactor of `GameObjectCreatorFromMetadata`.

#### Tests
Playground tests.

#### Documentation
Changelog + upgrade guide!

