### PR TITLE
Lay groundwork for serialization overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ### Internal
 
 - Added extension methods on the `SchemaObject` struct for easy serializing/deserializing of the `Entity` schema type. [#1053](https://github.com/spatialos/gdk-for-unity/pull/1053)
+- Added options and functionality for serialization overrides for schema types only.
 
 ## `0.2.5` - 2019-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 ### Internal
 
 - Added extension methods on the `SchemaObject` struct for easy serializing/deserializing of the `Entity` schema type. [#1053](https://github.com/spatialos/gdk-for-unity/pull/1053)
-- Added options and functionality for serialization overrides for schema types only.
+- Added options and functionality for serialization overrides for schema types only. [#1061](https://github.com/spatialos/gdk-for-unity/pull/1061)
 
 ## `0.2.5` - 2019-07-18
 

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityTypeContent.tt
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityTypeContent.tt
@@ -34,15 +34,22 @@ if (fieldDetailsList.Count > 0)
     {
         public static void Serialize(<#= typeDetails.CapitalisedName #> instance, global::Improbable.Worker.CInterop.SchemaObject obj)
         {
+<# if (typeDetails.HasSerializationOverride) { #>
+            <#= typeDetails.SerializationOverride.GetSerializationString("instance", "obj") #>
+<# } else { #>
 <# foreach (var fieldDetails in fieldDetailsList) { #>
             {
                 <#= fieldDetails.GetSerializationString("instance." + fieldDetails.PascalCaseName, "obj", 4) #>
             }
 <# } #>
+<# } #>
         }
 
         public static <#= typeDetails.CapitalisedName #> Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj)
         {
+<# if (typeDetails.HasSerializationOverride) { #>
+            return <#= typeDetails.SerializationOverride.GetDeserializeString("obj") #>;
+<# } else { #>
             var instance = new <#= typeDetails.CapitalisedName #>();
 <# foreach (var fieldDetails in fieldDetailsList) { #>
             {
@@ -50,6 +57,7 @@ if (fieldDetailsList.Count > 0)
             }
 <# } #>
             return instance;
+<# } #>
         }
     }
 <#

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Tests/Model/DetailsStoreTests.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Tests/Model/DetailsStoreTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Improbable.Gdk.CodeGeneration;
 using Improbable.Gdk.CodeGeneration.Tests.Model.SchemaBundleV1;
@@ -15,7 +16,12 @@ namespace GdkCodeGenerator.Tests.Model
         public void OneTimeSetup()
         {
             var json = JsonParsingTests.GetBundleContents();
-            store = new DetailsStore(SchemaBundle.LoadBundle(json));
+            var overrides = new List<string>
+            {
+                "global::Improbable.Gdk.Tests.SomeType;global::UserCode.SerializationExtensions.Type"
+            };
+
+            store = new DetailsStore(SchemaBundle.LoadBundle(json), overrides);
         }
 
         [Test]
@@ -68,6 +74,15 @@ namespace GdkCodeGenerator.Tests.Model
             var nestedTypes = store.GetNestedTypes(fqn);
 
             Assert.AreEqual(0, nestedTypes.Count);
+        }
+
+        [Test]
+        public void Serialization_overrides_are_correctly_propagated()
+        {
+            var fqn = "improbable.gdk.tests.SomeType";
+            var details = store.Types[fqn];
+
+            Assert.IsTrue(details.HasSerializationOverride);
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/CodeGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/CodeGenerator.cs
@@ -57,7 +57,7 @@ namespace Improbable.Gdk.CodeGenerator
 
             var bundlePath = GenerateBundle();
             var schemaBundle = SchemaBundle.LoadBundle(File.ReadAllText(bundlePath));
-            var store = new DetailsStore(schemaBundle);
+            var store = new DetailsStore(schemaBundle, options.SerializationOverrides);
             var workerGenerationJob = new WorkerGenerationJob(options.NativeOutputDirectory, options, fileSystem);
             var singleJob = new SingleGenerationJob(options.NativeOutputDirectory, store, fileSystem);
 

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/CodeGeneratorOptions.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/CodeGeneratorOptions.cs
@@ -17,6 +17,7 @@ namespace Improbable.Gdk.CodeGenerator
         public string HelpText { get; private set; }
         public List<string> SchemaInputDirs { get; } = new List<string>();
         public string SchemaCompilerPath { get; private set; }
+        public List<string> SerializationOverrides { get; } = new List<string>();
 
         public static CodeGeneratorOptions ParseArguments(ICollection<string> args)
         {
@@ -46,6 +47,10 @@ namespace Improbable.Gdk.CodeGenerator
                 {
                     "schema-compiler-path=", "REQUIRED: the path to the CoreSdk schema compiler",
                     u => options.SchemaCompilerPath = u
+                },
+                {
+                    "serialization-override=", "OPTIONAL: defines an override for serialization of a single type",
+                    u => options.SerializationOverrides.Add(u)
                 },
                 {
                     "h|help", "show help",

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/Generation/Model/Details/UnityTypeDetails.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/Generation/Model/Details/UnityTypeDetails.cs
@@ -17,6 +17,10 @@ namespace Improbable.Gdk.CodeGenerator
         public IReadOnlyList<UnityTypeDetails> ChildTypes;
         public IReadOnlyList<UnityEnumDetails> ChildEnums;
 
+        public SerializationOverride SerializationOverride;
+
+        public bool HasSerializationOverride => SerializationOverride != null;
+
         private TypeDefinition raw;
 
         public UnityTypeDetails(string package, TypeDefinition typeDefinitionRaw)
@@ -57,6 +61,26 @@ namespace Improbable.Gdk.CodeGenerator
                 .Select(field => new UnityFieldDetails(field, store))
                 .ToList()
                 .AsReadOnly();
+        }
+    }
+
+    public class SerializationOverride
+    {
+        private string staticClassFqn;
+
+        public SerializationOverride(string staticClassFqn)
+        {
+            this.staticClassFqn = staticClassFqn;
+        }
+
+        public string GetSerializationString(string instance, string schemaObject)
+        {
+            return $"{staticClassFqn}.Serialize({instance}, {schemaObject});";
+        }
+
+        public string GetDeserializeString(string schemaObject)
+        {
+            return $"{staticClassFqn}.Deserialize({schemaObject})";
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.tools/GdkToolsConfiguration.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/GdkToolsConfiguration.cs
@@ -14,6 +14,7 @@ namespace Improbable.Gdk.Tools
         public string DevAuthTokenDir;
         public int DevAuthTokenLifetimeDays;
         public bool SaveDevAuthTokenToFile;
+        public List<string> SerializationOverrides = new List<string>();
 
         public string DevAuthTokenFullDir => Path.Combine(Application.dataPath, DevAuthTokenDir);
         public string DevAuthTokenFilepath => Path.Combine(DevAuthTokenFullDir, "DevAuthToken.txt");

--- a/workers/unity/Packages/io.improbable.gdk.tools/GenerateCode.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/GenerateCode.cs
@@ -61,7 +61,7 @@ namespace Improbable.Gdk.Tools
             return !File.Exists(StartupCodegenMarkerFile);
         }
 
-        [MenuItem("SpatialOS/Generate code", false, MenuPriorities.GenerateCodePriority)]
+        [MenuItem("SpatialOS/Generate code", isValidateFunction: false, priority: MenuPriorities.GenerateCodePriority)]
         private static void GenerateMenu()
         {
             Debug.Log("Generating code...");
@@ -215,10 +215,14 @@ namespace Improbable.Gdk.Tools
             // Schema Descriptor
             baseArgs.Add($"--descriptor-dir=\"{toolsConfig.DescriptorOutputDir}\"");
 
+            baseArgs.AddRange(
+                toolsConfig.SerializationOverrides.Select(@override => $"--serialization-override=\"{@override}\""));
+
             return baseArgs.ToArray();
         }
 
-        [MenuItem("SpatialOS/Generate code (force)", false, MenuPriorities.GenerateCodeForcePriority)]
+        [MenuItem("SpatialOS/Generate code (force)", isValidateFunction: false,
+            priority: MenuPriorities.GenerateCodeForcePriority)]
         private static void ForceGenerateMenu()
         {
             Debug.Log("Generating code (forced rebuild)...");
@@ -230,7 +234,7 @@ namespace Improbable.Gdk.Tools
             var toolsConfig = GdkToolsConfiguration.GetOrCreateInstance();
             if (Directory.Exists(toolsConfig.CodegenOutputDir))
             {
-                Directory.Delete(toolsConfig.CodegenOutputDir, true);
+                Directory.Delete(toolsConfig.CodegenOutputDir, recursive: true);
             }
 
             Generate();


### PR DESCRIPTION
#### Description
- Added options for serialization overrides for schema types only. 
- Added this to the `GdkToolsConfiguration.json`, not exposed in the UI.
- Overrides are specified by key-value pairs like so: `"TargetTypeFqn;SerializationOverrideStaticClassFqn"`
- These are parsed and pushed into the `UnityTypeDetails` and replaces the content of the Serialize/Deserialize functions for that type.

#### Tests
Added unit test. Will do an end-to-end test.

#### Documentation
Changelog. No public docs.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
