### PR TITLE
Track network stats for incoming and outgoing messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Added a new Unity Editor window for forwarding a port from a worker that is running in the cloud. [#1133](https://github.com/spatialos/gdk-for-unity/pull/1133)
     - You can find this window in the Unity Editor menu at: **SpatialOS** > **Port Forwarding**.
     - This can be used to connect the Unity profile to workers running in the cloud.
+- Added network statistics collection for both sending and receiving messages. [#1135](https://github.com/spatialos/gdk-for-unity/pull/1135)
+    - This adds a single ECS system `NetworkStatisticsSystem`. This system will only run when running your workers inside the Unity Editor.
+    - Additionally, there are a set of data types supporting this system which can be found under the `Improbable.Gdk.Core.NetworkStats` namespace.
 
 ### Changed
 

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponentCommandDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponentCommandDiffDeserializer.cs
@@ -100,7 +100,7 @@ namespace Improbable.DependentSchema
                     {
                         // Send a command failure if the string is non-null.
 
-                        serializedMessages.AddFailure(response.FailureMessage, (uint) response.RequestId);
+                        serializedMessages.AddFailure(ComponentId, 1, response.FailureMessage, (uint) response.RequestId);
                         continue;
                     }
 

--- a/test-project/Assets/Generated/Source/improbable/testschema/TypeC.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/TypeC.cs
@@ -12,13 +12,11 @@ namespace Improbable.TestSchema
     [global::System.Serializable]
     public struct TypeC
     {
-        public global::Improbable.TestSchema.TypeB? BOption;
         public global::System.Collections.Generic.List<global::Improbable.TestSchema.TypeB> BList;
         public global::System.Collections.Generic.Dictionary<string,global::Improbable.TestSchema.TypeB> BMap;
     
-        public TypeC(global::Improbable.TestSchema.TypeB? bOption, global::System.Collections.Generic.List<global::Improbable.TestSchema.TypeB> bList, global::System.Collections.Generic.Dictionary<string,global::Improbable.TestSchema.TypeB> bMap)
+        public TypeC(global::System.Collections.Generic.List<global::Improbable.TestSchema.TypeB> bList, global::System.Collections.Generic.Dictionary<string,global::Improbable.TestSchema.TypeB> bMap)
         {
-            BOption = bOption;
             BList = bList;
             BMap = bMap;
         }
@@ -26,13 +24,6 @@ namespace Improbable.TestSchema
         {
             public static void Serialize(TypeC instance, global::Improbable.Worker.CInterop.SchemaObject obj)
             {
-                {
-                    if (instance.BOption.HasValue)
-                    {
-                        global::Improbable.TestSchema.TypeB.Serialization.Serialize(instance.BOption.Value, obj.AddObject(1));
-                    }
-                    
-                }
                 {
                     foreach (var value in instance.BList)
                     {
@@ -54,13 +45,6 @@ namespace Improbable.TestSchema
             public static TypeC Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj)
             {
                 var instance = new TypeC();
-                {
-                    if (obj.GetObjectCount(1) == 1)
-                    {
-                        instance.BOption = new global::Improbable.TestSchema.TypeB?(global::Improbable.TestSchema.TypeB.Serialization.Deserialize(obj.GetObject(1)));
-                    }
-                    
-                }
                 {
                     instance.BList = new global::System.Collections.Generic.List<global::Improbable.TestSchema.TypeB>();
                     var list = instance.BList;

--- a/workers/unity/Assets/Config/GdkToolsConfiguration.json
+++ b/workers/unity/Assets/Config/GdkToolsConfiguration.json
@@ -6,5 +6,6 @@
     "DescriptorOutputDir": "../../build/assembly/schema",
     "DevAuthTokenDir": "Resources",
     "DevAuthTokenLifetimeDays": 30,
-    "SaveDevAuthTokenToFile": false
+    "SaveDevAuthTokenToFile": false,
+    "SerializationOverrides": []
 }

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ae7011e298e3d8d48b11b1462557c2d6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/DataPoint.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/DataPoint.cs
@@ -1,0 +1,17 @@
+namespace Improbable.Gdk.Core.NetworkStats
+{
+    public struct DataPoint
+    {
+        public uint Count;
+        public uint Size;
+
+        public static DataPoint operator +(DataPoint first, DataPoint second)
+        {
+            return new DataPoint
+            {
+                Count = first.Count + second.Count,
+                Size = first.Size + second.Size
+            };
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/DataPoint.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/DataPoint.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0084ea430eb9b1241a59c92c049ec179
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/MessageType.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/MessageType.cs
@@ -26,6 +26,13 @@ namespace Improbable.Gdk.Core.NetworkStats
         WorldCommandResponse = 4
     }
 
+    /// <summary>
+    ///     Describes a type of a message.
+    /// </summary>
+    /// <remarks>
+    ///     Implemented as a C-style union. Can be thought of as a sum type where the discriminants are:
+    ///     Update, CommandRequest, CommandResponse, WorldCommandRequest, WorldCommandResponse
+    /// </remarks>
     [StructLayout(LayoutKind.Explicit)]
     public struct MessageTypeUnion : IEquatable<MessageTypeUnion>
     {

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/MessageType.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/MessageType.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Improbable.Gdk.Core.NetworkStats
+{
+    public enum WorldCommand
+    {
+        CreateEntity = 0,
+        DeleteEntity = 1,
+        ReserveEntityIds = 2,
+        EntityQuery = 3
+    }
+
+    public enum Direction
+    {
+        Incoming = 0,
+        Outgoing = 1
+    }
+
+    public enum MessageType
+    {
+        Update = 0,
+        CommandRequest = 1,
+        CommandResponse = 2,
+        WorldCommandRequest = 3,
+        WorldCommandResponse = 4
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct MessageTypeUnion : IEquatable<MessageTypeUnion>
+    {
+        [FieldOffset(offset: 0)] private MessageType Type;
+
+        [FieldOffset(sizeof(MessageType))] private uint UpdateInfo;
+
+        [FieldOffset(sizeof(MessageType))] private (uint, uint) CommandInfo;
+
+        [FieldOffset(sizeof(MessageType))] private WorldCommand WorldCommand;
+
+        public static MessageTypeUnion Update(uint componentId)
+        {
+            return new MessageTypeUnion
+            {
+                Type = MessageType.Update,
+                UpdateInfo = componentId
+            };
+        }
+
+        public static MessageTypeUnion CommandRequest(uint componentId, uint commandIndex)
+        {
+            return new MessageTypeUnion
+            {
+                Type = MessageType.CommandRequest,
+                CommandInfo = (componentId, commandIndex)
+            };
+        }
+
+        public static MessageTypeUnion CommandResponse(uint componentId, uint commandIndex)
+        {
+            return new MessageTypeUnion
+            {
+                Type = MessageType.CommandResponse,
+                CommandInfo = (componentId, commandIndex)
+            };
+        }
+
+        public static MessageTypeUnion WorldCommandRequest(WorldCommand worldCommand)
+        {
+            return new MessageTypeUnion
+            {
+                Type = MessageType.WorldCommandRequest,
+                WorldCommand = worldCommand
+            };
+        }
+
+        public static MessageTypeUnion WorldCommandResponse(WorldCommand worldCommand)
+        {
+            return new MessageTypeUnion
+            {
+                Type = MessageType.WorldCommandResponse,
+                WorldCommand = worldCommand
+            };
+        }
+
+        public bool Equals(MessageTypeUnion other)
+        {
+            if (Type != other.Type)
+            {
+                return false;
+            }
+
+            switch (Type)
+            {
+                case MessageType.Update:
+                    return UpdateInfo == other.UpdateInfo;
+                case MessageType.CommandRequest:
+                    return CommandInfo == other.CommandInfo;
+                case MessageType.CommandResponse:
+                    return CommandInfo == other.CommandInfo;
+                case MessageType.WorldCommandRequest:
+                    return WorldCommand == other.WorldCommand;
+                case MessageType.WorldCommandResponse:
+                    return WorldCommand == other.WorldCommand;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is MessageTypeUnion other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (int) Type;
+
+                switch (Type)
+                {
+                    case MessageType.Update:
+                        hashCode = (hashCode * 397) ^ (int) UpdateInfo;
+                        break;
+                    case MessageType.CommandRequest:
+                        hashCode = (hashCode * 397) ^ CommandInfo.GetHashCode();
+                        break;
+                    case MessageType.CommandResponse:
+                        hashCode = (hashCode * 397) ^ CommandInfo.GetHashCode();
+                        break;
+                    case MessageType.WorldCommandRequest:
+                        hashCode = (hashCode * 397) ^ (int) WorldCommand;
+                        break;
+                    case MessageType.WorldCommandResponse:
+                        hashCode = (hashCode * 397) ^ (int) WorldCommand;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+
+                return hashCode;
+            }
+        }
+
+        public static bool operator ==(MessageTypeUnion left, MessageTypeUnion right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(MessageTypeUnion left, MessageTypeUnion right)
+        {
+            return !left.Equals(right);
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/MessageType.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/MessageType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c086e3c96cf6e8348a851f808b235a00
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetFrameStats.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetFrameStats.cs
@@ -4,6 +4,9 @@ using Improbable.Worker.CInterop;
 
 namespace Improbable.Gdk.Core.NetworkStats
 {
+    /// <summary>
+    ///     Represents a single frame's data for either incoming or outgoing network messages.
+    /// </summary>
     public class NetFrameStats
     {
         public readonly Dictionary<MessageTypeUnion, DataPoint> Messages = new Dictionary<MessageTypeUnion, DataPoint>();

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetFrameStats.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetFrameStats.cs
@@ -1,0 +1,144 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using Improbable.Worker.CInterop;
+
+namespace Improbable.Gdk.Core.NetworkStats
+{
+    public class NetFrameStats
+    {
+        public readonly Dictionary<MessageTypeUnion, DataPoint> Messages = new Dictionary<MessageTypeUnion, DataPoint>();
+
+        private NetFrameStats()
+        {
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        public void AddUpdate(in ComponentUpdate update)
+        {
+            var messageType = MessageTypeUnion.Update(update.ComponentId);
+            var size = update.SchemaData.Value.GetFields().GetWriteBufferLength() +
+                update.SchemaData.Value.GetEvents().GetWriteBufferLength();
+
+            Messages.TryGetValue(messageType, out var metrics);
+            metrics.Count += 1;
+            metrics.Size += size;
+            Messages[messageType] = metrics;
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        public void AddCommandRequest(in CommandRequest request)
+        {
+            var componentId = request.ComponentId;
+            var commandIndex = request.CommandIndex;
+            var messageType = MessageTypeUnion.CommandRequest(componentId, commandIndex);
+            var size = request.SchemaData.Value.GetObject().GetWriteBufferLength();
+
+            Messages.TryGetValue(messageType, out var metrics);
+            metrics.Count += 1;
+            metrics.Size += size;
+            Messages[messageType] = metrics;
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        public void AddCommandResponse(in CommandResponse response, string message)
+        {
+            var componentId = response.ComponentId;
+            var commandIndex = response.CommandIndex;
+            var messageType = MessageTypeUnion.CommandResponse(componentId, commandIndex);
+
+            uint size;
+
+            if (response.SchemaData.HasValue)
+            {
+                size = response.SchemaData.Value.GetObject().GetWriteBufferLength();
+            }
+            else
+            {
+                // Approximation of on-wire size.
+                size = (uint) System.Text.Encoding.UTF8.GetByteCount(message);
+            }
+
+            Messages.TryGetValue(messageType, out var metrics);
+            metrics.Count += 1;
+            metrics.Size += size;
+            Messages[messageType] = metrics;
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        public void AddCommandResponse(string message, uint componentId, uint commandIndex)
+        {
+            var messageType = MessageTypeUnion.CommandResponse(componentId, commandIndex);
+            // Approximation of on-wire size.
+            var size = (uint) System.Text.Encoding.UTF8.GetByteCount(message);
+
+            Messages.TryGetValue(messageType, out var metrics);
+            metrics.Count += 1;
+            metrics.Size += size;
+            Messages[messageType] = metrics;
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        public void AddWorldCommandRequest(WorldCommand command)
+        {
+            var messageType = MessageTypeUnion.WorldCommandRequest(command);
+            Messages.TryGetValue(messageType, out var metrics);
+            metrics.Count += 1;
+            Messages[messageType] = metrics;
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        public void AddWorldCommandResponse(WorldCommand command)
+        {
+            var messageType = MessageTypeUnion.WorldCommandResponse(command);
+            Messages.TryGetValue(messageType, out var metrics);
+            metrics.Count += 1;
+            Messages[messageType] = metrics;
+        }
+
+        internal void CopyFrom(NetFrameStats other)
+        {
+            Clear();
+
+            foreach (var pair in other.Messages)
+            {
+                Messages[pair.Key] = pair.Value;
+            }
+        }
+
+        internal void Merge(NetFrameStats other)
+        {
+            foreach (var pair in other.Messages)
+            {
+                Messages.TryGetValue(pair.Key, out var data);
+                data += pair.Value;
+                Messages[pair.Key] = data;
+            }
+        }
+
+        internal void Clear()
+        {
+            Messages.Clear();
+        }
+
+        public static class Pool
+        {
+            private static readonly Queue<NetFrameStats> data = new Queue<NetFrameStats>();
+
+            public static NetFrameStats Rent()
+            {
+                if (data.Count != 0)
+                {
+                    return data.Dequeue();
+                }
+
+                return new NetFrameStats();
+            }
+
+            public static void Return(NetFrameStats frameStats)
+            {
+                frameStats.Clear();
+                data.Enqueue(frameStats);
+            }
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetFrameStats.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetFrameStats.cs
@@ -78,6 +78,7 @@ namespace Improbable.Gdk.Core.NetworkStats
             Messages[messageType] = metrics;
         }
 
+        // Note we cannot measure the on-wire size of a world command, so we just count them.
         [Conditional("UNITY_EDITOR")]
         public void AddWorldCommandRequest(WorldCommand command)
         {
@@ -87,6 +88,7 @@ namespace Improbable.Gdk.Core.NetworkStats
             Messages[messageType] = metrics;
         }
 
+        // Note we cannot measure the on-wire size of a world command, so we just count them.
         [Conditional("UNITY_EDITOR")]
         public void AddWorldCommandResponse(WorldCommand command)
         {

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetFrameStats.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetFrameStats.cs
@@ -8,6 +8,8 @@ namespace Improbable.Gdk.Core.NetworkStats
     {
         public readonly Dictionary<MessageTypeUnion, DataPoint> Messages = new Dictionary<MessageTypeUnion, DataPoint>();
 
+        internal TestDataInjector TestInjector => new TestDataInjector(this);
+
         private NetFrameStats()
         {
         }
@@ -138,6 +140,64 @@ namespace Improbable.Gdk.Core.NetworkStats
             {
                 frameStats.Clear();
                 data.Enqueue(frameStats);
+            }
+        }
+
+        internal class TestDataInjector
+        {
+            private NetFrameStats target;
+
+            public TestDataInjector(NetFrameStats target)
+            {
+                this.target = target;
+            }
+
+            public void AddComponentUpdate(uint componentId, uint size)
+            {
+                var messageType = MessageTypeUnion.Update(componentId);
+
+                target.Messages.TryGetValue(messageType, out var metrics);
+                metrics.Count += 1;
+                metrics.Size += size;
+                target.Messages[messageType] = metrics;
+            }
+
+            public void AddCommandRequest(uint componentId, uint commandIndex, uint size)
+            {
+                var messageType = MessageTypeUnion.CommandRequest(componentId, commandIndex);
+
+                target.Messages.TryGetValue(messageType, out var metrics);
+                metrics.Count += 1;
+                metrics.Size += size;
+                target.Messages[messageType] = metrics;
+            }
+
+            public void AddCommandResponse(uint componentId, uint commandIndex, uint size)
+            {
+                var messageType = MessageTypeUnion.CommandResponse(componentId, commandIndex);
+
+                target.Messages.TryGetValue(messageType, out var metrics);
+                metrics.Count += 1;
+                metrics.Size += size;
+                target.Messages[messageType] = metrics;
+            }
+
+            public void AddWorldCommandRequest(WorldCommand worldCommand)
+            {
+                var messageType = MessageTypeUnion.WorldCommandRequest(worldCommand);
+
+                target.Messages.TryGetValue(messageType, out var metrics);
+                metrics.Count += 1;
+                target.Messages[messageType] = metrics;
+            }
+
+            public void AddWorldCommandResponse(WorldCommand worldCommand)
+            {
+                var messageType = MessageTypeUnion.WorldCommandResponse(worldCommand);
+
+                target.Messages.TryGetValue(messageType, out var metrics);
+                metrics.Count += 1;
+                target.Messages[messageType] = metrics;
             }
         }
     }

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetFrameStats.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetFrameStats.cs
@@ -10,10 +10,6 @@ namespace Improbable.Gdk.Core.NetworkStats
 
         internal TestDataInjector TestInjector => new TestDataInjector(this);
 
-        private NetFrameStats()
-        {
-        }
-
         [Conditional("UNITY_EDITOR")]
         public void AddUpdate(in ComponentUpdate update)
         {
@@ -120,27 +116,6 @@ namespace Improbable.Gdk.Core.NetworkStats
         internal void Clear()
         {
             Messages.Clear();
-        }
-
-        public static class Pool
-        {
-            private static readonly Queue<NetFrameStats> data = new Queue<NetFrameStats>();
-
-            public static NetFrameStats Rent()
-            {
-                if (data.Count != 0)
-                {
-                    return data.Dequeue();
-                }
-
-                return new NetFrameStats();
-            }
-
-            public static void Return(NetFrameStats frameStats)
-            {
-                frameStats.Clear();
-                data.Enqueue(frameStats);
-            }
         }
 
         internal class TestDataInjector

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetFrameStats.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetFrameStats.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 451278228f70fc24cb48e20145f19b8d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetStats.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetStats.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+
+namespace Improbable.Gdk.Core.NetworkStats
+{
+    public class NetStats
+    {
+        private readonly int sequenceLength;
+        private readonly Dictionary<MessageTypeUnion, DataSequence> Data = new Dictionary<MessageTypeUnion, DataSequence>();
+        private readonly float[] frameTimes;
+
+        private int nextFrameIndex;
+
+        public NetStats(int sequenceLength)
+        {
+            this.sequenceLength = sequenceLength;
+            nextFrameIndex = sequenceLength - 1;
+
+            frameTimes = new float[sequenceLength];
+        }
+
+        public void SetFrameStats(NetFrameStats frameData, Direction direction)
+        {
+            // First we need to zero out the data before processing the _sparse_ data in the NetFrameStats.
+            foreach (var pair in Data)
+            {
+                pair.Value.Clear(nextFrameIndex, direction);
+            }
+
+            foreach (var pair in frameData.Messages)
+            {
+                if (!Data.TryGetValue(pair.Key, out var data))
+                {
+                    data = new DataSequence(sequenceLength);
+                }
+
+                data.AddFrame(nextFrameIndex, pair.Value, direction);
+                Data[pair.Key] = data;
+            }
+        }
+
+        public void SetFrameTime(float dt)
+        {
+            frameTimes[nextFrameIndex] = dt;
+        }
+
+        public void FinishFrame()
+        {
+            if (--nextFrameIndex == -1)
+            {
+                nextFrameIndex += sequenceLength;
+            }
+        }
+
+        public (DataPoint, float) GetSummary(MessageTypeUnion messageType, int numFrames, Direction direction)
+        {
+            float totalTime = 0.0f;
+
+            for (var i = 1; i <= numFrames; i++)
+            {
+                var index = (nextFrameIndex + i) % sequenceLength;
+                totalTime += frameTimes[index];
+            }
+
+            if (!Data.TryGetValue(messageType, out var data))
+            {
+                return (new DataPoint(), totalTime);
+            }
+
+            DataPoint[] frameData;
+
+            switch (direction)
+            {
+                case Direction.Incoming:
+                    frameData = data.Incoming;
+                    break;
+                case Direction.Outgoing:
+                    frameData = data.Outgoing;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(direction), direction, null);
+            }
+
+            var summary = new DataPoint();
+
+            for (var i = 1; i <= numFrames; i++)
+            {
+                var index = (nextFrameIndex + i) % sequenceLength;
+                summary += frameData[index];
+            }
+
+            return (summary, totalTime);
+        }
+
+        private struct DataSequence : IEquatable<DataSequence>
+        {
+            public readonly DataPoint[] Incoming;
+            public readonly DataPoint[] Outgoing;
+
+            public DataSequence(int size)
+            {
+                Incoming = new DataPoint[size];
+                Outgoing = new DataPoint[size];
+            }
+
+            public void AddFrame(int index, DataPoint data, Direction direction)
+            {
+                switch (direction)
+                {
+                    case Direction.Incoming:
+                        Incoming[index] = data;
+                        break;
+                    case Direction.Outgoing:
+                        Outgoing[index] = data;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(direction), direction, null);
+                }
+            }
+
+            public void Clear(int index, Direction direction)
+            {
+                switch (direction)
+                {
+                    case Direction.Incoming:
+                        Incoming[index] = new DataPoint();
+                        break;
+                    case Direction.Outgoing:
+                        Outgoing[index] = new DataPoint();
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(direction), direction, null);
+                }
+            }
+
+            public bool Equals(DataSequence other)
+            {
+                return Equals(Incoming, other.Incoming) && Equals(Outgoing, other.Outgoing);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is DataSequence other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return ((Incoming != null ? Incoming.GetHashCode() : 0) * 397) ^ (Outgoing != null ? Outgoing.GetHashCode() : 0);
+                }
+            }
+
+            public static bool operator ==(DataSequence left, DataSequence right)
+            {
+                return left.Equals(right);
+            }
+
+            public static bool operator !=(DataSequence left, DataSequence right)
+            {
+                return !left.Equals(right);
+            }
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetStats.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetStats.cs
@@ -46,7 +46,7 @@ namespace Improbable.Gdk.Core.NetworkStats
 
         public void FinishFrame()
         {
-            if (--nextFrameIndex == -1)
+            if (--nextFrameIndex < 0)
             {
                 nextFrameIndex += sequenceLength;
             }
@@ -56,7 +56,7 @@ namespace Improbable.Gdk.Core.NetworkStats
         {
             if (numFrames > sequenceLength)
             {
-                throw new InvalidOperationException($"Cannot fetch {numFrames} worth of data. This instance can only store to up {sequenceLength} frames.");
+                throw new ArgumentOutOfRangeException($"Cannot fetch {numFrames} worth of data. This instance can only store to up {sequenceLength} frames.");
             }
 
             float totalTime = 0.0f;

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetStats.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetStats.cs
@@ -54,6 +54,11 @@ namespace Improbable.Gdk.Core.NetworkStats
 
         public (DataPoint, float) GetSummary(MessageTypeUnion messageType, int numFrames, Direction direction)
         {
+            if (numFrames > sequenceLength)
+            {
+                throw new InvalidOperationException($"Cannot fetch {numFrames} worth of data. This instance can only store to up {sequenceLength} frames.");
+            }
+
             float totalTime = 0.0f;
 
             for (var i = 1; i <= numFrames; i++)

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetStats.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetStats.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f1615672368ba46478404c6ab46afa83
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetworkStatisticsSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetworkStatisticsSystem.cs
@@ -13,8 +13,8 @@ namespace Improbable.Gdk.Core.NetworkStats
         private const int DefaultBufferSize = 60;
 
         private readonly NetStats netStats = new NetStats(DefaultBufferSize);
-        private readonly NetFrameStats lastIncomingData = NetFrameStats.Pool.Rent();
-        private readonly NetFrameStats lastOutgoingData = NetFrameStats.Pool.Rent();
+        private readonly NetFrameStats lastIncomingData = new NetFrameStats();
+        private readonly NetFrameStats lastOutgoingData = new NetFrameStats();
 
         private float lastFrameTime;
 
@@ -24,12 +24,6 @@ namespace Improbable.Gdk.Core.NetworkStats
             Enabled = false;
         }
 #endif
-
-        protected override void OnDestroy()
-        {
-            NetFrameStats.Pool.Return(lastIncomingData);
-            NetFrameStats.Pool.Return(lastOutgoingData);
-        }
 
         protected override void OnUpdate()
         {

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetworkStatisticsSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetworkStatisticsSystem.cs
@@ -1,0 +1,58 @@
+using System.Diagnostics;
+using Unity.Entities;
+using UnityEngine;
+using Debug = UnityEngine.Debug;
+
+namespace Improbable.Gdk.Core.NetworkStats
+{
+    [DisableAutoCreation]
+    [UpdateInGroup(typeof(SpatialOSReceiveGroup.InternalSpatialOSReceiveGroup))]
+    [UpdateBefore(typeof(SpatialOSReceiveSystem))]
+    public class NetworkStatisticsSystem : ComponentSystem
+    {
+        private const int DefaultBufferSize = 60;
+
+        private readonly NetStats netStats = new NetStats(DefaultBufferSize);
+        private readonly NetFrameStats lastIncomingData = NetFrameStats.Pool.Rent();
+        private readonly NetFrameStats lastOutgoingData = NetFrameStats.Pool.Rent();
+
+        private float lastFrameTime;
+
+#if !UNITY_EDITOR
+        protected override void OnCreate()
+        {
+            Enabled = false;
+        }
+#endif
+
+        protected override void OnDestroy()
+        {
+            NetFrameStats.Pool.Return(lastIncomingData);
+            NetFrameStats.Pool.Return(lastOutgoingData);
+        }
+
+        protected override void OnUpdate()
+        {
+            netStats.SetFrameStats(lastIncomingData, Direction.Incoming);
+            netStats.SetFrameStats(lastOutgoingData, Direction.Outgoing);
+            netStats.SetFrameTime(lastFrameTime);
+            netStats.FinishFrame();
+
+            lastIncomingData.Clear();
+            lastOutgoingData.Clear();
+            lastFrameTime = Time.deltaTime;
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        internal void ApplyDiff(ViewDiff diff)
+        {
+            lastIncomingData.CopyFrom(diff.GetNetStats());
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        internal void AddOutgoingSample(NetFrameStats frameStats)
+        {
+            lastOutgoingData.CopyFrom(frameStats);
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetworkStatisticsSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetworkStatisticsSystem.cs
@@ -5,6 +5,15 @@ using Debug = UnityEngine.Debug;
 
 namespace Improbable.Gdk.Core.NetworkStats
 {
+    /*
+     *     This system runs before the receive system such that the order is:
+     *
+     *     NetworkStatisticsSystem -> SpatialOSReceiveSystem -> ... -> SpatialOSSendSystem
+     *
+     *     When both SpatialOSReceiveSystem and SpatialOSSendSystem runs they provide
+     *     network data to this system. This will store them until the next time it runs when it
+     *     will push this data in the underlying data storage and reset the temporary storage.
+     */
     [DisableAutoCreation]
     [UpdateInGroup(typeof(SpatialOSReceiveGroup.InternalSpatialOSReceiveGroup))]
     [UpdateBefore(typeof(SpatialOSReceiveSystem))]

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetworkStatisticsSystem.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetworkStatisticsSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fa82de07019ff4a41b5a0a5d5ebc3b6b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
@@ -1,4 +1,5 @@
 using System;
+using Improbable.Gdk.Core.NetworkStats;
 using Unity.Entities;
 using UnityEngine;
 using UnityEngine.Profiling;
@@ -15,6 +16,7 @@ namespace Improbable.Gdk.Core
         private WorkerSystem worker;
         private EcsViewSystem ecsViewSystem;
         private EntitySystem entitySystem;
+        private NetworkStatisticsSystem networkStatisticsSystem;
 
         protected override void OnCreate()
         {
@@ -23,6 +25,7 @@ namespace Improbable.Gdk.Core
             worker = World.GetExistingSystem<WorkerSystem>();
             ecsViewSystem = World.GetOrCreateSystem<EcsViewSystem>();
             entitySystem = World.GetOrCreateSystem<EntitySystem>();
+            networkStatisticsSystem = World.GetOrCreateSystem<NetworkStatisticsSystem>();
         }
 
         protected override void OnUpdate()
@@ -41,6 +44,10 @@ namespace Improbable.Gdk.Core
 
                 Profiler.BeginSample("ApplyDiff Entity");
                 entitySystem.ApplyDiff(diff);
+                Profiler.EndSample();
+
+                Profiler.BeginSample("ApplyDiff Networking Statistics");
+                networkStatisticsSystem.ApplyDiff(diff);
                 Profiler.EndSample();
             }
             catch (Exception e)

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/SpatialOSSendSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/SpatialOSSendSystem.cs
@@ -1,3 +1,4 @@
+using Improbable.Gdk.Core.NetworkStats;
 using Unity.Entities;
 
 namespace Improbable.Gdk.Core
@@ -8,17 +9,21 @@ namespace Improbable.Gdk.Core
     public class SpatialOSSendSystem : ComponentSystem
     {
         private WorkerSystem worker;
+        private NetworkStatisticsSystem networkStatisticsSystem;
 
         protected override void OnCreate()
         {
             base.OnCreate();
 
             worker = World.GetExistingSystem<WorkerSystem>();
+            networkStatisticsSystem = World.GetOrCreateSystem<NetworkStatisticsSystem>();
         }
 
         protected override void OnUpdate()
         {
-            worker.SendMessages();
+            var stats = NetFrameStats.Pool.Rent();
+            worker.SendMessages(stats);
+            networkStatisticsSystem.AddOutgoingSample(stats);
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/SpatialOSSendSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/SpatialOSSendSystem.cs
@@ -10,6 +10,7 @@ namespace Improbable.Gdk.Core
     {
         private WorkerSystem worker;
         private NetworkStatisticsSystem networkStatisticsSystem;
+        private NetFrameStats netFrameStats = new NetFrameStats();
 
         protected override void OnCreate()
         {
@@ -21,9 +22,9 @@ namespace Improbable.Gdk.Core
 
         protected override void OnUpdate()
         {
-            var stats = NetFrameStats.Pool.Rent();
-            worker.SendMessages(stats);
-            networkStatisticsSystem.AddOutgoingSample(stats);
+            worker.SendMessages(netFrameStats);
+            networkStatisticsSystem.AddOutgoingSample(netFrameStats);
+            netFrameStats.Clear();
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/WorkerSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/WorkerSystem.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Improbable.Gdk.Core.NetworkStats;
 using Improbable.Worker.CInterop;
 using Unity.Entities;
 using UnityEngine;
@@ -83,9 +84,9 @@ namespace Improbable.Gdk.Core
             Worker.Tick();
         }
 
-        internal void SendMessages()
+        internal void SendMessages(NetFrameStats frameStats)
         {
-            Worker.EnsureMessagesFlushed();
+            Worker.EnsureMessagesFlushed(frameStats);
         }
 
         protected override void OnCreate()

--- a/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/NetworkStats.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/NetworkStats.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b4e134112fa566e41bdb9e693f4664e4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/NetworkStats/MessageTypeUnionTests.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/NetworkStats/MessageTypeUnionTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Improbable.Gdk.Core.NetworkStats;
+using NUnit.Framework;
+
+namespace Improbable.Gdk.Core.EditmodeTests.NetworkStats
+{
+    [TestFixture]
+    public class MessageTypeUnionTests
+    {
+        [Test]
+        public void MessageTypeUnion_with_same_type_and_data_are_equal()
+        {
+            var update = MessageTypeUnion.Update(10);
+            Assert.AreEqual(update, update);
+
+            var commandRequest = MessageTypeUnion.CommandRequest(10, 10);
+            Assert.AreEqual(commandRequest, commandRequest);
+
+            var commandResponse = MessageTypeUnion.CommandResponse(10, 10);
+            Assert.AreEqual(commandResponse, commandResponse);
+
+            var worldCommandRequest = MessageTypeUnion.WorldCommandRequest(WorldCommand.CreateEntity);
+            Assert.AreEqual(worldCommandRequest, worldCommandRequest);
+
+            var worldCommandResponse = MessageTypeUnion.WorldCommandResponse(WorldCommand.CreateEntity);
+            Assert.AreEqual(worldCommandResponse, worldCommandResponse);
+        }
+
+        [Test]
+        public void MessageTypeUnion_are_not_equal_with_different_types()
+        {
+            var typeOne = MessageTypeUnion.Update(10);
+            var typeTwo = MessageTypeUnion.CommandRequest(10, 10);
+
+            Assert.AreNotEqual(typeOne, typeTwo);
+        }
+
+        [Test]
+        public void MessageTypeUnion_update_types_are_not_equal_with_different_data()
+        {
+            var updateOne = MessageTypeUnion.Update(1);
+            var updateTwo = MessageTypeUnion.Update(2);
+
+            Assert.AreNotEqual(updateOne, updateTwo);
+        }
+
+        [Test]
+        public void MessageTypeUnion_command_request_types_are_not_equal_with_different_data()
+        {
+            var commandRequestData = new List<MessageTypeUnion>
+            {
+                MessageTypeUnion.CommandRequest(1, 1),
+                MessageTypeUnion.CommandRequest(1, 2),
+                MessageTypeUnion.CommandRequest(2, 1),
+                MessageTypeUnion.CommandRequest(2, 2)
+            };
+
+            Assert.IsFalse(AreAnyEqual(commandRequestData));
+        }
+
+        [Test]
+        public void MessageTypeUnion_command_response_types_are_not_equal_with_different_data()
+        {
+            var commandResponseData = new List<MessageTypeUnion>
+            {
+                MessageTypeUnion.CommandResponse(1, 1),
+                MessageTypeUnion.CommandResponse(1, 2),
+                MessageTypeUnion.CommandResponse(2, 1),
+                MessageTypeUnion.CommandResponse(2, 2)
+            };
+
+            Assert.IsFalse(AreAnyEqual(commandResponseData));
+        }
+
+        [Test]
+        public void MessageTypeUnion_world_command_request_types_are_not_equal_with_different_data()
+        {
+            var worldCommandRequestOne = MessageTypeUnion.WorldCommandRequest(WorldCommand.CreateEntity);
+            var worldCommandRequestTwo = MessageTypeUnion.WorldCommandRequest(WorldCommand.DeleteEntity);
+
+            Assert.AreNotEqual(worldCommandRequestOne, worldCommandRequestTwo);
+        }
+
+        [Test]
+        public void MessageTypeUnion_world_command_response_types_are_not_equal_with_different_data()
+        {
+            var worldCommandResponseOne = MessageTypeUnion.WorldCommandResponse(WorldCommand.CreateEntity);
+            var worldCommandResponseTwo = MessageTypeUnion.WorldCommandResponse(WorldCommand.DeleteEntity);
+
+            Assert.AreNotEqual(worldCommandResponseOne, worldCommandResponseTwo);
+        }
+
+        // Checks if any element in a list is equal to any other element in a list.
+        private bool AreAnyEqual<T>(List<T> data) where T : IEquatable<T>
+        {
+            return data.Any(element => data.Except(new[] { element }).Any(other => other.Equals(element)));
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/NetworkStats/MessageTypeUnionTests.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/NetworkStats/MessageTypeUnionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 38ce7d41e0dd99340b3eb6a3bb1f17fb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/NetworkStats/NetStatsTests.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/NetworkStats/NetStatsTests.cs
@@ -10,7 +10,7 @@ namespace Improbable.Gdk.Core.EditmodeTests.NetworkStats
         public void GetSummary_throws_if_requested_frames_is_longer_than_sequence_stored()
         {
             var netStats = new NetStats(5);
-            Assert.Throws<InvalidOperationException>(() =>
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
                 netStats.GetSummary(MessageTypeUnion.Update(54), 10, Direction.Incoming));
         }
 

--- a/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/NetworkStats/NetStatsTests.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/NetworkStats/NetStatsTests.cs
@@ -62,7 +62,7 @@ namespace Improbable.Gdk.Core.EditmodeTests.NetworkStats
         public void SetFrameStats_inserts_into_the_correct_direction_and_message_type(Direction direction)
         {
             var netStats = new NetStats(5);
-            var netFrameStats = NetFrameStats.Pool.Rent();
+            var netFrameStats = new NetFrameStats();
             var dataInjector = netFrameStats.TestInjector;
 
             dataInjector.AddComponentUpdate(5, 3);
@@ -138,7 +138,7 @@ namespace Improbable.Gdk.Core.EditmodeTests.NetworkStats
         public void FrameStats_is_summed_in_summary_stats_and_wraps_correctly()
         {
             var netStats = new NetStats(5);
-            var netFrameStats = NetFrameStats.Pool.Rent();
+            var netFrameStats = new NetFrameStats();
             var dataInjector = netFrameStats.TestInjector;
 
             var messageType = MessageTypeUnion.Update(10);

--- a/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/NetworkStats/NetStatsTests.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/NetworkStats/NetStatsTests.cs
@@ -156,7 +156,6 @@ namespace Improbable.Gdk.Core.EditmodeTests.NetworkStats
             //           buffer - [5, 4, 3, 2, 1]
             //                 nextInsertIndex ^
 
-
             var (singleFrameData, _) = netStats.GetSummary(messageType, 1, direction);
             Assert.AreEqual(1, singleFrameData.Count);
             Assert.AreEqual(5, singleFrameData.Size);

--- a/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/NetworkStats/NetStatsTests.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/NetworkStats/NetStatsTests.cs
@@ -1,0 +1,173 @@
+using System;
+using Improbable.Gdk.Core.NetworkStats;
+using NUnit.Framework;
+
+namespace Improbable.Gdk.Core.EditmodeTests.NetworkStats
+{
+    public class NetStatsTests
+    {
+        [Test]
+        public void GetSummary_throws_if_requested_frames_is_longer_than_sequence_stored()
+        {
+            var netStats = new NetStats(5);
+            Assert.Throws<InvalidOperationException>(() =>
+                netStats.GetSummary(MessageTypeUnion.Update(54), 10, Direction.Incoming));
+        }
+
+        [Test]
+        public void FrameTime_is_summed_in_summary_stats()
+        {
+            var netStats = new NetStats(5);
+
+            netStats.SetFrameTime(1);
+            netStats.FinishFrame();
+
+            netStats.SetFrameTime(0.5f);
+            netStats.FinishFrame();
+
+            netStats.SetFrameTime(0.25f);
+            netStats.FinishFrame();
+
+            var (_, singleFrameTime) = netStats.GetSummary(MessageTypeUnion.Update(54), 1, Direction.Incoming);
+            Assert.AreEqual(0.25f, singleFrameTime, float.Epsilon);
+
+            var (_, twoFrameTime) = netStats.GetSummary(MessageTypeUnion.Update(54), 2, Direction.Incoming);
+            Assert.AreEqual(0.75f, twoFrameTime, float.Epsilon);
+
+            var (_, threeFrameTime) = netStats.GetSummary(MessageTypeUnion.Update(54), 3, Direction.Incoming);
+            Assert.AreEqual(1.75f, threeFrameTime, float.Epsilon);
+        }
+
+        [Test]
+        public void FrameTime_summation_wraps_correctly()
+        {
+            var netStats = new NetStats(5);
+
+            for (var i = 1; i <= 5; i++)
+            {
+                netStats.SetFrameTime(i);
+                netStats.FinishFrame();
+            }
+
+            // After the for loop:
+            // FrameTime buffer - [5, 4, 3, 2, 1]
+            //                 nextInsertIndex ^
+
+            var (_, threeFrameTime) = netStats.GetSummary(MessageTypeUnion.Update(54), 3, Direction.Incoming);
+            Assert.AreEqual(5 + 4 + 3, threeFrameTime, float.Epsilon);
+        }
+
+        [TestCase(Direction.Incoming)]
+        [TestCase(Direction.Outgoing)]
+        public void SetFrameStats_inserts_into_the_correct_direction_and_message_type(Direction direction)
+        {
+            var netStats = new NetStats(5);
+            var netFrameStats = NetFrameStats.Pool.Rent();
+            var dataInjector = netFrameStats.TestInjector;
+
+            dataInjector.AddComponentUpdate(5, 3);
+            dataInjector.AddComponentUpdate(10, 3);
+            dataInjector.AddComponentUpdate(10, 3);
+
+            dataInjector.AddCommandRequest(10, 5, 3);
+            dataInjector.AddCommandRequest(5, 10, 3);
+            dataInjector.AddCommandRequest(5, 10, 3);
+
+            dataInjector.AddCommandResponse(10, 5, 3);
+            dataInjector.AddCommandResponse(5, 10, 3);
+            dataInjector.AddCommandResponse(5, 10, 3);
+
+            // To eliminate the possibility of cross-talk we need to insert these in more than once or twice to get
+            // unique counts.
+
+            for (var i = 0; i < 3; i++)
+            {
+                dataInjector.AddWorldCommandRequest(WorldCommand.CreateEntity);
+                dataInjector.AddWorldCommandRequest(WorldCommand.DeleteEntity);
+                dataInjector.AddWorldCommandRequest(WorldCommand.DeleteEntity);
+            }
+
+            for (var i = 0; i < 5; i++)
+            {
+                dataInjector.AddWorldCommandResponse(WorldCommand.EntityQuery);
+                dataInjector.AddWorldCommandResponse(WorldCommand.ReserveEntityIds);
+                dataInjector.AddWorldCommandResponse(WorldCommand.ReserveEntityIds);
+            }
+
+            netStats.SetFrameStats(netFrameStats, direction);
+            netStats.FinishFrame();
+
+            var (updateOne, _) = netStats.GetSummary(MessageTypeUnion.Update(5), 1, direction);
+            Assert.AreEqual(1, updateOne.Count);
+            Assert.AreEqual(3, updateOne.Size);
+
+            var (updateTwo, _) = netStats.GetSummary(MessageTypeUnion.Update(10), 1, direction);
+            Assert.AreEqual(2, updateTwo.Count);
+            Assert.AreEqual(6, updateTwo.Size);
+
+            var (commandRequestOne, _) = netStats.GetSummary(MessageTypeUnion.CommandRequest(10, 5), 1, direction);
+            Assert.AreEqual(1, commandRequestOne.Count);
+            Assert.AreEqual(3, commandRequestOne.Size);
+
+            var (commandRequestTwo, _) = netStats.GetSummary(MessageTypeUnion.CommandRequest(5, 10), 1, direction);
+            Assert.AreEqual(2, commandRequestTwo.Count);
+            Assert.AreEqual(6, commandRequestTwo.Size);
+
+            var (commandResponseOne, _) = netStats.GetSummary(MessageTypeUnion.CommandResponse(10, 5), 1, direction);
+            Assert.AreEqual(1, commandResponseOne.Count);
+            Assert.AreEqual(3, commandResponseOne.Size);
+
+            var (commandResponseTwo, _) = netStats.GetSummary(MessageTypeUnion.CommandResponse(5, 10), 1, direction);
+            Assert.AreEqual(2, commandResponseTwo.Count);
+            Assert.AreEqual(6, commandResponseTwo.Size);
+
+            var (worldCommandRequestOne, _) = netStats.GetSummary(MessageTypeUnion.WorldCommandRequest(WorldCommand.CreateEntity), 1, direction);
+            Assert.AreEqual(3, worldCommandRequestOne.Count);
+
+            var (worldCommandRequestTwo, _) = netStats.GetSummary(MessageTypeUnion.WorldCommandRequest(WorldCommand.DeleteEntity), 1, direction);
+            Assert.AreEqual(6, worldCommandRequestTwo.Count);
+
+            var (worldCommandResponseOne, _) = netStats.GetSummary(MessageTypeUnion.WorldCommandResponse(WorldCommand.EntityQuery), 1, direction);
+            Assert.AreEqual(5, worldCommandResponseOne.Count);
+
+            var (worldCommandResponseTwo, _) = netStats.GetSummary(MessageTypeUnion.WorldCommandResponse(WorldCommand.ReserveEntityIds), 1, direction);
+            Assert.AreEqual(10, worldCommandResponseTwo.Count);
+        }
+
+        [Test]
+        public void FrameStats_is_summed_in_summary_stats_and_wraps_correctly()
+        {
+            var netStats = new NetStats(5);
+            var netFrameStats = NetFrameStats.Pool.Rent();
+            var dataInjector = netFrameStats.TestInjector;
+
+            var messageType = MessageTypeUnion.Update(10);
+            var direction = Direction.Incoming;
+
+            for (uint i = 1; i <= 5; i++)
+            {
+                dataInjector.AddComponentUpdate(10, i);
+                netStats.SetFrameStats(netFrameStats, direction);
+                netStats.FinishFrame();
+                netFrameStats.Clear();
+            }
+
+            // After the for loop, for the correct direction and message type.
+            //           buffer - [5, 4, 3, 2, 1]
+            //                 nextInsertIndex ^
+
+
+            var (singleFrameData, _) = netStats.GetSummary(messageType, 1, direction);
+            Assert.AreEqual(1, singleFrameData.Count);
+            Assert.AreEqual(5, singleFrameData.Size);
+
+            var (twoFrameData, _) = netStats.GetSummary(messageType, 2, direction);
+            Assert.AreEqual(2, twoFrameData.Count);
+            Assert.AreEqual(5 + 4, twoFrameData.Size);
+
+            var (threeFrameData, _) = netStats.GetSummary(messageType, 3, direction);
+            Assert.AreEqual(3, threeFrameData.Count);
+            Assert.AreEqual(5 + 4 + 3, threeFrameData.Size);
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/NetworkStats/NetStatsTests.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/NetworkStats/NetStatsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cdfec9d0fdcb792428972e647278ded6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/IConnectionHandler.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/IConnectionHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Improbable.Gdk.Core.NetworkStats;
 
 namespace Improbable.Gdk.Core
 {
@@ -41,7 +42,7 @@ namespace Improbable.Gdk.Core
         ///     The messages may not be sent immediately. This is up to the implementer.
         /// </remarks>
         /// <param name="messages">The set of messages to send.</param>
-        void PushMessagesToSend(MessagesToSend messages);
+        void PushMessagesToSend(MessagesToSend messages, NetFrameStats frameStats);
 
         /// <summary>
         ///     Gets a value indicating whether the underlying connection is connected.

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Improbable.Gdk.Core.NetworkStats;
 using Improbable.Worker.CInterop;
 
 namespace Improbable.Gdk.Core
@@ -111,7 +112,7 @@ namespace Improbable.Gdk.Core
             return new MessagesToSend();
         }
 
-        public void PushMessagesToSend(MessagesToSend messages)
+        public void PushMessagesToSend(MessagesToSend messages, NetFrameStats netFrameStats)
         {
             throw new System.NotImplementedException();
         }

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/MultiThreadedSpatialOSConnectionHandler.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/MultiThreadedSpatialOSConnectionHandler.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Improbable.Gdk.Core.NetworkStats;
 using Improbable.Worker.CInterop;
 
 namespace Improbable.Gdk.Core
@@ -56,17 +57,17 @@ namespace Improbable.Gdk.Core
             return serializationHandler.GetMessagesToSendContainer();
         }
 
-        public void PushMessagesToSend(MessagesToSend messages)
+        public void PushMessagesToSend(MessagesToSend messages, NetFrameStats frameStats)
         {
-            SendSerializedMessages();
+            SendSerializedMessages(frameStats);
             serializationHandler.EnqueueMessagesToSend(messages);
         }
 
-        private void SendSerializedMessages()
+        private void SendSerializedMessages(NetFrameStats frameStats)
         {
             while (serializationHandler.TryDequeueSerializedMessages(out var messages))
             {
-                var metaData = messages.SendAndClear(connection);
+                var metaData = messages.SendAndClear(connection, frameStats);
                 serializationHandler.ReturnSerializedMessageContainer(messages);
                 commandMetaDataManager.AddMetaData(metaData);
             }

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/SpatialOSConnectionHandler/SpatialOSConnectionHandler.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/SpatialOSConnectionHandler/SpatialOSConnectionHandler.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Improbable.Gdk.Core.NetworkStats;
 using Improbable.Worker.CInterop;
 
 namespace Improbable.Gdk.Core
@@ -53,10 +54,10 @@ namespace Improbable.Gdk.Core
             return messagesToSend;
         }
 
-        public void PushMessagesToSend(MessagesToSend messages)
+        public void PushMessagesToSend(MessagesToSend messages, NetFrameStats frameStats)
         {
             serializedMessagesToSend.SerializeFrom(messages, commandMetaDataManager.GetEmptyMetaDataStorage());
-            var metaData = serializedMessagesToSend.SendAndClear(connection);
+            var metaData = serializedMessagesToSend.SendAndClear(connection, frameStats);
             commandMetaDataManager.AddMetaData(metaData);
             serializedMessagesToSend.Clear();
             messages.Clear();

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/OpListConverter.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/OpListConverter.cs
@@ -1,4 +1,5 @@
 using System;
+using Improbable.Gdk.Core.NetworkStats;
 using Improbable.Worker.CInterop;
 
 namespace Improbable.Gdk.Core
@@ -23,7 +24,9 @@ namespace Improbable.Gdk.Core
                 shouldClear = false;
             }
 
-            for (int i = 0; i < opList.GetOpCount(); ++i)
+            var netStats = viewDiff.GetNetStats();
+
+            for (var i = 0; i < opList.GetOpCount(); ++i)
             {
                 switch (opList.GetOpType(i))
                 {
@@ -56,18 +59,22 @@ namespace Improbable.Gdk.Core
                         var reserveEntityIdsOp = opList.GetReserveEntityIdsResponseOp(i);
                         ComponentOpDeserializer.ApplyReserveEntityIdsResponse(reserveEntityIdsOp, viewDiff,
                             commandMetaData);
+                        netStats.AddWorldCommandResponse(WorldCommand.ReserveEntityIds);
                         break;
                     case OpType.CreateEntityResponse:
                         var createEntityOp = opList.GetCreateEntityResponseOp(i);
                         ComponentOpDeserializer.ApplyCreateEntityResponse(createEntityOp, viewDiff, commandMetaData);
+                        netStats.AddWorldCommandResponse(WorldCommand.CreateEntity);
                         break;
                     case OpType.DeleteEntityResponse:
                         var deleteEntityOp = opList.GetDeleteEntityResponseOp(i);
                         ComponentOpDeserializer.ApplyDeleteEntityResponse(deleteEntityOp, viewDiff, commandMetaData);
+                        netStats.AddWorldCommandResponse(WorldCommand.DeleteEntity);
                         break;
                     case OpType.EntityQueryResponse:
                         var entityQueryOp = opList.GetEntityQueryResponseOp(i);
                         ComponentOpDeserializer.ApplyEntityQueryResponse(entityQueryOp, viewDiff, commandMetaData);
+                        netStats.AddWorldCommandResponse(WorldCommand.EntityQuery);
                         break;
                     case OpType.AddComponent:
                         ComponentOpDeserializer.DeserializeAndAddComponent(opList.GetAddComponentOp(i), viewDiff);
@@ -81,18 +88,22 @@ namespace Improbable.Gdk.Core
                         viewDiff.SetAuthority(authorityOp.EntityId, authorityOp.ComponentId, authorityOp.Authority);
                         break;
                     case OpType.ComponentUpdate:
-                        ComponentOpDeserializer.DeserializeAndApplyComponentUpdate(opList.GetComponentUpdateOp(i),
-                            viewDiff, componentUpdateId);
+                        var updateOp = opList.GetComponentUpdateOp(i);
+                        ComponentOpDeserializer.DeserializeAndApplyComponentUpdate(updateOp, viewDiff,
+                            componentUpdateId);
                         ++componentUpdateId;
+                        netStats.AddUpdate(updateOp.Update);
                         break;
                     case OpType.CommandRequest:
-                        ComponentOpDeserializer.DeserializeAndApplyCommandRequestReceived(opList.GetCommandRequestOp(i),
-                            viewDiff);
+                        var commandRequestOp = opList.GetCommandRequestOp(i);
+                        ComponentOpDeserializer.DeserializeAndApplyCommandRequestReceived(commandRequestOp, viewDiff);
+                        netStats.AddCommandRequest(commandRequestOp.Request);
                         break;
                     case OpType.CommandResponse:
+                        var commandResponseOp = opList.GetCommandResponseOp(i);
                         ComponentOpDeserializer.DeserializeAndApplyCommandResponseReceived(
-                            opList.GetCommandResponseOp(i), viewDiff,
-                            commandMetaData);
+                            commandResponseOp, viewDiff, commandMetaData);
+                        netStats.AddCommandResponse(commandResponseOp.Response, commandResponseOp.Message);
                         break;
                     default:
                         throw new ArgumentOutOfRangeException(

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/SerializedMessagesToSend.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/SerializedMessagesToSend.cs
@@ -46,7 +46,7 @@ namespace Improbable.Gdk.Core
 
         private CommandMetaData metaData;
 
-        private NetFrameStats netFrameStats = NetFrameStats.Pool.Rent();
+        private NetFrameStats netFrameStats = new NetFrameStats();
 
         public SerializedMessagesToSend()
         {

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/SerializedMessagesToSend.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/SerializedMessagesToSend.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Improbable.Gdk.Core.NetworkStats;
 using Improbable.Worker.CInterop;
 using Improbable.Worker.CInterop.Query;
 
@@ -44,6 +45,8 @@ namespace Improbable.Gdk.Core
         private readonly List<ICommandSerializer> commandSerializers = new List<ICommandSerializer>();
 
         private CommandMetaData metaData;
+
+        private NetFrameStats netFrameStats = NetFrameStats.Pool.Rent();
 
         public SerializedMessagesToSend()
         {
@@ -120,9 +123,10 @@ namespace Improbable.Gdk.Core
             metricsToSend.Clear();
             logMessages.Clear();
             authorityLossAcks.Clear();
+            netFrameStats.Clear();
         }
 
-        public CommandMetaData SendAndClear(Connection connection)
+        public CommandMetaData SendAndClear(Connection connection, NetFrameStats frameStats)
         {
             for (int i = 0; i < updates.Count; ++i)
             {
@@ -195,6 +199,7 @@ namespace Improbable.Gdk.Core
                 connection.SendAuthorityLossImminentAcknowledgement(entityComponent.EntityId, entityComponent.ComponentId);
             }
 
+            frameStats.Merge(netFrameStats);
             Clear();
 
             return metaData;
@@ -203,41 +208,49 @@ namespace Improbable.Gdk.Core
         public void AddComponentUpdate(ComponentUpdate update, long entityId)
         {
             updates.Add(new UpdateToSend(update, entityId));
+            netFrameStats.AddUpdate(update);
         }
 
         public void AddRequest(CommandRequest request, uint commandId, long entityId, uint? timeout, long requestId)
         {
             requests.Add(new RequestToSend(request, commandId, entityId, timeout, requestId));
+            netFrameStats.AddCommandRequest(request);
         }
 
         public void AddResponse(CommandResponse response, uint requestId)
         {
             responses.Add(new ResponseToSend(response, requestId));
+            netFrameStats.AddCommandResponse(response, message: null);
         }
 
-        public void AddFailure(string reason, uint requestId)
+        public void AddFailure(uint componentId, uint commandIndex, string reason, uint requestId)
         {
             failures.Add(new FailureToSend(reason, requestId));
+            netFrameStats.AddCommandResponse(reason, componentId, commandIndex);
         }
 
         public void AddCreateEntityRequest(Entity entity, long? entityId, uint? timeout, long requestId)
         {
             createEntityRequests.Add(new CreateEntityRequestToSend(entity, entityId, timeout, requestId));
+            netFrameStats.AddWorldCommandRequest(WorldCommand.CreateEntity);
         }
 
         public void AddDeleteEntityRequest(long entityId, uint? timeout, long requestId)
         {
             deleteEntityRequests.Add(new DeleteEntityRequestToSend(entityId, timeout, requestId));
+            netFrameStats.AddWorldCommandRequest(WorldCommand.DeleteEntity);
         }
 
         public void AddReserveEntityIdsRequest(uint numberOfEntityIds, uint? timeout, long requestId)
         {
             reserveEntityIdsRequests.Add(new ReserveEntityIdsRequestToSend(numberOfEntityIds, timeout, requestId));
+            netFrameStats.AddWorldCommandRequest(WorldCommand.ReserveEntityIds);
         }
 
         public void AddEntityQueryRequest(EntityQuery query, uint? timeout, long requestId)
         {
             entityQueryRequests.Add(new EntityQueryRequestToSend(query, timeout, requestId));
+            netFrameStats.AddWorldCommandRequest(WorldCommand.EntityQuery);
         }
 
         internal void DestroyUnsentMessages()

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/ViewDiff.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/ViewDiff.cs
@@ -42,7 +42,7 @@ namespace Improbable.Gdk.Core
 
         private readonly WorldCommandsReceivedStorage worldCommandsReceivedStorage = new WorldCommandsReceivedStorage();
 
-        private readonly NetFrameStats netFrameStats;
+        private readonly NetFrameStats netFrameStats = new NetFrameStats();
 
         public ViewDiff()
         {
@@ -93,8 +93,6 @@ namespace Improbable.Gdk.Core
             typeToCommandStorage.Add(typeof(WorldCommands.DeleteEntity.ReceivedResponse), worldCommandsReceivedStorage);
             typeToCommandStorage.Add(typeof(WorldCommands.ReserveEntityIds.ReceivedResponse), worldCommandsReceivedStorage);
             typeToCommandStorage.Add(typeof(WorldCommands.EntityQuery.ReceivedResponse), worldCommandsReceivedStorage);
-
-            netFrameStats = NetFrameStats.Pool.Rent();
         }
 
         public void Clear()

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/ViewDiff.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/ViewDiff.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Improbable.Gdk.Core.Commands;
+using Improbable.Gdk.Core.NetworkStats;
 using Improbable.Worker.CInterop;
 
 namespace Improbable.Gdk.Core
@@ -40,6 +41,8 @@ namespace Improbable.Gdk.Core
         private readonly List<ICommandDiffStorage> commandStorageList = new List<ICommandDiffStorage>();
 
         private readonly WorldCommandsReceivedStorage worldCommandsReceivedStorage = new WorldCommandsReceivedStorage();
+
+        private readonly NetFrameStats netFrameStats;
 
         public ViewDiff()
         {
@@ -90,6 +93,8 @@ namespace Improbable.Gdk.Core
             typeToCommandStorage.Add(typeof(WorldCommands.DeleteEntity.ReceivedResponse), worldCommandsReceivedStorage);
             typeToCommandStorage.Add(typeof(WorldCommands.ReserveEntityIds.ReceivedResponse), worldCommandsReceivedStorage);
             typeToCommandStorage.Add(typeof(WorldCommands.EntityQuery.ReceivedResponse), worldCommandsReceivedStorage);
+
+            netFrameStats = NetFrameStats.Pool.Rent();
         }
 
         public void Clear()
@@ -112,6 +117,8 @@ namespace Improbable.Gdk.Core
             InCriticalSection = false;
             Disconnected = false;
             DisconnectMessage = null;
+
+            netFrameStats.Clear();
         }
 
         public void AddEntity(long entityId)
@@ -358,6 +365,11 @@ namespace Improbable.Gdk.Core
         internal HashSet<EntityId> GetEntitiesRemoved()
         {
             return entitiesRemoved;
+        }
+
+        internal NetFrameStats GetNetStats()
+        {
+            return netFrameStats;
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/Worker.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/Worker.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Improbable.Gdk.Core.NetworkStats;
 using Improbable.Worker.CInterop;
 
 namespace Improbable.Gdk.Core
@@ -89,9 +90,9 @@ namespace Improbable.Gdk.Core
             View.ApplyDiff(ViewDiff);
         }
 
-        public void EnsureMessagesFlushed()
+        public void EnsureMessagesFlushed(NetFrameStats frameStats)
         {
-            ConnectionHandler.PushMessagesToSend(MessagesToSend);
+            ConnectionHandler.PushMessagesToSend(MessagesToSend, frameStats);
             MessagesToSend = ConnectionHandler.GetMessagesToSendContainer();
         }
 

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/CommandDiffDeserializerGenerator.tt
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/CommandDiffDeserializerGenerator.tt
@@ -111,7 +111,7 @@ namespace <#= qualifiedNamespace #>
                     {
                         // Send a command failure if the string is non-null.
 
-                        serializedMessages.AddFailure(response.FailureMessage, (uint) response.RequestId);
+                        serializedMessages.AddFailure(ComponentId, <#= command.CommandIndex #>, response.FailureMessage, (uint) response.RequestId);
                         continue;
                     }
 


### PR DESCRIPTION
#### Description

This PR allows us to collect networking data about incoming and outgoing messages (in the Unity Editor only!). The points of interest are:
- `NetworkStatisticsSystem` which owns the underlying networking data. Note that the data only available the _next frame_. We run the systems in the order of: `NetworkStatisticsSystem` -> `SpatialOSReceiveSystem` -> `SpatialOSSendSystem` such that we insert last frame's data in this frame.
- `NetStats` which is the backing data container for our networking data. It stores the data in a map of message type to ring-buffered data points. Each data point represents a frame. We fill in the backing containers _backwards_ such that when we want to read data out, we can read the underlying array forward.
- `MessageTypeUnion` which is a C-style union to represent the types of messages that we track. Please review this carefully! 

This data collection has a low performance impact (less than receiving ops for example) and lazily allocates memory and does its best to cache heap-alloc'ed structures.

Commits are logical and roughly ordered. For the best reviewing experience, I recommend you read them in order.

**Remaining work**
- [x] Changelog
- [x] Integration tests between `NetStats` and `NetFrameStats`. 
- [x] API documentation / assorted comments or explanations in code.
