### PR TITLE
SendComponentSystem jobs improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Schema compilation error messages are now concatenated within the `GenerateCode` class before shown in the Console, creating only one error message instead of several. [#1107](https://github.com/spatialos/gdk-for-unity/pull/1107)
 - Changed some reactive components for events and commands that were not correctly encapsulated with the `USE_LEGACY_REACTIVE_COMPONENTS` symbol. [#1113](https://github.com/spatialos/gdk-for-unity/pull/1113)
+- Improved performance in SendComponentSystem through better job handling.
 
 ### Fixed
 

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/ComponentSendSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/ComponentSendSystem.cs
@@ -65,18 +65,18 @@ namespace Improbable.Gdk.Core
 
             Profiler.EndSample();
 
-            JobHandle.CompleteAll(gatheringJobs);
-
             for (var i = 0; i < componentReplicators.Count; i++)
             {
+                Profiler.BeginSample("ExecuteReplication");
+
+                gatheringJobs[i].Complete();
                 var replicator = componentReplicators[i];
                 var chunkArray = chunkArrayCache[i];
 
-                Profiler.BeginSample("ExecuteReplication");
                 replicator.Handler.SendUpdates(chunkArray, this, EntityManager, componentUpdateSystem);
-                Profiler.EndSample();
-
                 chunkArray.Dispose();
+
+                Profiler.EndSample();
             }
         }
 


### PR DESCRIPTION
#### Description
Don't wait for all gathering jobs to complete, but only the jobs we require for the next bit of work.
Shuffled the profile sampling around a bit to give a better indication of wait times.
