### PR TITLE
Remove leftover 13.7.1 references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Added extension methods on the `SchemaObject` struct for easy serializing/deserializing of the `Entity` schema type. [#1053](https://github.com/spatialos/gdk-for-unity/pull/1053)
 - Added options and functionality for serialization overrides for schema types only. [#1061](https://github.com/spatialos/gdk-for-unity/pull/1061)
 - Laid the groundwork for 2D support in the Transform Synchronization Feature Module. [#1064](https://github.com/spatialos/gdk-for-unity/pull/1064)
+- Removed `core-sdk.pinned` from the tools package.
 
 ## `0.2.5` - 2019-07-18
 

--- a/spatialos.json
+++ b/spatialos.json
@@ -1,8 +1,8 @@
 {
     "name": "unity_gdk",
     "project_version": "0.0.1",
-    "sdk_version": "13.7.1-gdk-for-unity",
+    "sdk_version": "13.8.2",
     "dependencies": [
-        {"name": "standard_library", "version": "13.7.1-gdk-for-unity"}
+        {"name": "standard_library", "version": "13.8.2"}
     ]
 }

--- a/workers/unity/Packages/io.improbable.gdk.core/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.core/package.json
@@ -6,7 +6,7 @@
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Core Module.",
   "dependencies": {
-    "io.improbable.worker.sdk": "13.7.1",
+    "io.improbable.worker.sdk": "13.8.2",
     "io.improbable.gdk.tools": "0.2.5",
     "io.improbable.gdk.testutils": "0.2.5",
     "com.unity.entities": "0.0.12-preview.33"

--- a/workers/unity/Packages/io.improbable.gdk.mobile/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.mobile/package.json
@@ -7,6 +7,6 @@
   "description": "SpatialOS GDK Mobile Support Module.",
   "dependencies": {
     "io.improbable.gdk.core": "0.2.5",
-    "io.improbable.worker.sdk.mobile": "13.7.1"
+    "io.improbable.worker.sdk.mobile": "13.8.2"
   }
 }

--- a/workers/unity/Packages/io.improbable.gdk.tools/core-sdk.version
+++ b/workers/unity/Packages/io.improbable.gdk.tools/core-sdk.version
@@ -1,1 +1,0 @@
-13.7.1-gdk-for-unity

--- a/workers/unity/Packages/io.improbable.gdk.tools/core-sdk.version.meta
+++ b/workers/unity/Packages/io.improbable.gdk.tools/core-sdk.version.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 58389603e1fa52e469b8a20bef8b2a6d
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
@zeroZshadow noticed we had a few remaining references. `grep`-ed the repo for other references and removed them.