### PR TITLE
Add `SpatialDeploymentManager` to test utils package

### DIFF
--- a/workers/unity/Packages/io.improbable.gdk.testutils/Editor.meta
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2f9f86d86fc870b48b83b5169abb7ab6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.testutils/Editor/Improbable.Gdk.TestUtils.Editor.asmdef
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/Editor/Improbable.Gdk.TestUtils.Editor.asmdef
@@ -1,0 +1,17 @@
+{
+    "name": "Improbable.Gdk.TestUtils.Editor",
+    "references": [
+        "Improbable.Gdk.Tools"
+    ],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
+}

--- a/workers/unity/Packages/io.improbable.gdk.testutils/Editor/Improbable.Gdk.TestUtils.Editor.asmdef.meta
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/Editor/Improbable.Gdk.TestUtils.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: de29554b8202d9f4cb9c0a270287f386
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.testutils/Editor/SpatialDeploymentManager.cs
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/Editor/SpatialDeploymentManager.cs
@@ -1,0 +1,213 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Improbable.Gdk.Tools;
+using Debug = UnityEngine.Debug;
+
+namespace Improbable.Gdk.TestUtils.Editor
+{
+    /// <summary>
+    ///     Manages a single `spatial local launch` instance.
+    /// </summary>
+    public class SpatialDeploymentManager : IDisposable
+    {
+        private Process spatialProcess;
+
+        public static Task<SpatialDeploymentManager> Start(string deploymentJsonPath, string snapshotPath)
+        {
+            if (!File.Exists(Path.Combine(Common.SpatialProjectRootDir, deploymentJsonPath)))
+            {
+                return Task.FromException<SpatialDeploymentManager>(
+                    new ArgumentException($"Could not find deployment config at {deploymentJsonPath}"));
+            }
+
+            if (!File.Exists(Path.Combine(Common.SpatialProjectRootDir, snapshotPath)))
+            {
+                return Task.FromException<SpatialDeploymentManager>(
+                    new ArgumentException($"Could not find snapshot at {snapshotPath}"));
+            }
+
+
+            var tcs = new TaskCompletionSource<SpatialDeploymentManager>();
+
+            var processInfo =
+                new ProcessStartInfo("spatial", $"local launch {deploymentJsonPath} --snapshot {snapshotPath} --enable_pre_run_check=false")
+                {
+                    CreateNoWindow = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    WorkingDirectory = Common.SpatialProjectRootDir
+                };
+
+            var process = new Process
+            {
+                StartInfo = processInfo,
+                EnableRaisingEvents = true
+            };
+
+            var output = new StringBuilder();
+
+            process.Exited += (sender, args) =>
+            {
+                tcs.TrySetException(
+                    new Exception($"Spatial process failed to start. Raw output:\n{output.ToString()}"));
+            };
+
+            process.OutputDataReceived += (sender, args) =>
+            {
+                if (string.IsNullOrEmpty(args.Data))
+                {
+                    return;
+                }
+
+                if (args.Data.Contains("localhost:21000/inspector-v2"))
+                {
+                    tcs.TrySetResult(new SpatialDeploymentManager
+                    {
+                        spatialProcess = process
+                    });
+                }
+
+                output.AppendLine(args.Data);
+            };
+
+            process.Start();
+            process.BeginOutputReadLine();
+
+            return tcs.Task;
+        }
+
+        public void Dispose()
+        {
+            var success = spatialProcess.KillTree();
+
+            if (success != 0)
+            {
+                Debug.LogWarning("Failed to stop spatial process tree.");
+            }
+        }
+    }
+
+    // Copied from: https://raw.githubusercontent.com/dotnet/cli/master/test/Microsoft.DotNet.Tools.Tests.Utilities/Extensions/ProcessExtensions.cs
+    // Licensed under MIT.
+    public static class ProcessExtensions
+    {
+        private static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(value: 30);
+
+        public static int KillTree(this Process process)
+        {
+            return process.KillTree(DefaultTimeout);
+        }
+
+        public static int KillTree(this Process process, TimeSpan timeout)
+        {
+            if (IsWindows)
+            {
+                return RunProcessAndWaitForExit(
+                    "taskkill",
+                    $"/T /F /PID {process.Id}",
+                    timeout,
+                    out _,
+                    out _);
+            }
+
+
+            var children = new HashSet<int>();
+            if (GetAllChildIdsUnix(process.Id, children, timeout) != 0)
+            {
+                return 1;
+            }
+
+            foreach (var childId in children)
+            {
+                if (KillProcessUnix(childId, timeout) != 0)
+                {
+                    return 1;
+                }
+            }
+
+            return KillProcessUnix(process.Id, timeout);
+        }
+
+        private static int GetAllChildIdsUnix(int parentId, ISet<int> children, TimeSpan timeout)
+        {
+            var exitCode = RunProcessAndWaitForExit(
+                "pgrep",
+                $"-P {parentId}",
+                timeout,
+                out var stdout,
+                out _);
+
+            if (exitCode == 0 && !string.IsNullOrEmpty(stdout))
+            {
+                using (var reader = new StringReader(stdout))
+                {
+                    while (true)
+                    {
+                        var text = reader.ReadLine();
+
+                        if (string.IsNullOrEmpty(text))
+                        {
+                            break;
+                        }
+
+                        if (int.TryParse(text, out var id))
+                        {
+                            children.Add(id);
+                            // Recursively get the children
+                            GetAllChildIdsUnix(id, children, timeout);
+                        }
+                    }
+                }
+            }
+
+            return exitCode;
+        }
+
+        private static int KillProcessUnix(int processId, TimeSpan timeout)
+        {
+            return RunProcessAndWaitForExit(
+                "kill",
+                $"-TERM {processId}",
+                timeout,
+                out _,
+                out _);
+        }
+
+        private static int RunProcessAndWaitForExit(string fileName, string arguments, TimeSpan timeout,
+            out string stdout, out string stderr)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+
+            var process = Process.Start(startInfo);
+
+            stdout = null;
+            stderr = null;
+
+            if (process.WaitForExit((int) timeout.TotalMilliseconds))
+            {
+                stdout = process.StandardOutput.ReadToEnd();
+                stderr = process.StandardError.ReadToEnd();
+            }
+            else
+            {
+                process.Kill();
+            }
+
+            return process.ExitCode;
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.testutils/Editor/SpatialDeploymentManager.cs
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/Editor/SpatialDeploymentManager.cs
@@ -31,7 +31,6 @@ namespace Improbable.Gdk.TestUtils.Editor
                     new ArgumentException($"Could not find snapshot at {snapshotPath}"));
             }
 
-
             var tcs = new TaskCompletionSource<SpatialDeploymentManager>();
 
             var processInfo =
@@ -116,7 +115,6 @@ namespace Improbable.Gdk.TestUtils.Editor
                     out _,
                     out _);
             }
-
 
             var children = new HashSet<int>();
             if (GetAllChildIdsUnix(process.Id, children, timeout) != 0)

--- a/workers/unity/Packages/io.improbable.gdk.testutils/Editor/SpatialDeploymentManager.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/Editor/SpatialDeploymentManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c9de4af395e2be5459a6f6f62557f1f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.testutils/Editor/Tests.meta
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/Editor/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e892165fb4713bb4a84a8f77b6e0d0e3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.testutils/Editor/Tests/Improbable.Gdk.TestUtils.Editor.Tests.asmdef
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/Editor/Tests/Improbable.Gdk.TestUtils.Editor.Tests.asmdef
@@ -13,7 +13,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": []
 }

--- a/workers/unity/Packages/io.improbable.gdk.testutils/Editor/Tests/Improbable.Gdk.TestUtils.Editor.Tests.asmdef
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/Editor/Tests/Improbable.Gdk.TestUtils.Editor.Tests.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "Improbable.Gdk.TestUtils.Editor.Tests",
+    "references": [
+        "Improbable.Gdk.TestUtils.Editor"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
+}

--- a/workers/unity/Packages/io.improbable.gdk.testutils/Editor/Tests/Improbable.Gdk.TestUtils.Editor.Tests.asmdef.meta
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/Editor/Tests/Improbable.Gdk.TestUtils.Editor.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c4d3b0035d2ad824fb5b9539e3451146
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.testutils/Editor/Tests/SpatialDeploymentManagerTests.cs
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/Editor/Tests/SpatialDeploymentManagerTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Linq;
+using System.Net;
+using NUnit.Framework;
+
+namespace Improbable.Gdk.TestUtils.Editor.Tests
+{
+    [TestFixture]
+    public class SpatialDeploymentManagerTests
+    {
+        [Test]
+        public void Start_throws_an_exception_if_deployment_config_does_not_exist()
+        {
+            var task = SpatialDeploymentManager.Start("does_not_exist.json", "snapshots/default.snapshot");
+            Assert.IsTrue(task.IsFaulted);
+            Assert.IsInstanceOf<ArgumentException>(task.Exception.InnerExceptions.First());
+        }
+
+        [Test]
+        public void Start_throws_an_exception_if_snapshot_does_not_exist()
+        {
+            var task = SpatialDeploymentManager.Start("default_launch.json", "does_not_exist.snapshot");
+            Assert.IsTrue(task.IsFaulted);
+            Assert.IsInstanceOf<ArgumentException>(task.Exception.InnerExceptions.First());
+        }
+
+        [Test]
+        public void Start_correctly_starts_a_spatial_deployment()
+        {
+            using (SpatialDeploymentManager.Start("default_launch.json", "snapshots/default.snapshot").Result)
+            {
+                var request = WebRequest.Create("http://localhost:21000/inspector");
+                Assert.DoesNotThrow(() => request.GetResponse());
+            }
+        }
+
+        [Test]
+        public void Deployment_is_dead_after_Dispose()
+        {
+            using (SpatialDeploymentManager.Start("default_launch.json", "snapshots/default.snapshot").Result)
+            {
+            }
+
+            var request = WebRequest.Create("http://localhost:21000/inspector");
+            Assert.Throws<WebException>(() => request.GetResponse());
+        }
+
+        [Test]
+        public void Start_throws_if_deployment_fails_to_start()
+        {
+            using (SpatialDeploymentManager.Start("default_launch.json", "snapshots/default.snapshot").Result)
+            {
+                var task = SpatialDeploymentManager.Start("default_launch.json", "snapshots/default.snapshot");
+                Assert.Throws<AggregateException>(() => task.Wait());
+            }
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.testutils/Editor/Tests/SpatialDeploymentManagerTests.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/Editor/Tests/SpatialDeploymentManagerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 64136c458bc2ae64f9261f2eb1c74ed8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#### Description
Added a `SpatialDeploymentManager` which allows you to create and manage the lifecycle of a deployment in the Editor. This is aimed to be used for automated connection testing. Also added some tests for the `SpatialDeploymentManager` to verify its behaviour 🎉 

#### Tests
Yes there are tests.

#### Documentation
- [ ] Changelog
- [ ] API documentation

