### PR TITLE
UTY-2091: Fix crash on recursive options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Workers will now log their `PlayerConnection` ports to SpatialOS after connecting. This port can be used for connecting the Unity profiler to workers running in the cloud. [#1128](https://github.com/spatialos/gdk-for-unity/pull/1128)
     - Note that this will only happen if the worker was built as a "Development Build".
 
+### Fixed
+
+- Fixed a bug where recursive options in schema types would cause a Mono hard crash. [#1131](https://github.com/spatialos/gdk-for-unity/pull/1131)
+
 ## `0.2.7` - 2019-08-19
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Fixed
 
 - Fixed a bug where recursive options in schema types would cause a Mono hard crash. [#1131](https://github.com/spatialos/gdk-for-unity/pull/1131)
+    - Any fields in a schema type that are a recursive option will now be _skipped_.
+    - This is a workaround until full recursive option support is implemented.
 
 ## `0.2.7` - 2019-08-19
 

--- a/init.ps1
+++ b/init.ps1
@@ -33,7 +33,7 @@ UpdatePackage worker_sdk c-dynamic-x86_64-vc140_mt-win32 "$SdkPath/Plugins/Impro
 UpdatePackage worker_sdk csharp_cinterop "$SdkPath/Plugins/Improbable/Sdk/Common" "Improbable.Worker.CInterop.pdb"
 
 UpdatePackage schema standard_library "$SdkPath/.schema"
-UpdatePackage schema test_schema_library "$TestSdkPath/.schema" "test_schema/recursion.schema"
+UpdatePackage schema test_schema_library "$TestSdkPath/.schema"
 
 UpdatePackage tools schema_compiler-x86_64-win32 "$SdkPath/.schema_compiler"
 UpdatePackage tools schema_compiler-x86_64-macos "$SdkPath/.schema_compiler"

--- a/init.sh
+++ b/init.sh
@@ -40,7 +40,7 @@ update_package worker_sdk c-dynamic-x86_64-vc140_mt-win32 "${SDK_PATH}/Plugins/I
 update_package worker_sdk csharp_cinterop "${SDK_PATH}/Plugins/Improbable/Sdk/Common" "Improbable.Worker.CInterop.pdb"
 
 update_package schema standard_library "${SDK_PATH}/.schema"
-update_package schema test_schema_library "${TEST_SDK_PATH}/.schema" "test_schema/recursion.schema"
+update_package schema test_schema_library "${TEST_SDK_PATH}/.schema"
 
 update_package tools schema_compiler-x86_64-win32 "${SDK_PATH}/.schema_compiler"
 update_package tools schema_compiler-x86_64-macos "${SDK_PATH}/.schema_compiler"

--- a/test-project/Assets/.schema/empty.schema
+++ b/test-project/Assets/.schema/empty.schema
@@ -1,5 +1,0 @@
-package improbable.gdk.test;
-
-component Empty {
-    id = 28901;
-}

--- a/test-project/Assets/.schema/test.schema
+++ b/test-project/Assets/.schema/test.schema
@@ -1,0 +1,43 @@
+package improbable.gdk.test;
+
+type SomeType {}
+enum SomeEnum {FOO = 0;}
+
+component Empty {
+    id = 28901;
+}
+
+component BlittableComponent {
+  id = 28902;
+
+  bool field1 = 1;
+  float field2 = 2;
+  int32 field4 = 4;
+  int64 field5 = 5;
+  double field6 = 6;
+  uint32 field8 = 8;
+  uint64 field9 = 9;
+  sint32 field10 = 10;
+  sint64 field11 = 11;
+  fixed32 field12 = 12;
+  fixed64 field13 = 13;
+  sfixed32 field14 = 14;
+  sfixed64 field15 = 15;
+  EntityId field16 = 16;
+  SomeType field17 = 17;
+  SomeEnum field18 = 18;
+}
+
+type SomeNonBlittableType {
+  string field1 = 1;
+}
+
+component NonBlittableComponent {
+  id = 28903;
+
+  string field1 = 1;
+  bytes field2 = 2;
+  list<int32> field3 = 3;
+  map<int32, int32> field4 = 4;
+  SomeNonBlittableType field5 = 5;
+}

--- a/test-project/Assets/Generated/Source/improbable/testschema/TypeA.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/TypeA.cs
@@ -1,0 +1,76 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Linq;
+using Improbable.Gdk.Core;
+using UnityEngine;
+
+namespace Improbable.TestSchema
+{
+    
+    [global::System.Serializable]
+    public struct TypeA
+    {
+        public global::System.Collections.Generic.List<global::Improbable.TestSchema.TypeA> AList;
+        public global::System.Collections.Generic.Dictionary<int,global::Improbable.TestSchema.TypeA> AMapValue;
+    
+        public TypeA(global::System.Collections.Generic.List<global::Improbable.TestSchema.TypeA> aList, global::System.Collections.Generic.Dictionary<int,global::Improbable.TestSchema.TypeA> aMapValue)
+        {
+            AList = aList;
+            AMapValue = aMapValue;
+        }
+        public static class Serialization
+        {
+            public static void Serialize(TypeA instance, global::Improbable.Worker.CInterop.SchemaObject obj)
+            {
+                {
+                    foreach (var value in instance.AList)
+                    {
+                        global::Improbable.TestSchema.TypeA.Serialization.Serialize(value, obj.AddObject(2));
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.AMapValue)
+                    {
+                        var mapObj = obj.AddObject(4);
+                        mapObj.AddInt32(1, keyValuePair.Key);
+                        global::Improbable.TestSchema.TypeA.Serialization.Serialize(keyValuePair.Value, mapObj.AddObject(2));
+                    }
+                    
+                }
+            }
+    
+            public static TypeA Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj)
+            {
+                var instance = new TypeA();
+                {
+                    instance.AList = new global::System.Collections.Generic.List<global::Improbable.TestSchema.TypeA>();
+                    var list = instance.AList;
+                    var listLength = obj.GetObjectCount(2);
+                    for (var i = 0; i < listLength; i++)
+                    {
+                        list.Add(global::Improbable.TestSchema.TypeA.Serialization.Deserialize(obj.IndexObject(2, (uint) i)));
+                    }
+                    
+                }
+                {
+                    instance.AMapValue = new global::System.Collections.Generic.Dictionary<int,global::Improbable.TestSchema.TypeA>();
+                    var map = instance.AMapValue;
+                    var mapSize = obj.GetObjectCount(4);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(4, (uint) i);
+                        var key = mapObj.GetInt32(1);
+                        var value = global::Improbable.TestSchema.TypeA.Serialization.Deserialize(mapObj.GetObject(2));
+                        map.Add(key, value);
+                    }
+                    
+                }
+                return instance;
+            }
+        }
+    }
+    
+}

--- a/test-project/Assets/Generated/Source/improbable/testschema/TypeB.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/TypeB.cs
@@ -1,0 +1,76 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Linq;
+using Improbable.Gdk.Core;
+using UnityEngine;
+
+namespace Improbable.TestSchema
+{
+    
+    [global::System.Serializable]
+    public struct TypeB
+    {
+        public global::System.Collections.Generic.List<global::Improbable.TestSchema.TypeC> CList;
+        public global::System.Collections.Generic.Dictionary<int,global::Improbable.TestSchema.TypeC> CMapValue;
+    
+        public TypeB(global::System.Collections.Generic.List<global::Improbable.TestSchema.TypeC> cList, global::System.Collections.Generic.Dictionary<int,global::Improbable.TestSchema.TypeC> cMapValue)
+        {
+            CList = cList;
+            CMapValue = cMapValue;
+        }
+        public static class Serialization
+        {
+            public static void Serialize(TypeB instance, global::Improbable.Worker.CInterop.SchemaObject obj)
+            {
+                {
+                    foreach (var value in instance.CList)
+                    {
+                        global::Improbable.TestSchema.TypeC.Serialization.Serialize(value, obj.AddObject(2));
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.CMapValue)
+                    {
+                        var mapObj = obj.AddObject(4);
+                        mapObj.AddInt32(1, keyValuePair.Key);
+                        global::Improbable.TestSchema.TypeC.Serialization.Serialize(keyValuePair.Value, mapObj.AddObject(2));
+                    }
+                    
+                }
+            }
+    
+            public static TypeB Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj)
+            {
+                var instance = new TypeB();
+                {
+                    instance.CList = new global::System.Collections.Generic.List<global::Improbable.TestSchema.TypeC>();
+                    var list = instance.CList;
+                    var listLength = obj.GetObjectCount(2);
+                    for (var i = 0; i < listLength; i++)
+                    {
+                        list.Add(global::Improbable.TestSchema.TypeC.Serialization.Deserialize(obj.IndexObject(2, (uint) i)));
+                    }
+                    
+                }
+                {
+                    instance.CMapValue = new global::System.Collections.Generic.Dictionary<int,global::Improbable.TestSchema.TypeC>();
+                    var map = instance.CMapValue;
+                    var mapSize = obj.GetObjectCount(4);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(4, (uint) i);
+                        var key = mapObj.GetInt32(1);
+                        var value = global::Improbable.TestSchema.TypeC.Serialization.Deserialize(mapObj.GetObject(2));
+                        map.Add(key, value);
+                    }
+                    
+                }
+                return instance;
+            }
+        }
+    }
+    
+}

--- a/test-project/Assets/Generated/Source/improbable/testschema/TypeC.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/TypeC.cs
@@ -1,0 +1,92 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Linq;
+using Improbable.Gdk.Core;
+using UnityEngine;
+
+namespace Improbable.TestSchema
+{
+    
+    [global::System.Serializable]
+    public struct TypeC
+    {
+        public global::Improbable.TestSchema.TypeB? BOption;
+        public global::System.Collections.Generic.List<global::Improbable.TestSchema.TypeB> BList;
+        public global::System.Collections.Generic.Dictionary<string,global::Improbable.TestSchema.TypeB> BMap;
+    
+        public TypeC(global::Improbable.TestSchema.TypeB? bOption, global::System.Collections.Generic.List<global::Improbable.TestSchema.TypeB> bList, global::System.Collections.Generic.Dictionary<string,global::Improbable.TestSchema.TypeB> bMap)
+        {
+            BOption = bOption;
+            BList = bList;
+            BMap = bMap;
+        }
+        public static class Serialization
+        {
+            public static void Serialize(TypeC instance, global::Improbable.Worker.CInterop.SchemaObject obj)
+            {
+                {
+                    if (instance.BOption.HasValue)
+                    {
+                        global::Improbable.TestSchema.TypeB.Serialization.Serialize(instance.BOption.Value, obj.AddObject(1));
+                    }
+                    
+                }
+                {
+                    foreach (var value in instance.BList)
+                    {
+                        global::Improbable.TestSchema.TypeB.Serialization.Serialize(value, obj.AddObject(2));
+                    }
+                    
+                }
+                {
+                    foreach (var keyValuePair in instance.BMap)
+                    {
+                        var mapObj = obj.AddObject(4);
+                        mapObj.AddString(1, keyValuePair.Key);
+                        global::Improbable.TestSchema.TypeB.Serialization.Serialize(keyValuePair.Value, mapObj.AddObject(2));
+                    }
+                    
+                }
+            }
+    
+            public static TypeC Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj)
+            {
+                var instance = new TypeC();
+                {
+                    if (obj.GetObjectCount(1) == 1)
+                    {
+                        instance.BOption = new global::Improbable.TestSchema.TypeB?(global::Improbable.TestSchema.TypeB.Serialization.Deserialize(obj.GetObject(1)));
+                    }
+                    
+                }
+                {
+                    instance.BList = new global::System.Collections.Generic.List<global::Improbable.TestSchema.TypeB>();
+                    var list = instance.BList;
+                    var listLength = obj.GetObjectCount(2);
+                    for (var i = 0; i < listLength; i++)
+                    {
+                        list.Add(global::Improbable.TestSchema.TypeB.Serialization.Deserialize(obj.IndexObject(2, (uint) i)));
+                    }
+                    
+                }
+                {
+                    instance.BMap = new global::System.Collections.Generic.Dictionary<string,global::Improbable.TestSchema.TypeB>();
+                    var map = instance.BMap;
+                    var mapSize = obj.GetObjectCount(4);
+                    for (var i = 0; i < mapSize; i++)
+                    {
+                        var mapObj = obj.IndexObject(4, (uint) i);
+                        var key = mapObj.GetString(1);
+                        var value = global::Improbable.TestSchema.TypeB.Serialization.Deserialize(mapObj.GetObject(2));
+                        map.Add(key, value);
+                    }
+                    
+                }
+                return instance;
+            }
+        }
+    }
+    
+}

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Tests/Model/SchemaBundleV1/Resources/exhaustive_bundle.json
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Tests/Model/SchemaBundleV1/Resources/exhaustive_bundle.json
@@ -1,6798 +1,6723 @@
 {
-  "schemaFiles": [
-   {
-    "canonicalPath": "improbable/gdk/core/common.schema",
-    "package": {
-     "sourceReference": {
-      "line": 1,
-      "column": 1
-     },
-     "name": "improbable.gdk.core"
+ "schemaFiles": [
+  {
+   "canonicalPath": "dependent_schema/test.schema",
+   "package": {
+    "sourceReference": {
+     "line": 1,
+     "column": 1
     },
-    "imports": [],
-    "enums": [],
-    "types": [
-     {
-      "sourceReference": {
-       "line": 3,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.core.Empty",
-      "name": "Empty",
-      "outerType": "",
-      "fields": []
-     }
-    ],
-    "components": []
+    "name": "improbable.dependent_schema"
    },
-   {
-    "canonicalPath": "improbable/gdk/player_lifecycle/owning_worker.schema",
-    "package": {
+   "imports": [
+    {
      "sourceReference": {
-      "line": 1,
+      "line": 2,
       "column": 1
      },
-     "name": "improbable.gdk.player_lifecycle"
-    },
-    "imports": [],
-    "enums": [],
-    "types": [],
-    "components": [
-     {
-      "sourceReference": {
-       "line": 3,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.player_lifecycle.OwningWorker",
-      "name": "OwningWorker",
-      "componentId": 13003,
-      "dataDefinition": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 6,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "worker_id",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "String"
-         }
+     "path": "test_schema/exhaustive_test.schema"
+    }
+   ],
+   "enums": [],
+   "types": [
+    {
+     "sourceReference": {
+      "line": 4,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.dependent_schema.DependentType",
+     "name": "DependentType",
+     "outerType": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 5,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "a",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "type": "improbable.test_schema.ExhaustiveRepeatedData"
         }
        }
-      ],
-      "events": [],
-      "commands": []
-     }
-    ]
+      },
+      {
+       "sourceReference": {
+        "line": 6,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "b",
+       "fieldId": 2,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "enum": "improbable.test_schema.SomeEnum"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 7,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "c",
+       "fieldId": 3,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "enum": "improbable.test_schema.SomeEnum"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 8,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "d",
+       "fieldId": 4,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "type": "improbable.test_schema.SomeType"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 9,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "e",
+       "fieldId": 5,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "enum": "improbable.test_schema.SomeEnum"
+        },
+        "valueType": {
+         "type": "improbable.test_schema.SomeType"
+        }
+       }
+      }
+     ]
+    }
+   ],
+   "components": [
+    {
+     "sourceReference": {
+      "line": 13,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.dependent_schema.DependentComponent",
+     "name": "DependentComponent",
+     "componentId": 198800,
+     "dataDefinition": "improbable.dependent_schema.DependentType",
+     "fields": [],
+     "events": [],
+     "commands": []
+    },
+    {
+     "sourceReference": {
+      "line": 18,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.dependent_schema.DependentDataComponent",
+     "name": "DependentDataComponent",
+     "componentId": 198801,
+     "dataDefinition": "improbable.test_schema.ExhaustiveOptionalData",
+     "fields": [],
+     "events": [
+      {
+       "sourceReference": {
+        "line": 21,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "foo_event",
+       "type": "improbable.test_schema.SomeType",
+       "eventIndex": 1
+      }
+     ],
+     "commands": [
+      {
+       "sourceReference": {
+        "line": 18,
+        "column": 1
+       },
+       "annotations": [],
+       "name": "bar_command",
+       "requestType": "improbable.test_schema.SomeType",
+       "responseType": "improbable.test_schema.SomeType",
+       "commandIndex": 1
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "canonicalPath": "improbable/gdk/core/common.schema",
+   "package": {
+    "sourceReference": {
+     "line": 1,
+     "column": 1
+    },
+    "name": "improbable.gdk.core"
    },
-   {
-    "canonicalPath": "improbable/gdk/player_lifecycle/player_creator.schema",
-    "package": {
+   "imports": [],
+   "enums": [],
+   "types": [
+    {
      "sourceReference": {
-      "line": 1,
+      "line": 3,
       "column": 1
      },
-     "name": "improbable.gdk.player_lifecycle"
+     "annotations": [],
+     "qualifiedName": "improbable.gdk.core.Empty",
+     "name": "Empty",
+     "outerType": "",
+     "fields": []
+    }
+   ],
+   "components": []
+  },
+  {
+   "canonicalPath": "improbable/gdk/player_lifecycle/owning_worker.schema",
+   "package": {
+    "sourceReference": {
+     "line": 1,
+     "column": 1
     },
-    "imports": [],
-    "enums": [],
-    "types": [
-     {
-      "sourceReference": {
-       "line": 3,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.player_lifecycle.CreatePlayerRequest",
-      "name": "CreatePlayerRequest",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 5,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "serialized_arguments",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Bytes"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 8,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.player_lifecycle.CreatePlayerResponse",
-      "name": "CreatePlayerResponse",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 10,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "created_entity_id",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "EntityId"
-         }
-        }
-       }
-      ]
-     }
-    ],
-    "components": [
-     {
-      "sourceReference": {
-       "line": 13,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.player_lifecycle.PlayerCreator",
-      "name": "PlayerCreator",
-      "componentId": 13000,
-      "dataDefinition": "",
-      "fields": [],
-      "events": [],
-      "commands": [
-       {
-        "sourceReference": {
-         "line": 13,
-         "column": 1
-        },
-        "annotations": [],
-        "name": "create_player",
-        "requestType": "improbable.gdk.player_lifecycle.CreatePlayerRequest",
-        "responseType": "improbable.gdk.player_lifecycle.CreatePlayerResponse",
-        "commandIndex": 1
-       }
-      ]
-     }
-    ]
+    "name": "improbable.gdk.player_lifecycle"
    },
-   {
-    "canonicalPath": "improbable/gdk/player_lifecycle/player_heartbeat.schema",
-    "package": {
+   "imports": [],
+   "enums": [],
+   "types": [],
+   "components": [
+    {
      "sourceReference": {
-      "line": 1,
+      "line": 3,
       "column": 1
      },
-     "name": "improbable.gdk.player_lifecycle"
-    },
-    "imports": [
-     {
-      "sourceReference": {
-       "line": 3,
-       "column": 1
-      },
-      "path": "improbable/gdk/core/common.schema"
-     }
-    ],
-    "enums": [],
-    "types": [],
-    "components": [
-     {
-      "sourceReference": {
-       "line": 5,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.player_lifecycle.PlayerHeartbeatClient",
-      "name": "PlayerHeartbeatClient",
-      "componentId": 13001,
-      "dataDefinition": "",
-      "fields": [],
-      "events": [],
-      "commands": [
-       {
-        "sourceReference": {
-         "line": 5,
-         "column": 1
-        },
-        "annotations": [],
-        "name": "player_heartbeat",
-        "requestType": "improbable.gdk.core.Empty",
-        "responseType": "improbable.gdk.core.Empty",
-        "commandIndex": 1
+     "annotations": [],
+     "qualifiedName": "improbable.gdk.player_lifecycle.OwningWorker",
+     "name": "OwningWorker",
+     "componentId": 13003,
+     "dataDefinition": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 6,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "worker_id",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "String"
+        }
        }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 11,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.player_lifecycle.PlayerHeartbeatServer",
-      "name": "PlayerHeartbeatServer",
-      "componentId": 13002,
-      "dataDefinition": "",
-      "fields": [],
-      "events": [],
-      "commands": []
-     }
-    ]
+      }
+     ],
+     "events": [],
+     "commands": []
+    }
+   ]
+  },
+  {
+   "canonicalPath": "improbable/gdk/player_lifecycle/player_creator.schema",
+   "package": {
+    "sourceReference": {
+     "line": 1,
+     "column": 1
+    },
+    "name": "improbable.gdk.player_lifecycle"
    },
-   {
-    "canonicalPath": "improbable/gdk/tests/alternate_schema_syntax.schema",
-    "package": {
+   "imports": [],
+   "enums": [],
+   "types": [
+    {
      "sourceReference": {
-      "line": 1,
+      "line": 3,
       "column": 1
      },
-     "name": "improbable.gdk.tests.alternate_schema_syntax"
-    },
-    "imports": [],
-    "enums": [],
-    "types": [
-     {
-      "sourceReference": {
-       "line": 3,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.alternate_schema_syntax.RandomDataType",
-      "name": "RandomDataType",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 4,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "value",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Int32"
-         }
+     "annotations": [],
+     "qualifiedName": "improbable.gdk.player_lifecycle.CreatePlayerRequest",
+     "name": "CreatePlayerRequest",
+     "outerType": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 5,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "serialized_arguments",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Bytes"
         }
        }
-      ]
-     }
-    ],
-    "components": [
-     {
-      "sourceReference": {
-       "line": 7,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.alternate_schema_syntax.Connection",
-      "name": "Connection",
-      "componentId": 1105,
-      "dataDefinition": "improbable.gdk.tests.alternate_schema_syntax.RandomDataType",
-      "fields": [],
-      "events": [
-       {
-        "sourceReference": {
-         "line": 11,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "my_event",
-        "type": "improbable.gdk.tests.alternate_schema_syntax.RandomDataType",
-        "eventIndex": 1
+      }
+     ]
+    },
+    {
+     "sourceReference": {
+      "line": 8,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.gdk.player_lifecycle.CreatePlayerResponse",
+     "name": "CreatePlayerResponse",
+     "outerType": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 10,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "created_entity_id",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "EntityId"
+        }
        }
-      ],
-      "commands": []
-     }
-    ]
+      }
+     ]
+    }
+   ],
+   "components": [
+    {
+     "sourceReference": {
+      "line": 13,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.gdk.player_lifecycle.PlayerCreator",
+     "name": "PlayerCreator",
+     "componentId": 13000,
+     "dataDefinition": "",
+     "fields": [],
+     "events": [],
+     "commands": [
+      {
+       "sourceReference": {
+        "line": 13,
+        "column": 1
+       },
+       "annotations": [],
+       "name": "create_player",
+       "requestType": "improbable.gdk.player_lifecycle.CreatePlayerRequest",
+       "responseType": "improbable.gdk.player_lifecycle.CreatePlayerResponse",
+       "commandIndex": 1
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "canonicalPath": "improbable/gdk/player_lifecycle/player_heartbeat.schema",
+   "package": {
+    "sourceReference": {
+     "line": 1,
+     "column": 1
+    },
+    "name": "improbable.gdk.player_lifecycle"
    },
-   {
-    "canonicalPath": "improbable/gdk/tests/blittable_types.schema",
-    "package": {
+   "imports": [
+    {
      "sourceReference": {
-      "line": 1,
+      "line": 3,
       "column": 1
      },
-     "name": "improbable.gdk.tests.blittable_types"
+     "path": "improbable/gdk/core/common.schema"
+    }
+   ],
+   "enums": [],
+   "types": [],
+   "components": [
+    {
+     "sourceReference": {
+      "line": 5,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.gdk.player_lifecycle.PlayerHeartbeatClient",
+     "name": "PlayerHeartbeatClient",
+     "componentId": 13001,
+     "dataDefinition": "",
+     "fields": [],
+     "events": [],
+     "commands": [
+      {
+       "sourceReference": {
+        "line": 5,
+        "column": 1
+       },
+       "annotations": [],
+       "name": "player_heartbeat",
+       "requestType": "improbable.gdk.core.Empty",
+       "responseType": "improbable.gdk.core.Empty",
+       "commandIndex": 1
+      }
+     ]
     },
-    "imports": [],
-    "enums": [],
-    "types": [
-     {
-      "sourceReference": {
-       "line": 3,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.blittable_types.FirstCommandRequest",
-      "name": "FirstCommandRequest",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 4,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Int32"
-         }
-        }
-       }
-      ]
+    {
+     "sourceReference": {
+      "line": 11,
+      "column": 1
      },
-     {
-      "sourceReference": {
-       "line": 7,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.blittable_types.FirstCommandResponse",
-      "name": "FirstCommandResponse",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 8,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "response",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Bool"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 11,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.blittable_types.SecondCommandRequest",
-      "name": "SecondCommandRequest",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 12,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Int64"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 15,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.blittable_types.SecondCommandResponse",
-      "name": "SecondCommandResponse",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 16,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "response",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Double"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 19,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.blittable_types.FirstEventPayload",
-      "name": "FirstEventPayload",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 20,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field1",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Bool"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 21,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field2",
-        "fieldId": 2,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Int32"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 24,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.blittable_types.SecondEventPayload",
-      "name": "SecondEventPayload",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 25,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field1",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Float"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 26,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field2",
-        "fieldId": 2,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Double"
-         }
-        }
-       }
-      ]
-     }
-    ],
-    "components": [
-     {
-      "sourceReference": {
-       "line": 29,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.blittable_types.BlittableComponent",
-      "name": "BlittableComponent",
-      "componentId": 1001,
-      "dataDefinition": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 31,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "bool_field",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Bool"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 32,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "int_field",
-        "fieldId": 2,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Int32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 33,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "long_field",
-        "fieldId": 3,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Int64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 34,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "float_field",
-        "fieldId": 4,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Float"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 35,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "double_field",
-        "fieldId": 5,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Double"
-         }
-        }
-       }
-      ],
-      "events": [
-       {
-        "sourceReference": {
-         "line": 40,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "first_event",
-        "type": "improbable.gdk.tests.blittable_types.FirstEventPayload",
-        "eventIndex": 1
-       },
-       {
-        "sourceReference": {
-         "line": 41,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "second_event",
-        "type": "improbable.gdk.tests.blittable_types.SecondEventPayload",
-        "eventIndex": 2
-       }
-      ],
-      "commands": [
-       {
-        "sourceReference": {
-         "line": 29,
-         "column": 1
-        },
-        "annotations": [],
-        "name": "first_command",
-        "requestType": "improbable.gdk.tests.blittable_types.FirstCommandRequest",
-        "responseType": "improbable.gdk.tests.blittable_types.FirstCommandResponse",
-        "commandIndex": 1
-       },
-       {
-        "sourceReference": {
-         "line": 29,
-         "column": 1
-        },
-        "annotations": [],
-        "name": "second_command",
-        "requestType": "improbable.gdk.tests.blittable_types.SecondCommandRequest",
-        "responseType": "improbable.gdk.tests.blittable_types.SecondCommandResponse",
-        "commandIndex": 2
-       }
-      ]
-     }
-    ]
+     "annotations": [],
+     "qualifiedName": "improbable.gdk.player_lifecycle.PlayerHeartbeatServer",
+     "name": "PlayerHeartbeatServer",
+     "componentId": 13002,
+     "dataDefinition": "",
+     "fields": [],
+     "events": [],
+     "commands": []
+    }
+   ]
+  },
+  {
+   "canonicalPath": "improbable/gdk/transform_synchronization/transform_internal.schema",
+   "package": {
+    "sourceReference": {
+     "line": 1,
+     "column": 1
+    },
+    "name": "improbable.gdk.transform_synchronization"
    },
-   {
-    "canonicalPath": "improbable/gdk/tests/empty_component.schema",
-    "package": {
+   "imports": [],
+   "enums": [],
+   "types": [
+    {
      "sourceReference": {
-      "line": 1,
+      "line": 3,
       "column": 1
      },
-     "name": "improbable.gdk.tests.components_with_no_fields"
-    },
-    "imports": [],
-    "enums": [],
-    "types": [
-     {
-      "sourceReference": {
-       "line": 3,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.components_with_no_fields.Empty",
-      "name": "Empty",
-      "outerType": "",
-      "fields": []
-     }
-    ],
-    "components": [
-     {
-      "sourceReference": {
-       "line": 5,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.components_with_no_fields.ComponentWithNoFields",
-      "name": "ComponentWithNoFields",
-      "componentId": 1003,
-      "dataDefinition": "",
-      "fields": [],
-      "events": [],
-      "commands": []
-     },
-     {
-      "sourceReference": {
-       "line": 9,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.components_with_no_fields.ComponentWithNoFieldsWithEvents",
-      "name": "ComponentWithNoFieldsWithEvents",
-      "componentId": 1004,
-      "dataDefinition": "",
-      "fields": [],
-      "events": [
-       {
-        "sourceReference": {
-         "line": 12,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "evt",
-        "type": "improbable.gdk.tests.components_with_no_fields.Empty",
-        "eventIndex": 1
-       }
-      ],
-      "commands": []
-     },
-     {
-      "sourceReference": {
-       "line": 15,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.components_with_no_fields.ComponentWithNoFieldsWithCommands",
-      "name": "ComponentWithNoFieldsWithCommands",
-      "componentId": 1005,
-      "dataDefinition": "",
-      "fields": [],
-      "events": [],
-      "commands": [
-       {
-        "sourceReference": {
-         "line": 15,
-         "column": 1
-        },
-        "annotations": [],
-        "name": "cmd",
-        "requestType": "improbable.gdk.tests.components_with_no_fields.Empty",
-        "responseType": "improbable.gdk.tests.components_with_no_fields.Empty",
-        "commandIndex": 1
-       }
-      ]
-     }
-    ]
-   },
-   {
-    "canonicalPath": "improbable/gdk/tests/exhaustive_test.schema",
-    "package": {
-     "sourceReference": {
-      "line": 1,
-      "column": 1
-     },
-     "name": "improbable.gdk.tests"
-    },
-    "imports": [],
-    "enums": [
-     {
-      "sourceReference": {
-       "line": 5,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.SomeEnum",
-      "name": "SomeEnum",
-      "outerType": "",
-      "values": [
-       {
-        "sourceReference": {
-         "line": 6,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "FIRST_VALUE",
-        "value": 0
+     "annotations": [],
+     "qualifiedName": "improbable.gdk.transform_synchronization.FixedPointVector3",
+     "name": "FixedPointVector3",
+     "outerType": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 4,
+        "column": 5
        },
-       {
-        "sourceReference": {
-         "line": 7,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "SECOND_VALUE",
-        "value": 1
+       "annotations": [],
+       "name": "x",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Sint32"
+        }
        }
-      ]
-     }
-    ],
-    "types": [
-     {
-      "sourceReference": {
-       "line": 3,
-       "column": 1
       },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.SomeType",
-      "name": "SomeType",
-      "outerType": "",
-      "fields": []
+      {
+       "sourceReference": {
+        "line": 5,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "y",
+       "fieldId": 2,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Sint32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 6,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "z",
+       "fieldId": 3,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Sint32"
+        }
+       }
+      }
+     ]
+    },
+    {
+     "sourceReference": {
+      "line": 9,
+      "column": 1
      },
-     {
-      "sourceReference": {
-       "line": 15,
-       "column": 1
+     "annotations": [],
+     "qualifiedName": "improbable.gdk.transform_synchronization.CompressedQuaternion",
+     "name": "CompressedQuaternion",
+     "outerType": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 10,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "data",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Uint32"
+        }
+       }
+      }
+     ]
+    }
+   ],
+   "components": [
+    {
+     "sourceReference": {
+      "line": 13,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.gdk.transform_synchronization.TransformInternal",
+     "name": "TransformInternal",
+     "componentId": 11000,
+     "dataDefinition": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 15,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "location",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "type": "improbable.gdk.transform_synchronization.FixedPointVector3"
+        }
+       }
       },
-      "annotations": [
-       {
-        "sourceReference": {
-         "line": 10,
-         "column": 1
+      {
+       "sourceReference": {
+        "line": 16,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "rotation",
+       "fieldId": 2,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "type": "improbable.gdk.transform_synchronization.CompressedQuaternion"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 17,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "velocity",
+       "fieldId": 3,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "type": "improbable.gdk.transform_synchronization.FixedPointVector3"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 18,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "physics_tick",
+       "fieldId": 4,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Uint32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 19,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "ticks_per_second",
+       "fieldId": 5,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Float"
+        }
+       }
+      }
+     ],
+     "events": [],
+     "commands": []
+    }
+   ]
+  },
+  {
+   "canonicalPath": "improbable/restricted/system_components.schema",
+   "package": {
+    "sourceReference": {
+     "line": 1,
+     "column": 1
+    },
+    "name": "improbable.restricted"
+   },
+   "imports": [],
+   "enums": [
+    {
+     "sourceReference": {
+      "line": 22,
+      "column": 3
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.restricted.Connection.ConnectionStatus",
+     "name": "ConnectionStatus",
+     "outerType": "improbable.restricted.Connection",
+     "values": [
+      {
+       "sourceReference": {
+        "line": 23,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "UNKNOWN",
+       "value": 0
+      },
+      {
+       "sourceReference": {
+        "line": 25,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "AWAITING_WORKER_CONNECTION",
+       "value": 1
+      },
+      {
+       "sourceReference": {
+        "line": 27,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "CONNECTED",
+       "value": 2
+      },
+      {
+       "sourceReference": {
+        "line": 29,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "DISCONNECTED",
+       "value": 3
+      }
+     ]
+    }
+   ],
+   "types": [
+    {
+     "sourceReference": {
+      "line": 21,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.restricted.Connection",
+     "name": "Connection",
+     "outerType": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 31,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "status",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "enum": "improbable.restricted.Connection.ConnectionStatus"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 39,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "data_latency_ms",
+       "fieldId": 2,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Uint32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 42,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "connected_since_utc",
+       "fieldId": 3,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Uint64"
+        }
+       }
+      }
+     ]
+    },
+    {
+     "sourceReference": {
+      "line": 46,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.restricted.DisconnectRequest",
+     "name": "DisconnectRequest",
+     "outerType": "",
+     "fields": []
+    },
+    {
+     "sourceReference": {
+      "line": 48,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.restricted.DisconnectResponse",
+     "name": "DisconnectResponse",
+     "outerType": "",
+     "fields": []
+    },
+    {
+     "sourceReference": {
+      "line": 63,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.restricted.PlayerIdentity",
+     "name": "PlayerIdentity",
+     "outerType": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 65,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "player_identifier",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "String"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 68,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "provider",
+       "fieldId": 2,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "String"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 73,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "metadata",
+       "fieldId": 3,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Bytes"
+        }
+       }
+      }
+     ]
+    }
+   ],
+   "components": [
+    {
+     "sourceReference": {
+      "line": 16,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.restricted.System",
+     "name": "System",
+     "componentId": 59,
+     "dataDefinition": "",
+     "fields": [],
+     "events": [],
+     "commands": []
+    },
+    {
+     "sourceReference": {
+      "line": 53,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.restricted.Worker",
+     "name": "Worker",
+     "componentId": 60,
+     "dataDefinition": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 55,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "worker_id",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "String"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 56,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "worker_type",
+       "fieldId": 2,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "String"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 57,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "connection",
+       "fieldId": 3,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "type": "improbable.restricted.Connection"
+        }
+       }
+      }
+     ],
+     "events": [],
+     "commands": [
+      {
+       "sourceReference": {
+        "line": 53,
+        "column": 1
+       },
+       "annotations": [],
+       "name": "disconnect",
+       "requestType": "improbable.restricted.DisconnectRequest",
+       "responseType": "improbable.restricted.DisconnectResponse",
+       "commandIndex": 1
+      }
+     ]
+    },
+    {
+     "sourceReference": {
+      "line": 79,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.restricted.PlayerClient",
+     "name": "PlayerClient",
+     "componentId": 61,
+     "dataDefinition": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 81,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "player_identity",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "type": "improbable.restricted.PlayerIdentity"
+        }
+       }
+      }
+     ],
+     "events": [],
+     "commands": []
+    }
+   ]
+  },
+  {
+   "canonicalPath": "improbable/standard_library.schema",
+   "package": {
+    "sourceReference": {
+     "line": 1,
+     "column": 1
+    },
+    "name": "improbable"
+   },
+   "imports": [],
+   "enums": [],
+   "types": [
+    {
+     "sourceReference": {
+      "line": 6,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.WorkerAttributeSet",
+     "name": "WorkerAttributeSet",
+     "outerType": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 9,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "attribute",
+       "fieldId": 1,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "primitive": "String"
+        }
+       }
+      }
+     ]
+    },
+    {
+     "sourceReference": {
+      "line": 24,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.WorkerRequirementSet",
+     "name": "WorkerRequirementSet",
+     "outerType": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 28,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "attribute_set",
+       "fieldId": 1,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "type": "improbable.WorkerAttributeSet"
+        }
+       }
+      }
+     ]
+    },
+    {
+     "sourceReference": {
+      "line": 62,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.Coordinates",
+     "name": "Coordinates",
+     "outerType": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 63,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "x",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Double"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 64,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "y",
+       "fieldId": 2,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Double"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 65,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "z",
+       "fieldId": 3,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Double"
+        }
+       }
+      }
+     ]
+    },
+    {
+     "sourceReference": {
+      "line": 69,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.EdgeLength",
+     "name": "EdgeLength",
+     "outerType": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 70,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "x",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Double"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 71,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "y",
+       "fieldId": 2,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Double"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 72,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "z",
+       "fieldId": 3,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Double"
+        }
+       }
+      }
+     ]
+    },
+    {
+     "sourceReference": {
+      "line": 103,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.ComponentInterest",
+     "name": "ComponentInterest",
+     "outerType": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 171,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "queries",
+       "fieldId": 1,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "type": "improbable.ComponentInterest.Query"
+        }
+       }
+      }
+     ]
+    },
+    {
+     "sourceReference": {
+      "line": 104,
+      "column": 3
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.ComponentInterest.Query",
+     "name": "Query",
+     "outerType": "improbable.ComponentInterest",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 105,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "constraint",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "type": "improbable.ComponentInterest.QueryConstraint"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 108,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "full_snapshot_result",
+       "fieldId": 2,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "primitive": "Bool"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 109,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "result_component_id",
+       "fieldId": 3,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "primitive": "Uint32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 126,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "frequency",
+       "fieldId": 4,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "primitive": "Float"
+        }
+       }
+      }
+     ]
+    },
+    {
+     "sourceReference": {
+      "line": 129,
+      "column": 3
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.ComponentInterest.QueryConstraint",
+     "name": "QueryConstraint",
+     "outerType": "improbable.ComponentInterest",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 132,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "sphere_constraint",
+       "fieldId": 1,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "type": "improbable.ComponentInterest.SphereConstraint"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 133,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "cylinder_constraint",
+       "fieldId": 2,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "type": "improbable.ComponentInterest.CylinderConstraint"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 134,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "box_constraint",
+       "fieldId": 3,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "type": "improbable.ComponentInterest.BoxConstraint"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 135,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "relative_sphere_constraint",
+       "fieldId": 4,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "type": "improbable.ComponentInterest.RelativeSphereConstraint"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 136,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "relative_cylinder_constraint",
+       "fieldId": 5,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "type": "improbable.ComponentInterest.RelativeCylinderConstraint"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 137,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "relative_box_constraint",
+       "fieldId": 6,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "type": "improbable.ComponentInterest.RelativeBoxConstraint"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 138,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "entity_id_constraint",
+       "fieldId": 7,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "primitive": "Int64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 139,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "component_constraint",
+       "fieldId": 8,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "primitive": "Uint32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 140,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "and_constraint",
+       "fieldId": 9,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "type": "improbable.ComponentInterest.QueryConstraint"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 141,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "or_constraint",
+       "fieldId": 10,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "type": "improbable.ComponentInterest.QueryConstraint"
+        }
+       }
+      }
+     ]
+    },
+    {
+     "sourceReference": {
+      "line": 144,
+      "column": 3
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.ComponentInterest.SphereConstraint",
+     "name": "SphereConstraint",
+     "outerType": "improbable.ComponentInterest",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 145,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "center",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "type": "improbable.Coordinates"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 146,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "radius",
+       "fieldId": 2,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Double"
+        }
+       }
+      }
+     ]
+    },
+    {
+     "sourceReference": {
+      "line": 149,
+      "column": 3
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.ComponentInterest.CylinderConstraint",
+     "name": "CylinderConstraint",
+     "outerType": "improbable.ComponentInterest",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 150,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "center",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "type": "improbable.Coordinates"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 151,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "radius",
+       "fieldId": 2,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Double"
+        }
+       }
+      }
+     ]
+    },
+    {
+     "sourceReference": {
+      "line": 154,
+      "column": 3
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.ComponentInterest.BoxConstraint",
+     "name": "BoxConstraint",
+     "outerType": "improbable.ComponentInterest",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 155,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "center",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "type": "improbable.Coordinates"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 156,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "edge_length",
+       "fieldId": 2,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "type": "improbable.EdgeLength"
+        }
+       }
+      }
+     ]
+    },
+    {
+     "sourceReference": {
+      "line": 159,
+      "column": 3
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.ComponentInterest.RelativeSphereConstraint",
+     "name": "RelativeSphereConstraint",
+     "outerType": "improbable.ComponentInterest",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 160,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "radius",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Double"
+        }
+       }
+      }
+     ]
+    },
+    {
+     "sourceReference": {
+      "line": 163,
+      "column": 3
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.ComponentInterest.RelativeCylinderConstraint",
+     "name": "RelativeCylinderConstraint",
+     "outerType": "improbable.ComponentInterest",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 164,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "radius",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Double"
+        }
+       }
+      }
+     ]
+    },
+    {
+     "sourceReference": {
+      "line": 167,
+      "column": 3
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.ComponentInterest.RelativeBoxConstraint",
+     "name": "RelativeBoxConstraint",
+     "outerType": "improbable.ComponentInterest",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 168,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "edge_length",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "type": "improbable.EdgeLength"
+        }
+       }
+      }
+     ]
+    }
+   ],
+   "components": [
+    {
+     "sourceReference": {
+      "line": 33,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.EntityAcl",
+     "name": "EntityAcl",
+     "componentId": 50,
+     "dataDefinition": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 40,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "read_acl",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "type": "improbable.WorkerRequirementSet"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 46,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "component_write_acl",
+       "fieldId": 2,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "Uint32"
         },
-        "typeValue": {
-         "type": "improbable.gdk.tests.ExhaustiveSingularData",
-         "fields": [
-          {
+        "valueType": {
+         "type": "improbable.WorkerRequirementSet"
+        }
+       }
+      }
+     ],
+     "events": [],
+     "commands": []
+    },
+    {
+     "sourceReference": {
+      "line": 51,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.Metadata",
+     "name": "Metadata",
+     "componentId": 53,
+     "dataDefinition": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 57,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "entity_type",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "String"
+        }
+       }
+      }
+     ],
+     "events": [],
+     "commands": []
+    },
+    {
+     "sourceReference": {
+      "line": 81,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.Position",
+     "name": "Position",
+     "componentId": 54,
+     "dataDefinition": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 83,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "coords",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "type": "improbable.Coordinates"
+        }
+       }
+      }
+     ],
+     "events": [],
+     "commands": []
+    },
+    {
+     "sourceReference": {
+      "line": 89,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.Persistence",
+     "name": "Persistence",
+     "componentId": 55,
+     "dataDefinition": "",
+     "fields": [],
+     "events": [],
+     "commands": []
+    },
+    {
+     "sourceReference": {
+      "line": 98,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.Interest",
+     "name": "Interest",
+     "componentId": 58,
+     "dataDefinition": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 100,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "component_interest",
+       "fieldId": 1,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "Uint32"
+        },
+        "valueType": {
+         "type": "improbable.ComponentInterest"
+        }
+       }
+      }
+     ],
+     "events": [],
+     "commands": []
+    }
+   ]
+  },
+  {
+   "canonicalPath": "improbable/tests/dependency_test.schema",
+   "package": {
+    "sourceReference": {
+     "line": 1,
+     "column": 1
+    },
+    "name": "improbable.tests"
+   },
+   "imports": [],
+   "enums": [],
+   "types": [],
+   "components": [
+    {
+     "sourceReference": {
+      "line": 3,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.tests.DependencyTest",
+     "name": "DependencyTest",
+     "componentId": 11111,
+     "dataDefinition": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 5,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "root",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Uint32"
+        }
+       }
+      }
+     ],
+     "events": [],
+     "commands": []
+    }
+   ]
+  },
+  {
+   "canonicalPath": "improbable/tests/dependency_test_child.schema",
+   "package": {
+    "sourceReference": {
+     "line": 1,
+     "column": 1
+    },
+    "name": "improbable.tests"
+   },
+   "imports": [],
+   "enums": [],
+   "types": [],
+   "components": [
+    {
+     "sourceReference": {
+      "line": 3,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.tests.DependencyTestChild",
+     "name": "DependencyTestChild",
+     "componentId": 11112,
+     "dataDefinition": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 5,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "child",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Uint32"
+        }
+       }
+      }
+     ],
+     "events": [],
+     "commands": []
+    }
+   ]
+  },
+  {
+   "canonicalPath": "improbable/tests/dependency_test_grandchild.schema",
+   "package": {
+    "sourceReference": {
+     "line": 1,
+     "column": 1
+    },
+    "name": "improbable.tests"
+   },
+   "imports": [],
+   "enums": [],
+   "types": [],
+   "components": [
+    {
+     "sourceReference": {
+      "line": 3,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.tests.DependencyTestGrandchild",
+     "name": "DependencyTestGrandchild",
+     "componentId": 11113,
+     "dataDefinition": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 5,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "grandchild",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Uint32"
+        }
+       }
+      }
+     ],
+     "events": [],
+     "commands": []
+    }
+   ]
+  },
+  {
+   "canonicalPath": "test.schema",
+   "package": {
+    "sourceReference": {
+     "line": 1,
+     "column": 1
+    },
+    "name": "improbable.gdk.test"
+   },
+   "imports": [],
+   "enums": [
+    {
+     "sourceReference": {
+      "line": 4,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.gdk.test.SomeEnum",
+     "name": "SomeEnum",
+     "outerType": "",
+     "values": [
+      {
+       "sourceReference": {
+        "line": 4,
+        "column": 16
+       },
+       "annotations": [],
+       "name": "FOO",
+       "value": 0
+      }
+     ]
+    }
+   ],
+   "types": [
+    {
+     "sourceReference": {
+      "line": 3,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.gdk.test.SomeType",
+     "name": "SomeType",
+     "outerType": "",
+     "fields": []
+    },
+    {
+     "sourceReference": {
+      "line": 31,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.gdk.test.SomeNonBlittableType",
+     "name": "SomeNonBlittableType",
+     "outerType": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 32,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field1",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "String"
+        }
+       }
+      }
+     ]
+    }
+   ],
+   "components": [
+    {
+     "sourceReference": {
+      "line": 6,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.gdk.test.Empty",
+     "name": "Empty",
+     "componentId": 28901,
+     "dataDefinition": "",
+     "fields": [],
+     "events": [],
+     "commands": []
+    },
+    {
+     "sourceReference": {
+      "line": 10,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.gdk.test.BlittableComponent",
+     "name": "BlittableComponent",
+     "componentId": 28902,
+     "dataDefinition": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 13,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field1",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Bool"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 14,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field2",
+       "fieldId": 2,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Float"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 15,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field4",
+       "fieldId": 4,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Int32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 16,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field5",
+       "fieldId": 5,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Int64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 17,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field6",
+       "fieldId": 6,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Double"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 18,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field8",
+       "fieldId": 8,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Uint32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 19,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field9",
+       "fieldId": 9,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Uint64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 20,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field10",
+       "fieldId": 10,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Sint32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 21,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field11",
+       "fieldId": 11,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Sint64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 22,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field12",
+       "fieldId": 12,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Fixed32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 23,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field13",
+       "fieldId": 13,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Fixed64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 24,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field14",
+       "fieldId": 14,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Sfixed32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 25,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field15",
+       "fieldId": 15,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Sfixed64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 26,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field16",
+       "fieldId": 16,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "EntityId"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 27,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field17",
+       "fieldId": 17,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "type": "improbable.gdk.test.SomeType"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 28,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field18",
+       "fieldId": 18,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "enum": "improbable.gdk.test.SomeEnum"
+        }
+       }
+      }
+     ],
+     "events": [],
+     "commands": []
+    },
+    {
+     "sourceReference": {
+      "line": 35,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.gdk.test.NonBlittableComponent",
+     "name": "NonBlittableComponent",
+     "componentId": 28903,
+     "dataDefinition": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 38,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field1",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "String"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 39,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field2",
+       "fieldId": 2,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Bytes"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 40,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field3",
+       "fieldId": 3,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "primitive": "Int32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 41,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field4",
+       "fieldId": 4,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "Int32"
+        },
+        "valueType": {
+         "primitive": "Int32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 42,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field5",
+       "fieldId": 5,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "type": "improbable.gdk.test.SomeNonBlittableType"
+        }
+       }
+      }
+     ],
+     "events": [],
+     "commands": []
+    }
+   ]
+  },
+  {
+   "canonicalPath": "test_schema/exhaustive_test.schema",
+   "package": {
+    "sourceReference": {
+     "line": 1,
+     "column": 1
+    },
+    "name": "improbable.test_schema"
+   },
+   "imports": [],
+   "enums": [
+    {
+     "sourceReference": {
+      "line": 4,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.test_schema.SomeEnum",
+     "name": "SomeEnum",
+     "outerType": "",
+     "values": [
+      {
+       "sourceReference": {
+        "line": 4,
+        "column": 16
+       },
+       "annotations": [],
+       "name": "FOO",
+       "value": 0
+      }
+     ]
+    }
+   ],
+   "types": [
+    {
+     "sourceReference": {
+      "line": 3,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.test_schema.SomeType",
+     "name": "SomeType",
+     "outerType": "",
+     "fields": []
+    },
+    {
+     "sourceReference": {
+      "line": 11,
+      "column": 1
+     },
+     "annotations": [
+      {
+       "sourceReference": {
+        "line": 6,
+        "column": 1
+       },
+       "typeValue": {
+        "type": "improbable.test_schema.ExhaustiveSingularData",
+        "fields": [
+         {
+          "sourceReference": {
+           "line": 7,
+           "column": 5
+          },
+          "name": "field1",
+          "value": {
            "sourceReference": {
-            "line": 11,
+            "line": 7,
             "column": 5
            },
-           "name": "field1",
-           "value": {
-            "sourceReference": {
-             "line": 11,
-             "column": 5
-            },
-            "boolValue": true
-           }
+           "boolValue": true
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 7,
+           "column": 20
           },
-          {
+          "name": "field2",
+          "value": {
            "sourceReference": {
-            "line": 11,
+            "line": 7,
             "column": 20
            },
-           "name": "field2",
-           "value": {
-            "sourceReference": {
-             "line": 11,
-             "column": 20
-            },
-            "floatValue": 10.5
-           }
+           "floatValue": 10.5
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 7,
+           "column": 35
           },
-          {
+          "name": "field3",
+          "value": {
            "sourceReference": {
-            "line": 11,
+            "line": 7,
             "column": 35
            },
-           "name": "field3",
-           "value": {
-            "sourceReference": {
-             "line": 11,
-             "column": 35
-            },
-            "bytesValue": "Zm9v"
-           }
+           "bytesValue": "Zm9v"
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 7,
+           "column": 51
           },
-          {
+          "name": "field4",
+          "value": {
            "sourceReference": {
-            "line": 11,
+            "line": 7,
             "column": 51
            },
-           "name": "field4",
-           "value": {
-            "sourceReference": {
-             "line": 11,
-             "column": 51
-            },
-            "int32Value": -2
-           }
+           "int32Value": -2
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 7,
+           "column": 64
           },
-          {
+          "name": "field5",
+          "value": {
            "sourceReference": {
-            "line": 11,
+            "line": 7,
             "column": 64
            },
-           "name": "field5",
-           "value": {
-            "sourceReference": {
-             "line": 11,
-             "column": 64
-            },
-            "int64Value": "3"
-           }
+           "int64Value": "3"
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 8,
+           "column": 5
           },
-          {
+          "name": "field6",
+          "value": {
            "sourceReference": {
-            "line": 12,
+            "line": 8,
             "column": 5
            },
-           "name": "field6",
-           "value": {
-            "sourceReference": {
-             "line": 12,
-             "column": 5
-            },
-            "doubleValue": -15.5
-           }
+           "doubleValue": -15.5
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 8,
+           "column": 21
           },
-          {
+          "name": "field7",
+          "value": {
            "sourceReference": {
-            "line": 12,
+            "line": 8,
             "column": 21
            },
-           "name": "field7",
-           "value": {
-            "sourceReference": {
-             "line": 12,
-             "column": 21
-            },
-            "stringValue": "bar"
-           }
+           "stringValue": "bar"
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 8,
+           "column": 37
           },
-          {
+          "name": "field8",
+          "value": {
            "sourceReference": {
-            "line": 12,
+            "line": 8,
             "column": 37
            },
-           "name": "field8",
-           "value": {
-            "sourceReference": {
-             "line": 12,
-             "column": 37
-            },
-            "uint32Value": 0
-           }
+           "uint32Value": 0
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 8,
+           "column": 49
           },
-          {
+          "name": "field9",
+          "value": {
            "sourceReference": {
-            "line": 12,
+            "line": 8,
             "column": 49
            },
-           "name": "field9",
-           "value": {
-            "sourceReference": {
-             "line": 12,
-             "column": 49
-            },
-            "uint64Value": "1"
-           }
+           "uint64Value": "1"
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 8,
+           "column": 61
           },
-          {
+          "name": "field10",
+          "value": {
            "sourceReference": {
-            "line": 12,
+            "line": 8,
             "column": 61
            },
-           "name": "field10",
-           "value": {
-            "sourceReference": {
-             "line": 12,
-             "column": 61
-            },
-            "int32Value": 4
-           }
+           "int32Value": 4
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 9,
+           "column": 5
           },
-          {
+          "name": "field11",
+          "value": {
            "sourceReference": {
-            "line": 13,
+            "line": 9,
             "column": 5
            },
-           "name": "field11",
-           "value": {
-            "sourceReference": {
-             "line": 13,
-             "column": 5
-            },
-            "int64Value": "5"
-           }
+           "int64Value": "5"
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 9,
+           "column": 18
           },
-          {
+          "name": "field12",
+          "value": {
            "sourceReference": {
-            "line": 13,
+            "line": 9,
             "column": 18
            },
-           "name": "field12",
-           "value": {
-            "sourceReference": {
-             "line": 13,
-             "column": 18
-            },
-            "uint32Value": 6
-           }
+           "uint32Value": 6
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 9,
+           "column": 31
           },
-          {
+          "name": "field13",
+          "value": {
            "sourceReference": {
-            "line": 13,
+            "line": 9,
             "column": 31
            },
-           "name": "field13",
-           "value": {
-            "sourceReference": {
-             "line": 13,
-             "column": 31
-            },
-            "uint64Value": "7"
-           }
+           "uint64Value": "7"
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 9,
+           "column": 44
           },
-          {
+          "name": "field14",
+          "value": {
            "sourceReference": {
-            "line": 13,
+            "line": 9,
             "column": 44
            },
-           "name": "field14",
-           "value": {
-            "sourceReference": {
-             "line": 13,
-             "column": 44
-            },
-            "int32Value": -8
-           }
+           "int32Value": -8
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 9,
+           "column": 58
           },
-          {
+          "name": "field15",
+          "value": {
            "sourceReference": {
-            "line": 13,
+            "line": 9,
             "column": 58
            },
-           "name": "field15",
-           "value": {
-            "sourceReference": {
-             "line": 13,
-             "column": 58
-            },
-            "int64Value": "-9"
-           }
+           "int64Value": "-9"
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 10,
+           "column": 5
           },
-          {
+          "name": "field16",
+          "value": {
            "sourceReference": {
-            "line": 14,
+            "line": 10,
             "column": 5
            },
-           "name": "field16",
-           "value": {
-            "sourceReference": {
-             "line": 14,
-             "column": 5
-            },
-            "entityIdValue": "10"
-           }
+           "entityIdValue": "10"
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 10,
+           "column": 19
           },
-          {
+          "name": "field17",
+          "value": {
            "sourceReference": {
-            "line": 14,
+            "line": 10,
             "column": 19
            },
-           "name": "field17",
-           "value": {
-            "sourceReference": {
-             "line": 14,
-             "column": 19
-            },
-            "typeValue": {
-             "type": "improbable.gdk.tests.SomeType",
-             "fields": []
-            }
+           "typeValue": {
+            "type": "improbable.test_schema.SomeType",
+            "fields": []
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 10,
+           "column": 39
           },
-          {
+          "name": "field18",
+          "value": {
            "sourceReference": {
-            "line": 14,
+            "line": 10,
             "column": 39
            },
-           "name": "field18",
-           "value": {
-            "sourceReference": {
-             "line": 14,
-             "column": 39
-            },
-            "enumValue": {
-             "enum": "improbable.gdk.tests.SomeEnum",
-             "value": "FIRST_VALUE"
+           "enumValue": {
+            "enum": "improbable.test_schema.SomeEnum",
+            "value": "FOO"
+           }
+          }
+         }
+        ]
+       }
+      }
+     ],
+     "qualifiedName": "improbable.test_schema.ExhaustiveSingularData",
+     "name": "ExhaustiveSingularData",
+     "outerType": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 12,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field1",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Bool"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 13,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field2",
+       "fieldId": 2,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Float"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 14,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field3",
+       "fieldId": 3,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Bytes"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 15,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field4",
+       "fieldId": 4,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Int32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 16,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field5",
+       "fieldId": 5,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Int64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 17,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field6",
+       "fieldId": 6,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Double"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 18,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field7",
+       "fieldId": 7,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "String"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 19,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field8",
+       "fieldId": 8,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Uint32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 20,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field9",
+       "fieldId": 9,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Uint64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 21,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field10",
+       "fieldId": 10,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Sint32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 22,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field11",
+       "fieldId": 11,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Sint64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 23,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field12",
+       "fieldId": 12,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Fixed32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 24,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field13",
+       "fieldId": 13,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Fixed64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 25,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field14",
+       "fieldId": 14,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Sfixed32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 26,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field15",
+       "fieldId": 15,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Sfixed64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 27,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field16",
+       "fieldId": 16,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "EntityId"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 28,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field17",
+       "fieldId": 17,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "type": "improbable.test_schema.SomeType"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 29,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field18",
+       "fieldId": 18,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "enum": "improbable.test_schema.SomeEnum"
+        }
+       }
+      }
+     ]
+    },
+    {
+     "sourceReference": {
+      "line": 42,
+      "column": 1
+     },
+     "annotations": [
+      {
+       "sourceReference": {
+        "line": 37,
+        "column": 1
+       },
+       "typeValue": {
+        "type": "improbable.test_schema.ExhaustiveOptionalData",
+        "fields": [
+         {
+          "sourceReference": {
+           "line": 38,
+           "column": 5
+          },
+          "name": "field1",
+          "value": {
+           "sourceReference": {
+            "line": 38,
+            "column": 5
+           },
+           "optionValue": {
+            "value": {
+             "sourceReference": {
+              "line": 0,
+              "column": 0
+             },
+             "boolValue": true
             }
            }
           }
-         ]
-        }
-       }
-      ],
-      "qualifiedName": "improbable.gdk.tests.ExhaustiveSingularData",
-      "name": "ExhaustiveSingularData",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 16,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field1",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Bool"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 17,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field2",
-        "fieldId": 2,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Float"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 18,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field3",
-        "fieldId": 3,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Bytes"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 19,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field4",
-        "fieldId": 4,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Int32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 20,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field5",
-        "fieldId": 5,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Int64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 21,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field6",
-        "fieldId": 6,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Double"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 22,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field7",
-        "fieldId": 7,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 23,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field8",
-        "fieldId": 8,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Uint32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 24,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field9",
-        "fieldId": 9,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Uint64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 25,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field10",
-        "fieldId": 10,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Sint32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 26,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field11",
-        "fieldId": 11,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Sint64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 27,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field12",
-        "fieldId": 12,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Fixed32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 28,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field13",
-        "fieldId": 13,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Fixed64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 29,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field14",
-        "fieldId": 14,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Sfixed32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 30,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field15",
-        "fieldId": 15,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Sfixed64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 31,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field16",
-        "fieldId": 16,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "EntityId"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 32,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field17",
-        "fieldId": 17,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "type": "improbable.gdk.tests.SomeType"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 33,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field18",
-        "fieldId": 18,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "enum": "improbable.gdk.tests.SomeEnum"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 46,
-       "column": 1
-      },
-      "annotations": [
-       {
-        "sourceReference": {
-         "line": 41,
-         "column": 1
-        },
-        "typeValue": {
-         "type": "improbable.gdk.tests.ExhaustiveOptionalData",
-         "fields": [
-          {
+         },
+         {
+          "sourceReference": {
+           "line": 38,
+           "column": 20
+          },
+          "name": "field2",
+          "value": {
            "sourceReference": {
-            "line": 42,
+            "line": 38,
+            "column": 20
+           },
+           "optionValue": {
+            "value": {
+             "sourceReference": {
+              "line": 0,
+              "column": 0
+             },
+             "floatValue": 10.5
+            }
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 38,
+           "column": 35
+          },
+          "name": "field3",
+          "value": {
+           "sourceReference": {
+            "line": 38,
+            "column": 35
+           },
+           "optionValue": {
+            "value": {
+             "sourceReference": {
+              "line": 0,
+              "column": 0
+             },
+             "bytesValue": "Zm9v"
+            }
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 38,
+           "column": 51
+          },
+          "name": "field4",
+          "value": {
+           "sourceReference": {
+            "line": 38,
+            "column": 51
+           },
+           "optionValue": {
+            "value": {
+             "sourceReference": {
+              "line": 0,
+              "column": 0
+             },
+             "int32Value": -2
+            }
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 38,
+           "column": 64
+          },
+          "name": "field5",
+          "value": {
+           "sourceReference": {
+            "line": 38,
+            "column": 64
+           },
+           "optionValue": {
+            "value": {
+             "sourceReference": {
+              "line": 0,
+              "column": 0
+             },
+             "int64Value": "3"
+            }
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 39,
+           "column": 5
+          },
+          "name": "field6",
+          "value": {
+           "sourceReference": {
+            "line": 39,
             "column": 5
            },
-           "name": "field1",
-           "value": {
-            "sourceReference": {
-             "line": 42,
-             "column": 5
-            },
-            "optionValue": {
-             "value": {
+           "optionValue": {
+            "value": {
+             "sourceReference": {
+              "line": 0,
+              "column": 0
+             },
+             "doubleValue": -15.5
+            }
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 39,
+           "column": 21
+          },
+          "name": "field7",
+          "value": {
+           "sourceReference": {
+            "line": 39,
+            "column": 21
+           },
+           "optionValue": {
+            "value": {
+             "sourceReference": {
+              "line": 0,
+              "column": 0
+             },
+             "stringValue": "bar"
+            }
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 39,
+           "column": 37
+          },
+          "name": "field8",
+          "value": {
+           "sourceReference": {
+            "line": 39,
+            "column": 37
+           },
+           "optionValue": {
+            "value": {
+             "sourceReference": {
+              "line": 0,
+              "column": 0
+             },
+             "uint32Value": 0
+            }
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 39,
+           "column": 49
+          },
+          "name": "field9",
+          "value": {
+           "sourceReference": {
+            "line": 39,
+            "column": 49
+           },
+           "optionValue": {
+            "value": {
+             "sourceReference": {
+              "line": 0,
+              "column": 0
+             },
+             "uint64Value": "1"
+            }
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 39,
+           "column": 61
+          },
+          "name": "field10",
+          "value": {
+           "sourceReference": {
+            "line": 39,
+            "column": 61
+           },
+           "optionValue": {
+            "value": {
+             "sourceReference": {
+              "line": 0,
+              "column": 0
+             },
+             "int32Value": 4
+            }
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 40,
+           "column": 5
+          },
+          "name": "field11",
+          "value": {
+           "sourceReference": {
+            "line": 40,
+            "column": 5
+           },
+           "optionValue": {
+            "value": {
+             "sourceReference": {
+              "line": 0,
+              "column": 0
+             },
+             "int64Value": "5"
+            }
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 40,
+           "column": 18
+          },
+          "name": "field12",
+          "value": {
+           "sourceReference": {
+            "line": 40,
+            "column": 18
+           },
+           "optionValue": {
+            "value": {
+             "sourceReference": {
+              "line": 0,
+              "column": 0
+             },
+             "uint32Value": 6
+            }
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 40,
+           "column": 31
+          },
+          "name": "field13",
+          "value": {
+           "sourceReference": {
+            "line": 40,
+            "column": 31
+           },
+           "optionValue": {
+            "value": {
+             "sourceReference": {
+              "line": 0,
+              "column": 0
+             },
+             "uint64Value": "7"
+            }
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 40,
+           "column": 44
+          },
+          "name": "field14",
+          "value": {
+           "sourceReference": {
+            "line": 40,
+            "column": 44
+           },
+           "optionValue": {
+            "value": {
+             "sourceReference": {
+              "line": 0,
+              "column": 0
+             },
+             "int32Value": -8
+            }
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 40,
+           "column": 58
+          },
+          "name": "field15",
+          "value": {
+           "sourceReference": {
+            "line": 40,
+            "column": 58
+           },
+           "optionValue": {
+            "value": {
+             "sourceReference": {
+              "line": 0,
+              "column": 0
+             },
+             "int64Value": "-9"
+            }
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 41,
+           "column": 5
+          },
+          "name": "field16",
+          "value": {
+           "sourceReference": {
+            "line": 41,
+            "column": 5
+           },
+           "optionValue": {
+            "value": {
+             "sourceReference": {
+              "line": 0,
+              "column": 0
+             },
+             "entityIdValue": "10"
+            }
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 41,
+           "column": 19
+          },
+          "name": "field17",
+          "value": {
+           "sourceReference": {
+            "line": 41,
+            "column": 19
+           },
+           "optionValue": {
+            "value": {
+             "sourceReference": {
+              "line": 0,
+              "column": 0
+             },
+             "typeValue": {
+              "type": "improbable.test_schema.SomeType",
+              "fields": []
+             }
+            }
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 41,
+           "column": 39
+          },
+          "name": "field18",
+          "value": {
+           "sourceReference": {
+            "line": 41,
+            "column": 39
+           },
+           "optionValue": {
+            "value": {
+             "sourceReference": {
+              "line": 0,
+              "column": 0
+             },
+             "enumValue": {
+              "enum": "improbable.test_schema.SomeEnum",
+              "value": "FOO"
+             }
+            }
+           }
+          }
+         }
+        ]
+       }
+      }
+     ],
+     "qualifiedName": "improbable.test_schema.ExhaustiveOptionalData",
+     "name": "ExhaustiveOptionalData",
+     "outerType": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 43,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field1",
+       "fieldId": 1,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "primitive": "Bool"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 44,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field2",
+       "fieldId": 2,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "primitive": "Float"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 45,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field3",
+       "fieldId": 3,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "primitive": "Bytes"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 46,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field4",
+       "fieldId": 4,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "primitive": "Int32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 47,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field5",
+       "fieldId": 5,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "primitive": "Int64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 48,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field6",
+       "fieldId": 6,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "primitive": "Double"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 49,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field7",
+       "fieldId": 7,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "primitive": "String"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 50,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field8",
+       "fieldId": 8,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "primitive": "Uint32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 51,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field9",
+       "fieldId": 9,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "primitive": "Uint64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 52,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field10",
+       "fieldId": 10,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "primitive": "Sint32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 53,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field11",
+       "fieldId": 11,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "primitive": "Sint64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 54,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field12",
+       "fieldId": 12,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "primitive": "Fixed32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 55,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field13",
+       "fieldId": 13,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "primitive": "Fixed64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 56,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field14",
+       "fieldId": 14,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "primitive": "Sfixed32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 57,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field15",
+       "fieldId": 15,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "primitive": "Sfixed64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 58,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field16",
+       "fieldId": 16,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "primitive": "EntityId"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 59,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field17",
+       "fieldId": 17,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "type": "improbable.test_schema.SomeType"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 60,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field18",
+       "fieldId": 18,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "enum": "improbable.test_schema.SomeEnum"
+        }
+       }
+      }
+     ]
+    },
+    {
+     "sourceReference": {
+      "line": 73,
+      "column": 1
+     },
+     "annotations": [
+      {
+       "sourceReference": {
+        "line": 68,
+        "column": 1
+       },
+       "typeValue": {
+        "type": "improbable.test_schema.ExhaustiveRepeatedData",
+        "fields": [
+         {
+          "sourceReference": {
+           "line": 69,
+           "column": 5
+          },
+          "name": "field1",
+          "value": {
+           "sourceReference": {
+            "line": 69,
+            "column": 5
+           },
+           "listValue": {
+            "values": [
+             {
               "sourceReference": {
-               "line": 0,
-               "column": 0
+               "line": 69,
+               "column": 15
               },
               "boolValue": true
              }
-            }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 69,
+           "column": 22
           },
-          {
+          "name": "field2",
+          "value": {
            "sourceReference": {
-            "line": 42,
-            "column": 20
+            "line": 69,
+            "column": 22
            },
-           "name": "field2",
-           "value": {
-            "sourceReference": {
-             "line": 42,
-             "column": 20
-            },
-            "optionValue": {
-             "value": {
+           "listValue": {
+            "values": [
+             {
               "sourceReference": {
-               "line": 0,
-               "column": 0
+               "line": 69,
+               "column": 32
               },
               "floatValue": 10.5
              }
-            }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 69,
+           "column": 39
           },
-          {
+          "name": "field3",
+          "value": {
            "sourceReference": {
-            "line": 42,
-            "column": 35
+            "line": 69,
+            "column": 39
            },
-           "name": "field3",
-           "value": {
-            "sourceReference": {
-             "line": 42,
-             "column": 35
-            },
-            "optionValue": {
-             "value": {
+           "listValue": {
+            "values": [
+             {
               "sourceReference": {
-               "line": 0,
-               "column": 0
+               "line": 69,
+               "column": 49
               },
               "bytesValue": "Zm9v"
              }
-            }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 69,
+           "column": 57
           },
-          {
+          "name": "field4",
+          "value": {
            "sourceReference": {
-            "line": 42,
-            "column": 51
+            "line": 69,
+            "column": 57
            },
-           "name": "field4",
-           "value": {
-            "sourceReference": {
-             "line": 42,
-             "column": 51
-            },
-            "optionValue": {
-             "value": {
+           "listValue": {
+            "values": [
+             {
               "sourceReference": {
-               "line": 0,
-               "column": 0
+               "line": 69,
+               "column": 67
               },
               "int32Value": -2
              }
-            }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 69,
+           "column": 72
           },
-          {
+          "name": "field5",
+          "value": {
            "sourceReference": {
-            "line": 42,
-            "column": 64
+            "line": 69,
+            "column": 72
            },
-           "name": "field5",
-           "value": {
-            "sourceReference": {
-             "line": 42,
-             "column": 64
-            },
-            "optionValue": {
-             "value": {
+           "listValue": {
+            "values": [
+             {
               "sourceReference": {
-               "line": 0,
-               "column": 0
+               "line": 69,
+               "column": 82
               },
               "int64Value": "3"
              }
-            }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 70,
+           "column": 5
           },
-          {
+          "name": "field6",
+          "value": {
            "sourceReference": {
-            "line": 43,
+            "line": 70,
             "column": 5
            },
-           "name": "field6",
-           "value": {
-            "sourceReference": {
-             "line": 43,
-             "column": 5
-            },
-            "optionValue": {
-             "value": {
+           "listValue": {
+            "values": [
+             {
               "sourceReference": {
-               "line": 0,
-               "column": 0
+               "line": 70,
+               "column": 15
               },
               "doubleValue": -15.5
              }
-            }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 70,
+           "column": 23
           },
-          {
+          "name": "field7",
+          "value": {
            "sourceReference": {
-            "line": 43,
-            "column": 21
+            "line": 70,
+            "column": 23
            },
-           "name": "field7",
-           "value": {
-            "sourceReference": {
-             "line": 43,
-             "column": 21
-            },
-            "optionValue": {
-             "value": {
+           "listValue": {
+            "values": [
+             {
               "sourceReference": {
-               "line": 0,
-               "column": 0
+               "line": 70,
+               "column": 33
               },
               "stringValue": "bar"
              }
-            }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 70,
+           "column": 41
           },
-          {
+          "name": "field8",
+          "value": {
            "sourceReference": {
-            "line": 43,
-            "column": 37
+            "line": 70,
+            "column": 41
            },
-           "name": "field8",
-           "value": {
-            "sourceReference": {
-             "line": 43,
-             "column": 37
-            },
-            "optionValue": {
-             "value": {
+           "listValue": {
+            "values": [
+             {
               "sourceReference": {
-               "line": 0,
-               "column": 0
+               "line": 70,
+               "column": 51
               },
               "uint32Value": 0
              }
-            }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 70,
+           "column": 55
           },
-          {
+          "name": "field9",
+          "value": {
            "sourceReference": {
-            "line": 43,
-            "column": 49
+            "line": 70,
+            "column": 55
            },
-           "name": "field9",
-           "value": {
-            "sourceReference": {
-             "line": 43,
-             "column": 49
-            },
-            "optionValue": {
-             "value": {
+           "listValue": {
+            "values": [
+             {
               "sourceReference": {
-               "line": 0,
-               "column": 0
+               "line": 70,
+               "column": 65
               },
               "uint64Value": "1"
              }
-            }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 70,
+           "column": 69
           },
-          {
+          "name": "field10",
+          "value": {
            "sourceReference": {
-            "line": 43,
-            "column": 61
+            "line": 70,
+            "column": 69
            },
-           "name": "field10",
-           "value": {
-            "sourceReference": {
-             "line": 43,
-             "column": 61
-            },
-            "optionValue": {
-             "value": {
+           "listValue": {
+            "values": [
+             {
               "sourceReference": {
-               "line": 0,
-               "column": 0
+               "line": 70,
+               "column": 80
               },
               "int32Value": 4
              }
-            }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 71,
+           "column": 5
           },
-          {
+          "name": "field11",
+          "value": {
            "sourceReference": {
-            "line": 44,
+            "line": 71,
             "column": 5
            },
-           "name": "field11",
-           "value": {
-            "sourceReference": {
-             "line": 44,
-             "column": 5
-            },
-            "optionValue": {
-             "value": {
+           "listValue": {
+            "values": [
+             {
               "sourceReference": {
-               "line": 0,
-               "column": 0
+               "line": 71,
+               "column": 16
               },
               "int64Value": "5"
              }
-            }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 71,
+           "column": 20
           },
-          {
+          "name": "field12",
+          "value": {
            "sourceReference": {
-            "line": 44,
-            "column": 18
+            "line": 71,
+            "column": 20
            },
-           "name": "field12",
-           "value": {
-            "sourceReference": {
-             "line": 44,
-             "column": 18
-            },
-            "optionValue": {
-             "value": {
+           "listValue": {
+            "values": [
+             {
               "sourceReference": {
-               "line": 0,
-               "column": 0
+               "line": 71,
+               "column": 31
               },
               "uint32Value": 6
              }
-            }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 71,
+           "column": 35
           },
-          {
+          "name": "field13",
+          "value": {
            "sourceReference": {
-            "line": 44,
-            "column": 31
+            "line": 71,
+            "column": 35
            },
-           "name": "field13",
-           "value": {
-            "sourceReference": {
-             "line": 44,
-             "column": 31
-            },
-            "optionValue": {
-             "value": {
+           "listValue": {
+            "values": [
+             {
               "sourceReference": {
-               "line": 0,
-               "column": 0
+               "line": 71,
+               "column": 46
               },
               "uint64Value": "7"
              }
-            }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 71,
+           "column": 50
           },
-          {
+          "name": "field14",
+          "value": {
            "sourceReference": {
-            "line": 44,
-            "column": 44
+            "line": 71,
+            "column": 50
            },
-           "name": "field14",
-           "value": {
-            "sourceReference": {
-             "line": 44,
-             "column": 44
-            },
-            "optionValue": {
-             "value": {
+           "listValue": {
+            "values": [
+             {
               "sourceReference": {
-               "line": 0,
-               "column": 0
+               "line": 71,
+               "column": 61
               },
               "int32Value": -8
              }
-            }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 71,
+           "column": 66
           },
-          {
+          "name": "field15",
+          "value": {
            "sourceReference": {
-            "line": 44,
-            "column": 58
+            "line": 71,
+            "column": 66
            },
-           "name": "field15",
-           "value": {
-            "sourceReference": {
-             "line": 44,
-             "column": 58
-            },
-            "optionValue": {
-             "value": {
+           "listValue": {
+            "values": [
+             {
               "sourceReference": {
-               "line": 0,
-               "column": 0
+               "line": 71,
+               "column": 77
               },
               "int64Value": "-9"
              }
-            }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 72,
+           "column": 5
           },
-          {
+          "name": "field16",
+          "value": {
            "sourceReference": {
-            "line": 45,
+            "line": 72,
             "column": 5
            },
-           "name": "field16",
-           "value": {
-            "sourceReference": {
-             "line": 45,
-             "column": 5
-            },
-            "optionValue": {
-             "value": {
+           "listValue": {
+            "values": [
+             {
               "sourceReference": {
-               "line": 0,
-               "column": 0
+               "line": 72,
+               "column": 16
               },
               "entityIdValue": "10"
              }
-            }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 72,
+           "column": 21
           },
-          {
+          "name": "field17",
+          "value": {
            "sourceReference": {
-            "line": 45,
-            "column": 19
+            "line": 72,
+            "column": 21
            },
-           "name": "field17",
-           "value": {
-            "sourceReference": {
-             "line": 45,
-             "column": 19
-            },
-            "optionValue": {
-             "value": {
+           "listValue": {
+            "values": [
+             {
               "sourceReference": {
-               "line": 0,
-               "column": 0
+               "line": 72,
+               "column": 32
               },
               "typeValue": {
-               "type": "improbable.gdk.tests.SomeType",
+               "type": "improbable.test_schema.SomeType",
                "fields": []
               }
              }
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 45,
-            "column": 39
-           },
-           "name": "field18",
-           "value": {
-            "sourceReference": {
-             "line": 45,
-             "column": 39
-            },
-            "optionValue": {
-             "value": {
-              "sourceReference": {
-               "line": 0,
-               "column": 0
-              },
-              "enumValue": {
-               "enum": "improbable.gdk.tests.SomeEnum",
-               "value": "FIRST_VALUE"
-              }
-             }
-            }
+            ]
            }
           }
-         ]
-        }
-       }
-      ],
-      "qualifiedName": "improbable.gdk.tests.ExhaustiveOptionalData",
-      "name": "ExhaustiveOptionalData",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 47,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field1",
-        "fieldId": 1,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "primitive": "Bool"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 48,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field2",
-        "fieldId": 2,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "primitive": "Float"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 49,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field3",
-        "fieldId": 3,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "primitive": "Bytes"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 50,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field4",
-        "fieldId": 4,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "primitive": "Int32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 51,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field5",
-        "fieldId": 5,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "primitive": "Int64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 52,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field6",
-        "fieldId": 6,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "primitive": "Double"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 53,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field7",
-        "fieldId": 7,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 54,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field8",
-        "fieldId": 8,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "primitive": "Uint32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 55,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field9",
-        "fieldId": 9,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "primitive": "Uint64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 56,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field10",
-        "fieldId": 10,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "primitive": "Sint32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 57,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field11",
-        "fieldId": 11,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "primitive": "Sint64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 58,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field12",
-        "fieldId": 12,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "primitive": "Fixed32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 59,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field13",
-        "fieldId": 13,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "primitive": "Fixed64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 60,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field14",
-        "fieldId": 14,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "primitive": "Sfixed32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 61,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field15",
-        "fieldId": 15,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "primitive": "Sfixed64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 62,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field16",
-        "fieldId": 16,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "primitive": "EntityId"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 63,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field17",
-        "fieldId": 17,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "type": "improbable.gdk.tests.SomeType"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 64,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field18",
-        "fieldId": 18,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "enum": "improbable.gdk.tests.SomeEnum"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 77,
-       "column": 1
-      },
-      "annotations": [
-       {
-        "sourceReference": {
-         "line": 72,
-         "column": 1
-        },
-        "typeValue": {
-         "type": "improbable.gdk.tests.ExhaustiveRepeatedData",
-         "fields": [
-          {
+         },
+         {
+          "sourceReference": {
+           "line": 72,
+           "column": 43
+          },
+          "name": "field18",
+          "value": {
            "sourceReference": {
-            "line": 73,
+            "line": 72,
+            "column": 43
+           },
+           "listValue": {
+            "values": [
+             {
+              "sourceReference": {
+               "line": 72,
+               "column": 54
+              },
+              "enumValue": {
+               "enum": "improbable.test_schema.SomeEnum",
+               "value": "FOO"
+              }
+             }
+            ]
+           }
+          }
+         }
+        ]
+       }
+      }
+     ],
+     "qualifiedName": "improbable.test_schema.ExhaustiveRepeatedData",
+     "name": "ExhaustiveRepeatedData",
+     "outerType": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 74,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field1",
+       "fieldId": 1,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "primitive": "Bool"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 75,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field2",
+       "fieldId": 2,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "primitive": "Float"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 76,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field3",
+       "fieldId": 3,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "primitive": "Bytes"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 77,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field4",
+       "fieldId": 4,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "primitive": "Int32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 78,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field5",
+       "fieldId": 5,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "primitive": "Int64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 79,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field6",
+       "fieldId": 6,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "primitive": "Double"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 80,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field7",
+       "fieldId": 7,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "primitive": "String"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 81,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field8",
+       "fieldId": 8,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "primitive": "Uint32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 82,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field9",
+       "fieldId": 9,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "primitive": "Uint64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 83,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field10",
+       "fieldId": 10,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "primitive": "Sint32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 84,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field11",
+       "fieldId": 11,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "primitive": "Sint64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 85,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field12",
+       "fieldId": 12,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "primitive": "Fixed32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 86,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field13",
+       "fieldId": 13,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "primitive": "Fixed64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 87,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field14",
+       "fieldId": 14,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "primitive": "Sfixed32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 88,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field15",
+       "fieldId": 15,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "primitive": "Sfixed64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 89,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field16",
+       "fieldId": 16,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "primitive": "EntityId"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 90,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field17",
+       "fieldId": 17,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "type": "improbable.test_schema.SomeType"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 91,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field18",
+       "fieldId": 18,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "enum": "improbable.test_schema.SomeEnum"
+        }
+       }
+      }
+     ]
+    },
+    {
+     "sourceReference": {
+      "line": 104,
+      "column": 1
+     },
+     "annotations": [
+      {
+       "sourceReference": {
+        "line": 99,
+        "column": 1
+       },
+       "typeValue": {
+        "type": "improbable.test_schema.ExhaustiveMapValueData",
+        "fields": [
+         {
+          "sourceReference": {
+           "line": 100,
+           "column": 5
+          },
+          "name": "field1",
+          "value": {
+           "sourceReference": {
+            "line": 100,
             "column": 5
            },
-           "name": "field1",
-           "value": {
-            "sourceReference": {
-             "line": 73,
-             "column": 5
-            },
-            "listValue": {
-             "values": [
-              {
+           "mapValue": {
+            "values": [
+             {
+              "key": {
                "sourceReference": {
-                "line": 73,
-                "column": 15
+                "line": 100,
+                "column": 6
+               },
+               "stringValue": "field1"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 100,
+                "column": 17
                },
                "boolValue": true
               }
-             ]
-            }
+             }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 100,
+           "column": 24
           },
-          {
+          "name": "field2",
+          "value": {
            "sourceReference": {
-            "line": 73,
-            "column": 22
+            "line": 100,
+            "column": 24
            },
-           "name": "field2",
-           "value": {
-            "sourceReference": {
-             "line": 73,
-             "column": 22
-            },
-            "listValue": {
-             "values": [
-              {
+           "mapValue": {
+            "values": [
+             {
+              "key": {
                "sourceReference": {
-                "line": 73,
-                "column": 32
+                "line": 100,
+                "column": 25
+               },
+               "stringValue": "field2"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 100,
+                "column": 36
                },
                "floatValue": 10.5
               }
-             ]
-            }
+             }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 100,
+           "column": 43
           },
-          {
+          "name": "field3",
+          "value": {
            "sourceReference": {
-            "line": 73,
-            "column": 39
+            "line": 100,
+            "column": 43
            },
-           "name": "field3",
-           "value": {
-            "sourceReference": {
-             "line": 73,
-             "column": 39
-            },
-            "listValue": {
-             "values": [
-              {
+           "mapValue": {
+            "values": [
+             {
+              "key": {
                "sourceReference": {
-                "line": 73,
-                "column": 49
+                "line": 100,
+                "column": 44
+               },
+               "stringValue": "field3"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 100,
+                "column": 55
                },
                "bytesValue": "Zm9v"
               }
-             ]
-            }
+             }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 100,
+           "column": 63
           },
-          {
+          "name": "field4",
+          "value": {
            "sourceReference": {
-            "line": 73,
-            "column": 57
+            "line": 100,
+            "column": 63
            },
-           "name": "field4",
-           "value": {
-            "sourceReference": {
-             "line": 73,
-             "column": 57
-            },
-            "listValue": {
-             "values": [
-              {
+           "mapValue": {
+            "values": [
+             {
+              "key": {
                "sourceReference": {
-                "line": 73,
-                "column": 67
+                "line": 100,
+                "column": 64
+               },
+               "stringValue": "field4"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 100,
+                "column": 75
                },
                "int32Value": -2
               }
-             ]
-            }
+             }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 100,
+           "column": 80
           },
-          {
+          "name": "field5",
+          "value": {
            "sourceReference": {
-            "line": 73,
-            "column": 72
+            "line": 100,
+            "column": 80
            },
-           "name": "field5",
-           "value": {
-            "sourceReference": {
-             "line": 73,
-             "column": 72
-            },
-            "listValue": {
-             "values": [
-              {
+           "mapValue": {
+            "values": [
+             {
+              "key": {
                "sourceReference": {
-                "line": 73,
-                "column": 82
+                "line": 100,
+                "column": 81
+               },
+               "stringValue": "field5"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 100,
+                "column": 92
                },
                "int64Value": "3"
               }
-             ]
-            }
+             }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 101,
+           "column": 5
           },
-          {
+          "name": "field6",
+          "value": {
            "sourceReference": {
-            "line": 74,
+            "line": 101,
             "column": 5
            },
-           "name": "field6",
-           "value": {
-            "sourceReference": {
-             "line": 74,
-             "column": 5
-            },
-            "listValue": {
-             "values": [
-              {
+           "mapValue": {
+            "values": [
+             {
+              "key": {
                "sourceReference": {
-                "line": 74,
-                "column": 15
+                "line": 101,
+                "column": 6
+               },
+               "stringValue": "field6"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 101,
+                "column": 17
                },
                "doubleValue": -15.5
               }
-             ]
-            }
+             }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 101,
+           "column": 25
           },
-          {
+          "name": "field7",
+          "value": {
            "sourceReference": {
-            "line": 74,
-            "column": 23
+            "line": 101,
+            "column": 25
            },
-           "name": "field7",
-           "value": {
-            "sourceReference": {
-             "line": 74,
-             "column": 23
-            },
-            "listValue": {
-             "values": [
-              {
+           "mapValue": {
+            "values": [
+             {
+              "key": {
                "sourceReference": {
-                "line": 74,
-                "column": 33
+                "line": 101,
+                "column": 26
+               },
+               "stringValue": "field7"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 101,
+                "column": 37
                },
                "stringValue": "bar"
               }
-             ]
-            }
+             }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 101,
+           "column": 45
           },
-          {
+          "name": "field8",
+          "value": {
            "sourceReference": {
-            "line": 74,
-            "column": 41
+            "line": 101,
+            "column": 45
            },
-           "name": "field8",
-           "value": {
-            "sourceReference": {
-             "line": 74,
-             "column": 41
-            },
-            "listValue": {
-             "values": [
-              {
+           "mapValue": {
+            "values": [
+             {
+              "key": {
                "sourceReference": {
-                "line": 74,
-                "column": 51
+                "line": 101,
+                "column": 46
+               },
+               "stringValue": "field8"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 101,
+                "column": 57
                },
                "uint32Value": 0
               }
-             ]
-            }
+             }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 101,
+           "column": 61
           },
-          {
+          "name": "field9",
+          "value": {
            "sourceReference": {
-            "line": 74,
-            "column": 55
+            "line": 101,
+            "column": 61
            },
-           "name": "field9",
-           "value": {
-            "sourceReference": {
-             "line": 74,
-             "column": 55
-            },
-            "listValue": {
-             "values": [
-              {
+           "mapValue": {
+            "values": [
+             {
+              "key": {
                "sourceReference": {
-                "line": 74,
-                "column": 65
+                "line": 101,
+                "column": 62
+               },
+               "stringValue": "field9"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 101,
+                "column": 73
                },
                "uint64Value": "1"
               }
-             ]
-            }
+             }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 101,
+           "column": 77
           },
-          {
+          "name": "field10",
+          "value": {
            "sourceReference": {
-            "line": 74,
-            "column": 69
+            "line": 101,
+            "column": 77
            },
-           "name": "field10",
-           "value": {
-            "sourceReference": {
-             "line": 74,
-             "column": 69
-            },
-            "listValue": {
-             "values": [
-              {
+           "mapValue": {
+            "values": [
+             {
+              "key": {
                "sourceReference": {
-                "line": 74,
-                "column": 80
+                "line": 101,
+                "column": 78
+               },
+               "stringValue": "field10"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 101,
+                "column": 90
                },
                "int32Value": 4
               }
-             ]
-            }
+             }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 102,
+           "column": 5
           },
-          {
+          "name": "field11",
+          "value": {
            "sourceReference": {
-            "line": 75,
+            "line": 102,
             "column": 5
            },
-           "name": "field11",
-           "value": {
-            "sourceReference": {
-             "line": 75,
-             "column": 5
-            },
-            "listValue": {
-             "values": [
-              {
+           "mapValue": {
+            "values": [
+             {
+              "key": {
                "sourceReference": {
-                "line": 75,
-                "column": 16
+                "line": 102,
+                "column": 6
+               },
+               "stringValue": "field11"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 102,
+                "column": 18
                },
                "int64Value": "5"
               }
-             ]
-            }
+             }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 102,
+           "column": 22
           },
-          {
+          "name": "field12",
+          "value": {
            "sourceReference": {
-            "line": 75,
-            "column": 20
+            "line": 102,
+            "column": 22
            },
-           "name": "field12",
-           "value": {
-            "sourceReference": {
-             "line": 75,
-             "column": 20
-            },
-            "listValue": {
-             "values": [
-              {
+           "mapValue": {
+            "values": [
+             {
+              "key": {
                "sourceReference": {
-                "line": 75,
-                "column": 31
+                "line": 102,
+                "column": 23
+               },
+               "stringValue": "field12"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 102,
+                "column": 35
                },
                "uint32Value": 6
               }
-             ]
-            }
+             }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 102,
+           "column": 39
           },
-          {
+          "name": "field13",
+          "value": {
            "sourceReference": {
-            "line": 75,
-            "column": 35
+            "line": 102,
+            "column": 39
            },
-           "name": "field13",
-           "value": {
-            "sourceReference": {
-             "line": 75,
-             "column": 35
-            },
-            "listValue": {
-             "values": [
-              {
+           "mapValue": {
+            "values": [
+             {
+              "key": {
                "sourceReference": {
-                "line": 75,
-                "column": 46
+                "line": 102,
+                "column": 40
+               },
+               "stringValue": "field13"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 102,
+                "column": 52
                },
                "uint64Value": "7"
               }
-             ]
-            }
+             }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 102,
+           "column": 56
           },
-          {
+          "name": "field14",
+          "value": {
            "sourceReference": {
-            "line": 75,
-            "column": 50
+            "line": 102,
+            "column": 56
            },
-           "name": "field14",
-           "value": {
-            "sourceReference": {
-             "line": 75,
-             "column": 50
-            },
-            "listValue": {
-             "values": [
-              {
+           "mapValue": {
+            "values": [
+             {
+              "key": {
                "sourceReference": {
-                "line": 75,
-                "column": 61
+                "line": 102,
+                "column": 57
+               },
+               "stringValue": "field14"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 102,
+                "column": 69
                },
                "int32Value": -8
               }
-             ]
-            }
+             }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 102,
+           "column": 74
           },
-          {
+          "name": "field15",
+          "value": {
            "sourceReference": {
-            "line": 75,
-            "column": 66
+            "line": 102,
+            "column": 74
            },
-           "name": "field15",
-           "value": {
-            "sourceReference": {
-             "line": 75,
-             "column": 66
-            },
-            "listValue": {
-             "values": [
-              {
+           "mapValue": {
+            "values": [
+             {
+              "key": {
                "sourceReference": {
-                "line": 75,
-                "column": 77
+                "line": 102,
+                "column": 75
+               },
+               "stringValue": "field15"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 102,
+                "column": 87
                },
                "int64Value": "-9"
               }
-             ]
-            }
+             }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 103,
+           "column": 5
           },
-          {
+          "name": "field16",
+          "value": {
            "sourceReference": {
-            "line": 76,
+            "line": 103,
             "column": 5
            },
-           "name": "field16",
-           "value": {
-            "sourceReference": {
-             "line": 76,
-             "column": 5
-            },
-            "listValue": {
-             "values": [
-              {
+           "mapValue": {
+            "values": [
+             {
+              "key": {
                "sourceReference": {
-                "line": 76,
-                "column": 16
+                "line": 103,
+                "column": 6
+               },
+               "stringValue": "field16"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 103,
+                "column": 18
                },
                "entityIdValue": "10"
               }
-             ]
-            }
+             }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 103,
+           "column": 23
           },
-          {
+          "name": "field17",
+          "value": {
            "sourceReference": {
-            "line": 76,
-            "column": 21
+            "line": 103,
+            "column": 23
            },
-           "name": "field17",
-           "value": {
-            "sourceReference": {
-             "line": 76,
-             "column": 21
-            },
-            "listValue": {
-             "values": [
-              {
+           "mapValue": {
+            "values": [
+             {
+              "key": {
                "sourceReference": {
-                "line": 76,
-                "column": 32
+                "line": 103,
+                "column": 24
+               },
+               "stringValue": "field17"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 103,
+                "column": 36
                },
                "typeValue": {
-                "type": "improbable.gdk.tests.SomeType",
+                "type": "improbable.test_schema.SomeType",
                 "fields": []
                }
               }
-             ]
-            }
+             }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 103,
+           "column": 47
           },
-          {
+          "name": "field18",
+          "value": {
            "sourceReference": {
-            "line": 76,
-            "column": 43
+            "line": 103,
+            "column": 47
            },
-           "name": "field18",
-           "value": {
-            "sourceReference": {
-             "line": 76,
-             "column": 43
-            },
-            "listValue": {
-             "values": [
-              {
+           "mapValue": {
+            "values": [
+             {
+              "key": {
                "sourceReference": {
-                "line": 76,
-                "column": 54
+                "line": 103,
+                "column": 48
+               },
+               "stringValue": "field18"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 103,
+                "column": 60
                },
                "enumValue": {
-                "enum": "improbable.gdk.tests.SomeEnum",
-                "value": "FIRST_VALUE"
+                "enum": "improbable.test_schema.SomeEnum",
+                "value": "FOO"
                }
               }
-             ]
-            }
+             }
+            ]
            }
           }
-         ]
+         }
+        ]
+       }
+      }
+     ],
+     "qualifiedName": "improbable.test_schema.ExhaustiveMapValueData",
+     "name": "ExhaustiveMapValueData",
+     "outerType": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 105,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field1",
+       "fieldId": 1,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "String"
+        },
+        "valueType": {
+         "primitive": "Bool"
         }
        }
-      ],
-      "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeatedData",
-      "name": "ExhaustiveRepeatedData",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 78,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field1",
-        "fieldId": 1,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "primitive": "Bool"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 79,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field2",
-        "fieldId": 2,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "primitive": "Float"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 80,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field3",
-        "fieldId": 3,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "primitive": "Bytes"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 81,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field4",
-        "fieldId": 4,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "primitive": "Int32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 82,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field5",
-        "fieldId": 5,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "primitive": "Int64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 83,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field6",
-        "fieldId": 6,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "primitive": "Double"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 84,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field7",
-        "fieldId": 7,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 85,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field8",
-        "fieldId": 8,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "primitive": "Uint32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 86,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field9",
-        "fieldId": 9,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "primitive": "Uint64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 87,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field10",
-        "fieldId": 10,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "primitive": "Sint32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 88,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field11",
-        "fieldId": 11,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "primitive": "Sint64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 89,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field12",
-        "fieldId": 12,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "primitive": "Fixed32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 90,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field13",
-        "fieldId": 13,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "primitive": "Fixed64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 91,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field14",
-        "fieldId": 14,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "primitive": "Sfixed32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 92,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field15",
-        "fieldId": 15,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "primitive": "Sfixed64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 93,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field16",
-        "fieldId": 16,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "primitive": "EntityId"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 94,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field17",
-        "fieldId": 17,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "type": "improbable.gdk.tests.SomeType"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 95,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field18",
-        "fieldId": 18,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "enum": "improbable.gdk.tests.SomeEnum"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 108,
-       "column": 1
       },
-      "annotations": [
-       {
-        "sourceReference": {
-         "line": 103,
-         "column": 1
+      {
+       "sourceReference": {
+        "line": 106,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field2",
+       "fieldId": 2,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "String"
         },
-        "typeValue": {
-         "type": "improbable.gdk.tests.ExhaustiveMapValueData",
-         "fields": [
-          {
+        "valueType": {
+         "primitive": "Float"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 107,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field3",
+       "fieldId": 3,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "String"
+        },
+        "valueType": {
+         "primitive": "Bytes"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 108,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field4",
+       "fieldId": 4,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "String"
+        },
+        "valueType": {
+         "primitive": "Int32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 109,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field5",
+       "fieldId": 5,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "String"
+        },
+        "valueType": {
+         "primitive": "Int64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 110,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field6",
+       "fieldId": 6,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "String"
+        },
+        "valueType": {
+         "primitive": "Double"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 111,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field7",
+       "fieldId": 7,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "String"
+        },
+        "valueType": {
+         "primitive": "String"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 112,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field8",
+       "fieldId": 8,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "String"
+        },
+        "valueType": {
+         "primitive": "Uint32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 113,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field9",
+       "fieldId": 9,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "String"
+        },
+        "valueType": {
+         "primitive": "Uint64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 114,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field10",
+       "fieldId": 10,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "String"
+        },
+        "valueType": {
+         "primitive": "Sint32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 115,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field11",
+       "fieldId": 11,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "String"
+        },
+        "valueType": {
+         "primitive": "Sint64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 116,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field12",
+       "fieldId": 12,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "String"
+        },
+        "valueType": {
+         "primitive": "Fixed32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 117,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field13",
+       "fieldId": 13,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "String"
+        },
+        "valueType": {
+         "primitive": "Fixed64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 118,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field14",
+       "fieldId": 14,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "String"
+        },
+        "valueType": {
+         "primitive": "Sfixed32"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 119,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field15",
+       "fieldId": 15,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "String"
+        },
+        "valueType": {
+         "primitive": "Sfixed64"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 120,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field16",
+       "fieldId": 16,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "String"
+        },
+        "valueType": {
+         "primitive": "EntityId"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 121,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field17",
+       "fieldId": 17,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "String"
+        },
+        "valueType": {
+         "type": "improbable.test_schema.SomeType"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 122,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field18",
+       "fieldId": 18,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "String"
+        },
+        "valueType": {
+         "enum": "improbable.test_schema.SomeEnum"
+        }
+       }
+      }
+     ]
+    },
+    {
+     "sourceReference": {
+      "line": 135,
+      "column": 1
+     },
+     "annotations": [
+      {
+       "sourceReference": {
+        "line": 130,
+        "column": 1
+       },
+       "typeValue": {
+        "type": "improbable.test_schema.ExhaustiveMapKeyData",
+        "fields": [
+         {
+          "sourceReference": {
+           "line": 131,
+           "column": 5
+          },
+          "name": "field1",
+          "value": {
            "sourceReference": {
-            "line": 104,
+            "line": 131,
             "column": 5
            },
-           "name": "field1",
-           "value": {
-            "sourceReference": {
-             "line": 104,
-             "column": 5
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 104,
-                 "column": 6
-                },
-                "stringValue": "field1"
+           "mapValue": {
+            "values": [
+             {
+              "key": {
+               "sourceReference": {
+                "line": 131,
+                "column": 6
                },
-               "value": {
-                "sourceReference": {
-                 "line": 104,
-                 "column": 17
-                },
-                "boolValue": true
-               }
+               "boolValue": true
+              },
+              "value": {
+               "sourceReference": {
+                "line": 131,
+                "column": 13
+               },
+               "stringValue": "field1"
               }
-             ]
-            }
+             }
+            ]
            }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 131,
+           "column": 24
           },
-          {
+          "name": "field2",
+          "value": {
            "sourceReference": {
-            "line": 104,
+            "line": 131,
             "column": 24
            },
-           "name": "field2",
-           "value": {
-            "sourceReference": {
-             "line": 104,
-             "column": 24
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 104,
-                 "column": 25
-                },
-                "stringValue": "field2"
+           "mapValue": {
+            "values": [
+             {
+              "key": {
+               "sourceReference": {
+                "line": 131,
+                "column": 25
                },
-               "value": {
-                "sourceReference": {
-                 "line": 104,
-                 "column": 36
-                },
-                "floatValue": 10.5
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 104,
-            "column": 43
-           },
-           "name": "field3",
-           "value": {
-            "sourceReference": {
-             "line": 104,
-             "column": 43
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 104,
-                 "column": 44
-                },
-                "stringValue": "field3"
+               "floatValue": 10.5
+              },
+              "value": {
+               "sourceReference": {
+                "line": 131,
+                "column": 32
                },
-               "value": {
-                "sourceReference": {
-                 "line": 104,
-                 "column": 55
-                },
-                "bytesValue": "Zm9v"
-               }
+               "stringValue": "field2"
               }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 104,
-            "column": 63
-           },
-           "name": "field4",
-           "value": {
-            "sourceReference": {
-             "line": 104,
-             "column": 63
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 104,
-                 "column": 64
-                },
-                "stringValue": "field4"
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 104,
-                 "column": 75
-                },
-                "int32Value": -2
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 104,
-            "column": 80
-           },
-           "name": "field5",
-           "value": {
-            "sourceReference": {
-             "line": 104,
-             "column": 80
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 104,
-                 "column": 81
-                },
-                "stringValue": "field5"
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 104,
-                 "column": 92
-                },
-                "int64Value": "3"
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 105,
-            "column": 5
-           },
-           "name": "field6",
-           "value": {
-            "sourceReference": {
-             "line": 105,
-             "column": 5
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 105,
-                 "column": 6
-                },
-                "stringValue": "field6"
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 105,
-                 "column": 17
-                },
-                "doubleValue": -15.5
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 105,
-            "column": 25
-           },
-           "name": "field7",
-           "value": {
-            "sourceReference": {
-             "line": 105,
-             "column": 25
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 105,
-                 "column": 26
-                },
-                "stringValue": "field7"
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 105,
-                 "column": 37
-                },
-                "stringValue": "bar"
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 105,
-            "column": 45
-           },
-           "name": "field8",
-           "value": {
-            "sourceReference": {
-             "line": 105,
-             "column": 45
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 105,
-                 "column": 46
-                },
-                "stringValue": "field8"
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 105,
-                 "column": 57
-                },
-                "uint32Value": 0
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 105,
-            "column": 61
-           },
-           "name": "field9",
-           "value": {
-            "sourceReference": {
-             "line": 105,
-             "column": 61
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 105,
-                 "column": 62
-                },
-                "stringValue": "field9"
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 105,
-                 "column": 73
-                },
-                "uint64Value": "1"
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 105,
-            "column": 77
-           },
-           "name": "field10",
-           "value": {
-            "sourceReference": {
-             "line": 105,
-             "column": 77
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 105,
-                 "column": 78
-                },
-                "stringValue": "field10"
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 105,
-                 "column": 90
-                },
-                "int32Value": 4
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 106,
-            "column": 5
-           },
-           "name": "field11",
-           "value": {
-            "sourceReference": {
-             "line": 106,
-             "column": 5
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 106,
-                 "column": 6
-                },
-                "stringValue": "field11"
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 106,
-                 "column": 18
-                },
-                "int64Value": "5"
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 106,
-            "column": 22
-           },
-           "name": "field12",
-           "value": {
-            "sourceReference": {
-             "line": 106,
-             "column": 22
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 106,
-                 "column": 23
-                },
-                "stringValue": "field12"
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 106,
-                 "column": 35
-                },
-                "uint32Value": 6
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 106,
-            "column": 39
-           },
-           "name": "field13",
-           "value": {
-            "sourceReference": {
-             "line": 106,
-             "column": 39
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 106,
-                 "column": 40
-                },
-                "stringValue": "field13"
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 106,
-                 "column": 52
-                },
-                "uint64Value": "7"
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 106,
-            "column": 56
-           },
-           "name": "field14",
-           "value": {
-            "sourceReference": {
-             "line": 106,
-             "column": 56
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 106,
-                 "column": 57
-                },
-                "stringValue": "field14"
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 106,
-                 "column": 69
-                },
-                "int32Value": -8
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 106,
-            "column": 74
-           },
-           "name": "field15",
-           "value": {
-            "sourceReference": {
-             "line": 106,
-             "column": 74
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 106,
-                 "column": 75
-                },
-                "stringValue": "field15"
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 106,
-                 "column": 87
-                },
-                "int64Value": "-9"
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 107,
-            "column": 5
-           },
-           "name": "field16",
-           "value": {
-            "sourceReference": {
-             "line": 107,
-             "column": 5
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 107,
-                 "column": 6
-                },
-                "stringValue": "field16"
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 107,
-                 "column": 18
-                },
-                "entityIdValue": "10"
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 107,
-            "column": 23
-           },
-           "name": "field17",
-           "value": {
-            "sourceReference": {
-             "line": 107,
-             "column": 23
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 107,
-                 "column": 24
-                },
-                "stringValue": "field17"
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 107,
-                 "column": 36
-                },
-                "typeValue": {
-                 "type": "improbable.gdk.tests.SomeType",
-                 "fields": []
-                }
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 107,
-            "column": 47
-           },
-           "name": "field18",
-           "value": {
-            "sourceReference": {
-             "line": 107,
-             "column": 47
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 107,
-                 "column": 48
-                },
-                "stringValue": "field18"
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 107,
-                 "column": 60
-                },
-                "enumValue": {
-                 "enum": "improbable.gdk.tests.SomeEnum",
-                 "value": "FIRST_VALUE"
-                }
-               }
-              }
-             ]
-            }
+             }
+            ]
            }
           }
-         ]
-        }
-       }
-      ],
-      "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValueData",
-      "name": "ExhaustiveMapValueData",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 109,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field1",
-        "fieldId": 1,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "String"
          },
-         "valueType": {
-          "primitive": "Bool"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 110,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field2",
-        "fieldId": 2,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "String"
-         },
-         "valueType": {
-          "primitive": "Float"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 111,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field3",
-        "fieldId": 3,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "String"
-         },
-         "valueType": {
-          "primitive": "Bytes"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 112,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field4",
-        "fieldId": 4,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "String"
-         },
-         "valueType": {
-          "primitive": "Int32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 113,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field5",
-        "fieldId": 5,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "String"
-         },
-         "valueType": {
-          "primitive": "Int64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 114,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field6",
-        "fieldId": 6,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "String"
-         },
-         "valueType": {
-          "primitive": "Double"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 115,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field7",
-        "fieldId": 7,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "String"
-         },
-         "valueType": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 116,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field8",
-        "fieldId": 8,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "String"
-         },
-         "valueType": {
-          "primitive": "Uint32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 117,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field9",
-        "fieldId": 9,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "String"
-         },
-         "valueType": {
-          "primitive": "Uint64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 118,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field10",
-        "fieldId": 10,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "String"
-         },
-         "valueType": {
-          "primitive": "Sint32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 119,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field11",
-        "fieldId": 11,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "String"
-         },
-         "valueType": {
-          "primitive": "Sint64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 120,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field12",
-        "fieldId": 12,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "String"
-         },
-         "valueType": {
-          "primitive": "Fixed32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 121,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field13",
-        "fieldId": 13,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "String"
-         },
-         "valueType": {
-          "primitive": "Fixed64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 122,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field14",
-        "fieldId": 14,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "String"
-         },
-         "valueType": {
-          "primitive": "Sfixed32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 123,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field15",
-        "fieldId": 15,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "String"
-         },
-         "valueType": {
-          "primitive": "Sfixed64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 124,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field16",
-        "fieldId": 16,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "String"
-         },
-         "valueType": {
-          "primitive": "EntityId"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 125,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field17",
-        "fieldId": 17,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "String"
-         },
-         "valueType": {
-          "type": "improbable.gdk.tests.SomeType"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 126,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field18",
-        "fieldId": 18,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "String"
-         },
-         "valueType": {
-          "enum": "improbable.gdk.tests.SomeEnum"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 139,
-       "column": 1
-      },
-      "annotations": [
-       {
-        "sourceReference": {
-         "line": 134,
-         "column": 1
-        },
-        "typeValue": {
-         "type": "improbable.gdk.tests.ExhaustiveMapKeyData",
-         "fields": [
-          {
-           "sourceReference": {
-            "line": 135,
-            "column": 5
-           },
-           "name": "field1",
-           "value": {
-            "sourceReference": {
-             "line": 135,
-             "column": 5
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 135,
-                 "column": 6
-                },
-                "boolValue": true
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 135,
-                 "column": 13
-                },
-                "stringValue": "field1"
-               }
-              }
-             ]
-            }
-           }
+         {
+          "sourceReference": {
+           "line": 131,
+           "column": 43
           },
-          {
+          "name": "field3",
+          "value": {
            "sourceReference": {
-            "line": 135,
-            "column": 24
-           },
-           "name": "field2",
-           "value": {
-            "sourceReference": {
-             "line": 135,
-             "column": 24
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 135,
-                 "column": 25
-                },
-                "floatValue": 10.5
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 135,
-                 "column": 32
-                },
-                "stringValue": "field2"
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 135,
+            "line": 131,
             "column": 43
            },
-           "name": "field3",
-           "value": {
-            "sourceReference": {
-             "line": 135,
-             "column": 43
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 135,
-                 "column": 44
-                },
-                "bytesValue": "Zm9v"
+           "mapValue": {
+            "values": [
+             {
+              "key": {
+               "sourceReference": {
+                "line": 131,
+                "column": 44
                },
-               "value": {
-                "sourceReference": {
-                 "line": 135,
-                 "column": 52
-                },
-                "stringValue": "field3"
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 135,
-            "column": 63
-           },
-           "name": "field4",
-           "value": {
-            "sourceReference": {
-             "line": 135,
-             "column": 63
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 135,
-                 "column": 64
-                },
-                "int32Value": -2
+               "bytesValue": "Zm9v"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 131,
+                "column": 52
                },
-               "value": {
-                "sourceReference": {
-                 "line": 135,
-                 "column": 69
-                },
-                "stringValue": "field4"
-               }
+               "stringValue": "field3"
               }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 135,
-            "column": 80
-           },
-           "name": "field5",
-           "value": {
-            "sourceReference": {
-             "line": 135,
-             "column": 80
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 135,
-                 "column": 81
-                },
-                "int64Value": "3"
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 135,
-                 "column": 85
-                },
-                "stringValue": "field5"
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 136,
-            "column": 5
-           },
-           "name": "field6",
-           "value": {
-            "sourceReference": {
-             "line": 136,
-             "column": 5
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 136,
-                 "column": 6
-                },
-                "doubleValue": -15.5
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 136,
-                 "column": 14
-                },
-                "stringValue": "field6"
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 136,
-            "column": 25
-           },
-           "name": "field7",
-           "value": {
-            "sourceReference": {
-             "line": 136,
-             "column": 25
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 136,
-                 "column": 26
-                },
-                "stringValue": "bar"
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 136,
-                 "column": 34
-                },
-                "stringValue": "field7"
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 136,
-            "column": 45
-           },
-           "name": "field8",
-           "value": {
-            "sourceReference": {
-             "line": 136,
-             "column": 45
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 136,
-                 "column": 46
-                },
-                "uint32Value": 0
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 136,
-                 "column": 50
-                },
-                "stringValue": "field8"
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 136,
-            "column": 61
-           },
-           "name": "field9",
-           "value": {
-            "sourceReference": {
-             "line": 136,
-             "column": 61
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 136,
-                 "column": 62
-                },
-                "uint64Value": "1"
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 136,
-                 "column": 66
-                },
-                "stringValue": "field9"
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 136,
-            "column": 77
-           },
-           "name": "field10",
-           "value": {
-            "sourceReference": {
-             "line": 136,
-             "column": 77
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 136,
-                 "column": 78
-                },
-                "int32Value": 4
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 136,
-                 "column": 82
-                },
-                "stringValue": "field10"
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 137,
-            "column": 5
-           },
-           "name": "field11",
-           "value": {
-            "sourceReference": {
-             "line": 137,
-             "column": 5
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 137,
-                 "column": 6
-                },
-                "int64Value": "5"
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 137,
-                 "column": 10
-                },
-                "stringValue": "field11"
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 137,
-            "column": 22
-           },
-           "name": "field12",
-           "value": {
-            "sourceReference": {
-             "line": 137,
-             "column": 22
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 137,
-                 "column": 23
-                },
-                "uint32Value": 6
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 137,
-                 "column": 27
-                },
-                "stringValue": "field12"
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 137,
-            "column": 39
-           },
-           "name": "field13",
-           "value": {
-            "sourceReference": {
-             "line": 137,
-             "column": 39
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 137,
-                 "column": 40
-                },
-                "uint64Value": "7"
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 137,
-                 "column": 44
-                },
-                "stringValue": "field13"
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 137,
-            "column": 56
-           },
-           "name": "field14",
-           "value": {
-            "sourceReference": {
-             "line": 137,
-             "column": 56
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 137,
-                 "column": 57
-                },
-                "int32Value": -8
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 137,
-                 "column": 62
-                },
-                "stringValue": "field14"
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 137,
-            "column": 74
-           },
-           "name": "field15",
-           "value": {
-            "sourceReference": {
-             "line": 137,
-             "column": 74
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 137,
-                 "column": 75
-                },
-                "int64Value": "-9"
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 137,
-                 "column": 80
-                },
-                "stringValue": "field15"
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 138,
-            "column": 5
-           },
-           "name": "field16",
-           "value": {
-            "sourceReference": {
-             "line": 138,
-             "column": 5
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 138,
-                 "column": 6
-                },
-                "entityIdValue": "10"
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 138,
-                 "column": 11
-                },
-                "stringValue": "field16"
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 138,
-            "column": 23
-           },
-           "name": "field17",
-           "value": {
-            "sourceReference": {
-             "line": 138,
-             "column": 23
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 138,
-                 "column": 24
-                },
-                "typeValue": {
-                 "type": "improbable.gdk.tests.SomeType",
-                 "fields": []
-                }
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 138,
-                 "column": 35
-                },
-                "stringValue": "field17"
-               }
-              }
-             ]
-            }
-           }
-          },
-          {
-           "sourceReference": {
-            "line": 138,
-            "column": 47
-           },
-           "name": "field18",
-           "value": {
-            "sourceReference": {
-             "line": 138,
-             "column": 47
-            },
-            "mapValue": {
-             "values": [
-              {
-               "key": {
-                "sourceReference": {
-                 "line": 138,
-                 "column": 48
-                },
-                "enumValue": {
-                 "enum": "improbable.gdk.tests.SomeEnum",
-                 "value": "FIRST_VALUE"
-                }
-               },
-               "value": {
-                "sourceReference": {
-                 "line": 138,
-                 "column": 71
-                },
-                "stringValue": "field18"
-               }
-              }
-             ]
-            }
+             }
+            ]
            }
           }
-         ]
+         },
+         {
+          "sourceReference": {
+           "line": 131,
+           "column": 63
+          },
+          "name": "field4",
+          "value": {
+           "sourceReference": {
+            "line": 131,
+            "column": 63
+           },
+           "mapValue": {
+            "values": [
+             {
+              "key": {
+               "sourceReference": {
+                "line": 131,
+                "column": 64
+               },
+               "int32Value": -2
+              },
+              "value": {
+               "sourceReference": {
+                "line": 131,
+                "column": 69
+               },
+               "stringValue": "field4"
+              }
+             }
+            ]
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 131,
+           "column": 80
+          },
+          "name": "field5",
+          "value": {
+           "sourceReference": {
+            "line": 131,
+            "column": 80
+           },
+           "mapValue": {
+            "values": [
+             {
+              "key": {
+               "sourceReference": {
+                "line": 131,
+                "column": 81
+               },
+               "int64Value": "3"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 131,
+                "column": 85
+               },
+               "stringValue": "field5"
+              }
+             }
+            ]
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 132,
+           "column": 5
+          },
+          "name": "field6",
+          "value": {
+           "sourceReference": {
+            "line": 132,
+            "column": 5
+           },
+           "mapValue": {
+            "values": [
+             {
+              "key": {
+               "sourceReference": {
+                "line": 132,
+                "column": 6
+               },
+               "doubleValue": -15.5
+              },
+              "value": {
+               "sourceReference": {
+                "line": 132,
+                "column": 14
+               },
+               "stringValue": "field6"
+              }
+             }
+            ]
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 132,
+           "column": 25
+          },
+          "name": "field7",
+          "value": {
+           "sourceReference": {
+            "line": 132,
+            "column": 25
+           },
+           "mapValue": {
+            "values": [
+             {
+              "key": {
+               "sourceReference": {
+                "line": 132,
+                "column": 26
+               },
+               "stringValue": "bar"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 132,
+                "column": 34
+               },
+               "stringValue": "field7"
+              }
+             }
+            ]
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 132,
+           "column": 45
+          },
+          "name": "field8",
+          "value": {
+           "sourceReference": {
+            "line": 132,
+            "column": 45
+           },
+           "mapValue": {
+            "values": [
+             {
+              "key": {
+               "sourceReference": {
+                "line": 132,
+                "column": 46
+               },
+               "uint32Value": 0
+              },
+              "value": {
+               "sourceReference": {
+                "line": 132,
+                "column": 50
+               },
+               "stringValue": "field8"
+              }
+             }
+            ]
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 132,
+           "column": 61
+          },
+          "name": "field9",
+          "value": {
+           "sourceReference": {
+            "line": 132,
+            "column": 61
+           },
+           "mapValue": {
+            "values": [
+             {
+              "key": {
+               "sourceReference": {
+                "line": 132,
+                "column": 62
+               },
+               "uint64Value": "1"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 132,
+                "column": 66
+               },
+               "stringValue": "field9"
+              }
+             }
+            ]
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 132,
+           "column": 77
+          },
+          "name": "field10",
+          "value": {
+           "sourceReference": {
+            "line": 132,
+            "column": 77
+           },
+           "mapValue": {
+            "values": [
+             {
+              "key": {
+               "sourceReference": {
+                "line": 132,
+                "column": 78
+               },
+               "int32Value": 4
+              },
+              "value": {
+               "sourceReference": {
+                "line": 132,
+                "column": 82
+               },
+               "stringValue": "field10"
+              }
+             }
+            ]
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 133,
+           "column": 5
+          },
+          "name": "field11",
+          "value": {
+           "sourceReference": {
+            "line": 133,
+            "column": 5
+           },
+           "mapValue": {
+            "values": [
+             {
+              "key": {
+               "sourceReference": {
+                "line": 133,
+                "column": 6
+               },
+               "int64Value": "5"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 133,
+                "column": 10
+               },
+               "stringValue": "field11"
+              }
+             }
+            ]
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 133,
+           "column": 22
+          },
+          "name": "field12",
+          "value": {
+           "sourceReference": {
+            "line": 133,
+            "column": 22
+           },
+           "mapValue": {
+            "values": [
+             {
+              "key": {
+               "sourceReference": {
+                "line": 133,
+                "column": 23
+               },
+               "uint32Value": 6
+              },
+              "value": {
+               "sourceReference": {
+                "line": 133,
+                "column": 27
+               },
+               "stringValue": "field12"
+              }
+             }
+            ]
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 133,
+           "column": 39
+          },
+          "name": "field13",
+          "value": {
+           "sourceReference": {
+            "line": 133,
+            "column": 39
+           },
+           "mapValue": {
+            "values": [
+             {
+              "key": {
+               "sourceReference": {
+                "line": 133,
+                "column": 40
+               },
+               "uint64Value": "7"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 133,
+                "column": 44
+               },
+               "stringValue": "field13"
+              }
+             }
+            ]
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 133,
+           "column": 56
+          },
+          "name": "field14",
+          "value": {
+           "sourceReference": {
+            "line": 133,
+            "column": 56
+           },
+           "mapValue": {
+            "values": [
+             {
+              "key": {
+               "sourceReference": {
+                "line": 133,
+                "column": 57
+               },
+               "int32Value": -8
+              },
+              "value": {
+               "sourceReference": {
+                "line": 133,
+                "column": 62
+               },
+               "stringValue": "field14"
+              }
+             }
+            ]
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 133,
+           "column": 74
+          },
+          "name": "field15",
+          "value": {
+           "sourceReference": {
+            "line": 133,
+            "column": 74
+           },
+           "mapValue": {
+            "values": [
+             {
+              "key": {
+               "sourceReference": {
+                "line": 133,
+                "column": 75
+               },
+               "int64Value": "-9"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 133,
+                "column": 80
+               },
+               "stringValue": "field15"
+              }
+             }
+            ]
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 134,
+           "column": 5
+          },
+          "name": "field16",
+          "value": {
+           "sourceReference": {
+            "line": 134,
+            "column": 5
+           },
+           "mapValue": {
+            "values": [
+             {
+              "key": {
+               "sourceReference": {
+                "line": 134,
+                "column": 6
+               },
+               "entityIdValue": "10"
+              },
+              "value": {
+               "sourceReference": {
+                "line": 134,
+                "column": 11
+               },
+               "stringValue": "field16"
+              }
+             }
+            ]
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 134,
+           "column": 23
+          },
+          "name": "field17",
+          "value": {
+           "sourceReference": {
+            "line": 134,
+            "column": 23
+           },
+           "mapValue": {
+            "values": [
+             {
+              "key": {
+               "sourceReference": {
+                "line": 134,
+                "column": 24
+               },
+               "typeValue": {
+                "type": "improbable.test_schema.SomeType",
+                "fields": []
+               }
+              },
+              "value": {
+               "sourceReference": {
+                "line": 134,
+                "column": 35
+               },
+               "stringValue": "field17"
+              }
+             }
+            ]
+           }
+          }
+         },
+         {
+          "sourceReference": {
+           "line": 134,
+           "column": 47
+          },
+          "name": "field18",
+          "value": {
+           "sourceReference": {
+            "line": 134,
+            "column": 47
+           },
+           "mapValue": {
+            "values": [
+             {
+              "key": {
+               "sourceReference": {
+                "line": 134,
+                "column": 48
+               },
+               "enumValue": {
+                "enum": "improbable.test_schema.SomeEnum",
+                "value": "FOO"
+               }
+              },
+              "value": {
+               "sourceReference": {
+                "line": 134,
+                "column": 63
+               },
+               "stringValue": "field18"
+              }
+             }
+            ]
+           }
+          }
+         }
+        ]
+       }
+      }
+     ],
+     "qualifiedName": "improbable.test_schema.ExhaustiveMapKeyData",
+     "name": "ExhaustiveMapKeyData",
+     "outerType": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 136,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field1",
+       "fieldId": 1,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "Bool"
+        },
+        "valueType": {
+         "primitive": "String"
         }
        }
-      ],
-      "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKeyData",
-      "name": "ExhaustiveMapKeyData",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 140,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field1",
-        "fieldId": 1,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "Bool"
-         },
-         "valueType": {
-          "primitive": "String"
-         }
-        }
+      },
+      {
+       "sourceReference": {
+        "line": 137,
+        "column": 3
        },
-       {
-        "sourceReference": {
-         "line": 141,
-         "column": 3
+       "annotations": [],
+       "name": "field2",
+       "fieldId": 2,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "Float"
         },
-        "annotations": [],
-        "name": "field2",
-        "fieldId": 2,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "Float"
-         },
-         "valueType": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 142,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field3",
-        "fieldId": 3,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "Bytes"
-         },
-         "valueType": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 143,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field4",
-        "fieldId": 4,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "Int32"
-         },
-         "valueType": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 144,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field5",
-        "fieldId": 5,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "Int64"
-         },
-         "valueType": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 145,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field6",
-        "fieldId": 6,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "Double"
-         },
-         "valueType": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 146,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field7",
-        "fieldId": 7,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "String"
-         },
-         "valueType": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 147,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field8",
-        "fieldId": 8,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "Uint32"
-         },
-         "valueType": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 148,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field9",
-        "fieldId": 9,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "Uint64"
-         },
-         "valueType": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 149,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field10",
-        "fieldId": 10,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "Sint32"
-         },
-         "valueType": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 150,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field11",
-        "fieldId": 11,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "Sint64"
-         },
-         "valueType": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 151,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field12",
-        "fieldId": 12,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "Fixed32"
-         },
-         "valueType": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 152,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field13",
-        "fieldId": 13,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "Fixed64"
-         },
-         "valueType": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 153,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field14",
-        "fieldId": 14,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "Sfixed32"
-         },
-         "valueType": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 154,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field15",
-        "fieldId": 15,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "Sfixed64"
-         },
-         "valueType": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 155,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field16",
-        "fieldId": 16,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "EntityId"
-         },
-         "valueType": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 156,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field17",
-        "fieldId": 17,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "type": "improbable.gdk.tests.SomeType"
-         },
-         "valueType": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 157,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field18",
-        "fieldId": 18,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "enum": "improbable.gdk.tests.SomeEnum"
-         },
-         "valueType": {
-          "primitive": "String"
-         }
+        "valueType": {
+         "primitive": "String"
         }
        }
-      ]
-     }
-    ],
-    "components": [
-     {
-      "sourceReference": {
-       "line": 36,
-       "column": 1
       },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.ExhaustiveSingular",
-      "name": "ExhaustiveSingular",
-      "componentId": 197715,
-      "dataDefinition": "improbable.gdk.tests.ExhaustiveSingularData",
-      "fields": [],
-      "events": [],
-      "commands": []
-     },
-     {
-      "sourceReference": {
-       "line": 67,
-       "column": 1
+      {
+       "sourceReference": {
+        "line": 138,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field3",
+       "fieldId": 3,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "Bytes"
+        },
+        "valueType": {
+         "primitive": "String"
+        }
+       }
       },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.ExhaustiveOptional",
-      "name": "ExhaustiveOptional",
-      "componentId": 197716,
-      "dataDefinition": "improbable.gdk.tests.ExhaustiveOptionalData",
-      "fields": [],
-      "events": [],
-      "commands": []
-     },
-     {
-      "sourceReference": {
-       "line": 98,
-       "column": 1
+      {
+       "sourceReference": {
+        "line": 139,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field4",
+       "fieldId": 4,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "Int32"
+        },
+        "valueType": {
+         "primitive": "String"
+        }
+       }
       },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.ExhaustiveRepeated",
-      "name": "ExhaustiveRepeated",
-      "componentId": 197717,
-      "dataDefinition": "improbable.gdk.tests.ExhaustiveRepeatedData",
-      "fields": [],
-      "events": [],
-      "commands": []
-     },
-     {
-      "sourceReference": {
-       "line": 129,
-       "column": 1
+      {
+       "sourceReference": {
+        "line": 140,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field5",
+       "fieldId": 5,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "Int64"
+        },
+        "valueType": {
+         "primitive": "String"
+        }
+       }
       },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.ExhaustiveMapValue",
-      "name": "ExhaustiveMapValue",
-      "componentId": 197718,
-      "dataDefinition": "improbable.gdk.tests.ExhaustiveMapValueData",
-      "fields": [],
-      "events": [],
-      "commands": []
-     },
-     {
-      "sourceReference": {
-       "line": 160,
-       "column": 1
+      {
+       "sourceReference": {
+        "line": 141,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field6",
+       "fieldId": 6,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "Double"
+        },
+        "valueType": {
+         "primitive": "String"
+        }
+       }
       },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.ExhaustiveMapKey",
-      "name": "ExhaustiveMapKey",
-      "componentId": 197719,
-      "dataDefinition": "improbable.gdk.tests.ExhaustiveMapKeyData",
-      "fields": [],
-      "events": [],
-      "commands": []
-     }
-    ]
-   },
-   {
-    "canonicalPath": "improbable/gdk/tests/nested_typenames.schema",
-    "package": {
+      {
+       "sourceReference": {
+        "line": 142,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field7",
+       "fieldId": 7,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "String"
+        },
+        "valueType": {
+         "primitive": "String"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 143,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field8",
+       "fieldId": 8,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "Uint32"
+        },
+        "valueType": {
+         "primitive": "String"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 144,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field9",
+       "fieldId": 9,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "Uint64"
+        },
+        "valueType": {
+         "primitive": "String"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 145,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field10",
+       "fieldId": 10,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "Sint32"
+        },
+        "valueType": {
+         "primitive": "String"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 146,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field11",
+       "fieldId": 11,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "Sint64"
+        },
+        "valueType": {
+         "primitive": "String"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 147,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field12",
+       "fieldId": 12,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "Fixed32"
+        },
+        "valueType": {
+         "primitive": "String"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 148,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field13",
+       "fieldId": 13,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "Fixed64"
+        },
+        "valueType": {
+         "primitive": "String"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 149,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field14",
+       "fieldId": 14,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "Sfixed32"
+        },
+        "valueType": {
+         "primitive": "String"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 150,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field15",
+       "fieldId": 15,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "Sfixed64"
+        },
+        "valueType": {
+         "primitive": "String"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 151,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field16",
+       "fieldId": 16,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "EntityId"
+        },
+        "valueType": {
+         "primitive": "String"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 152,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field17",
+       "fieldId": 17,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "type": "improbable.test_schema.SomeType"
+        },
+        "valueType": {
+         "primitive": "String"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 153,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field18",
+       "fieldId": 18,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "enum": "improbable.test_schema.SomeEnum"
+        },
+        "valueType": {
+         "primitive": "String"
+        }
+       }
+      }
+     ]
+    },
+    {
      "sourceReference": {
-      "line": 1,
+      "line": 161,
       "column": 1
      },
-     "name": "improbable.gdk.tests"
-    },
-    "imports": [],
-    "enums": [
-     {
-      "sourceReference": {
-       "line": 9,
-       "column": 13
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.TypeName.Other.NestedTypeName.NestedEnum",
-      "name": "NestedEnum",
-      "outerType": "improbable.gdk.tests.TypeName.Other.NestedTypeName",
-      "values": [
-       {
-        "sourceReference": {
-         "line": 10,
-         "column": 17
-        },
-        "annotations": [],
-        "name": "enum_value",
-        "value": 1
-       }
-      ]
-     }
-    ],
-    "types": [
-     {
-      "sourceReference": {
-       "line": 3,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.TypeName",
-      "name": "TypeName",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 17,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "other_type",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "type": "improbable.gdk.tests.TypeName.Other"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 4,
-       "column": 5
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.TypeName.Other",
-      "name": "Other",
-      "outerType": "improbable.gdk.tests.TypeName",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 15,
-         "column": 9
-        },
-        "annotations": [],
-        "name": "same_name",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "type": "improbable.gdk.tests.TypeName.Other.NestedTypeName"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 5,
-       "column": 9
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.TypeName.Other.NestedTypeName",
-      "name": "NestedTypeName",
-      "outerType": "improbable.gdk.tests.TypeName.Other",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 12,
-         "column": 13
-        },
-        "annotations": [],
-        "name": "other_zero",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "type": "improbable.gdk.tests.TypeName.Other.NestedTypeName.Other0"
-         }
-        }
+     "annotations": [],
+     "qualifiedName": "improbable.test_schema.ExhaustiveEntityData",
+     "name": "ExhaustiveEntityData",
+     "outerType": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 162,
+        "column": 3
        },
-       {
-        "sourceReference": {
-         "line": 13,
-         "column": 13
-        },
-        "annotations": [],
-        "name": "enum_field",
-        "fieldId": 2,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "enum": "improbable.gdk.tests.TypeName.Other.NestedTypeName.NestedEnum"
-         }
+       "annotations": [],
+       "name": "field1",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Entity"
         }
        }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 6,
-       "column": 13
       },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.TypeName.Other.NestedTypeName.Other0",
-      "name": "Other0",
-      "outerType": "improbable.gdk.tests.TypeName.Other.NestedTypeName",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 7,
-         "column": 17
-        },
-        "annotations": [],
-        "name": "foo",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Int32"
-         }
+      {
+       "sourceReference": {
+        "line": 163,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field2",
+       "fieldId": 2,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "primitive": "Entity"
         }
        }
-      ]
-     }
-    ],
-    "components": [
-     {
-      "sourceReference": {
-       "line": 20,
-       "column": 1
       },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.NestedComponent",
-      "name": "NestedComponent",
-      "componentId": 20152,
-      "dataDefinition": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 22,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "nested_type",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "type": "improbable.gdk.tests.TypeName"
-         }
+      {
+       "sourceReference": {
+        "line": 164,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field3",
+       "fieldId": 3,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "primitive": "Entity"
         }
        }
-      ],
-      "events": [],
-      "commands": []
-     }
-    ]
-   },
-   {
-    "canonicalPath": "improbable/gdk/tests/nonblittable_types.schema",
-    "package": {
+      },
+      {
+       "sourceReference": {
+        "line": 165,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field4",
+       "fieldId": 4,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "Entity"
+        },
+        "valueType": {
+         "primitive": "String"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 166,
+        "column": 3
+       },
+       "annotations": [],
+       "name": "field5",
+       "fieldId": 5,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "String"
+        },
+        "valueType": {
+         "primitive": "Entity"
+        }
+       }
+      }
+     ]
+    }
+   ],
+   "components": [
+    {
      "sourceReference": {
-      "line": 1,
+      "line": 32,
       "column": 1
      },
-     "name": "improbable.gdk.tests.nonblittable_types"
+     "annotations": [],
+     "qualifiedName": "improbable.test_schema.ExhaustiveSingular",
+     "name": "ExhaustiveSingular",
+     "componentId": 197715,
+     "dataDefinition": "improbable.test_schema.ExhaustiveSingularData",
+     "fields": [],
+     "events": [],
+     "commands": []
     },
-    "imports": [],
-    "enums": [],
-    "types": [
-     {
-      "sourceReference": {
-       "line": 3,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.nonblittable_types.FirstCommandRequest",
-      "name": "FirstCommandRequest",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 4,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Int32"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 7,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.nonblittable_types.FirstCommandResponse",
-      "name": "FirstCommandResponse",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 8,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "response",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "String"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 11,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.nonblittable_types.SecondCommandRequest",
-      "name": "SecondCommandRequest",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 12,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Int64"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 15,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.nonblittable_types.SecondCommandResponse",
-      "name": "SecondCommandResponse",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 16,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "response",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "String"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 19,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.nonblittable_types.FirstEventPayload",
-      "name": "FirstEventPayload",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 20,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field1",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Bool"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 21,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field2",
-        "fieldId": 2,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "String"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 24,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.nonblittable_types.SecondEventPayload",
-      "name": "SecondEventPayload",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 25,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field1",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Float"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 26,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "field2",
-        "fieldId": 2,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "primitive": "Double"
-         }
-        }
-       }
-      ]
-     }
-    ],
-    "components": [
-     {
-      "sourceReference": {
-       "line": 29,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.gdk.tests.nonblittable_types.NonBlittableComponent",
-      "name": "NonBlittableComponent",
-      "componentId": 1002,
-      "dataDefinition": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 31,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "bool_field",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Bool"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 32,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "int_field",
-        "fieldId": 2,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Int32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 33,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "long_field",
-        "fieldId": 3,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Int64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 34,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "float_field",
-        "fieldId": 4,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Float"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 35,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "double_field",
-        "fieldId": 5,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Double"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 36,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "string_field",
-        "fieldId": 6,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 37,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "optional_field",
-        "fieldId": 7,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "primitive": "Int32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 38,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "list_field",
-        "fieldId": 8,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "primitive": "Int32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 39,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "map_field",
-        "fieldId": 9,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "Int32"
-         },
-         "valueType": {
-          "primitive": "String"
-         }
-        }
-       }
-      ],
-      "events": [
-       {
-        "sourceReference": {
-         "line": 44,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "first_event",
-        "type": "improbable.gdk.tests.nonblittable_types.FirstEventPayload",
-        "eventIndex": 1
-       },
-       {
-        "sourceReference": {
-         "line": 45,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "second_event",
-        "type": "improbable.gdk.tests.nonblittable_types.SecondEventPayload",
-        "eventIndex": 2
-       }
-      ],
-      "commands": [
-       {
-        "sourceReference": {
-         "line": 29,
-         "column": 1
-        },
-        "annotations": [],
-        "name": "first_command",
-        "requestType": "improbable.gdk.tests.nonblittable_types.FirstCommandRequest",
-        "responseType": "improbable.gdk.tests.nonblittable_types.FirstCommandResponse",
-        "commandIndex": 1
-       },
-       {
-        "sourceReference": {
-         "line": 29,
-         "column": 1
-        },
-        "annotations": [],
-        "name": "second_command",
-        "requestType": "improbable.gdk.tests.nonblittable_types.SecondCommandRequest",
-        "responseType": "improbable.gdk.tests.nonblittable_types.SecondCommandResponse",
-        "commandIndex": 2
-       }
-      ]
-     }
-    ]
-   },
-   {
-    "canonicalPath": "improbable/gdk/tests/same_names.schema",
-    "package": {
+    {
      "sourceReference": {
-      "line": 1,
+      "line": 63,
       "column": 1
      },
-     "name": "name"
+     "annotations": [],
+     "qualifiedName": "improbable.test_schema.ExhaustiveOptional",
+     "name": "ExhaustiveOptional",
+     "componentId": 197716,
+     "dataDefinition": "improbable.test_schema.ExhaustiveOptionalData",
+     "fields": [],
+     "events": [],
+     "commands": []
     },
-    "imports": [],
-    "enums": [],
-    "types": [
-     {
-      "sourceReference": {
-       "line": 3,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "name.Test",
-      "name": "Test",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 4,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "color",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Float"
-         }
-        }
-       }
-      ]
-     }
-    ],
-    "components": [
-     {
-      "sourceReference": {
-       "line": 7,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "name.Name",
-      "name": "Name",
-      "componentId": 200,
-      "dataDefinition": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 10,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "name",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Float"
-         }
-        }
-       }
-      ],
-      "events": [],
-      "commands": []
-     }
-    ]
-   },
-   {
-    "canonicalPath": "improbable/restricted/system_components.schema",
-    "package": {
+    {
      "sourceReference": {
-      "line": 1,
+      "line": 94,
       "column": 1
      },
-     "name": "improbable.restricted"
+     "annotations": [],
+     "qualifiedName": "improbable.test_schema.ExhaustiveRepeated",
+     "name": "ExhaustiveRepeated",
+     "componentId": 197717,
+     "dataDefinition": "improbable.test_schema.ExhaustiveRepeatedData",
+     "fields": [],
+     "events": [],
+     "commands": []
     },
-    "imports": [],
-    "enums": [
-     {
-      "sourceReference": {
-       "line": 22,
-       "column": 3
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.restricted.Connection.ConnectionStatus",
-      "name": "ConnectionStatus",
-      "outerType": "improbable.restricted.Connection",
-      "values": [
-       {
-        "sourceReference": {
-         "line": 23,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "UNKNOWN",
-        "value": 0
-       },
-       {
-        "sourceReference": {
-         "line": 25,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "AWAITING_WORKER_CONNECTION",
-        "value": 1
-       },
-       {
-        "sourceReference": {
-         "line": 27,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "CONNECTED",
-        "value": 2
-       },
-       {
-        "sourceReference": {
-         "line": 29,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "DISCONNECTED",
-        "value": 3
-       }
-      ]
-     }
-    ],
-    "types": [
-     {
-      "sourceReference": {
-       "line": 21,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.restricted.Connection",
-      "name": "Connection",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 31,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "status",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "enum": "improbable.restricted.Connection.ConnectionStatus"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 39,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "data_latency_ms",
-        "fieldId": 2,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Uint32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 42,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "connected_since_utc",
-        "fieldId": 3,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Uint64"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 46,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.restricted.DisconnectRequest",
-      "name": "DisconnectRequest",
-      "outerType": "",
-      "fields": []
-     },
-     {
-      "sourceReference": {
-       "line": 48,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.restricted.DisconnectResponse",
-      "name": "DisconnectResponse",
-      "outerType": "",
-      "fields": []
-     },
-     {
-      "sourceReference": {
-       "line": 63,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.restricted.PlayerIdentity",
-      "name": "PlayerIdentity",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 65,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "player_identifier",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 68,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "provider",
-        "fieldId": 2,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 73,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "metadata",
-        "fieldId": 3,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Bytes"
-         }
-        }
-       }
-      ]
-     }
-    ],
-    "components": [
-     {
-      "sourceReference": {
-       "line": 16,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.restricted.System",
-      "name": "System",
-      "componentId": 59,
-      "dataDefinition": "",
-      "fields": [],
-      "events": [],
-      "commands": []
-     },
-     {
-      "sourceReference": {
-       "line": 53,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.restricted.Worker",
-      "name": "Worker",
-      "componentId": 60,
-      "dataDefinition": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 55,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "worker_id",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 56,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "worker_type",
-        "fieldId": 2,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "String"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 57,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "connection",
-        "fieldId": 3,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "type": "improbable.restricted.Connection"
-         }
-        }
-       }
-      ],
-      "events": [],
-      "commands": [
-       {
-        "sourceReference": {
-         "line": 53,
-         "column": 1
-        },
-        "annotations": [],
-        "name": "disconnect",
-        "requestType": "improbable.restricted.DisconnectRequest",
-        "responseType": "improbable.restricted.DisconnectResponse",
-        "commandIndex": 1
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 79,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.restricted.PlayerClient",
-      "name": "PlayerClient",
-      "componentId": 61,
-      "dataDefinition": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 81,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "player_identity",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "type": "improbable.restricted.PlayerIdentity"
-         }
-        }
-       }
-      ],
-      "events": [],
-      "commands": []
-     }
-    ]
-   },
-   {
-    "canonicalPath": "improbable/standard_library.schema",
-    "package": {
+    {
      "sourceReference": {
-      "line": 1,
+      "line": 125,
       "column": 1
      },
-     "name": "improbable"
+     "annotations": [],
+     "qualifiedName": "improbable.test_schema.ExhaustiveMapValue",
+     "name": "ExhaustiveMapValue",
+     "componentId": 197718,
+     "dataDefinition": "improbable.test_schema.ExhaustiveMapValueData",
+     "fields": [],
+     "events": [],
+     "commands": []
     },
-    "imports": [],
-    "enums": [],
-    "types": [
-     {
-      "sourceReference": {
-       "line": 6,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.WorkerAttributeSet",
-      "name": "WorkerAttributeSet",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 9,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "attribute",
-        "fieldId": 1,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "primitive": "String"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 24,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.WorkerRequirementSet",
-      "name": "WorkerRequirementSet",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 28,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "attribute_set",
-        "fieldId": 1,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "type": "improbable.WorkerAttributeSet"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 62,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.Coordinates",
-      "name": "Coordinates",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 63,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "x",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Double"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 64,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "y",
-        "fieldId": 2,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Double"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 65,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "z",
-        "fieldId": 3,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Double"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 69,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.EdgeLength",
-      "name": "EdgeLength",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 70,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "x",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Double"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 71,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "y",
-        "fieldId": 2,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Double"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 72,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "z",
-        "fieldId": 3,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Double"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 103,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.ComponentInterest",
-      "name": "ComponentInterest",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 171,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "queries",
-        "fieldId": 1,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "type": "improbable.ComponentInterest.Query"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 104,
-       "column": 3
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.ComponentInterest.Query",
-      "name": "Query",
-      "outerType": "improbable.ComponentInterest",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 105,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "constraint",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "type": "improbable.ComponentInterest.QueryConstraint"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 108,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "full_snapshot_result",
-        "fieldId": 2,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "primitive": "Bool"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 109,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "result_component_id",
-        "fieldId": 3,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "primitive": "Uint32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 126,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "frequency",
-        "fieldId": 4,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "primitive": "Float"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 129,
-       "column": 3
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.ComponentInterest.QueryConstraint",
-      "name": "QueryConstraint",
-      "outerType": "improbable.ComponentInterest",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 132,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "sphere_constraint",
-        "fieldId": 1,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "type": "improbable.ComponentInterest.SphereConstraint"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 133,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "cylinder_constraint",
-        "fieldId": 2,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "type": "improbable.ComponentInterest.CylinderConstraint"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 134,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "box_constraint",
-        "fieldId": 3,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "type": "improbable.ComponentInterest.BoxConstraint"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 135,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "relative_sphere_constraint",
-        "fieldId": 4,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "type": "improbable.ComponentInterest.RelativeSphereConstraint"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 136,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "relative_cylinder_constraint",
-        "fieldId": 5,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "type": "improbable.ComponentInterest.RelativeCylinderConstraint"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 137,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "relative_box_constraint",
-        "fieldId": 6,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "type": "improbable.ComponentInterest.RelativeBoxConstraint"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 138,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "entity_id_constraint",
-        "fieldId": 7,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "primitive": "Int64"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 139,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "component_constraint",
-        "fieldId": 8,
-        "transient": false,
-        "optionType": {
-         "innerType": {
-          "primitive": "Uint32"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 140,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "and_constraint",
-        "fieldId": 9,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "type": "improbable.ComponentInterest.QueryConstraint"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 141,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "or_constraint",
-        "fieldId": 10,
-        "transient": false,
-        "listType": {
-         "innerType": {
-          "type": "improbable.ComponentInterest.QueryConstraint"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 144,
-       "column": 3
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.ComponentInterest.SphereConstraint",
-      "name": "SphereConstraint",
-      "outerType": "improbable.ComponentInterest",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 145,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "center",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "type": "improbable.Coordinates"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 146,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "radius",
-        "fieldId": 2,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Double"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 149,
-       "column": 3
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.ComponentInterest.CylinderConstraint",
-      "name": "CylinderConstraint",
-      "outerType": "improbable.ComponentInterest",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 150,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "center",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "type": "improbable.Coordinates"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 151,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "radius",
-        "fieldId": 2,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Double"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 154,
-       "column": 3
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.ComponentInterest.BoxConstraint",
-      "name": "BoxConstraint",
-      "outerType": "improbable.ComponentInterest",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 155,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "center",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "type": "improbable.Coordinates"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 156,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "edge_length",
-        "fieldId": 2,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "type": "improbable.EdgeLength"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 159,
-       "column": 3
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.ComponentInterest.RelativeSphereConstraint",
-      "name": "RelativeSphereConstraint",
-      "outerType": "improbable.ComponentInterest",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 160,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "radius",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Double"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 163,
-       "column": 3
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.ComponentInterest.RelativeCylinderConstraint",
-      "name": "RelativeCylinderConstraint",
-      "outerType": "improbable.ComponentInterest",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 164,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "radius",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Double"
-         }
-        }
-       }
-      ]
-     },
-     {
-      "sourceReference": {
-       "line": 167,
-       "column": 3
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.ComponentInterest.RelativeBoxConstraint",
-      "name": "RelativeBoxConstraint",
-      "outerType": "improbable.ComponentInterest",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 168,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "edge_length",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "type": "improbable.EdgeLength"
-         }
-        }
-       }
-      ]
-     }
-    ],
-    "components": [
-     {
-      "sourceReference": {
-       "line": 33,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.EntityAcl",
-      "name": "EntityAcl",
-      "componentId": 50,
-      "dataDefinition": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 40,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "read_acl",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "type": "improbable.WorkerRequirementSet"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 46,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "component_write_acl",
-        "fieldId": 2,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "Uint32"
-         },
-         "valueType": {
-          "type": "improbable.WorkerRequirementSet"
-         }
-        }
-       }
-      ],
-      "events": [],
-      "commands": []
-     },
-     {
-      "sourceReference": {
-       "line": 51,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.Metadata",
-      "name": "Metadata",
-      "componentId": 53,
-      "dataDefinition": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 57,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "entity_type",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "String"
-         }
-        }
-       }
-      ],
-      "events": [],
-      "commands": []
-     },
-     {
-      "sourceReference": {
-       "line": 81,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.Position",
-      "name": "Position",
-      "componentId": 54,
-      "dataDefinition": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 83,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "coords",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "type": "improbable.Coordinates"
-         }
-        }
-       }
-      ],
-      "events": [],
-      "commands": []
-     },
-     {
-      "sourceReference": {
-       "line": 89,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.Persistence",
-      "name": "Persistence",
-      "componentId": 55,
-      "dataDefinition": "",
-      "fields": [],
-      "events": [],
-      "commands": []
-     },
-     {
-      "sourceReference": {
-       "line": 98,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.Interest",
-      "name": "Interest",
-      "componentId": 58,
-      "dataDefinition": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 100,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "component_interest",
-        "fieldId": 1,
-        "transient": false,
-        "mapType": {
-         "keyType": {
-          "primitive": "Uint32"
-         },
-         "valueType": {
-          "type": "improbable.ComponentInterest"
-         }
-        }
-       }
-      ],
-      "events": [],
-      "commands": []
-     }
-    ]
-   },
-   {
-    "canonicalPath": "improbable/tests/dependency_test.schema",
-    "package": {
+    {
      "sourceReference": {
-      "line": 1,
+      "line": 156,
       "column": 1
      },
-     "name": "improbable.tests"
+     "annotations": [],
+     "qualifiedName": "improbable.test_schema.ExhaustiveMapKey",
+     "name": "ExhaustiveMapKey",
+     "componentId": 197719,
+     "dataDefinition": "improbable.test_schema.ExhaustiveMapKeyData",
+     "fields": [],
+     "events": [],
+     "commands": []
     },
-    "imports": [],
-    "enums": [],
-    "types": [],
-    "components": [
-     {
-      "sourceReference": {
-       "line": 3,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.tests.DependencyTest",
-      "name": "DependencyTest",
-      "componentId": 11111,
-      "dataDefinition": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 5,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "root",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Uint32"
-         }
-        }
-       }
-      ],
-      "events": [],
-      "commands": []
-     }
-    ]
-   },
-   {
-    "canonicalPath": "improbable/tests/dependency_test_child.schema",
-    "package": {
+    {
      "sourceReference": {
-      "line": 1,
+      "line": 169,
       "column": 1
      },
-     "name": "improbable.tests"
+     "annotations": [],
+     "qualifiedName": "improbable.test_schema.ExhaustiveEntity",
+     "name": "ExhaustiveEntity",
+     "componentId": 197720,
+     "dataDefinition": "improbable.test_schema.ExhaustiveEntityData",
+     "fields": [],
+     "events": [],
+     "commands": []
+    }
+   ]
+  },
+  {
+   "canonicalPath": "test_schema/nested_typenames.schema",
+   "package": {
+    "sourceReference": {
+     "line": 1,
+     "column": 1
     },
-    "imports": [],
-    "enums": [],
-    "types": [],
-    "components": [
-     {
-      "sourceReference": {
-       "line": 3,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.tests.DependencyTestChild",
-      "name": "DependencyTestChild",
-      "componentId": 11112,
-      "dataDefinition": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 5,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "child",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Uint32"
-         }
-        }
-       }
-      ],
-      "events": [],
-      "commands": []
-     }
-    ]
+    "name": "improbable.test_schema"
    },
-   {
-    "canonicalPath": "improbable/tests/dependency_test_grandchild.schema",
-    "package": {
+   "imports": [],
+   "enums": [
+    {
      "sourceReference": {
-      "line": 1,
+      "line": 12,
+      "column": 9
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.test_schema.NestedTypeSameName.Other.NestedTypeSameName.Other1.NestedTypeSameName",
+     "name": "NestedTypeSameName",
+     "outerType": "improbable.test_schema.NestedTypeSameName.Other.NestedTypeSameName.Other1",
+     "values": [
+      {
+       "sourceReference": {
+        "line": 13,
+        "column": 11
+       },
+       "annotations": [],
+       "name": "Other1",
+       "value": 1
+      }
+     ]
+    },
+    {
+     "sourceReference": {
+      "line": 15,
+      "column": 9
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.test_schema.NestedTypeSameName.Other.NestedTypeSameName.Other1.NestedEnum",
+     "name": "NestedEnum",
+     "outerType": "improbable.test_schema.NestedTypeSameName.Other.NestedTypeSameName.Other1",
+     "values": [
+      {
+       "sourceReference": {
+        "line": 16,
+        "column": 11
+       },
+       "annotations": [],
+       "name": "NestedTypeSameName",
+       "value": 1
+      }
+     ]
+    }
+   ],
+   "types": [
+    {
+     "sourceReference": {
+      "line": 4,
       "column": 1
      },
-     "name": "improbable.tests"
+     "annotations": [],
+     "qualifiedName": "improbable.test_schema.NestedTypeSameName",
+     "name": "NestedTypeSameName",
+     "outerType": "",
+     "fields": []
     },
-    "imports": [],
-    "enums": [],
-    "types": [],
-    "components": [
-     {
-      "sourceReference": {
-       "line": 3,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.tests.DependencyTestGrandchild",
-      "name": "DependencyTestGrandchild",
-      "componentId": 11113,
-      "dataDefinition": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 5,
-         "column": 5
-        },
-        "annotations": [],
-        "name": "grandchild",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Uint32"
-         }
+    {
+     "sourceReference": {
+      "line": 5,
+      "column": 3
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.test_schema.NestedTypeSameName.Other",
+     "name": "Other",
+     "outerType": "improbable.test_schema.NestedTypeSameName",
+     "fields": []
+    },
+    {
+     "sourceReference": {
+      "line": 6,
+      "column": 5
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.test_schema.NestedTypeSameName.Other.NestedTypeSameName",
+     "name": "NestedTypeSameName",
+     "outerType": "improbable.test_schema.NestedTypeSameName.Other",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 7,
+        "column": 7
+       },
+       "annotations": [],
+       "name": "nested_field",
+       "fieldId": 1,
+       "transient": false,
+       "singularType": {
+        "type": {
+         "primitive": "Int32"
         }
        }
-      ],
-      "events": [],
-      "commands": []
-     }
-    ]
-   },
-   {
-    "canonicalPath": "improbable/vector3.schema",
-    "package": {
+      }
+     ]
+    },
+    {
      "sourceReference": {
-      "line": 1,
+      "line": 8,
+      "column": 7
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.test_schema.NestedTypeSameName.Other.NestedTypeSameName.Other0",
+     "name": "Other0",
+     "outerType": "improbable.test_schema.NestedTypeSameName.Other.NestedTypeSameName",
+     "fields": []
+    },
+    {
+     "sourceReference": {
+      "line": 9,
+      "column": 9
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.test_schema.NestedTypeSameName.Other.NestedTypeSameName.Other0.NestedTypeSameName",
+     "name": "NestedTypeSameName",
+     "outerType": "improbable.test_schema.NestedTypeSameName.Other.NestedTypeSameName.Other0",
+     "fields": []
+    },
+    {
+     "sourceReference": {
+      "line": 11,
+      "column": 7
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.test_schema.NestedTypeSameName.Other.NestedTypeSameName.Other1",
+     "name": "Other1",
+     "outerType": "improbable.test_schema.NestedTypeSameName.Other.NestedTypeSameName",
+     "fields": []
+    }
+   ],
+   "components": []
+  },
+  {
+   "canonicalPath": "test_schema/recursion.schema",
+   "package": {
+    "sourceReference": {
+     "line": 1,
+     "column": 1
+    },
+    "name": "improbable.test_schema"
+   },
+   "imports": [],
+   "enums": [],
+   "types": [
+    {
+     "sourceReference": {
+      "line": 3,
       "column": 1
      },
-     "name": "improbable"
+     "annotations": [],
+     "qualifiedName": "improbable.test_schema.TypeA",
+     "name": "TypeA",
+     "outerType": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 4,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "a_option",
+       "fieldId": 1,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "type": "improbable.test_schema.TypeA"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 5,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "a_list",
+       "fieldId": 2,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "type": "improbable.test_schema.TypeA"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 6,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "a_map_value",
+       "fieldId": 4,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "Int32"
+        },
+        "valueType": {
+         "type": "improbable.test_schema.TypeA"
+        }
+       }
+      }
+     ]
     },
-    "imports": [],
-    "enums": [],
-    "types": [
-     {
-      "sourceReference": {
-       "line": 3,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.Vector3f",
-      "name": "Vector3f",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 4,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "x",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Float"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 5,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "y",
-        "fieldId": 2,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Float"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 6,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "z",
-        "fieldId": 3,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Float"
-         }
-        }
-       }
-      ]
+    {
+     "sourceReference": {
+      "line": 9,
+      "column": 1
      },
-     {
-      "sourceReference": {
-       "line": 9,
-       "column": 1
-      },
-      "annotations": [],
-      "qualifiedName": "improbable.Vector3d",
-      "name": "Vector3d",
-      "outerType": "",
-      "fields": [
-       {
-        "sourceReference": {
-         "line": 10,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "x",
-        "fieldId": 1,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Double"
-         }
-        }
+     "annotations": [],
+     "qualifiedName": "improbable.test_schema.TypeB",
+     "name": "TypeB",
+     "outerType": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 10,
+        "column": 5
        },
-       {
-        "sourceReference": {
-         "line": 11,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "y",
-        "fieldId": 2,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Double"
-         }
-        }
-       },
-       {
-        "sourceReference": {
-         "line": 12,
-         "column": 3
-        },
-        "annotations": [],
-        "name": "z",
-        "fieldId": 3,
-        "transient": false,
-        "singularType": {
-         "type": {
-          "primitive": "Double"
-         }
+       "annotations": [],
+       "name": "c_option",
+       "fieldId": 1,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "type": "improbable.test_schema.TypeC"
         }
        }
-      ]
-     }
-    ],
-    "components": []
-   }
-  ]
- }
- 
+      },
+      {
+       "sourceReference": {
+        "line": 11,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "c_list",
+       "fieldId": 2,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "type": "improbable.test_schema.TypeC"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 12,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "c_map_value",
+       "fieldId": 4,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "Int32"
+        },
+        "valueType": {
+         "type": "improbable.test_schema.TypeC"
+        }
+       }
+      }
+     ]
+    },
+    {
+     "sourceReference": {
+      "line": 15,
+      "column": 1
+     },
+     "annotations": [],
+     "qualifiedName": "improbable.test_schema.TypeC",
+     "name": "TypeC",
+     "outerType": "",
+     "fields": [
+      {
+       "sourceReference": {
+        "line": 16,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "b_option",
+       "fieldId": 1,
+       "transient": false,
+       "optionType": {
+        "innerType": {
+         "type": "improbable.test_schema.TypeB"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 17,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "b_list",
+       "fieldId": 2,
+       "transient": false,
+       "listType": {
+        "innerType": {
+         "type": "improbable.test_schema.TypeB"
+        }
+       }
+      },
+      {
+       "sourceReference": {
+        "line": 18,
+        "column": 5
+       },
+       "annotations": [],
+       "name": "b_map",
+       "fieldId": 4,
+       "transient": false,
+       "mapType": {
+        "keyType": {
+         "primitive": "String"
+        },
+        "valueType": {
+         "type": "improbable.test_schema.TypeB"
+        }
+       }
+      }
+     ]
+    }
+   ],
+   "components": []
+  }
+ ]
+}

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Tests/Model/DetailsStoreTests.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Tests/Model/DetailsStoreTests.cs
@@ -18,7 +18,7 @@ namespace GdkCodeGenerator.Tests.Model
             var json = JsonParsingTests.GetBundleContents();
             var overrides = new List<string>
             {
-                "global::Improbable.Gdk.Tests.SomeType;global::UserCode.SerializationExtensions.Type"
+                "global::Improbable.TestSchema.SomeType;global::UserCode.SerializationExtensions.Type"
             };
 
             store = new DetailsStore(SchemaBundle.LoadBundle(json), overrides);
@@ -27,7 +27,7 @@ namespace GdkCodeGenerator.Tests.Model
         [Test]
         public void BlittableComponent_is_marked_as_blittable()
         {
-            var fqn = "improbable.gdk.tests.blittable_types.BlittableComponent";
+            var fqn = "improbable.gdk.test.BlittableComponent";
             Assert.IsTrue(store.BlittableSet.Contains(fqn));
 
             foreach (var field in store.Components[fqn].FieldDetails)
@@ -39,38 +39,38 @@ namespace GdkCodeGenerator.Tests.Model
         [Test]
         public void NonBlittableComponent_is_marked_as_nonblittable()
         {
-            var fqn = "improbable.gdk.tests.nonblittable_types.NonBlittableComponent";
+            var fqn = "improbable.gdk.test.NonBlittableComponent";
             Assert.IsFalse(store.BlittableSet.Contains(fqn));
         }
 
         [Test]
         public void GetNestedTypes_returns_direct_children_only()
         {
-            var parentFqn = "improbable.gdk.tests.TypeName";
+            var parentFqn = "improbable.test_schema.NestedTypeSameName";
 
             var nestedTypes = store.GetNestedTypes(parentFqn);
 
             Assert.AreEqual(1, nestedTypes.Count);
-            Assert.IsTrue(nestedTypes.Contains("improbable.gdk.tests.TypeName.Other"));
+            Assert.IsTrue(nestedTypes.Contains("improbable.test_schema.NestedTypeSameName.Other"));
         }
 
         [Test]
         public void GetNestedTypes_returns_child_enums_and_child_types()
         {
             var parentFqn =
-                "improbable.gdk.tests.TypeName.Other.NestedTypeName";
+                "improbable.test_schema.NestedTypeSameName.Other.NestedTypeSameName";
 
             var nestedTypes = store.GetNestedTypes(parentFqn);
 
             Assert.AreEqual(2, nestedTypes.Count);
-            Assert.IsTrue(nestedTypes.Contains("improbable.gdk.tests.TypeName.Other.NestedTypeName.Other0"));
-            Assert.IsTrue(nestedTypes.Contains("improbable.gdk.tests.TypeName.Other.NestedTypeName.NestedEnum"));
+            Assert.IsTrue(nestedTypes.Contains("improbable.test_schema.NestedTypeSameName.Other.NestedTypeSameName.Other0"));
+            Assert.IsTrue(nestedTypes.Contains("improbable.test_schema.NestedTypeSameName.Other.NestedTypeSameName.Other1"));
         }
 
         [Test]
         public void GetNestedTypes_returns_empty_set_if_no_children()
         {
-            var fqn = "improbable.gdk.tests.SomeType";
+            var fqn = "improbable.test_schema.SomeType";
             var nestedTypes = store.GetNestedTypes(fqn);
 
             Assert.AreEqual(0, nestedTypes.Count);
@@ -79,7 +79,7 @@ namespace GdkCodeGenerator.Tests.Model
         [Test]
         public void Serialization_overrides_are_correctly_propagated()
         {
-            var fqn = "improbable.gdk.tests.SomeType";
+            var fqn = "improbable.test_schema.SomeType";
             var details = store.Types[fqn];
 
             Assert.IsTrue(details.HasSerializationOverride);

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Tests/Model/DetailsStoreTests.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Tests/Model/DetailsStoreTests.cs
@@ -84,5 +84,27 @@ namespace GdkCodeGenerator.Tests.Model
 
             Assert.IsTrue(details.HasSerializationOverride);
         }
+
+        [TestCase("TypeA")]
+        [TestCase("TypeB")]
+        [TestCase("TypeC")]
+        public void No_recursive_options_allowed(string schemaType)
+        {
+            var fqn = $"improbable.test_schema.{schemaType}";
+
+            var type = store.Types[fqn];
+
+            // The third one has been stripped (recursive optional)
+            Assert.AreEqual(2, type.FieldDetails.Count);
+        }
+
+        [Test]
+        public void Non_recursive_options_are_left()
+        {
+            var fqn = "improbable.test_schema.ExhaustiveOptionalData";
+            var type = store.Types[fqn];
+
+            Assert.AreEqual(18, type.FieldDetails.Count);
+        }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/Generation/Model/Details/UnityFieldDetails.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/Generation/Model/Details/UnityFieldDetails.cs
@@ -16,6 +16,8 @@ namespace Improbable.Gdk.CodeGenerator
 
         private IFieldType fieldType;
 
+        internal FieldDefinition Raw;
+
         public UnityFieldDetails(FieldDefinition field, DetailsStore store)
         {
             PascalCaseName = Formatting.SnakeCaseToPascalCase(field.Name);
@@ -44,6 +46,8 @@ namespace Improbable.Gdk.CodeGenerator
                 var singularType = field.SingularType.Type;
                 fieldType = new SingularFieldType(singularType, store);
             }
+
+            Raw = field;
         }
 
         /// <summary>

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/Generation/Model/Details/UnityTypeDetails.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/src/Generation/Model/Details/UnityTypeDetails.cs
@@ -12,7 +12,7 @@ namespace Improbable.Gdk.CodeGenerator
         public string CamelCaseName { get; }
         public string FullyQualifiedTypeName { get; }
 
-        public IReadOnlyList<UnityFieldDetails> FieldDetails { get; private set; }
+        public IReadOnlyList<UnityFieldDetails> FieldDetails { get; internal set; }
 
         public IReadOnlyList<UnityTypeDetails> ChildTypes;
         public IReadOnlyList<UnityEnumDetails> ChildEnums;


### PR DESCRIPTION
#### Description
Historically, we have not supported recursive options due to reference-semantic options imposing serious performance penalties. However, this is supported at the schema level. Previously, this would simply cause a compile error, but recently it started causing a Mono hard crash.

This PR fixes this bug by explicitly skipping recursive optional fields in schema types. Additionally, this PR contains updates to the `exhaustive_bundle.json` used for testing and some extra tests for the recursive schema case.

The first 5 commits are mostly housekeeping, the commits after those will be the more interesting ones.

#### Tests
- There are some nice little test cases in here.

#### Documentation
- [x] Changelog
- [x] Add a note to the docs that recursive options are skipped. #1132 
