### PR TITLE
Add warning about recursive schema options

### DIFF
--- a/docs/reference/concepts/code-generation.md
+++ b/docs/reference/concepts/code-generation.md
@@ -24,7 +24,7 @@ The code generator maps from the [schema primitive types](https://docs.improbabl
 | `uint64`                       |               `ulong`                |
 | `float`                        |               `float`                |
 | `double`                       |               `double`               |
-| `bool`                         |           `BlittableBool`            |
+| `bool`                         |                `bool`                |
 | `string`                       |               `string`               |
 | `bytes`                        |               `byte[]`               |
 | `EntityId`                     |    `Improbable.Gdk.Core.EntityId`    |

--- a/docs/reference/concepts/code-generation.md
+++ b/docs/reference/concepts/code-generation.md
@@ -58,6 +58,8 @@ The GDK also implements the `+`, `-`, `*`, `/`, `==` and `!=` operators for the 
 
 The code generator generates a C# struct for each [user defined type in schema](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/schema/reference#user-defined-types). The generated struct is annotated with the [`System.Serializable` attribute](https://docs.unity3d.com/ScriptReference/Serializable.html) and has a constructor with a parameter per schema field.
 
+<%(Callout type="warn" message="Currently any fields on schema types that are recursive through an `option<>` will be skipped.")%>
+
 ## Enums
 
 The code generator generates a C# enum for each [enum in schema](https://docs.improbable.io/reference/<%(Var key="worker_sdk_version")%>/shared/schema/reference#enumerations). The generated enum is annotated with the [`System.Serializable` attribute](https://docs.unity3d.com/ScriptReference/Serializable.html).

--- a/docs/reference/concepts/code-generation.md
+++ b/docs/reference/concepts/code-generation.md
@@ -23,6 +23,7 @@ The code generator maps from the [schema primitive types](https://docs.improbabl
 | `int64` / `sint64`/ `fixed64`  |                `long`                |
 | `uint64`                       |               `ulong`                |
 | `float`                        |               `float`                |
+| `double`                       |               `double`               |
 | `bool`                         |           `BlittableBool`            |
 | `string`                       |               `string`               |
 | `bytes`                        |               `byte[]`               |


### PR DESCRIPTION
#### Description
Add a warning that we will skip these fields. Also noted that we do actually support `double`s 😉 