### PR TITLE
Port Forwarding UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Workers will now log their `PlayerConnection` ports to SpatialOS after connecting. This port can be used for connecting the Unity profiler to workers running in the cloud. [#1128](https://github.com/spatialos/gdk-for-unity/pull/1128)
     - Note that this will only happen if the worker was built as a "Development Build".
+- Added a new Unity Editor window for forwarding a port from a worker that is running in the cloud. [#1133](https://github.com/spatialos/gdk-for-unity/pull/1133)
+    - You can find this window in the Unity Editor menu at: **SpatialOS** > **Port Forwarding**.
+    - This can be used to connect the Unity profile to workers running in the cloud.
 
 ### Fixed
 

--- a/workers/unity/Packages/io.improbable.gdk.tools/MenuPriorities.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/MenuPriorities.cs
@@ -9,6 +9,7 @@ namespace Improbable.Gdk.Tools
         internal const int LocalLaunch = 71;
         internal const int LaunchStandaloneClient = 72;
         internal const int OpenInspector = 74;
+        internal const int PortForwarding = 75;
 
         internal const int GdkToolsConfiguration = 201;
         internal const int GenerateDevAuthToken = 202;

--- a/workers/unity/Packages/io.improbable.gdk.tools/PortForwardingWindow.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/PortForwardingWindow.cs
@@ -93,6 +93,11 @@ namespace Improbable.Gdk.Tools
             }
         }
 
+        private void OnDisable()
+        {
+            Cleanup();
+        }
+
         private void OnDestroy()
         {
             Cleanup();
@@ -168,10 +173,13 @@ namespace Improbable.Gdk.Tools
 
         private void Cleanup()
         {
-            activePortForwarding.Dispose();
-            activePortForwarding = null;
-            tokenSrc.Dispose();
+            tokenSrc?.Cancel();
+            tokenSrc?.Dispose();
             tokenSrc = null;
+
+            activePortForwarding?.Wait();
+            activePortForwarding?.Dispose();
+            activePortForwarding = null;
 
             EditorApplication.UnlockReloadAssemblies();
         }

--- a/workers/unity/Packages/io.improbable.gdk.tools/PortForwardingWindow.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/PortForwardingWindow.cs
@@ -10,9 +10,11 @@ namespace Improbable.Gdk.Tools
 {
     internal class PortForwardingWindow : EditorWindow
     {
-        private string deploymentName = "";
-        private string workerId = "";
-        private int port;
+        [SerializeField] private string deploymentName = "";
+
+        [SerializeField] private string workerId = "";
+
+        [SerializeField] private int port;
 
         private Task<RedirectedProcessResult> activePortForwarding;
         private CancellationTokenSource tokenSrc;

--- a/workers/unity/Packages/io.improbable.gdk.tools/PortForwardingWindow.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/PortForwardingWindow.cs
@@ -1,0 +1,179 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine;
+
+namespace Improbable.Gdk.Tools
+{
+    internal class PortForwardingWindow : EditorWindow
+    {
+        private string deploymentName = "";
+        private string workerId = "";
+        private int port;
+
+        private Task<RedirectedProcessResult> activePortForwarding;
+        private CancellationTokenSource tokenSrc;
+
+        private bool isConnected;
+        private bool portForwardingHasFailed;
+
+        [MenuItem("SpatialOS/Port Forwarding", isValidateFunction: false, priority: MenuPriorities.PortForwarding)]
+        public static void ShowWindow()
+        {
+            GetWindow<PortForwardingWindow>().Show();
+        }
+
+        private void OnEnable()
+        {
+            titleContent = new GUIContent("Port Forwarding");
+        }
+
+        public void OnGUI()
+        {
+            using (new EditorGUI.DisabledScope(activePortForwarding != null))
+            using (new EditorGUILayout.VerticalScope())
+            {
+                deploymentName = EditorGUILayout.TextField("Deployment Name", deploymentName);
+                workerId = EditorGUILayout.TextField("Worker ID", workerId);
+                port = EditorGUILayout.IntField("Port", port);
+
+                var errors = GetErrors().ToList();
+
+                if (errors.Any())
+                {
+                    EditorGUILayout.HelpBox(
+                        $"Cannot forward port due to the following errors:\n\n{string.Join("\n", errors)}",
+                        MessageType.Error);
+                }
+
+                using (new EditorGUI.DisabledScope(errors.Any()))
+                {
+                    if (GUILayout.Button("Forward port"))
+                    {
+                        portForwardingHasFailed = false;
+                        isConnected = false;
+                        activePortForwarding = RunPortForwarding();
+                    }
+                }
+            }
+
+            var messageType = MessageType.None;
+            string message = null;
+
+            if (isConnected)
+            {
+                messageType = MessageType.Info;
+                message = $"Connected successfully to {workerId}:{port} on {deploymentName}!\n\nAssembly reloading locked.";
+            }
+            else if (activePortForwarding != null)
+            {
+                messageType = MessageType.Warning;
+                message = "Establishing connection...\n\nAssembly reloading locked.";
+            }
+            else if (portForwardingHasFailed)
+            {
+                messageType = MessageType.Error;
+                message = "Failed to establish connection. Check the Unity Console for more information.";
+            }
+
+            if (message != null)
+            {
+                EditorGUILayout.HelpBox(message, messageType);
+            }
+
+            if (activePortForwarding != null)
+            {
+                if (GUILayout.Button("Cancel"))
+                {
+                    tokenSrc.Cancel();
+                }
+            }
+        }
+
+        private void OnDestroy()
+        {
+            Cleanup();
+        }
+
+        private void Update()
+        {
+            if (activePortForwarding == null)
+            {
+                return;
+            }
+
+            if (!activePortForwarding.IsCompleted)
+            {
+                return;
+            }
+
+            // Cancelling or killing the process will result in a non-zero exit code, so ensure that we weren't
+            // previously connected successfully.
+            portForwardingHasFailed = activePortForwarding.Result.ExitCode != 0 && !isConnected;
+
+            if (portForwardingHasFailed)
+            {
+                foreach (var error in activePortForwarding.Result.Stdout)
+                {
+                    Debug.LogError(error);
+                }
+            }
+
+            // Reset state.
+            isConnected = false;
+            Cleanup();
+        }
+
+        private IEnumerable<string> GetErrors()
+        {
+            if (port > ushort.MaxValue || port < 1)
+            {
+                yield return "Port must be a number in the range of 1 to 65535.";
+            }
+
+            if (string.IsNullOrEmpty(deploymentName))
+            {
+                yield return "Deployment name cannot be empty.";
+            }
+            else if (!Regex.IsMatch(deploymentName, @"^[a-z0-9_]{2,32}$"))
+            {
+                yield return
+                    $"Deployment Name \"{deploymentName}\" invalid. Must conform to the regex: ^[a-z0-9_]{{2,32}}$";
+            }
+
+            if (string.IsNullOrEmpty(workerId))
+            {
+                yield return "Worker ID cannot be empty.";
+            }
+        }
+
+        private Task<RedirectedProcessResult> RunPortForwarding()
+        {
+            EditorApplication.LockReloadAssemblies();
+
+            tokenSrc = new CancellationTokenSource();
+            return RedirectedProcess.Command(Common.SpatialBinary)
+                .InDirectory(Common.SpatialProjectRootDir)
+                .WithArgs("project", "deployment", "worker", "port-forward",
+                    "-d", deploymentName,
+                    "-w", workerId,
+                    "-p", $"{port}")
+                .RedirectOutputOptions(OutputRedirectBehaviour.None)
+                .AddOutputProcessing(line => isConnected |= line.Contains("Established tunnel"))
+                .RunAsync(tokenSrc.Token);
+        }
+
+        private void Cleanup()
+        {
+            activePortForwarding.Dispose();
+            activePortForwarding = null;
+            tokenSrc.Dispose();
+            tokenSrc = null;
+
+            EditorApplication.UnlockReloadAssemblies();
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.tools/PortForwardingWindow.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.tools/PortForwardingWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fffc22e10b55f3d4898acd37d3824a2e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#### Description
Adds a UI window to complement the feature implemented in #1128. This allows users to port forward without touching the CLI.

- Validation against user input
- Little responsive UI telling you what state the connection is in.
- Assembly reloading locked while the window is up.

~**Question about the lifetime of the port forwarding: While the window is open? While Unity is open?**~

~If the latter, we will need to serialize the process `Task` _somehow_.~

Decided to tie the lifetime to the window lifetime.

Screenshots:

![image](https://user-images.githubusercontent.com/13353733/63433299-d3049f00-c41a-11e9-8517-99cb7740e423.png)
_entering data_

![image](https://user-images.githubusercontent.com/13353733/63433328-df88f780-c41a-11e9-9d68-7c847be10246.png)
_connected successfully_

![image](https://user-images.githubusercontent.com/13353733/63433347-eca5e680-c41a-11e9-9bb8-5994ea39fa3a.png)
_failed attempt_


#### Tests
Tested the various states for connecting and the validation logic.

#### Documentation
- [x] Changelog
- [x] Update #1130 to use the GUI and only mention the CLI as an option in an expandable.
