### PR TITLE
Exit if we get linting errors

### DIFF
--- a/ci/build-lint-preview.sh
+++ b/ci/build-lint-preview.sh
@@ -34,6 +34,8 @@ function display_annotations() {
             buildkite-agent annotate --style 'error' --context 'ctx-error' --append "<li>${LINE}</li>"
         done < "${ERRORS_FILE}"
         buildkite-agent annotate --style 'error' --context 'ctx-error' --append "</ul>"
+
+        exit 1
     fi
 }
 


### PR DESCRIPTION
minor whoopsy

need to exit 1 if we get linting errors

Correctly fails here: https://buildkite.com/improbable/gdk-for-unity-docs/builds/154
Works correctly after fixing md links: https://buildkite.com/improbable/gdk-for-unity-docs/builds/153