### PR TITLE
Add receptionist flow testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Internal
 
-- Added tests for the `ReceptionistFlow` class [#1095](https://github.com/spatialos/gdk-for-unity/pull/1095)
+- Added tests for the `ReceptionistFlow` class. [#1095](https://github.com/spatialos/gdk-for-unity/pull/1095)
 
 ## `0.2.6` - 2019-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+- Added tests for the `ReceptionistFlow` class [#1095](https://github.com/spatialos/gdk-for-unity/pull/1095)
+
 ## `0.2.6` - 2019-08-05
 
 ### Breaking Changes

--- a/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Connection.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Connection.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 22528f84e9f11314280032c1b06f403d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Connection/ReceptionistFlowTests.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Connection/ReceptionistFlowTests.cs
@@ -14,7 +14,9 @@ namespace Improbable.Gdk.Core.EditmodeTests.Connection
         private Improbable.Worker.CInterop.Connection connection;
 
         private static string LaunchConfigPath = Path.Combine(Common.SpatialProjectRootDir, "default_launch.json");
-        private static string SnapshotPath = Path.Combine(Common.SpatialProjectRootDir, "snapshots", "default.snapshot");
+
+        private static string SnapshotPath =
+            Path.Combine(Common.SpatialProjectRootDir, "snapshots", "default.snapshot");
 
         [SetUp]
         public void Setup()
@@ -54,7 +56,8 @@ namespace Improbable.Gdk.Core.EditmodeTests.Connection
                 ReceptionistHost = "not-localhost"
             };
 
-            var aggregateException = Assert.Throws<AggregateException>(() => connection = receptionistFlow.CreateAsync(GetConnectionParameters()).Result);
+            var aggregateException = Assert.Throws<AggregateException>(() =>
+                connection = receptionistFlow.CreateAsync(GetConnectionParameters()).Result);
             Assert.IsInstanceOf<ConnectionFailedException>(aggregateException.InnerExceptions[0]);
         }
 
@@ -66,7 +69,8 @@ namespace Improbable.Gdk.Core.EditmodeTests.Connection
                 ReceptionistPort = 1337
             };
 
-            var aggregateException = Assert.Throws<AggregateException>(() => connection = receptionistFlow.CreateAsync(GetConnectionParameters()).Result);
+            var aggregateException = Assert.Throws<AggregateException>(() =>
+                connection = receptionistFlow.CreateAsync(GetConnectionParameters()).Result);
             Assert.IsInstanceOf<ConnectionFailedException>(aggregateException.InnerExceptions[0]);
         }
 

--- a/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Connection/ReceptionistFlowTests.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Connection/ReceptionistFlowTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.IO;
+using Improbable.Gdk.TestUtils.Editor;
+using Improbable.Gdk.Tools;
+using Improbable.Worker.CInterop;
+using NUnit.Framework;
+
+namespace Improbable.Gdk.Core.EditmodeTests.Connection
+{
+    [TestFixture]
+    public class ReceptionistFlowTests
+    {
+        private SpatialDeploymentManager deploymentManager;
+        private Improbable.Worker.CInterop.Connection connection;
+
+        private static string LaunchConfigPath = Path.Combine(Common.SpatialProjectRootDir, "default_launch.json");
+        private static string SnapshotPath = Path.Combine(Common.SpatialProjectRootDir, "snapshots", "default.snapshot");
+
+        [SetUp]
+        public void Setup()
+        {
+            deploymentManager = SpatialDeploymentManager.Start(LaunchConfigPath, SnapshotPath).Result;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            deploymentManager?.Dispose();
+            connection?.Dispose();
+        }
+
+        [Test]
+        public void ReceptionistFlow_connects_to_local_deployment_by_default()
+        {
+            var receptionistFlow = new ReceptionistFlow("My-Worker-Id");
+            Assert.DoesNotThrow(() => connection = receptionistFlow.CreateAsync(GetConnectionParameters()).Result);
+            Assert.AreEqual(ConnectionStatusCode.Success, connection.GetConnectionStatusCode());
+        }
+
+        [Test]
+        public void ReceptionistFlow_propagates_my_worker_id()
+        {
+            var receptionistFlow = new ReceptionistFlow("My-Worker-Id");
+            connection = receptionistFlow.CreateAsync(GetConnectionParameters()).Result;
+
+            Assert.AreEqual("My-Worker-Id", connection.GetWorkerId());
+        }
+
+        [Test]
+        public void ReceptionistFlow_fails_to_connect_with_invalid_host()
+        {
+            var receptionistFlow = new ReceptionistFlow("My-Worker-Id")
+            {
+                ReceptionistHost = "not-localhost"
+            };
+
+            var aggregateException = Assert.Throws<AggregateException>(() => connection = receptionistFlow.CreateAsync(GetConnectionParameters()).Result);
+            Assert.IsInstanceOf<ConnectionFailedException>(aggregateException.InnerExceptions[0]);
+        }
+
+        [Test]
+        public void ReceptionistFlow_fails_to_connection_with_invalid_port()
+        {
+            var receptionistFlow = new ReceptionistFlow("My-Worker-Id")
+            {
+                ReceptionistPort = 1337
+            };
+
+            var aggregateException = Assert.Throws<AggregateException>(() => connection = receptionistFlow.CreateAsync(GetConnectionParameters()).Result);
+            Assert.IsInstanceOf<ConnectionFailedException>(aggregateException.InnerExceptions[0]);
+        }
+
+        private static ConnectionParameters GetConnectionParameters()
+        {
+            return new ConnectionParameters
+            {
+                WorkerType = "UnityClient",
+                DefaultComponentVtable = new ComponentVtable()
+            };
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Connection/ReceptionistFlowTests.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Connection/ReceptionistFlowTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c91339211ba6b540a43130fa49d74b3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Improbable.Gdk.Core.EditmodeTests.asmdef
+++ b/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Improbable.Gdk.Core.EditmodeTests.asmdef
@@ -4,7 +4,9 @@
         "Improbable.Gdk.Core",
         "Unity.Entities",
         "Unity.Entities.Hybrid",
-        "Improbable.Gdk.TestUtils"
+        "Improbable.Gdk.TestUtils",
+        "Improbable.Gdk.TestUtils.Editor",
+        "Improbable.Gdk.Tools"
     ],
     "optionalUnityReferences": [
         "TestAssemblies"
@@ -13,5 +15,10 @@
         "Editor"
     ],
     "excludePlatforms": [],
-    "allowUnsafeCode": false
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
 }

--- a/workers/unity/Packages/io.improbable.gdk.testutils/Editor/SpatialDeploymentManager.cs
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/Editor/SpatialDeploymentManager.cs
@@ -125,7 +125,6 @@ namespace Improbable.Gdk.TestUtils.Editor
             return tcs.Task;
         }
 
-
         public void Dispose()
         {
             var success = spatialProcess.KillTree();

--- a/workers/unity/Packages/io.improbable.gdk.testutils/Editor/SpatialDeploymentManager.cs
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/Editor/SpatialDeploymentManager.cs
@@ -67,8 +67,16 @@ namespace Improbable.Gdk.TestUtils.Editor
                 else
                 {
                     tcs.TrySetException(
-                        new Exception($"Failed to build worker configs. Raw output:\n{process.StandardOutput.ReadToEnd()}\n Raw stderr: \n{process.StandardError.ReadToEnd()}"));
+                        new Exception($@"Failed to build worker configs with exit code: {process.ExitCode}.
+
+Raw output:
+{process.StandardOutput.ReadToEnd()}
+
+Raw stderr:
+{process.StandardError.ReadToEnd()}"));
                 }
+
+                process.Dispose();
             };
 
             process.Start();
@@ -81,7 +89,7 @@ namespace Improbable.Gdk.TestUtils.Editor
             var tcs = new TaskCompletionSource<Process>();
 
             var processInfo =
-                new ProcessStartInfo("spatial", $"local launch {deploymentJsonPath} --snapshot {snapshotPath} --enable_pre_run_check=false")
+                new ProcessStartInfo("spatial", $"local launch \"{deploymentJsonPath}\" --snapshot \"{snapshotPath}\" --enable_pre_run_check=false")
                 {
                     CreateNoWindow = true,
                     RedirectStandardOutput = true,


### PR DESCRIPTION
#### Description
- `SpatialDeploymentManager.Start()` builds worker configs as well (so that you may _actually_ connect a worker)
- Added tests for the `ReceptionistFlow`

#### Tests
Yes this is test.

#### Documentation
- [x] Changelog

