### PR TITLE
Fix ScrollView display for all tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Fixed a bug where the `TransformSynchronization` MonoBehaviour would not reset when disabled. [#1169](https://github.com/spatialos/gdk-for-unity/pull/1169)
 - Fixed a bug where the `UnlinkGameObjectFromEntity` method in the `EntityGameObjectLinker` would not cleanup the `gameObjectToComponentsAdded` dictionary. [#1169](https://github.com/spatialos/gdk-for-unity/pull/1169)
+- Fixed a bug where the Network Analyzer would not properly render all components/commands in the scroll view. [#1175](https://github.com/spatialos/gdk-for-unity/pull/1175)
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## Unreleased
 
-### Added
-
-- Added commands and world commands tabs to the Network Analyzer window. [#1174](https://github.com/spatialos/gdk-for-unity/pull/1174)
-
 ### Breaking Changes
 
 - The `GetComponentId<T>()` and `GetSnapshotComponentId<T>()` methods have been moved from `Dynamic` to `ComponentDatabase`. [#1173](https://github.com/spatialos/gdk-for-unity/pull/1173)
+
+### Added
+
+- Added commands and world commands tabs to the Network Analyzer window. [#1174](https://github.com/spatialos/gdk-for-unity/pull/1174)
 
 ### Fixed
 

--- a/workers/unity/Packages/io.improbable.gdk.debug/NetStatsViewer/NetStatsTab.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/NetStatsViewer/NetStatsTab.cs
@@ -36,13 +36,13 @@ namespace Improbable.Gdk.Debug.NetStats
         {
             var scrollView = this.Q<ScrollView>("container");
             var count = scrollView.childCount;
-            var viewportBound = scrollView.contentViewport.localBound;
+            var viewportBound = scrollView.contentViewport.worldBound;
 
             // Update all visible items in the list
             for (var i = 0; i < count; i++)
             {
                 var element = scrollView[i];
-                if (viewportBound.Overlaps(element.localBound))
+                if (viewportBound.Overlaps(element.worldBound))
                 {
                     UpdateElement(i, element);
                 }


### PR DESCRIPTION
Quick fix
When you have more components or commands to fit in the un-scaled scroll view, they would never update their data.