### PR TITLE
Add test failure reporting in Buildkite

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -7,6 +7,6 @@ if [[ -z "${BUILDKITE-}" ]]; then
   ci/bootstrap.sh
   exit 0
 fi
-if [[ "${BUILDKITE_AGENT_META_DATA_QUEUE}" != "trigger-pipelines" ]]; then
+if [[ "${BUILDKITE_AGENT_META_DATA_QUEUE}" != "trigger-pipelines" ]] && [[ "${BUILDKITE_AGENT_META_DATA_OS}" == "windows" ]]; then
   ci/bootstrap.sh
 fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -2,6 +2,6 @@
 set -euo pipefail
 [[ -n "${DEBUG:-}" ]] && set -x
 
-if [[ "${BUILDKITE_AGENT_META_DATA_CAPABLE_OF_BUILDING}" == "gdk-for-unity" ]]; then
+if [[ "${BUILDKITE_AGENT_META_DATA_CAPABLE_OF_BUILDING}" == "gdk-for-unity" ]] && [[ "${BUILDKITE_AGENT_META_DATA_OS}" == "windows" ]]; then
   spatial auth login --log_level debug
 fi

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -31,15 +31,46 @@ common: &common
       - exit_status: 128
         limit: 3
 
+linux: &linux
+  agents:
+    - "capable_of_building=gdk-for-unity"
+    - "environment=production"
+    - "permission_set=builder"
+    - "platform=linux"  # if you need a different platform, configure this: macos|linux|windows.
+    - "queue=v3-1562766449-11b126f880607f28-------z"
+  timeout_in_minutes: 60 # TODO(ENG-548): reduce timeout once agent-cold-start is optimised.
+  retry:
+    automatic:
+        # This is designed to trap and retry failures because agent lost connection. Agent exits with -1 in this case.
+      - exit_status: -1
+        limit: 3
+
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.
 # These are then relied on to have stable names by other things, so once named, please beware renaming has consequences.
 
+dag: true
+
 steps:
   - label: "test"
+    id: "test"
     command: bash -c ci/test.sh
     <<: *common
     artifact_paths:
       - logs/**/*
+
+  - label: "annotate test results :pencil2:"
+    depends_on: 
+      - step: "test"
+        allow_failure: true
+    plugins: 
+      - jamiebrynes7/test-summary#06aedb5c4da188cb4246a8cf4cb82783ec847c2f:
+          inputs:
+            - label: ":octagonal_sign: Test failures "
+              artifact_path: "logs\\nunit\\*.xml"
+              type: nunit
+          formatter:
+            type: details
+    <<: *linux
 
   - label: "build :android:"
     command: bash -c .shared-ci/scripts/build-worker.sh

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -38,6 +38,7 @@ linux: &linux
     - "permission_set=builder"
     - "platform=linux"  # if you need a different platform, configure this: macos|linux|windows.
     - "queue=v3-1562766449-11b126f880607f28-------z"
+    - "scaler_version=2"
   timeout_in_minutes: 60 # TODO(ENG-548): reduce timeout once agent-cold-start is optimised.
   retry:
     automatic:

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -63,7 +63,7 @@ steps:
       - step: "test"
         allow_failure: true
     plugins: 
-      - jamiebrynes7/test-summary#06aedb5c4da188cb4246a8cf4cb82783ec847c2f:
+      - improbable/test-summary#d7289cac8297018fd1b452dcf828979307b3ebc6:
           inputs:
             - label: ":octagonal_sign: Test failures "
               artifact_path: "logs\\nunit\\*.xml"

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -11,18 +11,13 @@ cd "$(dirname "$0")/../"
 source .shared-ci/scripts/pinned-tools.sh
 
 PROJECT_DIR="$(pwd)"
-mkdir -p "${PROJECT_DIR}/logs/"
-
-CODE_GEN_LIB_TEST_RESULTS_FILE="${PROJECT_DIR}/logs/code-gen-lib-test-results.xml"
-EDITMODE_TEST_RESULTS_FILE="${PROJECT_DIR}/logs/editmode-test-results.xml"
-PLAYMODE_TEST_RESULTS_FILE="${PROJECT_DIR}/logs/playmode-test-results.xml"
-TEST_PROJECT_EDITMODE_TEST_RESULTS_FILE="${PROJECT_DIR}/logs/test-project-editmode-test-results.xml"
-TEST_PROJECT_PLAYMODE_TEST_RESULTS_FILE="${PROJECT_DIR}/logs/test-project-playmode-test-results.xml"
+TEST_RESULTS_DIR="${PROJECT_DIR}/logs/nunit"
+mkdir -p "${TEST_RESULTS_DIR}"
 
 echo "--- Testing Code Generator :gear:"
 
 dotnet test \
-    --logger:"nunit;LogFilePath=${CODE_GEN_LIB_TEST_RESULTS_FILE}" \
+    --logger:"nunit;LogFilePath=${TEST_RESULTS_DIR}/code-gen-lib-test-results.xml" \
     workers/unity/Packages/io.improbable.gdk.tools/.CodeGenerator/CodeGeneration/CodeGeneration.csproj
 
 echo "--- Testing Unity: Editmode :writing_hand:"
@@ -33,7 +28,7 @@ pushd "workers/unity"
         -projectPath "${PROJECT_DIR}/workers/unity" \
         -runEditorTests \
         -logfile "${PROJECT_DIR}/logs/unity-editmode-test-run.log" \
-        -editorTestsResultFile "${EDITMODE_TEST_RESULTS_FILE}"
+        -editorTestsResultFile "${TEST_RESULTS_DIR}/editmode-test-results.xml"
 popd
 
 cleanUnity "$(pwd)/workers/unity"
@@ -47,7 +42,7 @@ pushd "workers/unity"
         -runTests \
         -testPlatform playmode \
         -logfile "${PROJECT_DIR}/logs/unity-playmode-test-run.log" \
-        -testResults "${PLAYMODE_TEST_RESULTS_FILE}"
+        -testResults "${TEST_RESULTS_DIR}/playmode-test-results.xml"
 popd
 
 echo "--- Testing Unity: Test Project Editmode :microscope:"
@@ -58,7 +53,7 @@ pushd "test-project"
         -projectPath "${PROJECT_DIR}/test-project" \
         -runEditorTests \
         -logfile "${PROJECT_DIR}/logs/test-project-editmode-test-run.log" \
-        -editorTestsResultFile "${TEST_PROJECT_EDITMODE_TEST_RESULTS_FILE}"
+        -editorTestsResultFile "${TEST_RESULTS_DIR}/test-project-editmode-test-results.xml"
 popd
 
 echo "--- Testing Unity: Test Project Playmode :joystick:"
@@ -70,5 +65,5 @@ pushd "test-project"
         -runTests \
         -testPlatform playmode \
         -logfile "${PROJECT_DIR}/logs/test-project-playmode-test-run.log" \
-        -testResults "${TEST_PROJECT_PLAYMODE_TEST_RESULTS_FILE}"
+        -testResults "${TEST_RESULTS_DIR}/test-project-playmode-test-results.xml"
 popd


### PR DESCRIPTION
#### Description

This PR introduces a Buildkite plugin which will report test failures as annotations on a build:

![image](https://user-images.githubusercontent.com/13353733/64604347-e374bd80-d3b9-11e9-911b-2d911bd6f0ac.png)

This allows you to understand which tests are broken without diving into the logs. This feature is using the new `dag` feature from Buildkite which allows us to declare dependencies between jobs. The reporting step will only run after the tests has completed, but doesn't care about any of the other steps.
