### PR TITLE
Prevent mobile launcher from resetting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Fixed a bug where `MonoBehaviour`s with `WorkerType` attributes would not be enabled even if the owning worker's type was a match for the `WorkerType` attribute. [#1147](https://github.com/spatialos/gdk-for-unity/pull/1147)
+- Fixed a bug where the mobile configuration would get reset whenever assembly got reloaded or you entered Playmode.
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Fixed
 
 - Fixed a bug where `MonoBehaviour`s with `WorkerType` attributes would not be enabled even if the owning worker's type was a match for the `WorkerType` attribute. [#1147](https://github.com/spatialos/gdk-for-unity/pull/1147)
-- Fixed a bug where the mobile configuration would get reset whenever assembly got reloaded or you entered Playmode.
+- Fixed a bug where the mobile configuration would get reset whenever assembly got reloaded or you entered Playmode. [#1157](https://github.com/spatialos/gdk-for-unity/pull/1157)
 
 ### Internal
 

--- a/workers/unity/Packages/io.improbable.gdk.mobile/Editor/MobileLaunchConfig.cs
+++ b/workers/unity/Packages/io.improbable.gdk.mobile/Editor/MobileLaunchConfig.cs
@@ -1,8 +1,10 @@
+using System;
 using UnityEditor;
 
 namespace Improbable.Gdk.Mobile
 {
-    public class MobileLaunchConfig
+    [Serializable]
+    public struct MobileLaunchConfig
     {
         private const string DevelopmentTeamIdEditorPrefKey = "DevelopmentTeam";
         private const string RuntimeIpEditorPrefKey = "RuntimeIp";

--- a/workers/unity/Packages/io.improbable.gdk.mobile/Editor/MobileLauncherWindow.cs
+++ b/workers/unity/Packages/io.improbable.gdk.mobile/Editor/MobileLauncherWindow.cs
@@ -37,8 +37,6 @@ namespace Improbable.Gdk.Mobile
 
         private void OnEnable()
         {
-            launchConfig = new MobileLaunchConfig();
-
 #if UNITY_EDITOR_OSX
             deviceNames = iOSLaunchUtils.RetrieveAvailableiOSDevices().Keys.ToArray();
             simulatorNames = iOSLaunchUtils.RetrieveAvailableiOSSimulators().Keys.ToArray();


### PR DESCRIPTION
#### Description
Changed the mobile launcher config to be a serialisable struct to prevent it from resetting the `ShouldConnectLocally` variable whenever play mode gets entered or assemblies get reloaded

#### Tests
tested it manually by entering/exiting play mode and regenerating code

#### Documentation
no documentation necessary

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
