### PR TITLE
Fix potential deadlock when using `RedirectedProcess.RunAsync()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed a bug where `RedirectedProcess.RunAsync()` could deadlock if you did not provide a `CancellationToken`. [#1102](https://github.com/spatialos/gdk-for-unity/pull/1102)
+
 ### Internal
 
 - Added tests for the `ReceptionistFlow` class. [#1095](https://github.com/spatialos/gdk-for-unity/pull/1095)

--- a/workers/unity/Packages/io.improbable.gdk.tools/RedirectedProcess.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/RedirectedProcess.cs
@@ -187,7 +187,7 @@ namespace Improbable.Gdk.Tools
 
             if (token == null)
             {
-                var exitCode = await Task.Run(Run);
+                var exitCode = await Task.Run(Run).ConfigureAwait(false);
 
                 return new RedirectedProcessResult
                 {


### PR DESCRIPTION
#### Description
Fixed a bug where if you didn't provide a cancellation token, the continuation could deadlock if you were `await`-ing on the same thread. Discovered this while playing around with the Platform SDK. 

#### Tests
My tests were deadlocking before this, they didn't after.

#### Documentation
- [x] Changelog

