### PR TITLE
Network stats - calculate outgoing stats and backing data store + API

### DIFF
--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponentCommandDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponentCommandDiffDeserializer.cs
@@ -100,7 +100,7 @@ namespace Improbable.DependentSchema
                     {
                         // Send a command failure if the string is non-null.
 
-                        serializedMessages.AddFailure(response.FailureMessage, (uint) response.RequestId);
+                        serializedMessages.AddFailure(ComponentId, 1, response.FailureMessage, (uint) response.RequestId);
                         continue;
                     }
 

--- a/test-project/Assets/Generated/Source/improbable/testschema/TypeC.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/TypeC.cs
@@ -12,13 +12,11 @@ namespace Improbable.TestSchema
     [global::System.Serializable]
     public struct TypeC
     {
-        public global::Improbable.TestSchema.TypeB? BOption;
         public global::System.Collections.Generic.List<global::Improbable.TestSchema.TypeB> BList;
         public global::System.Collections.Generic.Dictionary<string,global::Improbable.TestSchema.TypeB> BMap;
     
-        public TypeC(global::Improbable.TestSchema.TypeB? bOption, global::System.Collections.Generic.List<global::Improbable.TestSchema.TypeB> bList, global::System.Collections.Generic.Dictionary<string,global::Improbable.TestSchema.TypeB> bMap)
+        public TypeC(global::System.Collections.Generic.List<global::Improbable.TestSchema.TypeB> bList, global::System.Collections.Generic.Dictionary<string,global::Improbable.TestSchema.TypeB> bMap)
         {
-            BOption = bOption;
             BList = bList;
             BMap = bMap;
         }
@@ -26,13 +24,6 @@ namespace Improbable.TestSchema
         {
             public static void Serialize(TypeC instance, global::Improbable.Worker.CInterop.SchemaObject obj)
             {
-                {
-                    if (instance.BOption.HasValue)
-                    {
-                        global::Improbable.TestSchema.TypeB.Serialization.Serialize(instance.BOption.Value, obj.AddObject(1));
-                    }
-                    
-                }
                 {
                     foreach (var value in instance.BList)
                     {
@@ -54,13 +45,6 @@ namespace Improbable.TestSchema
             public static TypeC Deserialize(global::Improbable.Worker.CInterop.SchemaObject obj)
             {
                 var instance = new TypeC();
-                {
-                    if (obj.GetObjectCount(1) == 1)
-                    {
-                        instance.BOption = new global::Improbable.TestSchema.TypeB?(global::Improbable.TestSchema.TypeB.Serialization.Deserialize(obj.GetObject(1)));
-                    }
-                    
-                }
                 {
                     instance.BList = new global::System.Collections.Generic.List<global::Improbable.TestSchema.TypeB>();
                     var list = instance.BList;

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/DataPoint.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/DataPoint.cs
@@ -4,5 +4,14 @@ namespace Improbable.Gdk.Core.NetworkStats
     {
         public uint Count;
         public uint Size;
+
+        public static DataPoint operator +(DataPoint first, DataPoint second)
+        {
+            return new DataPoint
+            {
+                Count = first.Count + second.Count,
+                Size = first.Size + second.Size
+            };
+        }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/MessageType.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/MessageType.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Improbable.Gdk.Core.NetworkStats
+{
+    public enum WorldCommand
+    {
+        CreateEntity = 0,
+        DeleteEntity = 1,
+        ReserveEntityIds = 2,
+        EntityQuery = 3
+    }
+
+    public enum Direction
+    {
+        Incoming = 0,
+        Outgoing = 1
+    }
+
+    public enum MessageType
+    {
+        Update = 0,
+        CommandRequest = 1,
+        CommandResponse = 2,
+        WorldCommandRequest = 3,
+        WorldCommandResponse = 4
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct MessageTypeUnion : IEquatable<MessageTypeUnion>
+    {
+        [FieldOffset(offset: 0)] private MessageType Type;
+
+        [FieldOffset(sizeof(MessageType))] private uint UpdateInfo;
+
+        [FieldOffset(sizeof(MessageType))] private (uint, uint) CommandInfo;
+
+        [FieldOffset(sizeof(MessageType))] private WorldCommand WorldCommand;
+
+        public static MessageTypeUnion Update(uint componentId)
+        {
+            return new MessageTypeUnion
+            {
+                Type = MessageType.Update,
+                UpdateInfo = componentId
+            };
+        }
+
+        public static MessageTypeUnion CommandRequest(uint componentId, uint commandIndex)
+        {
+            return new MessageTypeUnion
+            {
+                Type = MessageType.CommandRequest,
+                CommandInfo = (componentId, commandIndex)
+            };
+        }
+
+        public static MessageTypeUnion CommandResponse(uint componentId, uint commandIndex)
+        {
+            return new MessageTypeUnion
+            {
+                Type = MessageType.CommandResponse,
+                CommandInfo = (componentId, commandIndex)
+            };
+        }
+
+        public static MessageTypeUnion WorldCommandRequest(WorldCommand worldCommand)
+        {
+            return new MessageTypeUnion
+            {
+                Type = MessageType.WorldCommandRequest,
+                WorldCommand = worldCommand
+            };
+        }
+
+        public static MessageTypeUnion WorldCommandResponse(WorldCommand worldCommand)
+        {
+            return new MessageTypeUnion
+            {
+                Type = MessageType.WorldCommandResponse,
+                WorldCommand = worldCommand
+            };
+        }
+
+        public bool Equals(MessageTypeUnion other)
+        {
+            if (Type != other.Type)
+            {
+                return false;
+            }
+
+            switch (Type)
+            {
+                case MessageType.Update:
+                    return UpdateInfo == other.UpdateInfo;
+                case MessageType.CommandRequest:
+                    return CommandInfo == other.CommandInfo;
+                case MessageType.CommandResponse:
+                    return CommandInfo == other.CommandInfo;
+                case MessageType.WorldCommandRequest:
+                    return WorldCommand == other.WorldCommand;
+                case MessageType.WorldCommandResponse:
+                    return WorldCommand == other.WorldCommand;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is MessageTypeUnion other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (int) Type;
+
+                switch (Type)
+                {
+                    case MessageType.Update:
+                        hashCode = (hashCode * 397) ^ (int) UpdateInfo;
+                        break;
+                    case MessageType.CommandRequest:
+                        hashCode = (hashCode * 397) ^ CommandInfo.GetHashCode();
+                        break;
+                    case MessageType.CommandResponse:
+                        hashCode = (hashCode * 397) ^ CommandInfo.GetHashCode();
+                        break;
+                    case MessageType.WorldCommandRequest:
+                        hashCode = (hashCode * 397) ^ (int) WorldCommand;
+                        break;
+                    case MessageType.WorldCommandResponse:
+                        hashCode = (hashCode * 397) ^ (int) WorldCommand;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+
+                return hashCode;
+            }
+        }
+
+        public static bool operator ==(MessageTypeUnion left, MessageTypeUnion right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(MessageTypeUnion left, MessageTypeUnion right)
+        {
+            return !left.Equals(right);
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/MessageType.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/MessageType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c086e3c96cf6e8348a851f808b235a00
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetFrameStats.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetFrameStats.cs
@@ -1,0 +1,197 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using Improbable.Worker.CInterop;
+
+namespace Improbable.Gdk.Core.NetworkStats
+{
+    public class NetFrameStats
+    {
+        public readonly Dictionary<uint, DataPoint> Updates = new Dictionary<uint, DataPoint>();
+        public readonly Dictionary<(uint, uint), DataPoint> CommandRequests = new Dictionary<(uint, uint), DataPoint>();
+        public readonly Dictionary<(uint, uint), DataPoint> CommandResponses = new Dictionary<(uint, uint), DataPoint>();
+        public readonly Dictionary<WorldCommand, DataPoint> WorldCommandRequests = new Dictionary<WorldCommand, DataPoint>();
+        public readonly Dictionary<WorldCommand, DataPoint> WorldCommandResponses = new Dictionary<WorldCommand, DataPoint>();
+
+        private NetFrameStats()
+        {
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        public void AddUpdate(in ComponentUpdate update)
+        {
+            var componentId = update.ComponentId;
+            var size = update.SchemaData.Value.GetFields().GetWriteBufferLength() +
+                update.SchemaData.Value.GetEvents().GetWriteBufferLength();
+
+            Updates.TryGetValue(componentId, out var metrics);
+            metrics.Count += 1;
+            metrics.Size += size;
+            Updates[componentId] = metrics;
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        public void AddCommandRequest(in CommandRequest request)
+        {
+            var componentId = request.ComponentId;
+            var commandIndex = request.CommandIndex;
+            var size = request.SchemaData.Value.GetObject().GetWriteBufferLength();
+
+            var key = (componentId, commandIndex);
+            CommandRequests.TryGetValue(key, out var metrics);
+            metrics.Count += 1;
+            metrics.Size += size;
+            CommandRequests[key] = metrics;
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        public void AddCommandResponse(in CommandResponse response, string message)
+        {
+            var componentId = response.ComponentId;
+            var commandIndex = response.CommandIndex;
+            uint size;
+
+            if (response.SchemaData.HasValue)
+            {
+                size = response.SchemaData.Value.GetObject().GetWriteBufferLength();
+            }
+            else
+            {
+                // Approximation of on-wire size.
+                size = (uint) System.Text.Encoding.UTF8.GetByteCount(message);
+            }
+
+            var key = (componentId, commandIndex);
+            CommandResponses.TryGetValue(key, out var metrics);
+            metrics.Count += 1;
+            metrics.Size += size;
+            CommandResponses[key] = metrics;
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        public void AddCommandResponse(string message, uint componentId, uint commandIndex)
+        {
+            // Approximation of on-wire size.
+            var size = (uint) System.Text.Encoding.UTF8.GetByteCount(message);
+
+            var key = (componentId, commandIndex);
+            CommandResponses.TryGetValue(key, out var metrics);
+            metrics.Count += 1;
+            metrics.Size += size;
+            CommandResponses[key] = metrics;
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        public void AddWorldCommandRequest(WorldCommand command)
+        {
+            WorldCommandRequests.TryGetValue(command, out var metrics);
+            metrics.Count += 1;
+            WorldCommandRequests[command] = metrics;
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        public void AddWorldCommandResponse(WorldCommand command)
+        {
+            WorldCommandResponses.TryGetValue(command, out var metrics);
+            metrics.Count += 1;
+            WorldCommandResponses[command] = metrics;
+        }
+
+        internal void CopyFrom(NetFrameStats other)
+        {
+            Clear();
+
+            foreach (var pair in other.Updates)
+            {
+                Updates[pair.Key] = pair.Value;
+            }
+
+            foreach (var pair in other.CommandRequests)
+            {
+                CommandRequests[pair.Key] = pair.Value;
+            }
+
+            foreach (var pair in other.CommandResponses)
+            {
+                CommandResponses[pair.Key] = pair.Value;
+            }
+
+            foreach (var pair in other.WorldCommandRequests)
+            {
+                WorldCommandRequests[pair.Key] = pair.Value;
+            }
+
+            foreach (var pair in other.WorldCommandResponses)
+            {
+                WorldCommandResponses[pair.Key] = pair.Value;
+            }
+        }
+
+        internal void Merge(NetFrameStats other)
+        {
+            foreach (var pair in other.Updates)
+            {
+                Updates.TryGetValue(pair.Key, out var data);
+                data += pair.Value;
+                Updates[pair.Key] = data;
+            }
+
+            foreach (var pair in other.CommandRequests)
+            {
+                CommandRequests.TryGetValue(pair.Key, out var data);
+                data += pair.Value;
+                CommandRequests[pair.Key] = data;
+            }
+
+            foreach (var pair in other.CommandResponses)
+            {
+                CommandResponses.TryGetValue(pair.Key, out var data);
+                data += pair.Value;
+                CommandResponses[pair.Key] = data;
+            }
+
+            foreach (var pair in other.WorldCommandRequests)
+            {
+                WorldCommandRequests.TryGetValue(pair.Key, out var data);
+                data += pair.Value;
+                WorldCommandRequests[pair.Key] = data;
+            }
+
+            foreach (var pair in other.WorldCommandResponses)
+            {
+                WorldCommandResponses.TryGetValue(pair.Key, out var data);
+                data += pair.Value;
+                WorldCommandResponses[pair.Key] = data;
+            }
+        }
+
+        internal void Clear()
+        {
+            Updates.Clear();
+            CommandRequests.Clear();
+            CommandResponses.Clear();
+            WorldCommandRequests.Clear();
+            WorldCommandResponses.Clear();
+        }
+
+        public static class Pool
+        {
+            private static readonly Queue<NetFrameStats> data = new Queue<NetFrameStats>();
+
+            public static NetFrameStats Rent()
+            {
+                if (data.Count != 0)
+                {
+                    return data.Dequeue();
+                }
+
+                return new NetFrameStats();
+            }
+
+            public static void Return(NetFrameStats frameStats)
+            {
+                frameStats.Clear();
+                data.Enqueue(frameStats);
+            }
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetFrameStats.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetFrameStats.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 451278228f70fc24cb48e20145f19b8d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetStats.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetStats.cs
@@ -1,159 +1,193 @@
+using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using Improbable.Worker.CInterop;
 
 namespace Improbable.Gdk.Core.NetworkStats
 {
     public class NetStats
     {
-        public enum WorldCommand
+        private readonly int sequenceLength;
+        private readonly Dictionary<MessageTypeUnion, DataSequence> Data = new Dictionary<MessageTypeUnion, DataSequence>();
+        private int nextFrameIndex;
+
+        public NetStats(int sequenceLength)
         {
-            CreateEntity = 1,
-            DeleteEntity = 2,
-            ReserveEntityIds = 3,
-            EntityQuery = 4
+            this.sequenceLength = sequenceLength;
+            nextFrameIndex = sequenceLength - 1;
         }
 
-        public IReadOnlyDictionary<uint, DataPoint> Updates => updates;
-        public IReadOnlyDictionary<(uint, uint), DataPoint> CommandRequests => commandRequests;
-        public IReadOnlyDictionary<(uint, uint), DataPoint> CommandResponses => commandResponses;
-        public IReadOnlyDictionary<WorldCommand, DataPoint> WorldCommandRequests => worldCommandRequests;
-        public IReadOnlyDictionary<WorldCommand, DataPoint> WorldCommandResponses => worldCommandResponses;
-
-        private readonly Dictionary<uint, DataPoint> updates = new Dictionary<uint, DataPoint>();
-        private readonly Dictionary<(uint, uint), DataPoint> commandRequests = new Dictionary<(uint, uint), DataPoint>();
-        private readonly Dictionary<(uint, uint), DataPoint> commandResponses = new Dictionary<(uint, uint), DataPoint>();
-        private readonly Dictionary<WorldCommand, DataPoint> worldCommandRequests = new Dictionary<WorldCommand, DataPoint>();
-        private readonly Dictionary<WorldCommand, DataPoint> worldCommandResponses = new Dictionary<WorldCommand, DataPoint>();
-
-        private NetStats()
+        public void AddFrame(NetFrameStats frameData, Direction direction)
         {
-        }
-
-        [Conditional("UNITY_EDITOR")]
-        public void AddUpdate(in ComponentUpdate update)
-        {
-            var componentId = update.ComponentId;
-            var size = update.SchemaData.Value.GetFields().GetWriteBufferLength() +
-                update.SchemaData.Value.GetEvents().GetWriteBufferLength();
-
-            updates.TryGetValue(componentId, out var metrics);
-            metrics.Count += 1;
-            metrics.Size += size;
-            updates[componentId] = metrics;
-        }
-
-        [Conditional("UNITY_EDITOR")]
-        public void AddCommandRequest(in CommandRequest request)
-        {
-            var componentId = request.ComponentId;
-            var commandIndex = request.CommandIndex;
-            var size = request.SchemaData.Value.GetObject().GetWriteBufferLength();
-
-            var key = (componentId, commandIndex);
-            commandRequests.TryGetValue(key, out var metrics);
-            metrics.Count += 1;
-            metrics.Size += size;
-            commandRequests[key] = metrics;
-        }
-
-        [Conditional("UNITY_EDITOR")]
-        public void AddCommandResponse(in CommandResponse response, string message)
-        {
-            var componentId = response.ComponentId;
-            var commandIndex = response.CommandIndex;
-            uint size;
-
-            if (response.SchemaData.HasValue)
+            // First we need to zero out the data before processing the _sparse_ data in the NetFrameStats.
+            foreach (var pair in Data)
             {
-                size = response.SchemaData.Value.GetObject().GetWriteBufferLength();
-            }
-            else
-            {
-                // Approximation of on-wire size.
-                size = (uint) System.Text.Encoding.UTF8.GetByteCount(message);
+                pair.Value.Clear(nextFrameIndex, direction);
             }
 
-            var key = (componentId, commandIndex);
-            commandResponses.TryGetValue(key, out var metrics);
-            metrics.Count += 1;
-            metrics.Size += size;
-            commandResponses[key] = metrics;
-        }
-
-        [Conditional("UNITY_EDITOR")]
-        public void AddWorldCommandRequest(WorldCommand command)
-        {
-            worldCommandRequests.TryGetValue(command, out var metrics);
-            metrics.Count += 1;
-            worldCommandRequests[command] = metrics;
-        }
-
-        [Conditional("UNITY_EDITOR")]
-        public void AddWorldCommandResponse(WorldCommand command)
-        {
-            worldCommandResponses.TryGetValue(command, out var metrics);
-            metrics.Count += 1;
-            worldCommandResponses[command] = metrics;
-        }
-
-        internal void CopyFrom(NetStats other)
-        {
-            Clear();
-
-            foreach (var pair in other.updates)
+            foreach (var pair in frameData.Updates)
             {
-                updates[pair.Key] = pair.Value;
-            }
-
-            foreach (var pair in other.commandRequests)
-            {
-                commandRequests[pair.Key] = pair.Value;
-            }
-
-            foreach (var pair in other.commandResponses)
-            {
-                commandResponses[pair.Key] = pair.Value;
-            }
-
-            foreach (var pair in other.worldCommandRequests)
-            {
-                worldCommandRequests[pair.Key] = pair.Value;
-            }
-
-            foreach (var pair in other.worldCommandResponses)
-            {
-                worldCommandResponses[pair.Key] = pair.Value;
-            }
-        }
-
-        internal void Clear()
-        {
-            updates.Clear();
-            commandRequests.Clear();
-            commandResponses.Clear();
-            worldCommandRequests.Clear();
-            worldCommandResponses.Clear();
-        }
-
-        public static class Pool
-        {
-            private static readonly Queue<NetStats> data = new Queue<NetStats>();
-
-            public static NetStats Rent()
-            {
-                if (data.Count != 0)
+                var type = MessageTypeUnion.Update(pair.Key);
+                if (!Data.TryGetValue(type, out var data))
                 {
-                    return data.Dequeue();
+                    data = new DataSequence(sequenceLength);
                 }
 
-                return new NetStats();
+                data.AddFrame(nextFrameIndex, pair.Value, direction);
+                Data[type] = data;
             }
 
-            public static void Return(NetStats stats)
+            foreach (var pair in frameData.CommandRequests)
             {
-                stats.Clear();
-                data.Enqueue(stats);
+                var type = MessageTypeUnion.CommandRequest(pair.Key.Item1, pair.Key.Item2);
+                if (!Data.TryGetValue(type, out var data))
+                {
+                    data = new DataSequence(sequenceLength);
+                }
+
+                data.AddFrame(nextFrameIndex, pair.Value, direction);
+                Data[type] = data;
+            }
+
+            foreach (var pair in frameData.CommandResponses)
+            {
+                var type = MessageTypeUnion.CommandResponse(pair.Key.Item1, pair.Key.Item2);
+                if (!Data.TryGetValue(type, out var data))
+                {
+                    data = new DataSequence(sequenceLength);
+                }
+
+                data.AddFrame(nextFrameIndex, pair.Value, direction);
+                Data[type] = data;
+            }
+
+            foreach (var pair in frameData.WorldCommandRequests)
+            {
+                var type = MessageTypeUnion.WorldCommandRequest(pair.Key);
+                if (!Data.TryGetValue(type, out var data))
+                {
+                    data = new DataSequence(sequenceLength);
+                }
+
+                data.AddFrame(nextFrameIndex, pair.Value, direction);
+                Data[type] = data;
+            }
+
+            foreach (var pair in frameData.WorldCommandResponses)
+            {
+                var type = MessageTypeUnion.WorldCommandResponse(pair.Key);
+                if (!Data.TryGetValue(type, out var data))
+                {
+                    data = new DataSequence(sequenceLength);
+                }
+
+                data.AddFrame(nextFrameIndex, pair.Value, direction);
+                Data[type] = data;
+            }
+
+            if (--nextFrameIndex == -1)
+            {
+                nextFrameIndex += sequenceLength;
+            }
+        }
+
+        public DataPoint GetSummary(MessageTypeUnion messageType, int numFrames, Direction direction)
+        {
+            if (!Data.TryGetValue(messageType, out var data))
+            {
+                return new DataPoint();
+            }
+
+            DataPoint[] frameData;
+
+            switch (direction)
+            {
+                case Direction.Incoming:
+                    frameData = data.Incoming;
+                    break;
+                case Direction.Outgoing:
+                    frameData = data.Outgoing;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(direction), direction, null);
+            }
+
+            var summary = new DataPoint();
+
+            for (var i = 1; i <= numFrames; i++)
+            {
+                var index = (nextFrameIndex + i) % sequenceLength;
+                summary += frameData[index];
+            }
+
+            return summary;
+        }
+
+        private struct DataSequence : IEquatable<DataSequence>
+        {
+            public readonly DataPoint[] Incoming;
+            public readonly DataPoint[] Outgoing;
+
+            public DataSequence(int size)
+            {
+                Incoming = new DataPoint[size];
+                Outgoing = new DataPoint[size];
+            }
+
+            public void AddFrame(int index, DataPoint data, Direction direction)
+            {
+                switch (direction)
+                {
+                    case Direction.Incoming:
+                        Incoming[index] = data;
+                        break;
+                    case Direction.Outgoing:
+                        Outgoing[index] = data;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(direction), direction, null);
+                }
+            }
+
+            public void Clear(int index, Direction direction)
+            {
+                switch (direction)
+                {
+                    case Direction.Incoming:
+                        Incoming[index] = new DataPoint();
+                        break;
+                    case Direction.Outgoing:
+                        Outgoing[index] = new DataPoint();
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(direction), direction, null);
+                }
+            }
+
+            public bool Equals(DataSequence other)
+            {
+                return Equals(Incoming, other.Incoming) && Equals(Outgoing, other.Outgoing);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is DataSequence other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return ((Incoming != null ? Incoming.GetHashCode() : 0) * 397) ^ (Outgoing != null ? Outgoing.GetHashCode() : 0);
+                }
+            }
+
+            public static bool operator ==(DataSequence left, DataSequence right)
+            {
+                return left.Equals(right);
+            }
+
+            public static bool operator !=(DataSequence left, DataSequence right)
+            {
+                return !left.Equals(right);
             }
         }
     }

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetworkStatisticsSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetworkStatisticsSystem.cs
@@ -27,9 +27,6 @@ namespace Improbable.Gdk.Core.NetworkStats
 
             lastIncomingData.Clear();
             lastOutgoingData.Clear();
-
-            var position = netStats.GetSummary(MessageTypeUnion.Update(54), 10, Direction.Incoming);
-            UnityEngine.Debug.Log($"Count: {position.Count}, Size: {position.Size}");
         }
 
         internal void ApplyDiff(ViewDiff diff)

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/SpatialOSSendSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/SpatialOSSendSystem.cs
@@ -1,3 +1,4 @@
+using Improbable.Gdk.Core.NetworkStats;
 using Unity.Entities;
 
 namespace Improbable.Gdk.Core
@@ -8,17 +9,21 @@ namespace Improbable.Gdk.Core
     public class SpatialOSSendSystem : ComponentSystem
     {
         private WorkerSystem worker;
+        private NetworkStatisticsSystem networkStatisticsSystem;
 
         protected override void OnCreate()
         {
             base.OnCreate();
 
             worker = World.GetExistingSystem<WorkerSystem>();
+            networkStatisticsSystem = World.GetOrCreateSystem<NetworkStatisticsSystem>();
         }
 
         protected override void OnUpdate()
         {
-            worker.SendMessages();
+            var stats = NetFrameStats.Pool.Rent();
+            worker.SendMessages(stats);
+            networkStatisticsSystem.AddOutgoingSample(stats);
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/WorkerSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/WorkerSystem.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Improbable.Gdk.Core.NetworkStats;
 using Improbable.Worker.CInterop;
 using Unity.Entities;
 using UnityEngine;
@@ -83,9 +84,9 @@ namespace Improbable.Gdk.Core
             Worker.Tick();
         }
 
-        internal void SendMessages()
+        internal void SendMessages(NetFrameStats frameStats)
         {
-            Worker.EnsureMessagesFlushed();
+            Worker.EnsureMessagesFlushed(frameStats);
         }
 
         protected override void OnCreate()

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/IConnectionHandler.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/IConnectionHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Improbable.Gdk.Core.NetworkStats;
 
 namespace Improbable.Gdk.Core
 {
@@ -41,7 +42,7 @@ namespace Improbable.Gdk.Core
         ///     The messages may not be sent immediately. This is up to the implementer.
         /// </remarks>
         /// <param name="messages">The set of messages to send.</param>
-        void PushMessagesToSend(MessagesToSend messages);
+        void PushMessagesToSend(MessagesToSend messages, NetFrameStats frameStats);
 
         /// <summary>
         ///     Gets a value indicating whether the underlying connection is connected.

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Improbable.Gdk.Core.NetworkStats;
 using Improbable.Worker.CInterop;
 
 namespace Improbable.Gdk.Core
@@ -111,7 +112,7 @@ namespace Improbable.Gdk.Core
             return new MessagesToSend();
         }
 
-        public void PushMessagesToSend(MessagesToSend messages)
+        public void PushMessagesToSend(MessagesToSend messages, NetFrameStats netFrameStats)
         {
             throw new System.NotImplementedException();
         }

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/MultiThreadedSpatialOSConnectionHandler.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/MultithreadedSpatialOSConnectionHandler/MultiThreadedSpatialOSConnectionHandler.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Improbable.Gdk.Core.NetworkStats;
 using Improbable.Worker.CInterop;
 
 namespace Improbable.Gdk.Core
@@ -56,17 +57,17 @@ namespace Improbable.Gdk.Core
             return serializationHandler.GetMessagesToSendContainer();
         }
 
-        public void PushMessagesToSend(MessagesToSend messages)
+        public void PushMessagesToSend(MessagesToSend messages, NetFrameStats frameStats)
         {
-            SendSerializedMessages();
+            SendSerializedMessages(frameStats);
             serializationHandler.EnqueueMessagesToSend(messages);
         }
 
-        private void SendSerializedMessages()
+        private void SendSerializedMessages(NetFrameStats frameStats)
         {
             while (serializationHandler.TryDequeueSerializedMessages(out var messages))
             {
-                var metaData = messages.SendAndClear(connection);
+                var metaData = messages.SendAndClear(connection, frameStats);
                 serializationHandler.ReturnSerializedMessageContainer(messages);
                 commandMetaDataManager.AddMetaData(metaData);
             }

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/SpatialOSConnectionHandler/SpatialOSConnectionHandler.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/SpatialOSConnectionHandler/SpatialOSConnectionHandler.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Improbable.Gdk.Core.NetworkStats;
 using Improbable.Worker.CInterop;
 
 namespace Improbable.Gdk.Core
@@ -53,10 +54,10 @@ namespace Improbable.Gdk.Core
             return messagesToSend;
         }
 
-        public void PushMessagesToSend(MessagesToSend messages)
+        public void PushMessagesToSend(MessagesToSend messages, NetFrameStats frameStats)
         {
             serializedMessagesToSend.SerializeFrom(messages, commandMetaDataManager.GetEmptyMetaDataStorage());
-            var metaData = serializedMessagesToSend.SendAndClear(connection);
+            var metaData = serializedMessagesToSend.SendAndClear(connection, frameStats);
             commandMetaDataManager.AddMetaData(metaData);
             serializedMessagesToSend.Clear();
             messages.Clear();

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/OpListConverter.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/OpListConverter.cs
@@ -59,22 +59,22 @@ namespace Improbable.Gdk.Core
                         var reserveEntityIdsOp = opList.GetReserveEntityIdsResponseOp(i);
                         ComponentOpDeserializer.ApplyReserveEntityIdsResponse(reserveEntityIdsOp, viewDiff,
                             commandMetaData);
-                        netStats.AddWorldCommandResponse(NetStats.WorldCommand.ReserveEntityIds);
+                        netStats.AddWorldCommandResponse(WorldCommand.ReserveEntityIds);
                         break;
                     case OpType.CreateEntityResponse:
                         var createEntityOp = opList.GetCreateEntityResponseOp(i);
                         ComponentOpDeserializer.ApplyCreateEntityResponse(createEntityOp, viewDiff, commandMetaData);
-                        netStats.AddWorldCommandResponse(NetStats.WorldCommand.CreateEntity);
+                        netStats.AddWorldCommandResponse(WorldCommand.CreateEntity);
                         break;
                     case OpType.DeleteEntityResponse:
                         var deleteEntityOp = opList.GetDeleteEntityResponseOp(i);
                         ComponentOpDeserializer.ApplyDeleteEntityResponse(deleteEntityOp, viewDiff, commandMetaData);
-                        netStats.AddWorldCommandResponse(NetStats.WorldCommand.DeleteEntity);
+                        netStats.AddWorldCommandResponse(WorldCommand.DeleteEntity);
                         break;
                     case OpType.EntityQueryResponse:
                         var entityQueryOp = opList.GetEntityQueryResponseOp(i);
                         ComponentOpDeserializer.ApplyEntityQueryResponse(entityQueryOp, viewDiff, commandMetaData);
-                        netStats.AddWorldCommandResponse(NetStats.WorldCommand.EntityQuery);
+                        netStats.AddWorldCommandResponse(WorldCommand.EntityQuery);
                         break;
                     case OpType.AddComponent:
                         ComponentOpDeserializer.DeserializeAndAddComponent(opList.GetAddComponentOp(i), viewDiff);

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/SerializedMessagesToSend.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/SerializedMessagesToSend.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Improbable.Gdk.Core.NetworkStats;
 using Improbable.Worker.CInterop;
 using Improbable.Worker.CInterop.Query;
 
@@ -44,6 +45,8 @@ namespace Improbable.Gdk.Core
         private readonly List<ICommandSerializer> commandSerializers = new List<ICommandSerializer>();
 
         private CommandMetaData metaData;
+
+        private NetFrameStats netFrameStats = NetFrameStats.Pool.Rent();
 
         public SerializedMessagesToSend()
         {
@@ -120,9 +123,10 @@ namespace Improbable.Gdk.Core
             metricsToSend.Clear();
             logMessages.Clear();
             authorityLossAcks.Clear();
+            netFrameStats.Clear();
         }
 
-        public CommandMetaData SendAndClear(Connection connection)
+        public CommandMetaData SendAndClear(Connection connection, NetFrameStats frameStats)
         {
             for (int i = 0; i < updates.Count; ++i)
             {
@@ -195,6 +199,7 @@ namespace Improbable.Gdk.Core
                 connection.SendAuthorityLossImminentAcknowledgement(entityComponent.EntityId, entityComponent.ComponentId);
             }
 
+            frameStats.Merge(netFrameStats);
             Clear();
 
             return metaData;
@@ -203,41 +208,49 @@ namespace Improbable.Gdk.Core
         public void AddComponentUpdate(ComponentUpdate update, long entityId)
         {
             updates.Add(new UpdateToSend(update, entityId));
+            netFrameStats.AddUpdate(update);
         }
 
         public void AddRequest(CommandRequest request, uint commandId, long entityId, uint? timeout, long requestId)
         {
             requests.Add(new RequestToSend(request, commandId, entityId, timeout, requestId));
+            netFrameStats.AddCommandRequest(request);
         }
 
         public void AddResponse(CommandResponse response, uint requestId)
         {
             responses.Add(new ResponseToSend(response, requestId));
+            netFrameStats.AddCommandResponse(response, message: null);
         }
 
-        public void AddFailure(string reason, uint requestId)
+        public void AddFailure(uint componentId, uint commandIndex, string reason, uint requestId)
         {
             failures.Add(new FailureToSend(reason, requestId));
+            netFrameStats.AddCommandResponse(reason, componentId, commandIndex);
         }
 
         public void AddCreateEntityRequest(Entity entity, long? entityId, uint? timeout, long requestId)
         {
             createEntityRequests.Add(new CreateEntityRequestToSend(entity, entityId, timeout, requestId));
+            netFrameStats.AddWorldCommandRequest(WorldCommand.CreateEntity);
         }
 
         public void AddDeleteEntityRequest(long entityId, uint? timeout, long requestId)
         {
             deleteEntityRequests.Add(new DeleteEntityRequestToSend(entityId, timeout, requestId));
+            netFrameStats.AddWorldCommandRequest(WorldCommand.DeleteEntity);
         }
 
         public void AddReserveEntityIdsRequest(uint numberOfEntityIds, uint? timeout, long requestId)
         {
             reserveEntityIdsRequests.Add(new ReserveEntityIdsRequestToSend(numberOfEntityIds, timeout, requestId));
+            netFrameStats.AddWorldCommandRequest(WorldCommand.ReserveEntityIds);
         }
 
         public void AddEntityQueryRequest(EntityQuery query, uint? timeout, long requestId)
         {
             entityQueryRequests.Add(new EntityQueryRequestToSend(query, timeout, requestId));
+            netFrameStats.AddWorldCommandRequest(WorldCommand.EntityQuery);
         }
 
         internal void DestroyUnsentMessages()

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/ViewDiff.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/ViewDiff.cs
@@ -42,7 +42,7 @@ namespace Improbable.Gdk.Core
 
         private readonly WorldCommandsReceivedStorage worldCommandsReceivedStorage = new WorldCommandsReceivedStorage();
 
-        private readonly NetStats netStats;
+        private readonly NetFrameStats netFrameStats;
 
         public ViewDiff()
         {
@@ -94,7 +94,7 @@ namespace Improbable.Gdk.Core
             typeToCommandStorage.Add(typeof(WorldCommands.ReserveEntityIds.ReceivedResponse), worldCommandsReceivedStorage);
             typeToCommandStorage.Add(typeof(WorldCommands.EntityQuery.ReceivedResponse), worldCommandsReceivedStorage);
 
-            netStats = NetStats.Pool.Rent();
+            netFrameStats = NetFrameStats.Pool.Rent();
         }
 
         public void Clear()
@@ -118,7 +118,7 @@ namespace Improbable.Gdk.Core
             Disconnected = false;
             DisconnectMessage = null;
 
-            netStats.Clear();
+            netFrameStats.Clear();
         }
 
         public void AddEntity(long entityId)
@@ -367,9 +367,9 @@ namespace Improbable.Gdk.Core
             return entitiesRemoved;
         }
 
-        internal NetStats GetNetStats()
+        internal NetFrameStats GetNetStats()
         {
-            return netStats;
+            return netFrameStats;
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/Worker.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/Worker.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Improbable.Gdk.Core.NetworkStats;
 using Improbable.Worker.CInterop;
 
 namespace Improbable.Gdk.Core
@@ -89,9 +90,9 @@ namespace Improbable.Gdk.Core
             View.ApplyDiff(ViewDiff);
         }
 
-        public void EnsureMessagesFlushed()
+        public void EnsureMessagesFlushed(NetFrameStats frameStats)
         {
-            ConnectionHandler.PushMessagesToSend(MessagesToSend);
+            ConnectionHandler.PushMessagesToSend(MessagesToSend, frameStats);
             MessagesToSend = ConnectionHandler.GetMessagesToSendContainer();
         }
 

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/CommandDiffDeserializerGenerator.tt
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/CommandDiffDeserializerGenerator.tt
@@ -111,7 +111,7 @@ namespace <#= qualifiedNamespace #>
                     {
                         // Send a command failure if the string is non-null.
 
-                        serializedMessages.AddFailure(response.FailureMessage, (uint) response.RequestId);
+                        serializedMessages.AddFailure(ComponentId, <#= command.CommandIndex #>, response.FailureMessage, (uint) response.RequestId);
                         continue;
                     }
 


### PR DESCRIPTION
#### Description
- Added network stats support for outgoing messages. This involves pushing a `NetStatsFrame` all the way down to `SerializedMessagesToSend` and populating it there.
- Redesigned the backing data storage for the `NetworkStatisticsSystem` to be a dictionary of message types to ring-buffered data points. This dictionary is lazily instantiated.
- Some general cleanups. 


#### Tests
- [ ] Unit tests for `NetStats`.

#### Documentation
- [ ] Changelog
- [ ] API docs?
