### PR TITLE
Find codegen jobs via reflection

### DIFF
--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/.codegen/Source/WorkerGenerationJob.cs
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/.codegen/Source/WorkerGenerationJob.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using Improbable.Gdk.CodeGeneration.FileHandling;
 using Improbable.Gdk.CodeGeneration.Jobs;
+using Improbable.Gdk.CodeGeneration.Model.Details;
 using Newtonsoft.Json.Linq;
 
 namespace Improbable.Gdk.CodeGenerator
@@ -18,13 +19,10 @@ namespace Improbable.Gdk.CodeGenerator
         private readonly string relativeOutputPath = Path.Combine("improbable", "buildsystem");
         private readonly string relativeEditorPath = Path.Combine("improbable", "buildsystem", "Editor");
 
-        public WorkerGenerationJob(string outputDir, CodeGeneratorOptions options, IFileSystem fileSystem) : base(
-            outputDir, fileSystem)
-        {
-            InputFiles = new List<string>();
-            OutputFiles = new List<string>();
 
-            workerTypesToGenerate = ExtractWorkerTypes(options.WorkerJsonDirectory);
+        public WorkerGenerationJob(string baseOutputDir, IFileSystem fileSystem, DetailsStore detailsStore) : base(baseOutputDir, fileSystem, detailsStore)
+        {
+            workerTypesToGenerate = ExtractWorkerTypes(CodeGeneratorOptions.Instance.WorkerJsonDirectory);
 
             OutputFiles.Add(Path.Combine(relativeEditorPath, workerFileName));
             OutputFiles.Add(Path.Combine(relativeEditorPath, workerListFileName));

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/SingleGenerationJob.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/SingleGenerationJob.cs
@@ -18,8 +18,8 @@ namespace Improbable.Gdk.CodeGenerator
 
         private const string FileExtension = ".cs";
 
-        public SingleGenerationJob(string outputDir, DetailsStore store, IFileSystem fileSystem) : base(
-            outputDir, fileSystem)
+        public SingleGenerationJob(string outputDir, IFileSystem fileSystem, DetailsStore store) : base(
+            outputDir, fileSystem, store)
         {
             InputFiles = store.SchemaFiles.ToList();
             OutputFiles = new List<string>();

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGeneratorOptions.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGeneratorOptions.cs
@@ -9,6 +9,7 @@ namespace Improbable.Gdk.CodeGenerator
     /// </summary>
     public class CodeGeneratorOptions
     {
+        public static CodeGeneratorOptions Instance { get; private set; }
         public string WorkerJsonDirectory { get; private set; }
         public string JsonDirectory { get; private set; }
         public string DescriptorDirectory { get; private set; }
@@ -66,6 +67,7 @@ namespace Improbable.Gdk.CodeGenerator
                 options.HelpText = sw.ToString();
             }
 
+            Instance = options;
 
             return options;
         }

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Jobs/CodegenJob.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Jobs/CodegenJob.cs
@@ -1,26 +1,30 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Improbable.Gdk.CodeGeneration.FileHandling;
+using Improbable.Gdk.CodeGeneration.Model.Details;
 
 namespace Improbable.Gdk.CodeGeneration.Jobs
 {
+    public class IgnoreCodegenJobAttribute : Attribute
+    {
+    }
+
     public abstract class CodegenJob
     {
-        public List<string> InputFiles { get; protected set; }
-        public List<string> OutputFiles { get; protected set; }
-        public string OutputDirectory { get; private set; }
+        public List<string> InputFiles = new List<string>();
+        public List<string> OutputFiles = new List<string>();
+        public readonly string OutputDirectory;
 
-        protected Dictionary<string, string> Content { get; set; }
+        protected readonly Dictionary<string, string> Content = new Dictionary<string, string>();
 
         private IFileSystem fileSystem;
 
-        public CodegenJob(string outputDirectory, IFileSystem fileSystem)
+        public CodegenJob(string baseOutputDirectory, IFileSystem fileSystem, DetailsStore detailsStore)
         {
-            OutputDirectory = outputDirectory;
+            OutputDirectory = baseOutputDirectory;
             this.fileSystem = fileSystem;
-
-            Content = new Dictionary<string, string>();
         }
 
         public void Clean()

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Tests/Jobs/CodegenJobTests.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/CodeGeneration/Tests/Jobs/CodegenJobTests.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Xml.Serialization;
 using CodeGeneration.Tests.FileHandling;
 using Improbable.Gdk.CodeGeneration.FileHandling;
 using Improbable.Gdk.CodeGeneration.Jobs;
+using Improbable.Gdk.CodeGeneration.Model.Details;
 using NUnit.Framework;
 
 namespace CodeGeneration.Tests.Jobs
@@ -88,19 +90,18 @@ namespace CodeGeneration.Tests.Jobs
             }
         }
 
+        [IgnoreCodegenJob]
         public class CodegenStub : CodegenJob
         {
             public static CodegenStub GetCleanInstance()
             {
-                return new CodegenStub("", new MockFileSystem());
+                return new CodegenStub("", new MockFileSystem(), null);
             }
 
             internal MockFileSystem myFileSystem;
 
-            public CodegenStub(string outputDirectory, IFileSystem fileSystem) : base(outputDirectory, fileSystem)
+            public CodegenStub(string outputDirectory, IFileSystem fileSystem, DetailsStore detailsStore) : base(outputDirectory, fileSystem, detailsStore)
             {
-                InputFiles = new List<string>();
-                OutputFiles = new List<string>();
                 myFileSystem = (MockFileSystem) fileSystem;
             }
 

--- a/workers/unity/Packages/io.improbable.gdk.tools/GenerateCode.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/GenerateCode.cs
@@ -57,6 +57,7 @@ namespace Improbable.Gdk.Tools
                 return;
             }
 
+            SetupProject();
             Generate();
         }
 
@@ -310,7 +311,7 @@ namespace Improbable.Gdk.Tools
             }
         }
 
-        /*  
+        /*
             This method edits the csproj XML to link in the constituent parts of the each codegen module.
             It expects any codegen module to be structured as follows:
 
@@ -323,9 +324,9 @@ namespace Improbable.Gdk.Tools
                         MyTemplate.tt
                     Partials/
                         Improbable.Vector3f
-            
+
             Each of the Source, Templates, and Partials folder are optional.
-        */ 
+        */
         private static void UpdateModules()
         {
             var csprojXml = XDocument.Load(CodegenExe);
@@ -337,7 +338,7 @@ namespace Improbable.Gdk.Tools
             var gdkItemGroups = projectNode
                 .Elements("ItemGroup")
                 .Where(ele => ele.Element("GdkPackageSource") != null)
-                .ToDictionary(ele => ele.Element("GdkPackageSource").Attribute("Include").Value, ele => ele);
+                .ToDictionary(ele => ele.Element("GdkPackageSource").Attribute("Remove").Value, ele => ele);
 
             foreach (var dir in codegenDirs)
             {
@@ -351,7 +352,7 @@ namespace Improbable.Gdk.Tools
 
                 // Add an identifier so we can match this item group against a codegen module on subsequent runs.
                 var idEle = new XElement("GdkPackageSource");
-                idEle.SetAttributeValue("Include", dir);
+                idEle.SetAttributeValue("Remove", dir);
                 itemGroup.Add(idEle);
 
                 var sourceDir = Path.Combine(dir, "Source");
@@ -373,7 +374,7 @@ namespace Improbable.Gdk.Tools
                 }
 
                 var partialDir = Path.Combine(dir, "Partials");
-                if (Directory.Exists(templateDir))
+                if (Directory.Exists(partialDir))
                 {
                     // Don't compile the partial.
                     var noneEle = new XElement("None");
@@ -387,7 +388,7 @@ namespace Improbable.Gdk.Tools
 
                     // Ensure that we can see the Partials in the project view.
                     var folderEle = new XElement("Folder");
-                    folderEle.SetAttributeValue("Include", Path.Combine(partialDir, "**"));
+                    folderEle.SetAttributeValue("Include", partialDir);
                     itemGroup.Add(folderEle);
                 }
 


### PR DESCRIPTION
#### Description

This PR removes the hard dependency between the `EntryPoint` and the code generation job by finding all types that are non-abstract, inherit from `CodegenJob`, and don't have the `IgnoreCodegenJob` attribute on them (used for tests). 

- Also makes the `CodeGenerationOptions` accessible as a singleton instance.
- Also includes a few tweaks/fixes in how we generate the `csproj`.  

#### Tests

Ran codegen locally, everything worked as expected.

#### Documentation
N/A

