### PR TITLE
Docs for Worker SDK 13.8.2 changes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,6 +18,6 @@ See [About the SpatialOS Unity GDK](../docs/README.md) for
  details on how to get started using the Unity GDK.
 
 ## Warning
-This [alpha](https://docs.improbable.io/reference/latest/shared/release-policy#maturity-stages) release is for evaluation purposes only, with limited documentation -
+This [alpha](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/release-policy#maturity-stages) release is for evaluation purposes only, with limited documentation -
  see the guidance on
   [Recommended use](../README.md#recommended-use).

--- a/docs/fragments/machine-setup.md
+++ b/docs/fragments/machine-setup.md
@@ -14,7 +14,7 @@ Refer to the [Unity system requirements](https://unity3d.com/unity/system-requir
 
 ### 3. Network settings
 
-To configure your network to work with SpatialOS, refer to the [SpatialOS network settings](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/setup/requirements#network-settings). 
+To configure your network to work with SpatialOS, refer to the [SpatialOS network settings](https://docs.improbable.io/reference/latest/shared/setup/requirements#network-settings). 
 
 ### 4. Install the GDK dependencies
 

--- a/docs/fragments/machine-setup.md
+++ b/docs/fragments/machine-setup.md
@@ -14,7 +14,7 @@ Refer to the [Unity system requirements](https://unity3d.com/unity/system-requir
 
 ### 3. Network settings
 
-To configure your network to work with SpatialOS, refer to the [SpatialOS network settings](https://docs.improbable.io/reference/latest/shared/setup/requirements#network-settings). 
+To configure your network to work with SpatialOS, refer to the [SpatialOS network settings](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/setup/requirements#network-settings). 
 
 ### 4. Install the GDK dependencies
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ The GDK is composed of three layers:
 <br/>
 <br/>
 * If you aren’t already familiar with SpatialOS, you can find out about the concepts which enable it to support game worlds with more persistence, scale, and complexity than previously possible.
-<br/> **Read the [SpatialOS concept docs](https://docs.improbable.io/reference/latest/shared/concepts/spatialos)** on the SpatialOS documentation website (5 minute read).
+<br/> **Read the [SpatialOS concept docs](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/concepts/spatialos)** on the SpatialOS documentation website (5 minute read).
 <br/>
 <br/>
 Find out what's involved in getting started with our [Get started with SpatialOS for Unity walk-through youtube video](https://www.youtube.com/watch?v=6PNDBYtIimw), based on our [Get Started guide]({{urlRoot}}/projects/fps/get-started/get-started) (15-minute watch).

--- a/docs/modules/deployment-launcher/launch-deployments.md
+++ b/docs/modules/deployment-launcher/launch-deployments.md
@@ -45,10 +45,10 @@ A deployment configuration is used to describe what parameters a deployment shou
 | --- | --- | --- |
 | Assembly Name | ✔️ | The identifier of an assembly you have uploaded. |
 | Deployment Name | ✔️ | The name you wish to give to the deployment. |
-| Snapshot Path | ❌ | Path to the [snapshot](https://docs.improbable.io/reference/latest/shared/glossary#snapshot) you wish to start the deployment with, relative from the root of your SpatialOS project. |
+| Snapshot Path | ❌ | Path to the [snapshot](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#snapshot) you wish to start the deployment with, relative from the root of your SpatialOS project. |
 | Launch Config | ✔️ | Path to the launch configuration you wish to start the deployment with, relative from the root of your SpatialOS project. |
 | Region | ✔️ | The geographical region code that the deployment is running in. |
-| Tags | ❌ | Metadata that can be added to a deployment. Some tags have built-in functionality. For example, the `dev_login` tag is used to connect into deployment through the [development authentication flow](https://docs.improbable.io/reference/latest/shared/auth/development-authentication). |
+| Tags | ❌ | Metadata that can be added to a deployment. Some tags have built-in functionality. For example, the `dev_login` tag is used to connect into deployment through the [development authentication flow](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/auth/development-authentication). |
 | Simulated Player Deployments | ❌ | A set of child deployments responsible for running [simulated players]({{urlRoot}}/reference/glossary#simulated-player) that connect into the parent deployment. These deployments are launched after the parent deployment has successfully started. |
 
 <%(/Expandable)%>
@@ -95,11 +95,11 @@ Where N is in range [1, number of simulated player deployments]
 
 | Field | Required? | Description |
 | --- | --- | --- |
-| Snapshot Path | ❌ | Path to the [snapshot](https://docs.improbable.io/reference/latest/shared/glossary#snapshot) you wish to start the deployment with, relative from the root of your SpatialOS project. |
+| Snapshot Path | ❌ | Path to the [snapshot](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#snapshot) you wish to start the deployment with, relative from the root of your SpatialOS project. |
 | Launch Config | ✔️ | Path to the launch configuration you wish to start the deployment with, relative from the root of your SpatialOS project. |
 | Region | ✔️ | The geographical region code that the deployment is running in. |
-| Tags | ❌ | Metadata that can be added to a deployment. Some tags have built-in functionality. For example, the `dev_login` tag is used to connect into deployment through the [development authentication flow](https://docs.improbable.io/reference/latest/shared/auth/development-authentication). |
-| Flag Prefix | ✔️ | The prefix to include on worker flags that the Deployment Launcher adds to simulated player deployments. This should follow [worker flag naming conventions](https://docs.improbable.io/reference/latest/shared/worker-configuration/worker-flags#naming-conventions). |
+| Tags | ❌ | Metadata that can be added to a deployment. Some tags have built-in functionality. For example, the `dev_login` tag is used to connect into deployment through the [development authentication flow](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/auth/development-authentication). |
+| Flag Prefix | ✔️ | The prefix to include on worker flags that the Deployment Launcher adds to simulated player deployments. This should follow [worker flag naming conventions](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/worker-configuration/worker-flags#naming-conventions). |
 | Worker Type | ✔️ | The worker type of the [simulated player coordinator]({{urlRoot}}/reference/glossary#simulated-player-coordinator), responsible for managing [simulated players]({{urlRoot}}/reference/glossary#simulated-player) in the child deployment and connecting them to the parent deployment. |
 
 <%(/Expandable)%>
@@ -222,7 +222,7 @@ Assembly reloading locked.
 <%(Callout message="
 When a deployment successfully launches:
 
-* The [Console](https://docs.improbable.io/reference/latest/shared/glossary#console) page for the deployment automatically opens in your browser.
+* The [Console](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#console) page for the deployment automatically opens in your browser.
 * The notification at the bottom of the Deployment Launcher window disappears.
 ")%>
 

--- a/docs/modules/deployment-launcher/manage-deployments.md
+++ b/docs/modules/deployment-launcher/manage-deployments.md
@@ -42,7 +42,7 @@ When there are live cloud deployments running, this section is updated with a li
 
 | Button name | Description |
 | --- | --- |
-| Open the SpatialOS Console (🌐) | When pressed, the [Console](https://docs.improbable.io/reference/latest/shared/glossary#console) page for the selected cloud deployment opens in your browser. |
+| Open the SpatialOS Console (🌐) | When pressed, the [Console](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#console) page for the selected cloud deployment opens in your browser. |
 | Stop deployment | When pressed, this begins to stop a deployment chosen from the list of running cloud deployments. |
 
 <%(/Expandable)%>

--- a/docs/modules/deployment-launcher/upload-assemblies.md
+++ b/docs/modules/deployment-launcher/upload-assemblies.md
@@ -14,7 +14,7 @@ The section of the Deployment Launcher window that you use to upload assemblies 
 
 | Field | Description |
 | --- | --- |
-| Assembly Name | This is an identifier for the assembly you will upload.<br/><br/>You can use this to reference an assembly when launching a deployment or to find the assembly in the [SpatialOS Console](https://docs.improbable.io/reference/latest/shared/glossary#console). |
+| Assembly Name | This is an identifier for the assembly you will upload.<br/><br/>You can use this to reference an assembly when launching a deployment or to find the assembly in the [SpatialOS Console](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#console). |
 | Force Upload | Denotes whether to force upload this assembly.<br/><br/>If this is checked, an assembly that previously was uploaded with the same assembly name will be overwritten. |
 
 <%(/Expandable)%>

--- a/docs/modules/mobile/cloud-deploy.md
+++ b/docs/modules/mobile/cloud-deploy.md
@@ -7,12 +7,12 @@ Before reading this document, make sure you have read:
 
 * [Setting up Android support for the GDK]({{urlRoot}}/modules/mobile/setup-android)
 * [Setting up iOS support for the GDK]({{urlRoot}}/modules/mobile/setup-ios)
-* [Development authentication flow](https://docs.improbable.io/reference/latest/shared/auth/development-authentication)
+* [Development authentication flow](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/auth/development-authentication)
 ")%>
 
 To connect your mobile device to a cloud deployment, you need to authenticate with our services.
 
-This guide describes how to authenticate using the [development authentication flow](https://docs.improbable.io/reference/latest/shared/auth/development-authentication) which we provide for the early stages of game development.
+This guide describes how to authenticate using the [development authentication flow](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/auth/development-authentication) which we provide for the early stages of game development.
 
 ## Prepare your project to connect to a cloud deployment{#prepare-deployment}
 

--- a/docs/modules/mobile/overview.md
+++ b/docs/modules/mobile/overview.md
@@ -2,7 +2,7 @@
 
 # Mobile Feature Module
 
-<%(Callout type="warn" message=" Mobile support is in [pre-alpha](https://docs.improbable.io/reference/latest/shared/release-policy#maturity-stages). Please follow our [Roadmap](https://github.com/spatialos/gdk-for-unity/projects/1) to learn more about updates to this in future releases.")%>
+<%(Callout type="warn" message=" Mobile support is in [pre-alpha](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/release-policy#maturity-stages). Please follow our [Roadmap](https://github.com/spatialos/gdk-for-unity/projects/1) to learn more about updates to this in future releases.")%>
 
 <%(Callout message="
 Before starting with mobile development, make sure you have read:

--- a/docs/modules/mobile/prepare-project.md
+++ b/docs/modules/mobile/prepare-project.md
@@ -6,7 +6,7 @@ Before reading this document, make sure you have read:
 * [Setting up Android support for the GDK]({{urlRoot}}/modules/mobile/setup-android)
 * [Setting up iOS Support for the GDK]({{urlRoot}}/modules/mobile/setup-ios)
 * [Creating workers with WorkerConnector](https://docs.improbable.io/unity/alpha/reference/workflows/monobehaviour/worker-connectors)
-* [Development authentication flow](https://docs.improbable.io/reference/latest/shared/auth/development-authentication)
+* [Development authentication flow](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/auth/development-authentication)
 ")%>
 
 ## Create your worker connector script
@@ -20,7 +20,7 @@ If you [added the GDK]({{urlRoot}}/projects/myo/setup) to an existing Unity proj
 
 ## Create your development authentication token
 
-To connect to a cloud deployment using your mobile device, you need to use the [development authentication flow](https://docs.improbable.io/reference/latest/shared/auth/development-authentication) which we provide for the early stages of game development. The GDK for Unity provides tooling around the development authentication flow to help you iterate faster on your mobile application.
+To connect to a cloud deployment using your mobile device, you need to use the [development authentication flow](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/auth/development-authentication) which we provide for the early stages of game development. The GDK for Unity provides tooling around the development authentication flow to help you iterate faster on your mobile application.
 
 1. Open your project in your Unity Editor.
 1. Navigate to **SpatialOS** > **GDK Tools configuration** to open the configuration window.
@@ -33,4 +33,4 @@ To connect to a cloud deployment using your mobile device, you need to use the [
 
     > If your worker connector inherits from the `DefaultMobileWorkerConnector` script, it will automatically read the content inside `DevAuthToken.txt` when running the application and authenticate against our services. See the section above to learn how to create a mobile worker connector.
 
-If you want to create your own authentication server, follow [this guide](https://docs.improbable.io/reference/latest/shared/auth/integrate-authentication-platform-sdk).
+If you want to create your own authentication server, follow [this guide](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/auth/integrate-authentication-platform-sdk).

--- a/docs/modules/player-lifecycle/heartbeating.md
+++ b/docs/modules/player-lifecycle/heartbeating.md
@@ -31,7 +31,7 @@ At intervals set by `PlayerLifecycleConfig.PlayerHeartbeatIntervalSeconds`, the 
 
 It sends a `PlayerHeartbeat` request to each of those entities. These requests need to be handled by the client-worker that the player entity belongs to.
 
-Note that there are numerous ways that a request may fail, as outlined [here](https://docs.improbable.io/reference/latest/shared/design/commands#failure-modes).
+Note that there are numerous ways that a request may fail, as outlined [here](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/design/commands#failure-modes).
 
 ### How to handle PlayerHeartbeat requests
 

--- a/docs/modules/qbi-helper/intro-to-qbi.md
+++ b/docs/modules/qbi-helper/intro-to-qbi.md
@@ -5,7 +5,7 @@
 <%(Callout message="
 Before reading this document, make sure you are familiar with:
 
-  * [Query-based interest](https://docs.improbable.io/reference/latest/shared/worker-configuration/query-based-interest#query-based-interest-beta)
+  * [Query-based interest](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/worker-configuration/query-based-interest#query-based-interest-beta)
   * [Workers in the GDK]({{urlRoot}}/reference/concepts/worker)
 ")%>
 
@@ -13,7 +13,7 @@ This page provides a quick overview of the key primitives in query-based interes
 
 ## Interest
 
-Query-based interest is enabled for an entity by adding the [`improbable.Interest`](https://docs.improbable.io/reference/latest/shared/schema/standard-schema-library#interest-optional) component to that entity.
+Query-based interest is enabled for an entity by adding the [`improbable.Interest`](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/schema/standard-schema-library#interest-optional) component to that entity.
 
 `Interest` is effectively a mapping from a component ID to a list of queries, where each list of queries is only active on the worker that is authoritative over the component with that ID.
 

--- a/docs/pricing-and-support/pricing.md
+++ b/docs/pricing-and-support/pricing.md
@@ -2,6 +2,6 @@
 
 The GDK for Unity uses SpatialOS core technology and cloud hosting. This means that when you use the GDK, you need to consider the SpatialOS pricing model.
 
-SpatialOS has a free tier and a paid tier, and you can use the GDK on either of these. For an introduction to the pricing model, see [Pricing introduction](https://docs.improbable.io/reference/latest/shared/pricing-and-support/pricing-intro).
+SpatialOS has a free tier and a paid tier, and you can use the GDK on either of these. For an introduction to the pricing model, see [Pricing introduction](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/pricing-and-support/pricing-intro).
 
-For more details, including information about what the free tier includes, an in-depth explanation of how we calculate prices, and examples of how much different types of games would cost, see [Pricing details](https://docs.improbable.io/reference/latest/shared/pricing-and-support/pricing-details).
+For more details, including information about what the free tier includes, an in-depth explanation of how we calculate prices, and examples of how much different types of games would cost, see [Pricing details](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/pricing-and-support/pricing-details).

--- a/docs/pricing-and-support/support.md
+++ b/docs/pricing-and-support/support.md
@@ -2,6 +2,6 @@
 
 We provide free technical support to all users via our [forums](https://forums.improbable.io/) and our [Discord](https://discordapp.com/channels/311273633307951114/) channels. 
 
-For more details, see [Support](https://docs.improbable.io/reference/latest/shared/pricing-and-support/support).
+For more details, see [Support](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/pricing-and-support/support).
 
 We also offer additional paid tiers of support. For more details, [get in touch](https://improbable.io/contact-us).

--- a/docs/projects/blank/overview.md
+++ b/docs/projects/blank/overview.md
@@ -13,7 +13,7 @@ It has the minimum GDK feature set you need to start developing games for Spatia
 - A Unity project already set up with the SpatialOS GDK for Unity.
 - Sample [local and cloud deployment]({{urlRoot}}/reference/glossary#deploying) configurations.
 - An empty [snapshot]({{urlRoot}}/reference/concepts/snapshots#snapshots).
-- [Client-worker and server-worker]({{urlRoot}}/reference/glossary#worker) JSON [configuration files](https://docs.improbable.io/reference/latest/shared/worker-configuration/bridge-config#worker-attribute-sets).
+- [Client-worker and server-worker]({{urlRoot}}/reference/glossary#worker) JSON [configuration files](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/worker-configuration/bridge-config#worker-attribute-sets).
 - Client-worker and server-worker [worker connectors]({{urlRoot}}/reference/workflows/monobehaviour/worker-connectors) and worker prefabs.
 - [Worker build configuration]({{urlRoot}}/projects/myo/build#build-your-workers).
 - A set of Unity Scenes to use in development.

--- a/docs/projects/fps/get-started/upload-launch.md
+++ b/docs/projects/fps/get-started/upload-launch.md
@@ -61,7 +61,7 @@ Ensure the `Project Name` matches the one specified in your `spatialos.json`. If
 
 ### 2. Upload your worker assemblies
 
-An [assembly](https://docs.improbable.io/reference/latest/shared/glossary#assembly) is a bundle of code, art assets and other files necessary to run your game in the cloud.
+An [assembly](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#assembly) is a bundle of code, art assets and other files necessary to run your game in the cloud.
 
 To run a deployment in the cloud, you need to upload the worker assemblies to your SpatialOS project.
 

--- a/docs/projects/fps/get-started/view-game-world.md
+++ b/docs/projects/fps/get-started/view-game-world.md
@@ -10,7 +10,7 @@ Let’s take a look at how many simulated player-clients are now running around 
 
 #### World Inspector
 
-The [World Inspector](https://docs.improbable.io/reference/latest/shared/operate/inspector#inspector) (shown below) provides a real-time view of what’s happening in a deployment, from the [perspective of SpatialOS](https://docs.improbable.io/reference/latest/shared/concepts/spatialos): where all the entities are, what their components are, which workers are running and which entities a worker-instance is reading from and writing to.
+The [World Inspector](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/operate/inspector#inspector) (shown below) provides a real-time view of what’s happening in a deployment, from the [perspective of SpatialOS](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/concepts/spatialos): where all the entities are, what their components are, which workers are running and which entities a worker-instance is reading from and writing to.
 
 We can use it, for instance, to highlight where all the simulated player-clients and player-entities are in the world (note: not cool to identify where your friends are hiding).
 
@@ -20,7 +20,7 @@ We can use it, for instance, to highlight where all the simulated player-clients
 
 #### Logs
 
-[The Logs tab](https://docs.improbable.io/reference/latest/shared/operate/logs#logs) (shown below), displays all your deployment’s logs (whether they come from the SpatialOS Runtime or the Worker code you have written).
+[The Logs tab](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/operate/logs#logs) (shown below), displays all your deployment’s logs (whether they come from the SpatialOS Runtime or the Worker code you have written).
 
 <img src="{{assetRoot}}assets/logs-app.png" style="margin: 0 auto; display: block;" />
 <br/>
@@ -28,11 +28,11 @@ We can use it, for instance, to highlight where all the simulated player-clients
 
 #### Metrics dashboards
 
-The [Metrics dashboards](https://docs.improbable.io/reference/latest/shared/operate/metrics#metrics) (shown below), show a selection of useful metrics, to help you check health of your deployment and debug issues.
+The [Metrics dashboards](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/operate/metrics#metrics) (shown below), show a selection of useful metrics, to help you check health of your deployment and debug issues.
 
 <img src="{{assetRoot}}assets/metrics.png" style="margin: 0 auto; display: block;" />
 <br/>
-<%(Callout message="Note that the Logs and Metrics are also [available via an API](https://docs.improbable.io/reference/latest/shared/operate/byo-metrics) if you wish to create your own dashboards or alerts.")%>
+<%(Callout message="Note that the Logs and Metrics are also [available via an API](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/operate/byo-metrics) if you wish to create your own dashboards or alerts.")%>
 
 ## Want to add more features?
 

--- a/docs/projects/fps/tutorial.md
+++ b/docs/projects/fps/tutorial.md
@@ -20,7 +20,7 @@ You will add health pack pick-ups to the game. These health pack pick-ups are su
 To implement this feature you will:
 
 * Add a new [SpatialOS component]({{urlRoot}}/reference/glossary#spatialos-component) to hold the state of the health packs.
-* Define a new [SpatialOS entity template](https://docs.improbable.io/reference/latest/shared/glossary#entity-template) called `HealthPickup`.
+* Define a new [SpatialOS entity template](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#entity-template) called `HealthPickup`.
 * Add `HealthPickup` entities to the [snapshot]({{urlRoot}}/reference/glossary#snapshot) so they are loaded in the [SpatialOS world]({{urlRoot}}/reference/glossary#spatialos-world) at startup.
 * Write game logic such that the health packs grant health to players.
 * Write game logic to "respawn" health packs after they have been consumed.
@@ -73,7 +73,7 @@ See the [schemalang reference](https://docs.improbable.io/reference/13.6/shared/
 <%(#Expandable title="Why are we assigning the fields?")%>
 Each field in a component must have a unique id (within the component) which it is assigned to.
 
-This allows us to maintain backwards compatibility when schema changes. See [schemalang reference](https://docs.improbable.io/reference/latest/shared/schema/reference#components) for more info.
+This allows us to maintain backwards compatibility when schema changes. See [schemalang reference](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/schema/reference#components) for more info.
 <%(/Expandable)%>
 
 **Step 5.** Add this folder to the GDK tools configuration.
@@ -84,7 +84,7 @@ From your Unity Editor menu, select **SpatialOS** > **Gdk tools configuration**.
 
 From your Unity Editor menu, select **SpatialOS** > **Generate code** to invoke the code generator.
 
-The code generator creates C# code based on the components and types defined in the [schemalang](https://docs.improbable.io/reference/latest/shared/glossary#schemalang). Any time you modify your `schema` files you **must** then run the code generator to see your changes reflected in code.
+The code generator creates C# code based on the components and types defined in the [schemalang](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#schemalang). Any time you modify your `schema` files you **must** then run the code generator to see your changes reflected in code.
 
 > When writing schema files, your properties must use snake case (for example, `health_value`), but the the code generator will create C# code in the [standard C# capitalisation conventions](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/capitalization-conventions).
 
@@ -138,7 +138,7 @@ Let's pull out some of the more interesting lines from the above snippet:
 > Our design constraints state that we should not trust the client, so we only give write-access to the `HealthPickup` component to the [server-worker]({{urlRoot}}/reference/glossary#server-worker). This means that a client cannot change the health value of the health pack or force it to be active.
 
 <%(#Expandable title="What are <code>Position</code>, <code>Metadata</code>, and <code>Persistence</code>?")%>
-These SpatialOS components are [standard library](https://docs.improbable.io/reference/latest/shared/schema/standard-schema-library) components.
+These SpatialOS components are [standard library](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/schema/standard-schema-library) components.
 
 * `Position` declares the location of this entity and is used for loadbalancing.
 * `Metadata` declares the "entity type" and is used to populate the information in the Inspector.
@@ -147,14 +147,14 @@ These SpatialOS components are [standard library](https://docs.improbable.io/ref
 <%(/Expandable)%>
 
 <%(#Expandable title="How would you give only a specific client write-access for a component?")%>
-You can state that a specific client has write-access for a component by passing in a value of `workerId: {myWorkerId}` for the write access, where `myWorkerId` is the [worker ID](https://docs.improbable.io/reference/latest/shared/glossary#worker-id) of the client.
+You can state that a specific client has write-access for a component by passing in a value of `workerId: {myWorkerId}` for the write access, where `myWorkerId` is the [worker ID](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#worker-id) of the client.
 
 Some component data should be editable by the player's client, but not by the clients of any other players. In the FPS Starter Project the `Player` entity template function in `FpsEntityTemplates.cs` grants the player's client write access over a number of components: `clientMovement`, `clientRotation`, `clientHeartbeat` etc.
 <%(/Expandable)%>
 
 <%(#Expandable title="Can I specify more than one worker type to have write-access to a single component?")%>Yes, you are not restricted to just one worker type being granted write-access.
 
-To find out about how to do this, read up about [layers](https://docs.improbable.io/reference/latest/shared/worker-configuration/layers#layers).
+To find out about how to do this, read up about [layers](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/worker-configuration/layers#layers).
 <%(/Expandable)%>
 
 ## Add your new entity to the snapshot
@@ -264,7 +264,7 @@ namespace Fps
 
 Now that you have changed the snapshot generation script in `SnapshotMenu.cs`, we will need to regenerate the snapshot to see the new `HealthPickup` entity appear in your game world.
 
-You can validate that the snapshot was updated by launching a local deployment (`Ctrl + L`/`Cmd + L` in your Unity Editor) and looking in the [Inspector](https://docs.improbable.io/reference/latest/shared/operate/inspector).
+You can validate that the snapshot was updated by launching a local deployment (`Ctrl + L`/`Cmd + L` in your Unity Editor) and looking in the [Inspector](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/operate/inspector).
 
 > **Note:** If you have a local deployment running, make sure to close it before launching a new one!
 
@@ -273,7 +273,7 @@ You can validate that the snapshot was updated by launching a local deployment (
 If we were to test the game at this point, the health pack entity would appear in the inspector but not in-game. This is because we have not yet defined how to represent the entity on your client or server-workers. We'll do this in the next section.
 
 <%(#Expandable title="How does the Inspector decide the entity name?")%>
-The Inspector uses the `entity_type` string field from the [schema standard library](https://docs.improbable.io/reference/latest/shared/schema/standard-schema-library) component `Metadata` as the entity name.
+The Inspector uses the `entity_type` string field from the [schema standard library](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/schema/standard-schema-library) component `Metadata` as the entity name.
 <%(/Expandable)%>
 
 <%(#Expandable title="Where are my snapshots?")%>
@@ -285,7 +285,7 @@ All SpatialOS GDK projects contain a directory named `snapshots` in the root of 
 
 <%(#Expandable title="Can I make my snapshots human-readable?")%>
 
-Yes, there is a `spatial` command that will convert snapshots to a human-readable format. However, you cannot launch a deployment from a human-readable snapshot, so it must be converted back to binary before it is usable. To find out more about working with snapshots you can read about the [spatial snapshot command](https://docs.improbable.io/reference/latest/shared/operate/snapshots#convert-a-snapshot).
+Yes, there is a `spatial` command that will convert snapshots to a human-readable format. However, you cannot launch a deployment from a human-readable snapshot, so it must be converted back to binary before it is usable. To find out more about working with snapshots you can read about the [spatial snapshot command](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/operate/snapshots#convert-a-snapshot).
 
 While they are human-readable and you can manually edit the values of the properties within, be careful to not make mistakes that will inhibit the conversion back to binary form!
 <%(/Expandable)%>
@@ -579,7 +579,7 @@ Most functions will **only** be called if the `MonoBehaviour` is enabled, but `O
 Here, we send a component update to the SpatialOS Runtime. The fields within the `Update` struct indicate whether the corresponding field should be updated. If the `Option` is empty, the field will **not** be updated. If the `Option` is not empty, the field will be updated.
 
 * `private void HandleCollisionWithPlayer(GameObject player)`<br/>
-This function will be called any time a player walks through a health pack. It handles cross-worker interaction using [commands](https://docs.improbable.io/reference/latest/shared/glossary#command). When you send a command it acts as a request, which SpatialOS delivers to the worker-instance that has write-access for the component that the command is intended for.
+This function will be called any time a player walks through a health pack. It handles cross-worker interaction using [commands](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#command). When you send a command it acts as a request, which SpatialOS delivers to the worker-instance that has write-access for the component that the command is intended for.
 
 > Cross-worker interactions can be necessary when your game has multiple `UnityGameLogic` server-workers, because the worker with write-access for the `HealthPack` entity may not be the same worker that has write-access to the `Player` entity who has collided with that health pack.
 
@@ -587,7 +587,7 @@ This function will be called any time a player walks through a health pack. It h
 This coroutine re-activates consumed health packs after a cool-down period. It starts at the end of the `HandleCollisionWithPlayer` function as well as in `OnEnable` for any health pack entities which are inactive. Any running coroutines are stopped in `OnDisable`.
 
 <%(#Expandable title="Why is only one worker at a time able to have write-access for a component?")%>
-This prevents simultaneous changes putting the world into an inconsistent state. It is known as the single writer principle. If you want to learn more when you're done with the tutorial, have a look at [Understanding read and write access](https://docs.improbable.io/reference/latest/shared/design/understanding-access).
+This prevents simultaneous changes putting the world into an inconsistent state. It is known as the single writer principle. If you want to learn more when you're done with the tutorial, have a look at [Understanding read and write access](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/design/understanding-access).
 <%(/Expandable)%>
 
 <%(#Expandable title="How are clients prevented from sending health-giving commands?")%>

--- a/docs/projects/myo/setup.md
+++ b/docs/projects/myo/setup.md
@@ -8,7 +8,7 @@ _Make sure you have followed the [Setup & installation]({{urlRoot}}/machine-setu
 
 To use the SpatialOS GDK for Unity in a new project, you need to:
 
-1. Setup the [SpatialOS project structure](https://docs.improbable.io/reference/latest/shared/reference/project-structure).
+1. Setup the [SpatialOS project structure](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/reference/project-structure).
 1. Add the GDK packages to your Unity project.
 
 ## Setup a SpatialOS project

--- a/docs/reference/concepts/code-generation.md
+++ b/docs/reference/concepts/code-generation.md
@@ -2,7 +2,7 @@
 
 # Code generator
 
-The code generator uses `.schema` files to generate C# code that you can use to interact with SpatialOS in Unity. See the [schemalang reference](https://docs.improbable.io/reference/latest/shared/schema/introduction#schema-introduction) for details on how to create schema components.
+The code generator uses `.schema` files to generate C# code that you can use to interact with SpatialOS in Unity. See the [schemalang reference](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/schema/introduction#schema-introduction) for details on how to create schema components.
 
 The code generator runs when you do one of the following:
 
@@ -12,7 +12,7 @@ The code generator runs when you do one of the following:
 
 ## Type mappings
 
-The code generator maps from the [schema primitive types](https://docs.improbable.io/reference/latest/shared/schema/reference#primitive-types) to C# types according to the following table:
+The code generator maps from the [schema primitive types](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/schema/reference#primitive-types) to C# types according to the following table:
 
 | Schemalang type                | C# type      |
 | ------------------------------ | :---------------------: |
@@ -27,7 +27,7 @@ The code generator maps from the [schema primitive types](https://docs.improbabl
 | `EntityId`                     | `Improbable.Gdk.Core.EntityId` |
 | `Entity`                       | `Improbable.Gdk.Core.EntitySnapshot` |
 
-The code generator also maps [schema collection types](https://docs.improbable.io/reference/latest/shared/schema/reference#collection-types) to C# collections according to the following table:
+The code generator also maps [schema collection types](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/schema/reference#collection-types) to C# collections according to the following table:
 
 | Schemalang collection | C# collection                         |
 | --------------------- | :-----------------------------------------------: |
@@ -37,17 +37,17 @@ The code generator also maps [schema collection types](https://docs.improbable.i
 
 ## User defined types
 
-The code generator generates a C# struct for each [user defined type in schema](https://docs.improbable.io/reference/latest/shared/schema/reference#user-defined-types). The generated struct is annotated with the [`System.Serializable` attribute](https://docs.unity3d.com/ScriptReference/Serializable.html) and has a constructor with a parameter per schema field.
+The code generator generates a C# struct for each [user defined type in schema](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/schema/reference#user-defined-types). The generated struct is annotated with the [`System.Serializable` attribute](https://docs.unity3d.com/ScriptReference/Serializable.html) and has a constructor with a parameter per schema field.
 
 ## Enums
 
-The code generator generates a C# enum for each [enum in schema](https://docs.improbable.io/reference/latest/shared/schema/reference#enumerations). The generated enum is annotated with the [`System.Serializable` attribute](https://docs.unity3d.com/ScriptReference/Serializable.html).
+The code generator generates a C# enum for each [enum in schema](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/schema/reference#enumerations). The generated enum is annotated with the [`System.Serializable` attribute](https://docs.unity3d.com/ScriptReference/Serializable.html).
 
 > The `uint` values defined for the generated C# enum are not guaranteed to be the same as the defined schemalang field IDs.
 
 ## Components
 
-The code generator generates two C# structs for each [SpatialOS component defined in schema](https://docs.improbable.io/reference/latest/shared/schema/reference#components): a **snapshot** struct and a **component** struct.
+The code generator generates two C# structs for each [SpatialOS component defined in schema](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/schema/reference#components): a **snapshot** struct and a **component** struct.
 
 ### Snapshot
 

--- a/docs/reference/concepts/code-generation.md
+++ b/docs/reference/concepts/code-generation.md
@@ -25,6 +25,7 @@ The code generator maps from the [schema primitive types](https://docs.improbabl
 | `string`                       | `string`                |
 | `bytes`                        | `byte[]`                |
 | `EntityId`                     | `Improbable.Gdk.Core.EntityId` |
+| `Entity`                       | `Improbable.Gdk.Core.EntitySnapshot` |
 
 The code generator also maps [schema collection types](https://docs.improbable.io/reference/latest/shared/schema/reference#collection-types) to C# collections according to the following table:
 

--- a/docs/reference/concepts/connection-flows.md
+++ b/docs/reference/concepts/connection-flows.md
@@ -31,7 +31,7 @@ There are three steps for connecting a worker to a cloud deployment:
 
 Note that this debugging flow **does not work** for mobile clients. You need to use the new v13.5+ Locator connection flow instead.
 
-For more information about the `spatial cloud connect external` command, see the [CLI documentation](https://docs.improbable.io/reference/latest/shared/spatial-cli/spatial-cloud-connect-external).
+For more information about the `spatial cloud connect external` command, see the [CLI documentation](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/spatial-cli/spatial-cloud-connect-external).
 
 <%(/Expandable)%>
 
@@ -43,7 +43,7 @@ From SpatialOS v13.5 onwards, there are two versions of the Locator connection. 
 
 Use this Locator connection flow for:
 
-* Connecting a client-worker to a cloud deployment via the [SpatialOS Launcher](https://docs.improbable.io/reference/latest/shared/operate/launcher#the-launcher).
+* Connecting a client-worker to a cloud deployment via the [SpatialOS Launcher](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/operate/launcher#the-launcher).
 * [Connecting a mobile worker-instance to a cloud deployment]({{urlRoot}}/modules/mobile/cloud-deploy).
 * (For debugging) Connecting a server-worker or client-worker instance to a cloud deployment from your local machine.
 
@@ -51,4 +51,4 @@ Use this Locator connection flow for:
 
 Use this Locator connection flow for:
 
-* Connecting a client-worker to a cloud deployment via the [SpatialOS Launcher](https://docs.improbable.io/reference/latest/shared/operate/launcher#the-launcher).
+* Connecting a client-worker to a cloud deployment via the [SpatialOS Launcher](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/operate/launcher#the-launcher).

--- a/docs/reference/concepts/deployments.md
+++ b/docs/reference/concepts/deployments.md
@@ -18,7 +18,7 @@ Before you launch a deployment, you need to ensure that it is configured correct
 
 The launch configuration file specifies the parameters of your game world as well as your load balancing configuration. The load balancing configuration determines the worker-instances that the SpatialOS Runtime starts and how they are balanced across your game world.
 
-For more information, see the [comprehensive launch configuration documentation](https://docs.improbable.io/reference/latest/shared/project-layout/launch-config#launch-configuration-file).
+For more information, see the [comprehensive launch configuration documentation](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/project-layout/launch-config#launch-configuration-file).
 
 > **Note:** If the SpatialOS Runtime fails to start a worker in a deployment that you were expecting, double check that your load balancing configuration is correct.
 
@@ -26,7 +26,7 @@ For more information, see the [comprehensive launch configuration documentation]
 
 The worker configuration file specifies the parameters of a specific worker-type as well as describing how the SpatialOS Runtime should start them. 
 
-For more information, see the [comprehensive worker configuration documentation](https://docs.improbable.io/reference/latest/shared/project-layout/introduction#configuration-file).
+For more information, see the [comprehensive worker configuration documentation](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/project-layout/introduction#configuration-file).
 
 > **Note:** The `build` section of the worker configuration files are **not** used by the GDK for Unity.
 

--- a/docs/reference/concepts/entity-templates.md
+++ b/docs/reference/concepts/entity-templates.md
@@ -6,10 +6,10 @@
 Before reading this document, make sure you are familiar with:
 
   * [Workers in the GDK]({{urlRoot}}/reference/concepts/worker)
-  * [Standard schema library components](https://docs.improbable.io/reference/latest/shared/glossary#standard-schema-library-components)
+  * [Standard schema library components](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#standard-schema-library-components)
 ")%>
 
-An [`EntityTemplate`]({{urlRoot}}/api/core/entity-template) specifies what [components]({{urlRoot}}/reference/glossary#spatialos-component) a [SpatialOS entity]({{urlRoot}}/reference/glossary#spatialos-entity) contains, the initial values of these components and which [layers](https://docs.improbable.io/reference/latest/shared/glossary#layers) get [write access]({{urlRoot}}/reference//glossary#authority) to each component.
+An [`EntityTemplate`]({{urlRoot}}/api/core/entity-template) specifies what [components]({{urlRoot}}/reference/glossary#spatialos-component) a [SpatialOS entity]({{urlRoot}}/reference/glossary#spatialos-entity) contains, the initial values of these components and which [layers](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#layers) get [write access]({{urlRoot}}/reference//glossary#authority) to each component.
 
 ## How to define an entity template
 
@@ -25,11 +25,11 @@ An `EntityTemplate` can be mutated and used multiple times.
 
 All SpatialOS entities require the `Position` and `EntityAcl` components.
 
-The `Position` component must be added to the entity template manually. It is used by SpatialOS for [load-balancing](https://docs.improbable.io/reference/latest/shared/worker-configuration/load-balancing) purposes and [relative constraints in query-based interest](https://docs.improbable.io/reference/latest/shared/worker-configuration/query-based-interest#relative-constraints).
+The `Position` component must be added to the entity template manually. It is used by SpatialOS for [load-balancing](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/worker-configuration/load-balancing) purposes and [relative constraints in query-based interest](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/worker-configuration/query-based-interest#relative-constraints).
 
 The `EntityAcl` component is automatically handled by the [`EntityTemplate`]({{urlRoot}}/api/core/entity-template) class. This component determines which types of workers have read access to an entity and, for each component, which type of worker can have write access. Note that at any point in time, only instance of a worker can be authoritative over an entity's component.
 
-> To learn more about the standard schema library components, [go to this documentation](https://docs.improbable.io/reference/latest/shared/glossary#standard-schema-library-components).
+> To learn more about the standard schema library components, [go to this documentation](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#standard-schema-library-components).
 
 To add components to the entity template and specify which worker type has write access over the component, use the `AddComponent` method.
 

--- a/docs/reference/concepts/snapshots.md
+++ b/docs/reference/concepts/snapshots.md
@@ -4,9 +4,9 @@
 
 _This document relates to both [MonoBehaviour and ECS workflows]({{urlRoot}}/reference/workflows/overview)._
 
-A [snapshot](https://docs.improbable.io/reference/latest/shared/glossary#snapshot) is a representation of the state of a simulated world at some point in time. It stores each [entity](https://docs.improbable.io/reference/13.2/shared/glossary#entity) (as long as the entity has the [Persistence component](https://docs.improbable.io/reference/latest/shared/glossary#persistence)) and the values of the entity’s [components’](https://docs.improbable.io/reference/latest/shared/glossary#component) [properties](https://docs.improbable.io/reference/13.2/shared/glossary#property).
+A [snapshot](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#snapshot) is a representation of the state of a simulated world at some point in time. It stores each [entity](https://docs.improbable.io/reference/13.2/shared/glossary#entity) (as long as the entity has the [Persistence component](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#persistence)) and the values of the entity’s [components’](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#component) [properties](https://docs.improbable.io/reference/13.2/shared/glossary#property).
 
-You use a snapshot as the starting point for your [world](https://docs.improbable.io/reference/latest/shared/glossary#spatialos-world) when you [deploy](https://docs.improbable.io/reference/latest/shared/glossary#deploying), [locally](https://docs.improbable.io/reference/latest/shared/glossary#local-deployment) or [to the cloud](https://docs.improbable.io/reference/latest/shared/glossary#cloud-deployment).
+You use a snapshot as the starting point for your [world](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#spatialos-world) when you [deploy](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#deploying), [locally](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#local-deployment) or [to the cloud](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#cloud-deployment).
 
 ## How to create a snapshot
 

--- a/docs/reference/concepts/worker.md
+++ b/docs/reference/concepts/worker.md
@@ -11,7 +11,7 @@ They perform the computation associated with a world: they can read what’s hap
 
 We differentiate between [client-workers]({{urlRoot}}/reference/glossary#client-worker) and [server-workers]({{urlRoot}}/reference/glossary#server-worker).
 
->Find out more about SpatialOS entity, component, and worker concepts, in the [SpatialOS concept documentaiton](https://docs.improbable.io/reference/latest/shared/concepts/spatialos).
+>Find out more about SpatialOS entity, component, and worker concepts, in the [SpatialOS concept documentaiton](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/concepts/spatialos).
 
 ## Workers and ECS worlds
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -2,7 +2,7 @@
 
 # Glossary
 
->**Note:** This glossary **only** contains the concepts you need to understand in order to use the SpatialOS GDK for Unity. See the [core concepts](https://docs.improbable.io/reference/latest/shared/concepts/spatialos) and [glossary](https://docs.improbable.io/reference/latest/shared/glossary) sections for a full glossary of generic SpatialOS concepts.
+>**Note:** This glossary **only** contains the concepts you need to understand in order to use the SpatialOS GDK for Unity. See the [core concepts](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/concepts/spatialos) and [glossary](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary) sections for a full glossary of generic SpatialOS concepts.
 >
 >**Note:** There are many concepts in this glossary that mean different things in different contexts. When semantically overloaded words or phrases are unavoidable, we explicitly prefix them to avoid confusion. [.NET assemblies (.NET documentation)](https://docs.microsoft.com/en-us/dotnet/framework/app-domains/assemblies-in-the-common-language-runtime) and [SpatialOS assemblies](#spatialos-assembly) are an example of this.
 
@@ -25,11 +25,11 @@ In the SpatialOS GDK, the [EntityTemplate implementation]({{urlRoot}}/reference/
 Many [workers](#worker) can connect to a [SpatialOS world](#spatialos-world). Each component on a [SpatialOS Entity](#spatialos-entity) has no more than one worker that is authoritative over it. This worker is the only one able to modify the component’s state and handling commands for that component. Authority is sometimes called [write-access](#write-access).
 
 Which types of workers can have authority (or write access) is governed by each entity’s [access control list (ACL)](#access-control-list-acl).
-Which specific worker actually has write access is managed by SpatialOS, and can change regularly due to [load balancing](https://docs.improbable.io/reference/latest/shared/glossary#load-balancing).
+Which specific worker actually has write access is managed by SpatialOS, and can change regularly due to [load balancing](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#load-balancing).
 
 > Related:
 >
-> * [Understanding read and write access](https://docs.improbable.io/reference/latest/shared/design/understanding-access#understanding-read-and-write-access-authority)
+> * [Understanding read and write access](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/design/understanding-access#understanding-read-and-write-access-authority)
 
 ### Building
 
@@ -41,16 +41,16 @@ The guide on [how to build your game]({{urlRoot}}/projects/myo/build) explains t
 
 ### Checking out
 
-Each individual [worker](#worker) checks out only part of the [SpatialOS world](#spatialos-world). This happens on a [chunk](https://docs.improbable.io/reference/latest/shared/glossary#chunk)-by-chunk basis. A worker “checking out a chunk” means that:
+Each individual [worker](#worker) checks out only part of the [SpatialOS world](#spatialos-world). This happens on a [chunk](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#chunk)-by-chunk basis. A worker “checking out a chunk” means that:
 
 * The worker has a local representation of every [SpatialOS entity](#spatialos-entity) in that chunk
 * The SpatialOS Runtime sends updates about those entities to the worker
 
-A worker checks out all chunks that it is [interested in](https://docs.improbable.io/reference/latest/shared/glossary#interest).
+A worker checks out all chunks that it is [interested in](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#interest).
 
 > Related:
 >
-> * [Entity interest](https://docs.improbable.io/reference/latest/shared/worker-configuration/bridge-config#entity-interest)
+> * [Entity interest](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/worker-configuration/bridge-config#entity-interest)
 
 ### Client-worker
 
@@ -62,7 +62,7 @@ Client-workers are mostly tasked with visualizing what’s happening in the [Spa
 
 > Related:
 >
-> * [External worker (client-worker) launch configuration](https://docs.improbable.io/reference/latest/shared/worker-configuration/launch-configuration#external-worker-launch-configuration)
+> * [External worker (client-worker) launch configuration](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/worker-configuration/launch-configuration#external-worker-launch-configuration)
 
 ### Code generation
 
@@ -71,7 +71,7 @@ Client-workers are mostly tasked with visualizing what’s happening in the [Spa
 Generated code is generated from the [schema](#schema). It is used by [workers](#worker) to interact with [SpatialOS entities](#spatialos-entity). Using generated code, workers can:
 
 * Read the state of SpatialOS entities and their [SpatialOS components](#spatialos-component).
-* [Send updates](https://docs.improbable.io/reference/latest/shared/glossary#sending-an-update) to SpatialOS components via the [SpatialOS Runtime](#spatialos-runtime).
+* [Send updates](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#sending-an-update) to SpatialOS components via the [SpatialOS Runtime](#spatialos-runtime).
 
 Code generation automatically occurs when you open the [Unity Project](#unity-project) in your Unity editor. You can also manually trigger code generation from inside your Unity Editor by selecting **SpatialOS** > **Generate code**. You only need to do this when you have:
 
@@ -80,7 +80,7 @@ Code generation automatically occurs when you open the [Unity Project](#unity-pr
 
 > Related:
 >
-> * [Generating code from the schema](https://docs.improbable.io/reference/latest/shared/schema/introduction#generating-code-from-the-schema)
+> * [Generating code from the schema](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/schema/introduction#generating-code-from-the-schema)
 
 ### Connection
 
@@ -96,17 +96,17 @@ Before the [worker](#worker) can interact with the [SpatialOS world](#spatialos-
 
 > Not to be confused with the [Unity Console Window](https://docs.unity3d.com/Manual/Console.html)
 
-The [Console](https://console.improbable.io/) is the main landing page for managing [cloud deployments](https://docs.improbable.io/reference/latest/shared/glossary#cloud-deployment). It shows you:
+The [Console](https://console.improbable.io/) is the main landing page for managing [cloud deployments](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#cloud-deployment). It shows you:
 
 * Your [project name](#project-name)
-* Your past and present [cloud deployments](https://docs.improbable.io/reference/latest/shared/glossary#cloud-deployment)
+* Your past and present [cloud deployments](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#cloud-deployment)
 * All of the [SpatialOS assemblies](#spatialos-assembly) you’ve uploaded
 * Links to the [Inspector](#inspector), [Launcher](#launcher), and the logs and metrics page for your deployments.
 
 > Related:
 >
-> * [Logs](https://docs.improbable.io/reference/latest/shared/operate/logs#cloud-deployments)
-> * [Metrics](https://docs.improbable.io/reference/latest/shared/operate/metrics)
+> * [Logs](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/operate/logs#cloud-deployments)
+> * [Metrics](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/operate/metrics)
 
 ### Core module
 
@@ -128,9 +128,9 @@ When you want to try out your game, you need to deploy it. This means
 launching SpatialOS itself. SpatialOS sets up the [world](#spatialos-world) based on a [snapshot](#snapshot), then starts up the [server-workers](#worker) needed to run the world.
 There are two types of deployment: local and cloud.
 
-[Local deployments](https://docs.improbable.io/reference/latest/shared/glossary#local-deployment) allow you to start the [SpatialOS Runtime](#spatialos-runtime) locally to test changes quickly.
+[Local deployments](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#local-deployment) allow you to start the [SpatialOS Runtime](#spatialos-runtime) locally to test changes quickly.
 
-As their name suggests, [cloud deployments](https://docs.improbable.io/reference/latest/shared/deploy/deploy-cloud) run in the cloud on [nodes](#node). They allow you to share your game with other people, and run your game at a scale not possible on one local machine. Once a cloud deployment is running, you can connect [game clients](#game-client) to it using the [Launcher](#launcher).
+As their name suggests, [cloud deployments](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/deploy/deploy-cloud) run in the cloud on [nodes](#node). They allow you to share your game with other people, and run your game at a scale not possible on one local machine. Once a cloud deployment is running, you can connect [game clients](#game-client) to it using the [Launcher](#launcher).
 
 > Related:
 >
@@ -170,28 +170,28 @@ In the [MonoBehaviour workflow]({{urlRoot}}/reference/workflows/monobehaviour/in
 ### Inspector
 
 The Inspector is a web-based tool that you use to explore the internal state of a [SpatialOS world](#spatialos-world).
-It gives you a real time view of what’s happening in a [deployment](#deploying), [locally](https://docs.improbable.io/reference/latest/shared/glossary#local-deployment)
-or in the [cloud](https://docs.improbable.io/reference/latest/shared/glossary#cloud-deployment). Among other things, it displays:
+It gives you a real time view of what’s happening in a [deployment](#deploying), [locally](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#local-deployment)
+or in the [cloud](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#cloud-deployment). Among other things, it displays:
 
 * which [workers](#worker) are connected to the [deployment](#deploying)
-* how much [load](https://docs.improbable.io/reference/latest/shared/glossary#load-balancing) the workers are under
+* how much [load](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#load-balancing) the workers are under
 * which [SpatialOS entities](#spatialos-entity) are in the world
-* what their [SpatialOS components](#spatialos-component)' [properties](https://docs.improbable.io/reference/latest/shared/glossary#property) are
+* what their [SpatialOS components](#spatialos-component)' [properties](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#property) are
 * which [workers](#worker) are authoritative over each [SpatialOS component](#spatialos-component)
 
 > Related:
 >
-> * [The Inspector](https://docs.improbable.io/reference/latest/shared/operate/inspector)
+> * [The Inspector](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/operate/inspector)
 
 ### Launcher
 
-The Launcher is a tool that can download and launch [game clients](#game-client) that connect to [cloud deployments](https://docs.improbable.io/reference/latest/shared/glossary#cloud-deployment). It's available as an application for Windows and macOS. From the [Console](#console), you can use the Launcher to connect a game client to your own [cloud deployment](https://docs.improbable.io/reference/latest/shared/glossary#cloud-deployment), or generate a share link so anyone with the link can download a game client and join your game.
+The Launcher is a tool that can download and launch [game clients](#game-client) that connect to [cloud deployments](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#cloud-deployment). It's available as an application for Windows and macOS. From the [Console](#console), you can use the Launcher to connect a game client to your own [cloud deployment](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#cloud-deployment), or generate a share link so anyone with the link can download a game client and join your game.
 
 The Launcher downloads the client executable from the [SpatialOS assembly](#spatialos-assembly) you uploaded.
 
 > Related:
 >
-> * [The Launcher](https://docs.improbable.io/reference/latest/shared/operate/launcher)
+> * [The Launcher](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/operate/launcher)
 
 ### Locator connection flow
 
@@ -200,13 +200,13 @@ From SpatialOS v13.5, there are two versions of the Locator connection. The new 
 #### v10.4+ Locator connection flow (stable version)
 
 Use this Locator connection flow to:
- * Connect a client-worker to a cloud deployment via the SpatialOS Launcher - [see SpatialOS documentation on the Launcher](https://docs.improbable.io/reference/latest/shared/operate/launcher#the-launcher)
+ * Connect a client-worker to a cloud deployment via the SpatialOS Launcher - [see SpatialOS documentation on the Launcher](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/operate/launcher#the-launcher)
 
 #### New v13.5+ Locator connection flow (alpha version)
 
 Use this Locator connection flow to:
 
-* Connect a client-worker to a cloud deployment via the SpatialOS Launcher - [see SpatialOS documentation on the Launcher](https://docs.improbable.io/reference/latest/shared/operate/launcher#the-launcher)
+* Connect a client-worker to a cloud deployment via the SpatialOS Launcher - [see SpatialOS documentation on the Launcher](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/operate/launcher#the-launcher)
 * Connect a client-worker to a cloud deployment via your Unity Editor so that you can debug using the [development authentication flow](https://docs.improbable.io/reference/13.5/shared/auth/development-authentication). (Note that you can also use the Receptionist to connect in this situation.)
 
 Note that there are [other ways](https://docs.improbable.io/reference/13.3/shared/deploy/connect-external) to connect a client-worker to a cloud deployment without using the Locator flow.
@@ -215,15 +215,15 @@ Note that there are [other ways](https://docs.improbable.io/reference/13.3/share
 >
 > * [Connecting to SpatialOS]({{urlRoot}}/reference/concepts/connection-flows)
 > * [Connection](#connection)
-> * [Creating your own game authentication server](https://docs.improbable.io/reference/latest/shared/auth/integrate-authentication-platform-sdk)
-> * [Development authentication flow](https://docs.improbable.io/reference/latest/shared/auth/development-authentication)
+> * [Creating your own game authentication server](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/auth/integrate-authentication-platform-sdk)
+> * [Development authentication flow](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/auth/development-authentication)
 
 ### Message
 
-A [worker](#worker) can send and receive updates and messages to and from the [SpatialOS Runtime](#spatialos-runtime). While updates are simply property updates for any [SpatialOS component](#spatialos-component) that the worker is [interested](https://docs.improbable.io/reference/latest/shared/glossary#interest) in, messages can be either:
+A [worker](#worker) can send and receive updates and messages to and from the [SpatialOS Runtime](#spatialos-runtime). While updates are simply property updates for any [SpatialOS component](#spatialos-component) that the worker is [interested](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#interest) in, messages can be either:
 
-* [Events](https://docs.improbable.io/reference/latest/shared/glossary#event): messages about something that happened to a SpatialOS entity that are broadcasted to all workers.
-* [Commands](https://docs.improbable.io/reference/latest/shared/glossary#command): Messages used to send a direct message to another worker that has [write access](#write-access) over the corresponding SpatialOS component.
+* [Events](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#event): messages about something that happened to a SpatialOS entity that are broadcasted to all workers.
+* [Commands](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#command): Messages used to send a direct message to another worker that has [write access](#write-access) over the corresponding SpatialOS component.
 
 > Related:
 >
@@ -250,7 +250,7 @@ A node refers to a single machine used by a [cloud deployment](#deploying). Its 
 
 Your project name is randomly generated when you sign up for SpatialOS. It’s usually something like `beta_someword_anotherword_000`.
 
-You must specify this name in the [spatialos.json](https://docs.improbable.io/reference/latest/shared/reference/file-formats/spatialos-json) file in the root of your [SpatialOS project](#spatialos-project) when you run a [cloud deployment](https://docs.improbable.io/reference/latest/shared/glossary#cloud-deployment).
+You must specify this name in the [spatialos.json](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/reference/file-formats/spatialos-json) file in the root of your [SpatialOS project](#spatialos-project) when you run a [cloud deployment](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#cloud-deployment).
 
 You can find your project name in the [Console](https://console.improbable.io/).
 
@@ -264,7 +264,7 @@ If an entity doesn’t have this component, it won’t be captured in snapshots.
 
 Position is a [component](#spatialos-component) in the standard [schema](#schema) library; all SpatialOS [entities](#spatialos-entity) must have this component. It lets SpatialOS know what the position of an entity in the [world](#world) is.
 
-This is used by SpatialOS few specific purposes, like [load balancing](https://docs.improbable.io/reference/latest/shared/glossary#load-balancing) and [queries](https://docs.improbable.io/reference/latest/shared/glossary#queries).
+This is used by SpatialOS few specific purposes, like [load balancing](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#load-balancing) and [queries](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#queries).
 
 ### Reactive component
 
@@ -296,7 +296,7 @@ The Receptionist service allows for a direct connection to the SpatialOS runtime
 
 > Related:
 >
-> * [Understanding read and write access](https://docs.improbable.io/reference/latest/shared/design/understanding-access)
+> * [Understanding read and write access](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/design/understanding-access)
 
 ### Replication
 
@@ -306,7 +306,7 @@ Replication is the process by which all workers in the [SpatialOS world](#spatia
 
 ### Server-worker
 
-A server-worker is a [worker](#worker) whose lifecycle is managed by SpatialOS. When running a [deployment](#deploying), the SpatialOS Runtime starts and stops server-workers based on your chosen [load balancing](https://docs.improbable.io/reference/latest/shared/glossary#load-balancing) configuration.
+A server-worker is a [worker](#worker) whose lifecycle is managed by SpatialOS. When running a [deployment](#deploying), the SpatialOS Runtime starts and stops server-workers based on your chosen [load balancing](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#load-balancing) configuration.
 
 Server-workers are usually tasked with implementing game logic and physics simulation.
 
@@ -315,7 +315,7 @@ You can have one server-worker connected to your [deployment](#deploying), or do
 
 > Related:
 >
-> * [Managed worker (server-worker) launch configuration](https://docs.improbable.io/reference/latest/shared/worker-configuration/launch-configuration#managed-worker-launch-configuration)
+> * [Managed worker (server-worker) launch configuration](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/worker-configuration/launch-configuration#managed-worker-launch-configuration)
 
 ### Scene
 
@@ -328,14 +328,14 @@ Scenes are an abstraction used to represent the part of the [SpatialOS world](#s
 
 The schema is where you define all the [SpatialOS components](#spatialos-component) in your [SpatialOS world](#spatialos-world).
 
-You define your schema in `.schema` files that are written in [schemalang](https://docs.improbable.io/reference/latest/shared/glossary#schemalang). Schema files are stored in the `schema` folder in the root directory of your SpatialOS project.
+You define your schema in `.schema` files that are written in [schemalang](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#schemalang). Schema files are stored in the `schema` folder in the root directory of your SpatialOS project.
 
 SpatialOS uses the schema to [generate code](#code-generation). You can use this generated code in your [workers](#worker) to interact with [SpatialOS entities](#spatialos-entity) in the SpatialOS world.
 
 > Related:
 >
-> * [Introduction to schema](https://docs.improbable.io/reference/latest/shared/schema/introduction)
-> * [Schema reference](https://docs.improbable.io/reference/latest/shared/schema/reference)
+> * [Introduction to schema](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/schema/introduction)
+> * [Schema reference](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/schema/reference)
 
 ### Simulated Player
 
@@ -349,13 +349,13 @@ A simulated player coordinator is a server-worker responsible for launching simu
 
 ### Snapshot
 
-A snapshot is a representation of the state of a [SpatialOS world](#spatialos-world) at some point in time. It stores each [persistent](#persistence) [SpatialOS entity](#spatialos-entity) and the values of their [SpatialOS components](#spatialos-component)' [properties](https://docs.improbable.io/reference/latest/shared/glossary#property).
+A snapshot is a representation of the state of a [SpatialOS world](#spatialos-world) at some point in time. It stores each [persistent](#persistence) [SpatialOS entity](#spatialos-entity) and the values of their [SpatialOS components](#spatialos-component)' [properties](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#property).
 
-You'll use a snapshot as the starting point (an [initial snapshot](https://docs.improbable.io/reference/latest/shared/glossary#initial-snapshot)) for your [SpatialOS world](#spatialos-world) when you [deploy your game](#deploying).
+You'll use a snapshot as the starting point (an [initial snapshot](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#initial-snapshot)) for your [SpatialOS world](#spatialos-world) when you [deploy your game](#deploying).
 
 > Related:
 >
-> * [Snapshots](https://docs.improbable.io/reference/latest/shared/operate/snapshots)
+> * [Snapshots](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/operate/snapshots)
 
 ### SpatialOS Assembly
 
@@ -367,17 +367,17 @@ The SpatialOS assembly is stored locally at `build\assembly` in the root directo
 
 > Related:
 >
-> * [spatial cloud upload](https://docs.improbable.io/reference/latest/shared/spatial-cli/spatial-cloud-upload)
+> * [spatial cloud upload](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/spatial-cli/spatial-cloud-upload)
 > * [Deploying to the cloud]({{urlRoot}}/reference/concepts/deployments#cloud-deployment)
 
 ### `spatial` command-line tool (CLI)
 
-The `spatial` command-line tool provides a set of commands that you use to interact with a [SpatialOS project](#spatialos-project). Among other things, you use it to [deploy](#deploying) your game (using [`spatial local launch`](https://docs.improbable.io/reference/latest/shared/spatial-cli/spatial-local-launch) or [`spatial cloud launch`](https://docs.improbable.io/reference/latest/shared/spatial-cli/spatial-cloud-launch)).
+The `spatial` command-line tool provides a set of commands that you use to interact with a [SpatialOS project](#spatialos-project). Among other things, you use it to [deploy](#deploying) your game (using [`spatial local launch`](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/spatial-cli/spatial-local-launch) or [`spatial cloud launch`](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/spatial-cli/spatial-cloud-launch)).
 
 > Related:
 >
-> * [An introduction to the `spatial` command-line tool](https://docs.improbable.io/reference/latest/shared/spatial-cli-introduction). Note that the GDK does not support any `spatial worker` commands.
-> * [`spatial` reference](https://docs.improbable.io/reference/latest/shared/spatial-cli/spatial)
+> * [An introduction to the `spatial` command-line tool](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/spatial-cli-introduction). Note that the GDK does not support any `spatial worker` commands.
+> * [`spatial` reference](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/spatial-cli/spatial)
 
 
 ### SpatialOS component
@@ -388,12 +388,12 @@ A [SpatialOS entity](#spatialos-entity) is defined by a set of components. Commo
 
 Components can contain:
 
-* [properties](https://docs.improbable.io/reference/latest/shared/glossary#property), which describe persistent values that change over time (for example, a property for a `Health` component could be “the current health value for this entity”.)
-* [events](https://docs.improbable.io/reference/latest/shared/glossary#event), which are transient things that can happen to an entity (for example, `StartedWalking`)
-* [commands](https://docs.improbable.io/reference/latest/shared/glossary#command) that another worker can call to ask the component to do something, optionally returning a value (for example, `Teleport`)
+* [properties](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#property), which describe persistent values that change over time (for example, a property for a `Health` component could be “the current health value for this entity”.)
+* [events](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#event), which are transient things that can happen to an entity (for example, `StartedWalking`)
+* [commands](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#command) that another worker can call to ask the component to do something, optionally returning a value (for example, `Teleport`)
 
-A SpatialOS entity can have as many components as you like, but it must have at least [`Position`](https://docs.improbable.io/reference/latest/shared/glossary#position) and
-[`EntityAcl`](#access-control-list-acl). Most entities will have the [`Metadata`](https://docs.improbable.io/reference/latest/shared/glossary#metadata) component.
+A SpatialOS entity can have as many components as you like, but it must have at least [`Position`](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#position) and
+[`EntityAcl`](#access-control-list-acl). Most entities will have the [`Metadata`](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#metadata) component.
 
 > Unlike Unity ECS components, it is not possible to add or remove SpatialOS components on already existing SpatialOS entities.
 
@@ -403,9 +403,9 @@ Components are defined as files in your [schema](#schema).
 
 > Related:
 >
-> * [Designing components](https://docs.improbable.io/reference/latest/shared/design/design-components)
-> * [Component best practices](https://docs.improbable.io/reference/latest/shared/design/component-best-practices)
-> * [Introduction to schema](https://docs.improbable.io/reference/latest/shared/schema/introduction)
+> * [Designing components](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/design/design-components)
+> * [Component best practices](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/design/component-best-practices)
+> * [Introduction to schema](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/schema/introduction)
 
 ### SpatialOS entity
 
@@ -415,16 +415,16 @@ All of the objects inside a [SpatialOS world](#spatialos-world) are SpatialOS en
 
 SpatialOS entities are made up of [SpatialOS components](#spatialos-component), which store data associated with that entity.
 
-[Workers](#worker) can only see the entities they're [interested in](https://docs.improbable.io/reference/latest/shared/glossary#interest).
+[Workers](#worker) can only see the entities they're [interested in](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#interest).
 
-For example, for client-workers built using Unity, you might want to have a prefab associated with each entity type, and spawn a GameObject for each entity the worker has [checked out](https://docs.improbable.io/reference/latest/shared/glossary#checking-out).
+For example, for client-workers built using Unity, you might want to have a prefab associated with each entity type, and spawn a GameObject for each entity the worker has [checked out](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#checking-out).
 
 You can have other objects that are *not* entities locally on workers - like UI for a player - but no other worker will be able to see them, because they're not part of the [SpatialOS world](#spatialos-world).
 
 > Related:
 >
-> * [SpatialOS Concepts:Entities](https://docs.improbable.io/reference/latest/shared/concepts/world-entities-components#entities)
-> * [Designing SpatialOS entities](https://docs.improbable.io/reference/latest/shared/design/design-entities)
+> * [SpatialOS Concepts:Entities](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/concepts/world-entities-components#entities)
+> * [Designing SpatialOS entities](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/design/design-entities)
 
 
 ### SpatialOS project
@@ -439,12 +439,12 @@ A SpatialOS project includes (but isn't limited to):
 
 * The source code of all [workers](#worker) used by the project
 * The project’s [schema](#schema)
-* Optional [snapshots](#snapshot) of the project’s [SpatialOS world](https://docs.improbable.io/reference/latest/shared/glossary#spatialos-world)
-* Configuration files, mostly containing settings for [deployments](#deploying) (for example, [launch configuration files](https://docs.improbable.io/reference/latest/shared/worker-configuration/launch-configuration))
+* Optional [snapshots](#snapshot) of the project’s [SpatialOS world](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#spatialos-world)
+* Configuration files, mostly containing settings for [deployments](#deploying) (for example, [launch configuration files](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/worker-configuration/launch-configuration))
 
 > Related:
 >
-> * [Project directory structure](https://docs.improbable.io/reference/latest/shared/reference/project-structure)
+> * [Project directory structure](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/reference/project-structure)
 
 ### SpatialOS Runtime
 
@@ -458,18 +458,18 @@ A SpatialOS Runtime instance manages the [SpatialOS world](#spatialos-world) of 
 From SpatialOS version 13.4 there is a new SpatialOS Runtime.
 It consists of three elements:
 
-* The new [bridge](https://docs.improbable.io/reference/latest/shared/worker-configuration/bridge-config#bridge-configuration).
-* The new [load balancer](https://docs.improbable.io/reference/latest/shared/glossary#load-balancing).
+* The new [bridge](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/worker-configuration/bridge-config#bridge-configuration).
+* The new [load balancer](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#load-balancing).
 * The new entity database.
 
-It also contains a new feature: [Query-based interest](https://docs.improbable.io/reference/latest/shared/worker-configuration/query-based-interest#query-based-interest-beta).
+It also contains a new feature: [Query-based interest](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/worker-configuration/query-based-interest#query-based-interest-beta).
 
 The GDK for Unity version Alpha 0.1.4, uses the new SpatialOS Runtime (available from SpatialOS version 13.4); wherever the documentation refers to the “Runtime”, it means the new v13.4+ SpatialOS Runtime.
 
 > Related:
 >
 > * [The new Runtime (blog post)](https://improbable.io/games/blog/the-new-runtime-is-here-with-a-new-feature-for-managing-areas-of-interest)
-> * [Upgrade to the new Runtime](https://docs.improbable.io/reference/latest/releases/upgrade-guides/upgrade-runtime)
+> * [Upgrade to the new Runtime](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/releases/upgrade-guides/upgrade-runtime)
 
 ### SpatialOS world
 
@@ -479,9 +479,9 @@ The SpatialOS world is a central concept in SpatialOS. It’s the canonical sour
 
 SpatialOS manages the world, keeping track of all entities and their state.
 
-Changes to the world are made by [workers](#worker). Each worker has a view onto the world (the part of the world that they're [interested in](https://docs.improbable.io/reference/latest/shared/glossary#interest)), and SpatialOS sends them updates when anything changes in that view.
+Changes to the world are made by [workers](#worker). Each worker has a view onto the world (the part of the world that they're [interested in](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#interest)), and SpatialOS sends them updates when anything changes in that view.
 
-It's important to recognize this fundamental separation between the SpatialOS world and the subset view of that world that an individual worker [checks out](https://docs.improbable.io/reference/latest/shared/glossary#checking-out). This is why workers must [send updates](https://docs.improbable.io/reference/latest/shared/glossary#sending-an-update) to SpatialOS when they want to change the world: they don't control the canonical state of the world, they must use the [Worker SDK](https://docs.improbable.io/reference/latest/shared/glossary#worker-sdk) API to change it.
+It's important to recognize this fundamental separation between the SpatialOS world and the subset view of that world that an individual worker [checks out](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#checking-out). This is why workers must [send updates](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#sending-an-update) to SpatialOS when they want to change the world: they don't control the canonical state of the world, they must use the [Worker SDK](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#worker-sdk) API to change it.
 
 ### Standard replication
 
@@ -607,41 +607,41 @@ There are two types of workers, [server-workers](#server-worker) and [client-wor
 
 In order to achieve huge scale, SpatialOS divides up the SpatialOS entities in the world between workers, balancing the work so none of them are overloaded. For each SpatialOS entity in the world, it decides which worker should have [write access](#write-access) to each SpatialOS component on the SpatialOS entity. To prevent multiple workers writing to a component at the same time, only one worker at a time can have write access to a SpatialOS component.
 
-As the world changes over time, the position of SpatialOS entities and the amount of work associated with them changes. [Server-workers](#server-worker) report back to SpatialOS how much load they're under, and SpatialOS adjusts which workers have write access to components on which SpatialOS entities (and starts up new workers when needed). This is called [load balancing](https://docs.improbable.io/reference/latest/shared/glossary#load-balancing).
+As the world changes over time, the position of SpatialOS entities and the amount of work associated with them changes. [Server-workers](#server-worker) report back to SpatialOS how much load they're under, and SpatialOS adjusts which workers have write access to components on which SpatialOS entities (and starts up new workers when needed). This is called [load balancing](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#load-balancing).
 
-Around the SpatialOS entities they have write access to, each worker has an area of the world they are [interested in](https://docs.improbable.io/reference/latest/shared/glossary#interest).
+Around the SpatialOS entities they have write access to, each worker has an area of the world they are [interested in](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#interest).
 
-A worker can read the current properties of the SpatialOS entities within this area, and SpatialOS sends [updates and messages](https://docs.improbable.io/reference/latest/shared/glossary#sending-an-update) about these SpatialOS entities to the worker.
+A worker can read the current properties of the SpatialOS entities within this area, and SpatialOS sends [updates and messages](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#sending-an-update) about these SpatialOS entities to the worker.
 
-If the worker has write access to a SpatialOS component, it can [send updates and messages](https://docs.improbable.io/reference/latest/shared/glossary#sending-an-update):
-it can update [properties](https://docs.improbable.io/reference/latest/shared/glossary#property), send and handle [commands](https://docs.improbable.io/reference/latest/shared/glossary#command) and trigger [events](https://docs.improbable.io/reference/latest/shared/glossary#event).
+If the worker has write access to a SpatialOS component, it can [send updates and messages](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#sending-an-update):
+it can update [properties](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#property), send and handle [commands](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#command) and trigger [events](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#event).
 
 See also the [Workers in the GDK]({{urlRoot}}/reference/concepts/worker) documentation.
 
 > Related:
 >
-> * [Concepts: Workers and load balancing](https://docs.improbable.io/reference/latest/shared/concepts/workers-load-balancing)
+> * [Concepts: Workers and load balancing](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/concepts/workers-load-balancing)
 
 ### Worker attribute
 
-Worker attributes are used to denote a [worker’s](#worker) capabilities. The [SpatialOS runtime](#spatialos-runtime) uses these attributes to delegate [authority](#authority) over [SpatialOS components](#spatialos-component) in combination with the defined [ACL](#access-control-list-acl). A worker’s attributes are defined in its [worker configuration JSON](https://docs.improbable.io/reference/latest/shared/worker-configuration/bridge-config#worker-attribute-sets).
+Worker attributes are used to denote a [worker’s](#worker) capabilities. The [SpatialOS runtime](#spatialos-runtime) uses these attributes to delegate [authority](#authority) over [SpatialOS components](#spatialos-component) in combination with the defined [ACL](#access-control-list-acl). A worker’s attributes are defined in its [worker configuration JSON](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/worker-configuration/bridge-config#worker-attribute-sets).
 
 > Related:
 >
-> * [Worker attributes](https://docs.improbable.io/reference/latest/shared/glossary#worker-attribute)
-> * [Bridge configuration](https://docs.improbable.io/reference/latest/shared/worker-configuration/bridge-config#worker-attribute-sets)
+> * [Worker attributes](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#worker-attribute)
+> * [Bridge configuration](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/worker-configuration/bridge-config#worker-attribute-sets)
 
 ### Worker flags
 
-A worker flag is a key-value pair that workers can access during runtime. Worker flags can be set in their [launch configuration](https://docs.improbable.io/reference/latest/shared/reference/file-formats/launch-config) or added/changed/removed at runtime through the SpatialOS console. [This SpatialOS documentation](https://docs.improbable.io/reference/latest/shared/worker-configuration/worker-flags#worker-flags) describes how to define and change worker flags.
+A worker flag is a key-value pair that workers can access during runtime. Worker flags can be set in their [launch configuration](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/reference/file-formats/launch-config) or added/changed/removed at runtime through the SpatialOS console. [This SpatialOS documentation](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/worker-configuration/worker-flags#worker-flags) describes how to define and change worker flags.
 
 ### Worker SDK
 
-The GDK is built on top of a specialized version of the C# Worker SDK. This specialized C# Worker SDK is itself built on top of the [C API](https://docs.improbable.io/reference/latest/capi/introduction). The Worker SDK handles the implementation details of communicating to the SpatialOS runtime and provides a serialization library.
+The GDK is built on top of a specialized version of the C# Worker SDK. This specialized C# Worker SDK is itself built on top of the [C API](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/capi/introduction). The Worker SDK handles the implementation details of communicating to the SpatialOS runtime and provides a serialization library.
 
 > Related:
 >
-> * [Worker SDK](https://docs.improbable.io/reference/latest/shared/glossary#worker-sdk)
+> * [Worker SDK](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#worker-sdk)
 
 ### Worker Origin
 
@@ -658,7 +658,7 @@ Within these broad types, users can define their own worker sub-types to create 
 
 ### Worker’s view
 
-A worker’s view consists of all [SpatialOS entities](#spatialos-entity) that a worker is currently [interested in](https://docs.improbable.io/reference/latest/shared/glossary#interest) and has [checked out](#checking-out). In the GDK, this view is used to populate the [worker’s world](#worker-s-world) and to synchronize any changes between the worker’s view and the worker’s world.
+A worker’s view consists of all [SpatialOS entities](#spatialos-entity) that a worker is currently [interested in](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#interest) and has [checked out](#checking-out). In the GDK, this view is used to populate the [worker’s world](#worker-s-world) and to synchronize any changes between the worker’s view and the worker’s world.
 
 ### Worker’s world
 
@@ -668,7 +668,7 @@ In the GDK, during the creation of a [worker](#worker), the worker connects to t
 
 The SpatialOS world, also known as “the world” and “the game world”. The world is a central concept in SpatialOS. It’s the canonical source of truth about your game. All the world’s data is stored within SpatialOS [entities](#spatialos-entity); specifically, within their [components](#spatialos-component).
 
-SpatialOS manages the world, keeping track of all the SpatialOS entities and what state they’re in. Changes to the world are made by [workers](#worker). Each worker has a view onto the world (the part of the world that they’re [interested in](https://docs.improbable.io/reference/latest/shared/glossary#interest)), and SpatialOS sends them updates when anything changes in that view.
+SpatialOS manages the world, keeping track of all the SpatialOS entities and what state they’re in. Changes to the world are made by [workers](#worker). Each worker has a view onto the world (the part of the world that they’re [interested in](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#interest)), and SpatialOS sends them updates when anything changes in that view.
 
 It’s important to recognize this fundamental separation between the SpatialOS world and the view (or representation) of that world that a worker [checks out](#checking-out) locally. This is why workers must send updates to SpatialOS when they want to change the world: they don’t control the canonical state of the world, they must use SpatialOS APIs to change it.
 
@@ -678,8 +678,8 @@ It’s important to recognize this fundamental separation between the SpatialOS 
 
 Many [workers](#worker) can connect to a [SpatialOS world](#spatialos-world). To prevent them from clashing, SpatialOS only allows one worker at a time to write to each [SpatialOS component](#spatialos-component). Write access is defined at the component level.
 
-Which individual worker *actually has* write access is managed by SpatialOS, and can change regularly because of [load balancing](https://docs.improbable.io/reference/latest/shared/glossary#load-balancing). However, the list of workers that could *possibly* gain write access is constrained by the [access control lists](#access-control-list-acl).
+Which individual worker *actually has* write access is managed by SpatialOS, and can change regularly because of [load balancing](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#load-balancing). However, the list of workers that could *possibly* gain write access is constrained by the [access control lists](#access-control-list-acl).
 
 > Related:
 >
-> * [Understanding read and write access](https://docs.improbable.io/reference/latest/shared/design/understanding-access)
+> * [Understanding read and write access](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/design/understanding-access)

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -8,7 +8,7 @@ If you are new to the GDK, the best place to start is with the [Get started]({{u
 
 ### SpatialOS concepts
 
-If you are new to SpatialOS, you can check out the SpatialOS concept documentation on the SpatialOS [main documentation site](https://docs.improbable.io/reference/latest/shared/concepts/spatialos).
+If you are new to SpatialOS, you can check out the SpatialOS concept documentation on the SpatialOS [main documentation site](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/concepts/spatialos).
 
 ### Where to start with the GDK reference documentation
 

--- a/docs/reference/workflows/ecs/interaction/authority.md
+++ b/docs/reference/workflows/ecs/interaction/authority.md
@@ -5,8 +5,8 @@
 <%(Callout message="
 Before reading this document, make sure you are familiar with:
 
-* [Authority in SpatialOS](https://docs.improbable.io/reference/latest/shared/concepts/interest-authority#authority-also-known-as-write-access)
-* [Understanding read and write access](https://docs.improbable.io/reference/latest/shared/design/understanding-access)
+* [Authority in SpatialOS](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/concepts/interest-authority#authority-also-known-as-write-access)
+* [Understanding read and write access](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/design/understanding-access)
 ")%>
 
 Authority is how SpatialOS represents which worker instances can write to a specific [SpatialOS component]({{urlRoot}}/reference/glossary#spatialos-component).

--- a/docs/reference/workflows/ecs/interaction/component-commands.md
+++ b/docs/reference/workflows/ecs/interaction/component-commands.md
@@ -5,7 +5,7 @@
 <%(Callout message="
 Before reading this document, make sure you are familiar with:
 
-* [SpatialOS component commands](https://docs.improbable.io/reference/latest/shared/design/commands#component-commands)
+* [SpatialOS component commands](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/design/commands#component-commands)
 ")%>
 
 For each command defined in your schema components, the GDK generates the following types:

--- a/docs/reference/workflows/ecs/interaction/events.md
+++ b/docs/reference/workflows/ecs/interaction/events.md
@@ -5,7 +5,7 @@
 <%(Callout message="
 Before reading this document, make sure you are familiar with
 
-  * [SpatialOS events](https://docs.improbable.io/reference/latest/shared/design/object-interaction#events)
+  * [SpatialOS events](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/design/object-interaction#events)
 ")%>
 
 ## Sending events

--- a/docs/reference/workflows/ecs/interaction/reactive-components/overview.md
+++ b/docs/reference/workflows/ecs/interaction/reactive-components/overview.md
@@ -16,11 +16,11 @@ Reactive components are removed by the GDK at the end of each frame, as they are
 
 These are the types of reactive component available:
 
-* `AuthorityChanges`: All updates to the [authority](https://docs.improbable.io/reference/latest/shared/design/understanding-access#understanding-read-and-write-access-authority) the current worker instance has over a SpatialOS component.
-* `ReceivedUpdates`:  All received [SpatialOS component updates](https://docs.improbable.io/reference/latest/shared/design/operations#component-related-operations) for the current SpatialOS entity.
-* `ReceivedEvents`: All received [events](https://docs.improbable.io/reference/latest/shared/design/object-interaction#events) for the current entity.
-* `CommandRequests`: All received [command](https://docs.improbable.io/reference/latest/shared/design/commands) requests.
-* `CommandResponses`: All received [command](https://docs.improbable.io/reference/latest/shared/design/commands) responses.
+* `AuthorityChanges`: All updates to the [authority](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/design/understanding-access#understanding-read-and-write-access-authority) the current worker instance has over a SpatialOS component.
+* `ReceivedUpdates`:  All received [SpatialOS component updates](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/design/operations#component-related-operations) for the current SpatialOS entity.
+* `ReceivedEvents`: All received [events](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/design/object-interaction#events) for the current entity.
+* `CommandRequests`: All received [command](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/design/commands) requests.
+* `CommandResponses`: All received [command](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/design/commands) responses.
 * [`ComponentAdded<T>`]({{urlRoot}}/api/reactive-components/component-added): Denotes that a SpatialOS component of type `T` has been added to this entity.
 * [`ComponentRemoved<T>`]({{urlRoot}}/api/reactive-components/component-removed): Denotes that a SpatialOS component of type `T` has been removed to this entity.
 

--- a/docs/reference/workflows/ecs/interaction/world-commands.md
+++ b/docs/reference/workflows/ecs/interaction/world-commands.md
@@ -5,7 +5,7 @@
 <%(Callout message="
 Before reading this document, make sure you are familiar with:
 
-* [World commands](https://docs.improbable.io/reference/13.8/shared/design/commands#world-commands)
+* [World commands](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/design/commands#world-commands)
 ")%>
 
 World commands are built-in commands that are used to interact with the SpatialOS runtime to ask it to reserve entity ids, create or delete entities, or request information about entities.
@@ -73,7 +73,7 @@ commandSystem.GetResponses<WorldCommands.CreateEntity.ReceivedResponse>();
 
 ## Entity queries
 
-You can use entity queries to get information about entities in the world. For more information, see [entity queries](https://docs.improbable.io/reference/latest/shared/glossary#queries) in the SpatialOS documentation.
+You can use entity queries to get information about entities in the world. For more information, see [entity queries](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#queries) in the SpatialOS documentation.
 
 Create a [`WorldCommands.EntityQuery.Request`]({{urlRoot}}/api/core/commands/world-commands/entity-query/request) struct with the [`EntityQuery`]({{urlRoot}}/api/core/commands/world-commands/entity-query#entityquery-class). The `TimeoutMillis` field is optional.
 

--- a/docs/reference/workflows/monobehaviour/interaction/reader-writers/events.md
+++ b/docs/reference/workflows/monobehaviour/interaction/reader-writers/events.md
@@ -6,7 +6,7 @@ _This document relates to the [MonoBehaviour workflow]({{urlRoot}}/reference/wor
 
 Events are SpatialOS's equivalent of broadcasted messages. They allow you to send messages to all interested workers.
 
-> For more information, see the documentation on [events](https://docs.improbable.io/reference/latest/shared/glossary#events).
+> For more information, see the documentation on [events](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#events).
 
 We provide code-generated Readers and Writers for sending and receiving SpatialOS events. Before reading this document, make sure you are familiar with
 

--- a/docs/reference/workflows/monobehaviour/interaction/reader-writers/index.md
+++ b/docs/reference/workflows/monobehaviour/interaction/reader-writers/index.md
@@ -24,7 +24,7 @@ Readers and Writers allow you to inspect and change the state of SpatialOS compo
 
 * Change the property values of a SpatialOS component.
 * Send events defined in a SpatialOS component.
-* Send acknowledgements for [`AuthorityLossImminent` notifications](https://docs.improbable.io/reference/latest/shared/design/understanding-access#enabling-and-configuring-authoritylossimminent-notifications).
+* Send acknowledgements for [`AuthorityLossImminent` notifications](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/design/understanding-access#enabling-and-configuring-authoritylossimminent-notifications).
 * All the functionality that a Reader provides.
 
 > Note that a writer will only receive authority state change callbacks for `AuthorityLossImminent`.
@@ -136,4 +136,4 @@ Parameters:
 ```csharp
 void AcknowledgeAuthorityLoss();
 ```
-Allows you to send acknowledgements for [`AuthorityLossImminent` notifications](https://docs.improbable.io/reference/latest/shared/design/understanding-access#enabling-and-configuring-authoritylossimminent-notifications).
+Allows you to send acknowledgements for [`AuthorityLossImminent` notifications](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/design/understanding-access#enabling-and-configuring-authoritylossimminent-notifications).

--- a/docs/reference/workflows/monobehaviour/worker-connectors.md
+++ b/docs/reference/workflows/monobehaviour/worker-connectors.md
@@ -102,7 +102,7 @@ The `SpatialOSConnectionHandlerBuilder` object is central to this framework. It 
 The [`WorkerConnector`]({{urlRoot}}/api/core/worker-connector) class has a `CreateConnectionParameters(string workerType)` method which returns reasonable defaults for your `ConnectionParameters`. You can then tweak these to fit your use case. For example:
 
 - If you are implementing a client worker, you may want to use the `KCP` networking stack.
-- If you are debugging the low level networking of a worker, you may want to enable [protocol logging](https://docs.improbable.io/reference/latest/shared/debugging#protocol-logging).
+- If you are debugging the low level networking of a worker, you may want to enable [protocol logging](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/debugging#protocol-logging).
 
 ### How do I populate my connection flow parameters
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -60,7 +60,7 @@
         - [Strategies]({{urlRoot}}/modules/transform-sync/strategies)
 - <h3>Reference</h3>
     - [Overview]({{urlRoot}}/reference/overview)
-    - [SpatialOS concepts](https://docs.improbable.io/reference/latest/shared/concepts/spatialos)
+    - [SpatialOS concepts](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/concepts/spatialos)
     - GDK concepts
         - [Code generator]({{urlRoot}}/reference/concepts/code-generation)
         - [Connection flows]({{urlRoot}}/reference/concepts/connection-flows)
@@ -97,7 +97,7 @@
                 - [System update order]({{urlRoot}}/reference/workflows/ecs/concepts/system-update-order)
                 - [Temporary components]({{urlRoot}}/reference/workflows/ecs/concepts/temporary-components)
                 - [ECS entity contracts]({{urlRoot}}/reference/workflows/ecs/concepts/entity-contracts)
-    - [SpatialOS glossary](https://docs.improbable.io/reference/latest/shared/glossary#concepts-glossary)
+    - [SpatialOS glossary](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/glossary#concepts-glossary)
     - [GDK glossary]({{urlRoot}}/reference/glossary)
     - [Troubleshooting]({{urlRoot}}/reference/troubleshooting)
     - [Known issues](https://github.com/spatialos/gdk-for-unity/projects/2)

--- a/docs/variable.properties
+++ b/docs/variable.properties
@@ -1,1 +1,2 @@
 current_version=0.2.5
+worker_sdk_version=13.8

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -26,7 +26,7 @@ The GDK is composed of three layers:
 <br/>
 <br/>
 * If you aren’t already familiar with SpatialOS, you can find out about the concepts which enable it to support game worlds with more persistence, scale, and complexity than previously possible.
-<br/> **Read the [SpatialOS concept docs](https://docs.improbable.io/reference/latest/shared/concepts/spatialos)** on the SpatialOS documentation website (5 minute read).
+<br/> **Read the [SpatialOS concept docs](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/concepts/spatialos)** on the SpatialOS documentation website (5 minute read).
 <br/>
 <br/>
 Find out what's involved in getting started with our [Get started with SpatialOS for Unity walk-through youtube video](https://www.youtube.com/watch?v=6PNDBYtIimw), based on our [Get Started guide]({{urlRoot}}/projects/fps/get-started/get-started) (15-minute watch).


### PR DESCRIPTION
#### Description
- Added the `Entity` schema type to the table.
- Pinned all our improbadoc references to `13.8` (with a variable!)
