### PR TITLE
Update build system cli docs

### DIFF
--- a/docs/modules/build-system/cli.md
+++ b/docs/modules/build-system/cli.md
@@ -7,7 +7,7 @@ We expose a single static method: [`Improbable.Gdk.BuildSystem.WorkerBuilder.Bui
 - `buildWorkerTypes`: REQUIRED. The type of the worker to build.
 - `buildEnvironment`: REQUIRED. The target for the worker build. Either `local` or `cloud`.
 - `scriptingBackend`: Optional. Which scripting backend to use for the build. Either `mono` or `il2cpp`. If ommitted, this defaults to `mono`.
-- `buildTargetFilter`: Optional. A comma delimited list of build targets to filter for. For example, "win, macos". If ommitted, this defaults to all targets for the given environment.
+- `buildTargetFilter`: Optional. A comma delimited list of build targets to filter for. For example, "win,macos". If ommitted, this defaults to all targets for the given environment.
 
 ## Example
 
@@ -46,4 +46,4 @@ Unity.exe -projectPath "${GDK_PROJECT_PATH}" \
 
 This command builds the `UnityClient` worker type for cloud with the `mono` scripting backend, but only for MacOS. A `UnityClient` for Windows is _not_ built.
 
-> **Note:** The build target filter must be a subset of the available build targets for a given worker type on a given environment.
+> **Note:** The build target filter must be a subset of the available build targets for a given worker type on a given environment. Otherwise, an error will be thrown.

--- a/docs/modules/build-system/cli.md
+++ b/docs/modules/build-system/cli.md
@@ -5,8 +5,9 @@ The build system exposes a command line interface (CLI) that you can use to buil
 We expose a single static method: [`Improbable.Gdk.BuildSystem.WorkerBuilder.Build`]({{urlRoot}}/api/build-system/worker-builder) for use in the CLI. It accepts the following arguments:
 
 - `buildWorkerTypes`: REQUIRED. The type of the worker to build.
-- `buildTarget`: REQUIRED. The target for the worker build. Either `local` or `cloud`.
+- `buildEnvironment`: REQUIRED. The target for the worker build. Either `local` or `cloud`.
 - `scriptingBackend`: Optional. Which scripting backend to use for the build. Either `mono` or `il2cpp`. If ommitted, this defaults to `mono`.
+- `buildTargetFilter`: Optional. A comma delimited list of build targets to filter for. For example, "win, macos". If ommitted, this defaults to all targets for the given environment.
 
 ## Example
 
@@ -19,10 +20,30 @@ Unity.exe -projectPath "${GDK_PROJECT_PATH}" \
     -logfile ${LOG_FILE_PATH} \
     -executeMethod "Improbable.Gdk.BuildSystem.WorkerBuilder.Build" \
     +buildWorkerTypes "UnityClient" \
-    +buildTarget "cloud" \
+    +buildEnvironment "cloud" \
     +scriptingBackend "mono"
 ```
 
 This command builds the `UnityClient` worker type for cloud with the `mono` scripting backend.
 
 > **Note:** `Unity.exe` may not be in your path. You may need to call it via a fully qualified path.
+
+### Filtering build targets
+
+To build workers for a specific build target of a build environment, you need to provide the `buildTargetFilter` argument like the following:
+
+```bash
+Unity.exe -projectPath "${GDK_PROJECT_PATH}" \
+    -batchmode \
+    -quit \
+    -logfile ${LOG_FILE_PATH} \
+    -executeMethod "Improbable.Gdk.BuildSystem.WorkerBuilder.Build" \
+    +buildWorkerTypes "UnityClient" \
+    +buildEnvironment "cloud" \
+    +scriptingBackend "mono" \
+    +buildTargetFilter "macos"
+```
+
+This command builds the `UnityClient` worker type for cloud with the `mono` scripting backend, but only for MacOS. A `UnityClient` for Windows is _not_ built.
+
+> **Note:** The build target filter must be a subset of the available build targets for a given worker type on a given environment.


### PR DESCRIPTION
Updating the build system CLI docs to reflect following changes:

- `buildTarget` --> `buildEnvironment` rename
- describe new `buildTargetFilter` argument