### PR TITLE
update publish packages script

### DIFF
--- a/ci/publish_packages.sh
+++ b/ci/publish_packages.sh
@@ -27,6 +27,7 @@ pushd "${PKG_ROOT}" > /dev/null
             # Created package is the last line of output.
             PACKAGE_NAME=$(npm pack | tail -n 1)
             cloudsmith push npm spatialos/gdk-for-unity "${PACKAGE_NAME}" --republish "${EXTRA_CLOUDSMITH_ARGS}"
+            rm "${PACKGE_NAME}"
         popd > /dev/null
     done
 popd > /dev/null

--- a/ci/publish_packages.sh
+++ b/ci/publish_packages.sh
@@ -2,18 +2,26 @@
 
 set -e -u -o pipefail
 
+if [[ -n "${DEBUG-}" ]]; then
+  set -x
+fi
+
 cd "$(dirname "$0")/../"
 
 PKG_ROOT="workers/unity/Packages"
-REGISTRY="https://npm.improbable.io/gdk-for-unity/"
+
+./init.sh
 
 # Re-publish all packages
-pushd $PKG_ROOT
-    for dir in */;
+pushd "${PKG_ROOT}" > /dev/null
+    for package_dir in */;
     do
-        echo $dir
-        pushd $dir
-            npm publish --registry="${REGISTRY}"
-        popd
+        echo "${package_dir}"
+        pushd "${package_dir}" > /dev/null
+            # Created package is the last line of output.
+            PACKAGE_NAME=$(npm pack | tail -n 1)
+            cloudsmith push npm spatialos/gdk-for-unity "${PACKAGE_NAME}" --republish
+        popd > /dev/null
     done
-popd
+popd > /dev/null
+

--- a/ci/publish_packages.sh
+++ b/ci/publish_packages.sh
@@ -10,6 +10,12 @@ cd "$(dirname "$0")/../"
 
 PKG_ROOT="workers/unity/Packages"
 
+if [[ -n "${DRY_RUN-}" ]]; then
+    EXTRA_CLOUDSMITH_ARGS="--dry-run"
+else
+    EXTRA_CLOUDSMITH_ARGS=""
+fi
+
 ./init.sh
 
 # Re-publish all packages
@@ -20,7 +26,7 @@ pushd "${PKG_ROOT}" > /dev/null
         pushd "${package_dir}" > /dev/null
             # Created package is the last line of output.
             PACKAGE_NAME=$(npm pack | tail -n 1)
-            cloudsmith push npm spatialos/gdk-for-unity "${PACKAGE_NAME}" --republish
+            cloudsmith push npm spatialos/gdk-for-unity "${PACKAGE_NAME}" --republish "${EXTRA_CLOUDSMITH_ARGS}"
         popd > /dev/null
     done
 popd > /dev/null


### PR DESCRIPTION
#### Description

Update package publishing script to prepare it for running it in CI.

This will:

- Grab the Worker SDK/`spot`/schema std lib
- Pack each package
- Push it to cloudsmith, overwriting any package that exists with that version (this allows us to overwrite the packages in the case where we detect a defect later in QA). 

There will be work that needs to be done in https://github.com/spatialos/gdk-for-unity-shared-ci to setup and run this script. 
