### PR TITLE
Add `CommandLineConnectionFlowInitializer` Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Internal
 
 - Added tests for the `ReceptionistFlow` class. [#1095](https://github.com/spatialos/gdk-for-unity/pull/1095)
+- Added tests for the `CommandLineConnectionFlowInitializer` class. [#1096](https://github.com/spatialos/gdk-for-unity/pull/1096)
 
 ## `0.2.6` - 2019-08-05
 

--- a/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Connection/CommandLineConnectionFlowInitializerTests.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Connection/CommandLineConnectionFlowInitializerTests.cs
@@ -1,0 +1,148 @@
+using System.Collections.Generic;
+using Improbable.Worker.CInterop;
+using NUnit.Framework;
+
+namespace Improbable.Gdk.Core.EditmodeTests.Connection
+{
+    [TestFixture]
+    public class CommandLineConnectionFlowInitializerTests
+    {
+        private static Dictionary<string, string> BaseArgs => new Dictionary<string, string>
+        {
+            { RuntimeConfigNames.SteamDeploymentTag, "my_steam_deployment" },
+            { RuntimeConfigNames.SteamTicket, "steam_ticket" },
+            { RuntimeConfigNames.LoginToken, "login_token" },
+            { RuntimeConfigNames.PlayerIdentityToken, "pit" },
+            { RuntimeConfigNames.ReceptionistHost, "receptionist_host" },
+            { RuntimeConfigNames.ReceptionistPort, "1337" },
+            { RuntimeConfigNames.WorkerId, "my_worker_id" },
+            { RuntimeConfigNames.LocatorHost, "locator_host" },
+            { RuntimeConfigNames.ProjectName, "my_project" },
+        };
+
+        [Test]
+        public void GetConnectionService_returns_locator_if_steam_is_set()
+        {
+            var service = new CommandLineConnectionFlowInitializer(BaseArgs).GetConnectionService();
+            Assert.AreEqual(ConnectionService.Locator, service);
+        }
+
+        [Test]
+        public void GetConnectionService_returns_alpha_locator_if_pit_and_login_token_are_present()
+        {
+            var args = BaseArgs;
+            args.Remove(RuntimeConfigNames.SteamDeploymentTag);
+            args.Remove(RuntimeConfigNames.SteamTicket);
+
+            var service = new CommandLineConnectionFlowInitializer(args).GetConnectionService();
+            Assert.AreEqual(ConnectionService.AlphaLocator, service);
+        }
+
+        [Test]
+        public void GetConnectionService_returns_locator_if_only_login_token_is_present()
+        {
+            var args = BaseArgs;
+            args.Remove(RuntimeConfigNames.SteamDeploymentTag);
+            args.Remove(RuntimeConfigNames.SteamTicket);
+            args.Remove(RuntimeConfigNames.PlayerIdentityToken);
+
+            var service = new CommandLineConnectionFlowInitializer(args).GetConnectionService();
+            Assert.AreEqual(ConnectionService.Locator, service);
+        }
+
+        [Test]
+        public void GetConnectionService_falls_back_to_receptionist()
+        {
+            var service = new CommandLineConnectionFlowInitializer(new Dictionary<string, string>()).GetConnectionService();
+            Assert.AreEqual(ConnectionService.Receptionist, service);
+        }
+
+        [Test]
+        public void Initialize_receptionist_flow_correctly()
+        {
+            var initializer = new CommandLineConnectionFlowInitializer(BaseArgs);
+            var flow = new ReceptionistFlow("a_worker_id", initializer);
+
+            Assert.AreEqual(BaseArgs[RuntimeConfigNames.ReceptionistHost], flow.ReceptionistHost);
+            Assert.AreEqual(1337, flow.ReceptionistPort);
+            Assert.AreEqual(BaseArgs[RuntimeConfigNames.WorkerId], flow.WorkerId);
+        }
+
+        [Test]
+        public void Initialize_receptionist_ignores_params_that_arent_there()
+        {
+            var initializer = new CommandLineConnectionFlowInitializer(new Dictionary<string, string>());
+            var flow = new ReceptionistFlow("a_worker_id", initializer);
+
+            Assert.AreEqual(RuntimeConfigDefaults.ReceptionistHost, flow.ReceptionistHost);
+            Assert.AreEqual(RuntimeConfigDefaults.ReceptionistPort, flow.ReceptionistPort);
+            Assert.AreEqual("a_worker_id", flow.WorkerId);
+        }
+
+        [Test]
+        public void Initialize_locator_flow_correctly()
+        {
+            var initializer = new CommandLineConnectionFlowInitializer(BaseArgs);
+            var flow = new LocatorFlow(initializer);
+
+            Assert.AreEqual(BaseArgs[RuntimeConfigNames.LocatorHost], flow.LocatorHost);
+            Assert.AreEqual(BaseArgs[RuntimeConfigNames.ProjectName], flow.LocatorParameters.ProjectName);
+            Assert.AreEqual(BaseArgs[RuntimeConfigNames.LoginToken], flow.LocatorParameters.LoginToken.Token);
+            Assert.AreEqual(BaseArgs[RuntimeConfigNames.SteamDeploymentTag], flow.LocatorParameters.Steam.DeploymentTag);
+            Assert.AreEqual(BaseArgs[RuntimeConfigNames.SteamTicket], flow.LocatorParameters.Steam.Ticket);
+        }
+
+        [Test]
+        public void Initialize_locator_flow_uses_steam_credentials_if_present()
+        {
+            var initializer = new CommandLineConnectionFlowInitializer(BaseArgs);
+            var flow = new LocatorFlow(initializer);
+
+            Assert.AreEqual(LocatorCredentialsType.Steam, flow.LocatorParameters.CredentialsType);
+        }
+
+        [Test]
+        public void Initialize_locator_flow_uses_login_token_credentials_if_present()
+        {
+            var args = BaseArgs;
+            args.Remove(RuntimeConfigNames.SteamDeploymentTag);
+            args.Remove(RuntimeConfigNames.SteamTicket);
+
+            var initializer = new CommandLineConnectionFlowInitializer(args);
+            var flow = new LocatorFlow(initializer);
+
+            Assert.AreEqual(LocatorCredentialsType.LoginToken, flow.LocatorParameters.CredentialsType);
+        }
+
+        [Test]
+        public void Initialize_alpha_locator_flow_correctly()
+        {
+            var initializer = new CommandLineConnectionFlowInitializer(BaseArgs);
+            var flow = new AlphaLocatorFlow(initializer);
+
+            Assert.AreEqual(BaseArgs[RuntimeConfigNames.LocatorHost], flow.LocatorHost);
+            Assert.AreEqual(BaseArgs[RuntimeConfigNames.LoginToken], flow.LocatorParameters.PlayerIdentity.LoginToken);
+            Assert.AreEqual(BaseArgs[RuntimeConfigNames.PlayerIdentityToken], flow.LocatorParameters.PlayerIdentity.PlayerIdentityToken);
+        }
+
+        [Test]
+        public void Initialize_alpha_locator_sets_dev_auth_flow_correctly()
+        {
+            {
+                var initializer = new CommandLineConnectionFlowInitializer(BaseArgs);
+                var flow = new AlphaLocatorFlow(initializer);
+                Assert.IsFalse(flow.UseDevAuthFlow);
+            }
+
+            {
+                var args = BaseArgs;
+                args.Remove(RuntimeConfigNames.PlayerIdentityToken);
+                args.Remove(RuntimeConfigNames.LoginToken);
+
+                var initializer = new CommandLineConnectionFlowInitializer(args);
+                var flow = new AlphaLocatorFlow(initializer);
+                Assert.IsTrue(flow.UseDevAuthFlow);
+            }
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Connection/CommandLineConnectionFlowInitializerTests.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Connection/CommandLineConnectionFlowInitializerTests.cs
@@ -7,30 +7,33 @@ namespace Improbable.Gdk.Core.EditmodeTests.Connection
     [TestFixture]
     public class CommandLineConnectionFlowInitializerTests
     {
-        private static Dictionary<string, string> BaseArgs => new Dictionary<string, string>
+        private static Dictionary<string, string> GetBaseArgs()
         {
-            { RuntimeConfigNames.SteamDeploymentTag, "my_steam_deployment" },
-            { RuntimeConfigNames.SteamTicket, "steam_ticket" },
-            { RuntimeConfigNames.LoginToken, "login_token" },
-            { RuntimeConfigNames.PlayerIdentityToken, "pit" },
-            { RuntimeConfigNames.ReceptionistHost, "receptionist_host" },
-            { RuntimeConfigNames.ReceptionistPort, "1337" },
-            { RuntimeConfigNames.WorkerId, "my_worker_id" },
-            { RuntimeConfigNames.LocatorHost, "locator_host" },
-            { RuntimeConfigNames.ProjectName, "my_project" },
-        };
+            return new Dictionary<string, string>
+            {
+                { RuntimeConfigNames.SteamDeploymentTag, "my_steam_deployment" },
+                { RuntimeConfigNames.SteamTicket, "steam_ticket" },
+                { RuntimeConfigNames.LoginToken, "login_token" },
+                { RuntimeConfigNames.PlayerIdentityToken, "pit" },
+                { RuntimeConfigNames.ReceptionistHost, "receptionist_host" },
+                { RuntimeConfigNames.ReceptionistPort, "1337" },
+                { RuntimeConfigNames.WorkerId, "my_worker_id" },
+                { RuntimeConfigNames.LocatorHost, "locator_host" },
+                { RuntimeConfigNames.ProjectName, "my_project" },
+            };
+        }
 
         [Test]
         public void GetConnectionService_returns_locator_if_steam_is_set()
         {
-            var service = new CommandLineConnectionFlowInitializer(BaseArgs).GetConnectionService();
+            var service = new CommandLineConnectionFlowInitializer(GetBaseArgs()).GetConnectionService();
             Assert.AreEqual(ConnectionService.Locator, service);
         }
 
         [Test]
         public void GetConnectionService_returns_alpha_locator_if_pit_and_login_token_are_present()
         {
-            var args = BaseArgs;
+            var args = GetBaseArgs();
             args.Remove(RuntimeConfigNames.SteamDeploymentTag);
             args.Remove(RuntimeConfigNames.SteamTicket);
 
@@ -41,7 +44,7 @@ namespace Improbable.Gdk.Core.EditmodeTests.Connection
         [Test]
         public void GetConnectionService_returns_locator_if_only_login_token_is_present()
         {
-            var args = BaseArgs;
+            var args = GetBaseArgs();
             args.Remove(RuntimeConfigNames.SteamDeploymentTag);
             args.Remove(RuntimeConfigNames.SteamTicket);
             args.Remove(RuntimeConfigNames.PlayerIdentityToken);
@@ -60,12 +63,12 @@ namespace Improbable.Gdk.Core.EditmodeTests.Connection
         [Test]
         public void Initialize_receptionist_flow_correctly()
         {
-            var initializer = new CommandLineConnectionFlowInitializer(BaseArgs);
+            var initializer = new CommandLineConnectionFlowInitializer(GetBaseArgs());
             var flow = new ReceptionistFlow("a_worker_id", initializer);
 
-            Assert.AreEqual(BaseArgs[RuntimeConfigNames.ReceptionistHost], flow.ReceptionistHost);
+            Assert.AreEqual(GetBaseArgs()[RuntimeConfigNames.ReceptionistHost], flow.ReceptionistHost);
             Assert.AreEqual(1337, flow.ReceptionistPort);
-            Assert.AreEqual(BaseArgs[RuntimeConfigNames.WorkerId], flow.WorkerId);
+            Assert.AreEqual(GetBaseArgs()[RuntimeConfigNames.WorkerId], flow.WorkerId);
         }
 
         [Test]
@@ -82,20 +85,20 @@ namespace Improbable.Gdk.Core.EditmodeTests.Connection
         [Test]
         public void Initialize_locator_flow_correctly()
         {
-            var initializer = new CommandLineConnectionFlowInitializer(BaseArgs);
+            var initializer = new CommandLineConnectionFlowInitializer(GetBaseArgs());
             var flow = new LocatorFlow(initializer);
 
-            Assert.AreEqual(BaseArgs[RuntimeConfigNames.LocatorHost], flow.LocatorHost);
-            Assert.AreEqual(BaseArgs[RuntimeConfigNames.ProjectName], flow.LocatorParameters.ProjectName);
-            Assert.AreEqual(BaseArgs[RuntimeConfigNames.LoginToken], flow.LocatorParameters.LoginToken.Token);
-            Assert.AreEqual(BaseArgs[RuntimeConfigNames.SteamDeploymentTag], flow.LocatorParameters.Steam.DeploymentTag);
-            Assert.AreEqual(BaseArgs[RuntimeConfigNames.SteamTicket], flow.LocatorParameters.Steam.Ticket);
+            Assert.AreEqual(GetBaseArgs()[RuntimeConfigNames.LocatorHost], flow.LocatorHost);
+            Assert.AreEqual(GetBaseArgs()[RuntimeConfigNames.ProjectName], flow.LocatorParameters.ProjectName);
+            Assert.AreEqual(GetBaseArgs()[RuntimeConfigNames.LoginToken], flow.LocatorParameters.LoginToken.Token);
+            Assert.AreEqual(GetBaseArgs()[RuntimeConfigNames.SteamDeploymentTag], flow.LocatorParameters.Steam.DeploymentTag);
+            Assert.AreEqual(GetBaseArgs()[RuntimeConfigNames.SteamTicket], flow.LocatorParameters.Steam.Ticket);
         }
 
         [Test]
         public void Initialize_locator_flow_uses_steam_credentials_if_present()
         {
-            var initializer = new CommandLineConnectionFlowInitializer(BaseArgs);
+            var initializer = new CommandLineConnectionFlowInitializer(GetBaseArgs());
             var flow = new LocatorFlow(initializer);
 
             Assert.AreEqual(LocatorCredentialsType.Steam, flow.LocatorParameters.CredentialsType);
@@ -104,7 +107,7 @@ namespace Improbable.Gdk.Core.EditmodeTests.Connection
         [Test]
         public void Initialize_locator_flow_uses_login_token_credentials_if_present()
         {
-            var args = BaseArgs;
+            var args = GetBaseArgs();
             args.Remove(RuntimeConfigNames.SteamDeploymentTag);
             args.Remove(RuntimeConfigNames.SteamTicket);
 
@@ -117,25 +120,25 @@ namespace Improbable.Gdk.Core.EditmodeTests.Connection
         [Test]
         public void Initialize_alpha_locator_flow_correctly()
         {
-            var initializer = new CommandLineConnectionFlowInitializer(BaseArgs);
+            var initializer = new CommandLineConnectionFlowInitializer(GetBaseArgs());
             var flow = new AlphaLocatorFlow(initializer);
 
-            Assert.AreEqual(BaseArgs[RuntimeConfigNames.LocatorHost], flow.LocatorHost);
-            Assert.AreEqual(BaseArgs[RuntimeConfigNames.LoginToken], flow.LocatorParameters.PlayerIdentity.LoginToken);
-            Assert.AreEqual(BaseArgs[RuntimeConfigNames.PlayerIdentityToken], flow.LocatorParameters.PlayerIdentity.PlayerIdentityToken);
+            Assert.AreEqual(GetBaseArgs()[RuntimeConfigNames.LocatorHost], flow.LocatorHost);
+            Assert.AreEqual(GetBaseArgs()[RuntimeConfigNames.LoginToken], flow.LocatorParameters.PlayerIdentity.LoginToken);
+            Assert.AreEqual(GetBaseArgs()[RuntimeConfigNames.PlayerIdentityToken], flow.LocatorParameters.PlayerIdentity.PlayerIdentityToken);
         }
 
         [Test]
         public void Initialize_alpha_locator_sets_dev_auth_flow_correctly()
         {
             {
-                var initializer = new CommandLineConnectionFlowInitializer(BaseArgs);
+                var initializer = new CommandLineConnectionFlowInitializer(GetBaseArgs());
                 var flow = new AlphaLocatorFlow(initializer);
                 Assert.IsFalse(flow.UseDevAuthFlow);
             }
 
             {
-                var args = BaseArgs;
+                var args = GetBaseArgs();
                 args.Remove(RuntimeConfigNames.PlayerIdentityToken);
                 args.Remove(RuntimeConfigNames.LoginToken);
 

--- a/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Connection/CommandLineConnectionFlowInitializerTests.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Connection/CommandLineConnectionFlowInitializerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 63592a9273052c4438b261002baa88a7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/ConnectionFlowInitializers.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/ConnectionFlowInitializers.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Improbable.Worker.CInterop;
 
 namespace Improbable.Gdk.Core
@@ -32,13 +34,18 @@ namespace Improbable.Gdk.Core
             commandLineArgs = CommandLineArgs.FromCommandLine();
         }
 
+        internal CommandLineConnectionFlowInitializer(Dictionary<string, string> commandLineArgs)
+        {
+            this.commandLineArgs = CommandLineArgs.From(commandLineArgs);
+        }
+
         /// <summary>
         ///     Gets the connection service to use based on command line arguments.
         /// </summary>
         /// <returns>The connection service to use.</returns>
         public ConnectionService GetConnectionService()
         {
-            if (commandLineArgs.Contains(RuntimeConfigNames.SteamDeploymentTag) ||
+            if (commandLineArgs.Contains(RuntimeConfigNames.SteamDeploymentTag) &&
                 commandLineArgs.Contains(RuntimeConfigNames.SteamTicket))
             {
                 return ConnectionService.Locator;
@@ -73,13 +80,13 @@ namespace Improbable.Gdk.Core
             commandLineArgs.TryGetCommandLineValue(RuntimeConfigNames.SteamTicket,
                 ref locator.LocatorParameters.Steam.Ticket);
 
-            if (!string.IsNullOrEmpty(locator.LocatorParameters.LoginToken.Token))
-            {
-                locator.LocatorParameters.CredentialsType = LocatorCredentialsType.LoginToken;
-            }
-            else if (!string.IsNullOrEmpty(locator.LocatorParameters.Steam.Ticket) && !string.IsNullOrEmpty(locator.LocatorParameters.Steam.DeploymentTag))
+            if (!string.IsNullOrEmpty(locator.LocatorParameters.Steam.Ticket) && !string.IsNullOrEmpty(locator.LocatorParameters.Steam.DeploymentTag))
             {
                 locator.LocatorParameters.CredentialsType = LocatorCredentialsType.Steam;
+            }
+            else if (!string.IsNullOrEmpty(locator.LocatorParameters.LoginToken.Token))
+            {
+                locator.LocatorParameters.CredentialsType = LocatorCredentialsType.LoginToken;
             }
         }
 


### PR DESCRIPTION
#### Description
- Added unit tests for `CommandLineConnectionFlowInitializer`.
- While writing the tests, I noticed some semantic errors, which I fixed in `CommandLineConnectionFlowInitializer`.

#### Tests
Also yes.

#### Documentation
- [x] Changelog

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
