### PR TITLE
Add component metaclass / command metaclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-- The `GetComponentId<T>()` and `GetSnapshotComponentId<T>()` methods have been moved from `Dynamic` to `ComponentDatabase`.
+- The `GetComponentId<T>()` and `GetSnapshotComponentId<T>()` methods have been moved from `Dynamic` to `ComponentDatabase`. [#1173](https://github.com/spatialos/gdk-for-unity/pull/1173)
 
 ### Fixed
 
@@ -13,7 +13,7 @@
 
 ### Internal
 
-- Added the `IComponentMetaclass` and `ICommandMetaclass` interfaces. Where we previously would use reflection to find instances of various component/command related types, we now lookup through generated metaclasses.
+- Added the `IComponentMetaclass` and `ICommandMetaclass` interfaces. Where we previously would use reflection to find instances of various component/command related types, we now lookup through generated metaclasses. [#1173](https://github.com/spatialos/gdk-for-unity/pull/1173)
 
 ## `0.2.9` - 2019-09-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,18 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- The `GetComponentId<T>()` and `GetSnapshotComponentId<T>()` methods have been moved from `Dynamic` to `ComponentDatabase`.
+
 ### Fixed
 
 - Fixed a bug where the `TransformSynchronization` MonoBehaviour would not reset when disabled. [#1169](https://github.com/spatialos/gdk-for-unity/pull/1169)
 - Fixed a bug where the `UnlinkGameObjectFromEntity` method in the `EntityGameObjectLinker` would not cleanup the `gameObjectToComponentsAdded` dictionary. [#1169](https://github.com/spatialos/gdk-for-unity/pull/1169)
+
+### Internal
+
+- Added the `IComponentMetaclass` and `ICommandMetaclass` interfaces. Where we previously would use reflection to find instances of various component/command related types, we now lookup through generated metaclasses.
 
 ## `0.2.9` - 2019-09-16
 

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -1,5 +1,22 @@
 # Upgrade Guide
 
+## From `0.2.9` to `0.2.10`
+
+### General
+
+* Replace all usages of `Dynamic.GetComponentId<T>` with `ComponentDatabase.GetComponentId<T>`.
+* Replace all usages of `Dynamic.GetSnapshotComponentId<T>` with `ComponentDatabase.GetSnapshotComponentId<T>`.
+    ```csharp
+        // Previously
+        var componentId = Dynamic.GetComponentId<Position.Component>();
+        var componentId = Dynamic.GetSnapshotComponentId<Position.Snapshot>();
+
+        // Now
+        var componentId = ComponentDatabase.GetComponentId<Position.Component>();
+        var componentId = ComponentDatabase.GetSnapshotComponentId<Position.Snapshot>();
+    ```
+
+
 ## From `0.2.6` to `0.2.7`
 
 ### Worker SDK `14.0.1` upgrade

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentComponentMetaclass.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentComponentMetaclass.cs
@@ -1,0 +1,36 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Commands;
+
+namespace Improbable.DependentSchema
+{
+    public partial class DependentComponent
+    {
+        public class ComponentMetaclass : IComponentMetaclass
+        {
+            public uint ComponentId => 198800;
+            public string Name => "DependentComponent";
+
+            public Type Data { get; } = typeof(global::Improbable.DependentSchema.DependentComponent.Component);
+            public Type Snapshot { get; } = typeof(global::Improbable.DependentSchema.DependentComponent.Snapshot);
+            public Type Update { get; } = typeof(global::Improbable.DependentSchema.DependentComponent.Update);
+
+            public Type ReplicationHandler { get; } = typeof(global::Improbable.DependentSchema.DependentComponent.ComponentReplicator);
+            public Type Serializer { get; } = typeof(global::Improbable.DependentSchema.DependentComponent.ComponentSerializer);
+            public Type DiffDeserializer { get; } = typeof(global::Improbable.DependentSchema.DependentComponent.DiffComponentDeserializer);
+
+            public Type DiffStorage { get; } = typeof(global::Improbable.DependentSchema.DependentComponent.DiffComponentStorage);
+            public Type ViewStorage { get; } = typeof(global::Improbable.DependentSchema.DependentComponent.DependentComponentViewStorage);
+            public Type EcsViewManager { get; } = typeof(global::Improbable.DependentSchema.DependentComponent.EcsViewManager);
+            public Type DynamicInvokable { get; } = typeof(global::Improbable.DependentSchema.DependentComponent.DependentComponentDynamic);
+
+            public ICommandMetaclass[] Commands { get; } = new ICommandMetaclass[] 
+            { 
+            };
+        }
+    }
+}

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponentMetaclass.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponentMetaclass.cs
@@ -1,0 +1,51 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Commands;
+
+namespace Improbable.DependentSchema
+{
+    public partial class DependentDataComponent
+    {
+        public class ComponentMetaclass : IComponentMetaclass
+        {
+            public uint ComponentId => 198801;
+            public string Name => "DependentDataComponent";
+
+            public Type Data { get; } = typeof(global::Improbable.DependentSchema.DependentDataComponent.Component);
+            public Type Snapshot { get; } = typeof(global::Improbable.DependentSchema.DependentDataComponent.Snapshot);
+            public Type Update { get; } = typeof(global::Improbable.DependentSchema.DependentDataComponent.Update);
+
+            public Type ReplicationHandler { get; } = typeof(global::Improbable.DependentSchema.DependentDataComponent.ComponentReplicator);
+            public Type Serializer { get; } = typeof(global::Improbable.DependentSchema.DependentDataComponent.ComponentSerializer);
+            public Type DiffDeserializer { get; } = typeof(global::Improbable.DependentSchema.DependentDataComponent.DiffComponentDeserializer);
+
+            public Type DiffStorage { get; } = typeof(global::Improbable.DependentSchema.DependentDataComponent.DiffComponentStorage);
+            public Type ViewStorage { get; } = typeof(global::Improbable.DependentSchema.DependentDataComponent.DependentDataComponentViewStorage);
+            public Type EcsViewManager { get; } = typeof(global::Improbable.DependentSchema.DependentDataComponent.EcsViewManager);
+            public Type DynamicInvokable { get; } = typeof(global::Improbable.DependentSchema.DependentDataComponent.DependentDataComponentDynamic);
+
+            public ICommandMetaclass[] Commands { get; } = new ICommandMetaclass[] 
+            { 
+                new BarCommandMetaclass(),
+            };
+        }
+ 
+
+        public class BarCommandMetaclass : ICommandMetaclass 
+        {
+            public uint CommandIndex => 1;
+            public string Name => "BarCommand";
+
+            public Type DiffDeserializer { get; } = typeof(global::Improbable.DependentSchema.DependentDataComponent.BarCommandDiffCommandDeserializer);
+            public Type Serializer { get; } = typeof(global::Improbable.DependentSchema.DependentDataComponent.BarCommandCommandSerializer);
+            
+            public Type MetaDataStorage { get; } = typeof(global::Improbable.DependentSchema.DependentDataComponent.BarCommandCommandMetaDataStorage);
+            public Type SendStorage { get; } = typeof(global::Improbable.DependentSchema.DependentDataComponent.BarCommandCommandsToSendStorage);
+            public Type DiffStorage { get; } = typeof(global::Improbable.DependentSchema.DependentDataComponent.DiffBarCommandCommandStorage);
+        }
+    }
+}

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestChildMetaclass.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestChildMetaclass.cs
@@ -1,0 +1,36 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Commands;
+
+namespace Improbable.Tests
+{
+    public partial class DependencyTestChild
+    {
+        public class ComponentMetaclass : IComponentMetaclass
+        {
+            public uint ComponentId => 11112;
+            public string Name => "DependencyTestChild";
+
+            public Type Data { get; } = typeof(global::Improbable.Tests.DependencyTestChild.Component);
+            public Type Snapshot { get; } = typeof(global::Improbable.Tests.DependencyTestChild.Snapshot);
+            public Type Update { get; } = typeof(global::Improbable.Tests.DependencyTestChild.Update);
+
+            public Type ReplicationHandler { get; } = typeof(global::Improbable.Tests.DependencyTestChild.ComponentReplicator);
+            public Type Serializer { get; } = typeof(global::Improbable.Tests.DependencyTestChild.ComponentSerializer);
+            public Type DiffDeserializer { get; } = typeof(global::Improbable.Tests.DependencyTestChild.DiffComponentDeserializer);
+
+            public Type DiffStorage { get; } = typeof(global::Improbable.Tests.DependencyTestChild.DiffComponentStorage);
+            public Type ViewStorage { get; } = typeof(global::Improbable.Tests.DependencyTestChild.DependencyTestChildViewStorage);
+            public Type EcsViewManager { get; } = typeof(global::Improbable.Tests.DependencyTestChild.EcsViewManager);
+            public Type DynamicInvokable { get; } = typeof(global::Improbable.Tests.DependencyTestChild.DependencyTestChildDynamic);
+
+            public ICommandMetaclass[] Commands { get; } = new ICommandMetaclass[] 
+            { 
+            };
+        }
+    }
+}

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestGrandchildMetaclass.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestGrandchildMetaclass.cs
@@ -1,0 +1,36 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Commands;
+
+namespace Improbable.Tests
+{
+    public partial class DependencyTestGrandchild
+    {
+        public class ComponentMetaclass : IComponentMetaclass
+        {
+            public uint ComponentId => 11113;
+            public string Name => "DependencyTestGrandchild";
+
+            public Type Data { get; } = typeof(global::Improbable.Tests.DependencyTestGrandchild.Component);
+            public Type Snapshot { get; } = typeof(global::Improbable.Tests.DependencyTestGrandchild.Snapshot);
+            public Type Update { get; } = typeof(global::Improbable.Tests.DependencyTestGrandchild.Update);
+
+            public Type ReplicationHandler { get; } = typeof(global::Improbable.Tests.DependencyTestGrandchild.ComponentReplicator);
+            public Type Serializer { get; } = typeof(global::Improbable.Tests.DependencyTestGrandchild.ComponentSerializer);
+            public Type DiffDeserializer { get; } = typeof(global::Improbable.Tests.DependencyTestGrandchild.DiffComponentDeserializer);
+
+            public Type DiffStorage { get; } = typeof(global::Improbable.Tests.DependencyTestGrandchild.DiffComponentStorage);
+            public Type ViewStorage { get; } = typeof(global::Improbable.Tests.DependencyTestGrandchild.DependencyTestGrandchildViewStorage);
+            public Type EcsViewManager { get; } = typeof(global::Improbable.Tests.DependencyTestGrandchild.EcsViewManager);
+            public Type DynamicInvokable { get; } = typeof(global::Improbable.Tests.DependencyTestGrandchild.DependencyTestGrandchildDynamic);
+
+            public ICommandMetaclass[] Commands { get; } = new ICommandMetaclass[] 
+            { 
+            };
+        }
+    }
+}

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestMetaclass.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestMetaclass.cs
@@ -1,0 +1,36 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Commands;
+
+namespace Improbable.Tests
+{
+    public partial class DependencyTest
+    {
+        public class ComponentMetaclass : IComponentMetaclass
+        {
+            public uint ComponentId => 11111;
+            public string Name => "DependencyTest";
+
+            public Type Data { get; } = typeof(global::Improbable.Tests.DependencyTest.Component);
+            public Type Snapshot { get; } = typeof(global::Improbable.Tests.DependencyTest.Snapshot);
+            public Type Update { get; } = typeof(global::Improbable.Tests.DependencyTest.Update);
+
+            public Type ReplicationHandler { get; } = typeof(global::Improbable.Tests.DependencyTest.ComponentReplicator);
+            public Type Serializer { get; } = typeof(global::Improbable.Tests.DependencyTest.ComponentSerializer);
+            public Type DiffDeserializer { get; } = typeof(global::Improbable.Tests.DependencyTest.DiffComponentDeserializer);
+
+            public Type DiffStorage { get; } = typeof(global::Improbable.Tests.DependencyTest.DiffComponentStorage);
+            public Type ViewStorage { get; } = typeof(global::Improbable.Tests.DependencyTest.DependencyTestViewStorage);
+            public Type EcsViewManager { get; } = typeof(global::Improbable.Tests.DependencyTest.EcsViewManager);
+            public Type DynamicInvokable { get; } = typeof(global::Improbable.Tests.DependencyTest.DependencyTestDynamic);
+
+            public ICommandMetaclass[] Commands { get; } = new ICommandMetaclass[] 
+            { 
+            };
+        }
+    }
+}

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveEntityMetaclass.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveEntityMetaclass.cs
@@ -1,0 +1,36 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Commands;
+
+namespace Improbable.TestSchema
+{
+    public partial class ExhaustiveEntity
+    {
+        public class ComponentMetaclass : IComponentMetaclass
+        {
+            public uint ComponentId => 197720;
+            public string Name => "ExhaustiveEntity";
+
+            public Type Data { get; } = typeof(global::Improbable.TestSchema.ExhaustiveEntity.Component);
+            public Type Snapshot { get; } = typeof(global::Improbable.TestSchema.ExhaustiveEntity.Snapshot);
+            public Type Update { get; } = typeof(global::Improbable.TestSchema.ExhaustiveEntity.Update);
+
+            public Type ReplicationHandler { get; } = typeof(global::Improbable.TestSchema.ExhaustiveEntity.ComponentReplicator);
+            public Type Serializer { get; } = typeof(global::Improbable.TestSchema.ExhaustiveEntity.ComponentSerializer);
+            public Type DiffDeserializer { get; } = typeof(global::Improbable.TestSchema.ExhaustiveEntity.DiffComponentDeserializer);
+
+            public Type DiffStorage { get; } = typeof(global::Improbable.TestSchema.ExhaustiveEntity.DiffComponentStorage);
+            public Type ViewStorage { get; } = typeof(global::Improbable.TestSchema.ExhaustiveEntity.ExhaustiveEntityViewStorage);
+            public Type EcsViewManager { get; } = typeof(global::Improbable.TestSchema.ExhaustiveEntity.EcsViewManager);
+            public Type DynamicInvokable { get; } = typeof(global::Improbable.TestSchema.ExhaustiveEntity.ExhaustiveEntityDynamic);
+
+            public ICommandMetaclass[] Commands { get; } = new ICommandMetaclass[] 
+            { 
+            };
+        }
+    }
+}

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapKeyMetaclass.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapKeyMetaclass.cs
@@ -1,0 +1,36 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Commands;
+
+namespace Improbable.TestSchema
+{
+    public partial class ExhaustiveMapKey
+    {
+        public class ComponentMetaclass : IComponentMetaclass
+        {
+            public uint ComponentId => 197719;
+            public string Name => "ExhaustiveMapKey";
+
+            public Type Data { get; } = typeof(global::Improbable.TestSchema.ExhaustiveMapKey.Component);
+            public Type Snapshot { get; } = typeof(global::Improbable.TestSchema.ExhaustiveMapKey.Snapshot);
+            public Type Update { get; } = typeof(global::Improbable.TestSchema.ExhaustiveMapKey.Update);
+
+            public Type ReplicationHandler { get; } = typeof(global::Improbable.TestSchema.ExhaustiveMapKey.ComponentReplicator);
+            public Type Serializer { get; } = typeof(global::Improbable.TestSchema.ExhaustiveMapKey.ComponentSerializer);
+            public Type DiffDeserializer { get; } = typeof(global::Improbable.TestSchema.ExhaustiveMapKey.DiffComponentDeserializer);
+
+            public Type DiffStorage { get; } = typeof(global::Improbable.TestSchema.ExhaustiveMapKey.DiffComponentStorage);
+            public Type ViewStorage { get; } = typeof(global::Improbable.TestSchema.ExhaustiveMapKey.ExhaustiveMapKeyViewStorage);
+            public Type EcsViewManager { get; } = typeof(global::Improbable.TestSchema.ExhaustiveMapKey.EcsViewManager);
+            public Type DynamicInvokable { get; } = typeof(global::Improbable.TestSchema.ExhaustiveMapKey.ExhaustiveMapKeyDynamic);
+
+            public ICommandMetaclass[] Commands { get; } = new ICommandMetaclass[] 
+            { 
+            };
+        }
+    }
+}

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapValueMetaclass.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapValueMetaclass.cs
@@ -1,0 +1,36 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Commands;
+
+namespace Improbable.TestSchema
+{
+    public partial class ExhaustiveMapValue
+    {
+        public class ComponentMetaclass : IComponentMetaclass
+        {
+            public uint ComponentId => 197718;
+            public string Name => "ExhaustiveMapValue";
+
+            public Type Data { get; } = typeof(global::Improbable.TestSchema.ExhaustiveMapValue.Component);
+            public Type Snapshot { get; } = typeof(global::Improbable.TestSchema.ExhaustiveMapValue.Snapshot);
+            public Type Update { get; } = typeof(global::Improbable.TestSchema.ExhaustiveMapValue.Update);
+
+            public Type ReplicationHandler { get; } = typeof(global::Improbable.TestSchema.ExhaustiveMapValue.ComponentReplicator);
+            public Type Serializer { get; } = typeof(global::Improbable.TestSchema.ExhaustiveMapValue.ComponentSerializer);
+            public Type DiffDeserializer { get; } = typeof(global::Improbable.TestSchema.ExhaustiveMapValue.DiffComponentDeserializer);
+
+            public Type DiffStorage { get; } = typeof(global::Improbable.TestSchema.ExhaustiveMapValue.DiffComponentStorage);
+            public Type ViewStorage { get; } = typeof(global::Improbable.TestSchema.ExhaustiveMapValue.ExhaustiveMapValueViewStorage);
+            public Type EcsViewManager { get; } = typeof(global::Improbable.TestSchema.ExhaustiveMapValue.EcsViewManager);
+            public Type DynamicInvokable { get; } = typeof(global::Improbable.TestSchema.ExhaustiveMapValue.ExhaustiveMapValueDynamic);
+
+            public ICommandMetaclass[] Commands { get; } = new ICommandMetaclass[] 
+            { 
+            };
+        }
+    }
+}

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveOptionalMetaclass.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveOptionalMetaclass.cs
@@ -1,0 +1,36 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Commands;
+
+namespace Improbable.TestSchema
+{
+    public partial class ExhaustiveOptional
+    {
+        public class ComponentMetaclass : IComponentMetaclass
+        {
+            public uint ComponentId => 197716;
+            public string Name => "ExhaustiveOptional";
+
+            public Type Data { get; } = typeof(global::Improbable.TestSchema.ExhaustiveOptional.Component);
+            public Type Snapshot { get; } = typeof(global::Improbable.TestSchema.ExhaustiveOptional.Snapshot);
+            public Type Update { get; } = typeof(global::Improbable.TestSchema.ExhaustiveOptional.Update);
+
+            public Type ReplicationHandler { get; } = typeof(global::Improbable.TestSchema.ExhaustiveOptional.ComponentReplicator);
+            public Type Serializer { get; } = typeof(global::Improbable.TestSchema.ExhaustiveOptional.ComponentSerializer);
+            public Type DiffDeserializer { get; } = typeof(global::Improbable.TestSchema.ExhaustiveOptional.DiffComponentDeserializer);
+
+            public Type DiffStorage { get; } = typeof(global::Improbable.TestSchema.ExhaustiveOptional.DiffComponentStorage);
+            public Type ViewStorage { get; } = typeof(global::Improbable.TestSchema.ExhaustiveOptional.ExhaustiveOptionalViewStorage);
+            public Type EcsViewManager { get; } = typeof(global::Improbable.TestSchema.ExhaustiveOptional.EcsViewManager);
+            public Type DynamicInvokable { get; } = typeof(global::Improbable.TestSchema.ExhaustiveOptional.ExhaustiveOptionalDynamic);
+
+            public ICommandMetaclass[] Commands { get; } = new ICommandMetaclass[] 
+            { 
+            };
+        }
+    }
+}

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveRepeatedMetaclass.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveRepeatedMetaclass.cs
@@ -1,0 +1,36 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Commands;
+
+namespace Improbable.TestSchema
+{
+    public partial class ExhaustiveRepeated
+    {
+        public class ComponentMetaclass : IComponentMetaclass
+        {
+            public uint ComponentId => 197717;
+            public string Name => "ExhaustiveRepeated";
+
+            public Type Data { get; } = typeof(global::Improbable.TestSchema.ExhaustiveRepeated.Component);
+            public Type Snapshot { get; } = typeof(global::Improbable.TestSchema.ExhaustiveRepeated.Snapshot);
+            public Type Update { get; } = typeof(global::Improbable.TestSchema.ExhaustiveRepeated.Update);
+
+            public Type ReplicationHandler { get; } = typeof(global::Improbable.TestSchema.ExhaustiveRepeated.ComponentReplicator);
+            public Type Serializer { get; } = typeof(global::Improbable.TestSchema.ExhaustiveRepeated.ComponentSerializer);
+            public Type DiffDeserializer { get; } = typeof(global::Improbable.TestSchema.ExhaustiveRepeated.DiffComponentDeserializer);
+
+            public Type DiffStorage { get; } = typeof(global::Improbable.TestSchema.ExhaustiveRepeated.DiffComponentStorage);
+            public Type ViewStorage { get; } = typeof(global::Improbable.TestSchema.ExhaustiveRepeated.ExhaustiveRepeatedViewStorage);
+            public Type EcsViewManager { get; } = typeof(global::Improbable.TestSchema.ExhaustiveRepeated.EcsViewManager);
+            public Type DynamicInvokable { get; } = typeof(global::Improbable.TestSchema.ExhaustiveRepeated.ExhaustiveRepeatedDynamic);
+
+            public ICommandMetaclass[] Commands { get; } = new ICommandMetaclass[] 
+            { 
+            };
+        }
+    }
+}

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveSingularMetaclass.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveSingularMetaclass.cs
@@ -1,0 +1,36 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Commands;
+
+namespace Improbable.TestSchema
+{
+    public partial class ExhaustiveSingular
+    {
+        public class ComponentMetaclass : IComponentMetaclass
+        {
+            public uint ComponentId => 197715;
+            public string Name => "ExhaustiveSingular";
+
+            public Type Data { get; } = typeof(global::Improbable.TestSchema.ExhaustiveSingular.Component);
+            public Type Snapshot { get; } = typeof(global::Improbable.TestSchema.ExhaustiveSingular.Snapshot);
+            public Type Update { get; } = typeof(global::Improbable.TestSchema.ExhaustiveSingular.Update);
+
+            public Type ReplicationHandler { get; } = typeof(global::Improbable.TestSchema.ExhaustiveSingular.ComponentReplicator);
+            public Type Serializer { get; } = typeof(global::Improbable.TestSchema.ExhaustiveSingular.ComponentSerializer);
+            public Type DiffDeserializer { get; } = typeof(global::Improbable.TestSchema.ExhaustiveSingular.DiffComponentDeserializer);
+
+            public Type DiffStorage { get; } = typeof(global::Improbable.TestSchema.ExhaustiveSingular.DiffComponentStorage);
+            public Type ViewStorage { get; } = typeof(global::Improbable.TestSchema.ExhaustiveSingular.ExhaustiveSingularViewStorage);
+            public Type EcsViewManager { get; } = typeof(global::Improbable.TestSchema.ExhaustiveSingular.EcsViewManager);
+            public Type DynamicInvokable { get; } = typeof(global::Improbable.TestSchema.ExhaustiveSingular.ExhaustiveSingularDynamic);
+
+            public ICommandMetaclass[] Commands { get; } = new ICommandMetaclass[] 
+            { 
+            };
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Parts/MetaclassGeneratorPart.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Parts/MetaclassGeneratorPart.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using Improbable.Gdk.CodeGeneration.Model.Details;
+
+namespace Improbable.Gdk.CodeGenerator
+{
+    public partial class MetaclassGenerator
+    {
+        private UnityComponentDetails details;
+        private string qualifiedNamespace;
+
+        public string Generate(UnityComponentDetails details, string package)
+        {
+            qualifiedNamespace = package;
+            this.details = details;
+
+            return TransformText();
+        }
+
+        private UnityComponentDetails GetComponentDetails()
+        {
+            return details;
+        }
+
+        private IReadOnlyList<UnityCommandDetails> GetCommandDetailsList()
+        {
+            return details.CommandDetails;
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/SingleGenerationJob.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/SingleGenerationJob.cs
@@ -97,6 +97,7 @@ namespace Improbable.Gdk.CodeGenerator
                     Path.ChangeExtension($"{componentName}ComponentReaderWriter", FileExtension)));
                 OutputFiles.Add(Path.Combine(relativeOutputPath,
                     Path.ChangeExtension($"{componentName}ViewStorage", FileExtension)));
+                OutputFiles.Add(Path.Combine(relativeOutputPath, Path.ChangeExtension($"{componentName}Metaclass", FileExtension)));
             }
 
             foreach (var enumTarget in enumsToGenerate)
@@ -128,6 +129,7 @@ namespace Improbable.Gdk.CodeGenerator
             var commandDiffStorageGenerator = new CommandDiffStorageGenerator();
             var viewStorageGenerator = new ViewStorageGenerator();
             var commandMetaDataStorageGenerator = new CommandMetaDataStorageGenerator();
+            var metaclassGenerator = new MetaclassGenerator();
 
             foreach (var enumTarget in enumsToGenerate)
             {
@@ -248,6 +250,10 @@ namespace Improbable.Gdk.CodeGenerator
                 var viewStorageFileName = Path.ChangeExtension($"{componentName}ViewStorage", FileExtension);
                 var viewStorageCode = viewStorageGenerator.Generate(componentTarget.Content, package);
                 Content.Add(Path.Combine(relativeOutputPath, viewStorageFileName), viewStorageCode);
+
+                var metaclassFileName = Path.ChangeExtension($"{componentName}Metaclass", FileExtension);
+                var metaclassCode = metaclassGenerator.Generate(componentTarget.Content, package);
+                Content.Add(Path.Combine(relativeOutputPath, metaclassFileName), metaclassCode);
             }
         }
 

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Templates/MetaclassGenerator.tt
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Templates/MetaclassGenerator.tt
@@ -1,0 +1,60 @@
+<#@ template language="C#" #>
+<#@ output extension=".cs" #>
+<#
+    var componentDetails = GetComponentDetails();
+    var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
+    var commandDetailsList = GetCommandDetailsList();
+    var rootNamespace = $"global::{qualifiedNamespace}.{componentDetails.ComponentName}";
+#>
+<#= generatedHeader #>
+
+using System;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Commands;
+
+namespace <#= qualifiedNamespace #>
+{
+    public partial class <#= componentDetails.ComponentName #>
+    {
+        public class ComponentMetaclass : IComponentMetaclass
+        {
+            public uint ComponentId => <#= componentDetails.ComponentId #>;
+            public string Name => "<#= componentDetails.ComponentName #>";
+
+            public Type Data { get; } = typeof(<#= rootNamespace #>.Component);
+            public Type Snapshot { get; } = typeof(<#= rootNamespace #>.Snapshot);
+            public Type Update { get; } = typeof(<#= rootNamespace #>.Update);
+
+            public Type ReplicationHandler { get; } = typeof(<#= rootNamespace #>.ComponentReplicator);
+            public Type Serializer { get; } = typeof(<#= rootNamespace #>.ComponentSerializer);
+            public Type DiffDeserializer { get; } = typeof(<#= rootNamespace #>.DiffComponentDeserializer);
+
+            public Type DiffStorage { get; } = typeof(<#= rootNamespace #>.DiffComponentStorage);
+            public Type ViewStorage { get; } = typeof(<#= rootNamespace #>.<#= componentDetails.ComponentName #>ViewStorage);
+            public Type EcsViewManager { get; } = typeof(<#= rootNamespace #>.EcsViewManager);
+            public Type DynamicInvokable { get; } = typeof(<#= rootNamespace #>.<#= componentDetails.ComponentName #>Dynamic);
+
+            public ICommandMetaclass[] Commands { get; } = new ICommandMetaclass[] 
+            { 
+<# foreach (var command in commandDetailsList) { #>
+                new <#= command.CommandName #>Metaclass(),
+<# } #>
+            };
+        }
+<# foreach (var command in commandDetailsList) { #> 
+
+        public class <#= command.CommandName #>Metaclass : ICommandMetaclass 
+        {
+            public uint CommandIndex => <#= command.CommandIndex #>;
+            public string Name => "<#= command.CommandName #>";
+
+            public Type DiffDeserializer { get; } = typeof(<#= rootNamespace #>.<#= command.CommandName #>DiffCommandDeserializer);
+            public Type Serializer { get; } = typeof(<#= rootNamespace #>.<#= command.CommandName #>CommandSerializer);
+            
+            public Type MetaDataStorage { get; } = typeof(<#= rootNamespace #>.<#= command.CommandName #>CommandMetaDataStorage);
+            public Type SendStorage { get; } = typeof(<#= rootNamespace #>.<#= command.CommandName #>CommandsToSendStorage);
+            public Type DiffStorage { get; } = typeof(<#= rootNamespace #>.Diff<#= command.CommandName #>CommandStorage);
+        }
+<# } #>
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/Commands/ICommandMetaclass.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Commands/ICommandMetaclass.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Improbable.Gdk.Core.Commands
+{
+    public interface ICommandMetaclass
+    {
+        uint CommandIndex { get; }
+        string Name { get; }
+
+        Type DiffDeserializer { get; }
+        Type Serializer { get; }
+
+        Type MetaDataStorage { get; }
+        Type SendStorage { get; }
+        Type DiffStorage { get; }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/Commands/ICommandMetaclass.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/Commands/ICommandMetaclass.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e8896ecd9e6cf33408d68da672caff6e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.core/Components/IComponentMetaclass.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Components/IComponentMetaclass.cs
@@ -1,0 +1,26 @@
+using System;
+using Improbable.Gdk.Core.Commands;
+
+namespace Improbable.Gdk.Core
+{
+    public interface IComponentMetaclass
+    {
+        uint ComponentId { get; }
+        string Name { get; }
+
+        Type Data { get; }
+        Type Snapshot { get; }
+        Type Update { get; }
+
+        Type ReplicationHandler { get; }
+        Type Serializer { get; }
+        Type DiffDeserializer { get; }
+
+        Type DiffStorage { get; }
+        Type ViewStorage { get; }
+        Type EcsViewManager { get; }
+        Type DynamicInvokable { get; }
+
+        ICommandMetaclass[] Commands { get; }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/Components/IComponentMetaclass.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/Components/IComponentMetaclass.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2a6ef135d3b663d4ea3e7d5640a3e0a7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/ComponentSendSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/ComponentSendSystem.cs
@@ -93,7 +93,7 @@ namespace Improbable.Gdk.Core
         private void PopulateDefaultComponentReplicators()
         {
             // Find all component specific replicators and create an instance.
-            var types = ReflectionUtility.GetNonAbstractTypes(typeof(IComponentReplicationHandler));
+            var types = ComponentDatabase.Metaclasses.Select(type => type.Value.ReplicationHandler);
             foreach (var type in types)
             {
                 if (type.GetCustomAttribute<DisableAutoRegisterAttribute>() != null)

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/EcsViewSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/EcsViewSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Unity.Entities;
 using UnityEngine.Profiling;
 
@@ -56,7 +57,7 @@ namespace Improbable.Gdk.Core
 
             worker = World.GetExistingSystem<WorkerSystem>();
 
-            foreach (var type in ReflectionUtility.GetNonAbstractTypes(typeof(IEcsViewManager)))
+            foreach (var type in ComponentDatabase.Metaclasses.Select(type => type.Value.EcsViewManager))
             {
                 var instance = (IEcsViewManager) Activator.CreateInstance(type);
                 instance.Init(World);

--- a/workers/unity/Packages/io.improbable.gdk.core/Utility/EntitySnapshot.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Utility/EntitySnapshot.cs
@@ -17,7 +17,7 @@ namespace Improbable.Gdk.Core
         /// <typeparam name="T">The component type.</typeparam>
         public T? GetComponentSnapshot<T>() where T : struct, ISpatialComponentSnapshot
         {
-            var id = Dynamic.GetSnapshotComponentId<T>();
+            var id = ComponentDatabase.GetSnapshotComponentId<T>();
             if (components.TryGetValue(id, out var data))
             {
                 return (T) data;

--- a/workers/unity/Packages/io.improbable.gdk.core/Utility/EntityTemplate.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Utility/EntityTemplate.cs
@@ -69,7 +69,7 @@ namespace Improbable.Gdk.Core
         /// <returns>The component snapshot, if the component snapshot exists, null otherwise.</returns>
         public TSnapshot? GetComponent<TSnapshot>() where TSnapshot : struct, ISpatialComponentSnapshot
         {
-            if (entityData.TryGetValue(Dynamic.GetSnapshotComponentId<TSnapshot>(), out var snapshot))
+            if (entityData.TryGetValue(ComponentDatabase.GetSnapshotComponentId<TSnapshot>(), out var snapshot))
             {
                 return (TSnapshot) snapshot;
             }
@@ -94,7 +94,7 @@ namespace Improbable.Gdk.Core
         /// <returns>True, if the component snapshot exists, false otherwise.</returns>
         public bool HasComponent<TSnapshot>() where TSnapshot : struct, ISpatialComponentSnapshot
         {
-            return HasComponent(Dynamic.GetSnapshotComponentId<TSnapshot>());
+            return HasComponent(ComponentDatabase.GetSnapshotComponentId<TSnapshot>());
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace Improbable.Gdk.Core
         /// <typeparam name="TSnapshot">The type of the component snapshot.</typeparam>
         public void RemoveComponent<TSnapshot>() where TSnapshot : struct, ISpatialComponentSnapshot
         {
-            var id = Dynamic.GetSnapshotComponentId<TSnapshot>();
+            var id = ComponentDatabase.GetSnapshotComponentId<TSnapshot>();
             entityData.Remove(id);
             acl.RemoveComponentWriteAccess(id);
         }
@@ -138,7 +138,7 @@ namespace Improbable.Gdk.Core
         /// <returns>The write access worker attribute, if it exists, null otherwise.</returns>
         public string GetComponentWriteAccess<TSnapshot>() where TSnapshot : struct, ISpatialComponentSnapshot
         {
-            return GetComponentWriteAccess(Dynamic.GetSnapshotComponentId<TSnapshot>());
+            return GetComponentWriteAccess(ComponentDatabase.GetSnapshotComponentId<TSnapshot>());
         }
 
         /// <summary>
@@ -159,7 +159,7 @@ namespace Improbable.Gdk.Core
         public void SetComponentWriteAccess<TSnapshot>(string writeAccess)
             where TSnapshot : struct, ISpatialComponentSnapshot
         {
-            SetComponentWriteAccess(Dynamic.GetSnapshotComponentId<TSnapshot>(), writeAccess);
+            SetComponentWriteAccess(ComponentDatabase.GetSnapshotComponentId<TSnapshot>(), writeAccess);
         }
 
         /// <summary>

--- a/workers/unity/Packages/io.improbable.gdk.core/View/View.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/View/View.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Improbable.Worker.CInterop;
 using UnityEngine;
 
@@ -16,7 +17,7 @@ namespace Improbable.Gdk.Core
 
         public View()
         {
-            var types = ReflectionUtility.GetNonAbstractTypes(typeof(IViewStorage));
+            var types = ComponentDatabase.Metaclasses.Select(type => type.Value.ViewStorage);
             foreach (var type in types)
             {
                 var instance = (IViewStorage) Activator.CreateInstance(type);
@@ -50,7 +51,7 @@ namespace Improbable.Gdk.Core
         {
             if (!HasComponent<T>(entityId))
             {
-                throw new ArgumentException($"The view does not have entity with Entity ID: {entityId.Id} and component with ID: {Dynamic.GetSnapshotComponentId<T>()}");
+                throw new ArgumentException($"The view does not have entity with Entity ID: {entityId.Id} and component with ID: {ComponentDatabase.GetSnapshotComponentId<T>()}");
             }
 
             var storage = (IViewComponentStorage<T>) typeToViewStorage[typeof(T)];

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/CommandMetaData.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/CommandMetaData.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Unity.Entities;
 
 namespace Improbable.Gdk.Core
@@ -36,7 +37,10 @@ namespace Improbable.Gdk.Core
         {
             if (storageTypes == null)
             {
-                storageTypes = ReflectionUtility.GetNonAbstractTypes(typeof(ICommandMetaDataStorage));
+                storageTypes = ComponentDatabase.Metaclasses
+                    .SelectMany(type => type.Value.Commands)
+                    .Select(commandMetaclass => commandMetaclass.MetaDataStorage)
+                    .ToList();
             }
 
             foreach (var type in storageTypes)
@@ -52,6 +56,11 @@ namespace Improbable.Gdk.Core
 
                 commandIdToStorage.Add(instance.GetCommandId(), instance);
             }
+
+            componentIdToCommandIdToStorage.Add(0, new Dictionary<uint, ICommandMetaDataStorage>
+            {
+                { 0, new WorldCommandMetaDataStorage() }
+            });
         }
 
         public void MarkIdForRemoval(uint componentId, uint commandId, long internalRequestId)

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/MessagesToSend.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/MessagesToSend.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Improbable.Gdk.Core.Commands;
 using Improbable.Worker.CInterop;
+using UnityEngine;
 
 namespace Improbable.Gdk.Core
 {
@@ -39,12 +41,17 @@ namespace Improbable.Gdk.Core
         {
             if (componentTypes == null)
             {
-                componentTypes = ReflectionUtility.GetNonAbstractTypes(typeof(IComponentDiffStorage));
+                componentTypes = ComponentDatabase.Metaclasses
+                    .Select(pair => pair.Value.DiffStorage)
+                    .ToList();
             }
 
             if (commandTypes == null)
             {
-                commandTypes = ReflectionUtility.GetNonAbstractTypes(typeof(IComponentCommandSendStorage));
+                commandTypes = ComponentDatabase.Metaclasses
+                    .SelectMany(pair => pair.Value.Commands)
+                    .Select(metaclass => metaclass.SendStorage)
+                    .ToList();
             }
 
             foreach (var type in componentTypes)
@@ -83,6 +90,8 @@ namespace Improbable.Gdk.Core
             typeToCommandStorage.Add(typeof(WorldCommands.DeleteEntity.Request), worldCommandStorage);
             typeToCommandStorage.Add(typeof(WorldCommands.ReserveEntityIds.Request), worldCommandStorage);
             typeToCommandStorage.Add(typeof(WorldCommands.EntityQuery.Request), worldCommandStorage);
+
+            Debug.Log("Y");
         }
 
         public void Clear()

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/MessagesToSend.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/MessagesToSend.cs
@@ -90,8 +90,6 @@ namespace Improbable.Gdk.Core
             typeToCommandStorage.Add(typeof(WorldCommands.DeleteEntity.Request), worldCommandStorage);
             typeToCommandStorage.Add(typeof(WorldCommands.ReserveEntityIds.Request), worldCommandStorage);
             typeToCommandStorage.Add(typeof(WorldCommands.EntityQuery.Request), worldCommandStorage);
-
-            Debug.Log("Y");
         }
 
         public void Clear()

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/ViewDiff.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/ViewDiff.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Improbable.Gdk.Core.Commands;
 using Improbable.Gdk.Core.NetworkStats;
 using Improbable.Worker.CInterop;
@@ -48,12 +49,17 @@ namespace Improbable.Gdk.Core
         {
             if (componentStorageTypes == null)
             {
-                componentStorageTypes = ReflectionUtility.GetNonAbstractTypes(typeof(IComponentDiffStorage));
+                componentStorageTypes = ComponentDatabase.Metaclasses
+                    .Select(pair => pair.Value.DiffStorage)
+                    .ToList();
             }
 
             if (commandStorageTypes == null)
             {
-                commandStorageTypes = ReflectionUtility.GetNonAbstractTypes(typeof(IComponentCommandDiffStorage));
+                commandStorageTypes = ComponentDatabase.Metaclasses
+                    .SelectMany(pair => pair.Value.Commands)
+                    .Select(metaclass => metaclass.DiffStorage)
+                    .ToList();
             }
 
             foreach (var type in componentStorageTypes)

--- a/workers/unity/Packages/io.improbable.gdk.debug/NetStatsViewer/NetStatViewer.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/NetStatsViewer/NetStatViewer.cs
@@ -31,8 +31,8 @@ namespace Improbable.Gdk.Debug
         private void OnEnable()
         {
             // Generate list of types
-            spatialComponents = ComponentDatabase.ComponentsToIds
-                .Select(pair => (pair.Key.DeclaringType.Name, pair.Value))
+            spatialComponents = ComponentDatabase.Metaclasses
+                .Select(pair => (pair.Value.Name, pair.Key))
                 .ToList();
 
             // Load UI
@@ -70,7 +70,7 @@ namespace Improbable.Gdk.Debug
         {
             // Find spatial worlds
             var spatialWorlds = World.AllWorlds
-            	.Where(w => w.GetExistingSystem<NetworkStatisticsSystem>() != null)
+                .Where(w => w.GetExistingSystem<NetworkStatisticsSystem>() != null)
                 .ToList();
 
             // Fill menu items

--- a/workers/unity/Packages/io.improbable.gdk.querybasedinteresthelper/Constraint.cs
+++ b/workers/unity/Packages/io.improbable.gdk.querybasedinteresthelper/Constraint.cs
@@ -294,7 +294,7 @@ namespace Improbable.Gdk.QueryBasedInterest
         public static Constraint Component<T>() where T : ISpatialComponentData
         {
             var constraint = Default();
-            constraint.ComponentConstraint = Dynamic.GetComponentId<T>();
+            constraint.ComponentConstraint = ComponentDatabase.GetComponentId<T>();
             return new Constraint(constraint);
         }
 

--- a/workers/unity/Packages/io.improbable.gdk.querybasedinteresthelper/InterestTemplate.cs
+++ b/workers/unity/Packages/io.improbable.gdk.querybasedinteresthelper/InterestTemplate.cs
@@ -104,7 +104,7 @@ namespace Improbable.Gdk.QueryBasedInterest
             params InterestQuery[] interestQueries)
             where T : ISpatialComponentData
         {
-            return AddQueries(Dynamic.GetComponentId<T>(), interestQuery, interestQueries);
+            return AddQueries(ComponentDatabase.GetComponentId<T>(), interestQuery, interestQueries);
         }
 
         /// <summary>
@@ -150,7 +150,7 @@ namespace Improbable.Gdk.QueryBasedInterest
         public InterestTemplate AddQueries<T>(IEnumerable<InterestQuery> interestQueries)
             where T : ISpatialComponentData
         {
-            return AddQueries(Dynamic.GetComponentId<T>(), interestQueries);
+            return AddQueries(ComponentDatabase.GetComponentId<T>(), interestQueries);
         }
 
         /// <summary>
@@ -217,7 +217,7 @@ namespace Improbable.Gdk.QueryBasedInterest
             params InterestQuery[] interestQueries)
             where T : ISpatialComponentData
         {
-            return ReplaceQueries(Dynamic.GetComponentId<T>(), interestQuery, interestQueries);
+            return ReplaceQueries(ComponentDatabase.GetComponentId<T>(), interestQuery, interestQueries);
         }
 
         /// <summary>
@@ -263,7 +263,7 @@ namespace Improbable.Gdk.QueryBasedInterest
         public InterestTemplate ReplaceQueries<T>(IEnumerable<InterestQuery> interestQueries)
             where T : ISpatialComponentData
         {
-            return ReplaceQueries(Dynamic.GetComponentId<T>(), interestQueries);
+            return ReplaceQueries(ComponentDatabase.GetComponentId<T>(), interestQueries);
         }
 
         /// <summary>
@@ -322,7 +322,7 @@ namespace Improbable.Gdk.QueryBasedInterest
         public InterestTemplate ClearQueries<T>()
             where T : ISpatialComponentData
         {
-            return ClearQueries(Dynamic.GetComponentId<T>());
+            return ClearQueries(ComponentDatabase.GetComponentId<T>());
         }
 
         /// <summary>


### PR DESCRIPTION
#### Description

In the quest to expose (component ID, command index) -> command name pairs in preparation for command network stats GUI work, we found that we could simplify and reduce the amount of reflection required at startup by introducing metadata classes.

Whereas previously, for every type we wanted to reflect over related to a component (i.e. - serializer, diff storage, etc) we would do a full search through all the assemblies for these types.

Now we statically generate this information in the metaclass and do reflection _once_ to find those metaclasses. This also has the benefit of allowing us to expose the information ((component ID, command index) -> command name pairs) that we originally wanted in a clean way.

Along the way we made a small breaking change to improve the coherency of the API.

#### Tests

- Ran playground 
- Ran tests

#### Documentation
- [x] Changelog
- [x] Upgrade guide
- ~❓ Docs?~ Turns out there are none
