### PR TITLE
Fix mac launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### Internal
 
-- Work-around for Mac Launcher using wrong executable name. Generating hardcoded "launcher_client_config.json" for Mac builds. [#1142](https://github.com/spatialos/gdk-for-unity/pull/1142)
+- Work-around for Mac Launcher using wrong executable name. Generating hardcoded `launcher_client_config.json` for Mac builds. [#1142](https://github.com/spatialos/gdk-for-unity/pull/1142)
 
 ## `0.2.7` - 2019-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
     - Any fields in a schema type that are a recursive option will now be _skipped_.
     - This is a workaround until full recursive option support is implemented.
 
+### Internal
+
+- Work-around for Mac Launcher using wrong executable name. Generating hardcoded "launcher_client_config.json" for Mac builds. [#1142](https://github.com/spatialos/gdk-for-unity/pull/1142)
+
 ## `0.2.7` - 2019-08-19
 
 ### Breaking Changes


### PR DESCRIPTION
#### Description
Mac builds now include a json file telling the launcher where to find the executable to launch.
A quick fix for our release.

#### Tests
Build a Mac client on Windows, uploaded through the Deployment Launcher, and launched client successfully on a Mac.