### PR TITLE
Refactor & Fixes to `AlphaLocatorFlow`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- Renamed the public field `AnonymousAuthenticationPort` to `LocatorPort` on the `AlphaLocatorFlow` class. [#1105](https://github.com/spatialos/gdk-for-unity/pull/1105)
+
+### Added
+
+- Added the ability to connect to an arbitrary host/port combo for the `AlphaLocatorFlow`. [#1105](https://github.com/spatialos/gdk-for-unity/pull/1105)
+
 ### Changed
 
 - Schema compilation error messages are now concatenated within the `GenerateCode` class before shown in the Console, creating only one error message instead of several. [#1107](https://github.com/spatialos/gdk-for-unity/pull/1107)
@@ -9,6 +17,7 @@
 ### Fixed
 
 - Fixed a bug where `RedirectedProcess.RunAsync()` could deadlock if you did not provide a `CancellationToken`. [#1102](https://github.com/spatialos/gdk-for-unity/pull/1102)
+- Fixed a bug in the `AlphaLocatorFlow` where the default implementation of `GetDevelopmentLoginTokens` did not respect the host/port fields. [#1105](https://github.com/spatialos/gdk-for-unity/pull/1105)
 
 ### Internal
 

--- a/workers/unity/Packages/io.improbable.gdk.core/Config/RuntimeConfig.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Config/RuntimeConfig.cs
@@ -1,4 +1,3 @@
-using System;
 using Improbable.Worker.CInterop;
 
 namespace Improbable.Gdk.Core
@@ -14,7 +13,7 @@ namespace Improbable.Gdk.Core
         public const string LocalEnvironment = "local";
         public const string CloudEnvironment = "cloud";
         public const ushort ReceptionistPort = 7777;
-        public const ushort AnonymousAuthenticationPort = 444;
+        public const ushort LocatorPort = 444;
     }
 
     /// <summary>

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/ConnectionFlows.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/ConnectionFlows.cs
@@ -177,14 +177,14 @@ namespace Improbable.Gdk.Core
     public class AlphaLocatorFlow : IConnectionFlow
     {
         /// <summary>
-        ///     The IP address of the Locator to use when connecting.
+        ///     The host of the Locator to use for the development authentication flow and the Locator.
         /// </summary>
         public string LocatorHost = RuntimeConfigDefaults.LocatorHost;
 
         /// <summary>
-        ///     The port to use when connecting via development authentication.
+        ///     The port of the Locator to use for the development authentication flow and the Locator.
         /// </summary>
-        public ushort AnonymousAuthPort = RuntimeConfigDefaults.AnonymousAuthenticationPort;
+        public ushort LocatorPort = RuntimeConfigDefaults.LocatorPort;
 
         /// <summary>
         ///     The development authentication token to use when connecting via with development authentication.
@@ -235,7 +235,7 @@ namespace Improbable.Gdk.Core
                 LocatorParameters.PlayerIdentity.LoginToken = SelectLoginToken(loginTokenDetails);
             }
 
-            using (var locator = new AlphaLocator(LocatorHost, LocatorParameters))
+            using (var locator = new AlphaLocator(LocatorHost, LocatorPort, LocatorParameters))
             {
                 using (var connectionFuture = locator.ConnectAsync(parameters))
                 {
@@ -253,12 +253,13 @@ namespace Improbable.Gdk.Core
         {
             var result = DevelopmentAuthentication.CreateDevelopmentPlayerIdentityTokenAsync(
                 LocatorHost,
-                AnonymousAuthPort,
+                LocatorPort,
                 new PlayerIdentityTokenRequest
                 {
                     DevelopmentAuthenticationToken = DevAuthToken,
                     PlayerId = GetPlayerId(),
                     DisplayName = GetDisplayName(),
+                    UseInsecureConnection = LocatorParameters.UseInsecureConnection,
                 }
             ).Get();
 
@@ -286,13 +287,13 @@ namespace Improbable.Gdk.Core
         protected virtual List<LoginTokenDetails> GetDevelopmentLoginTokens(string workerType, string playerIdentityToken)
         {
             var result = DevelopmentAuthentication.CreateDevelopmentLoginTokensAsync(
-                RuntimeConfigDefaults.LocatorHost,
-                RuntimeConfigDefaults.AnonymousAuthenticationPort,
+                LocatorHost,
+                LocatorPort,
                 new LoginTokensRequest
                 {
                     WorkerType = workerType,
                     PlayerIdentityToken = playerIdentityToken,
-                    UseInsecureConnection = false,
+                    UseInsecureConnection = LocatorParameters.UseInsecureConnection,
                     DurationSeconds = 120,
                 }
             ).Get();


### PR DESCRIPTION
#### Description
In preparation for the testing of this flow, fixing some bugs/missing features I found ahead of time: 

- `GetDevelopmentLoginTokens` now correctly uses the host/port combo 
- Allow you to set `UseInsecureConnection` for all parts of the flow.
- Allow you to connect to a non-default locator port.
- Renamed `AnonymousAuthenticationPort` -> `LocatorPort` for consistency. 
- Updated doc strings.

#### Tests
Coming soon ™️ 

#### Documentation
- [x] Changelog

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
