### PR TITLE
Fix publish packages

### DIFF
--- a/ci/publish_packages.sh
+++ b/ci/publish_packages.sh
@@ -10,12 +10,6 @@ cd "$(dirname "$0")/../"
 
 PKG_ROOT="workers/unity/Packages"
 
-if [[ -n "${DRY_RUN-}" ]]; then
-    EXTRA_CLOUDSMITH_ARGS="--dry-run"
-else
-    EXTRA_CLOUDSMITH_ARGS=""
-fi
-
 ./init.sh
 
 # Re-publish all packages
@@ -26,9 +20,12 @@ pushd "${PKG_ROOT}" > /dev/null
         pushd "${package_dir}" > /dev/null
             # Created package is the last line of output.
             PACKAGE_NAME=$(npm pack | tail -n 1)
-            cloudsmith push npm spatialos/gdk-for-unity "${PACKAGE_NAME}" --republish "${EXTRA_CLOUDSMITH_ARGS}"
+            if [[ -n "${DRY_RUN-}" ]]; then
+                cloudsmith push npm spatialos/gdk-for-unity "${PACKAGE_NAME}" --republish --dry-run
+            else
+                cloudsmith push npm spatialos/gdk-for-unity "${PACKAGE_NAME}" --republish
+            fi
             rm "${PACKAGE_NAME}"
         popd > /dev/null
     done
 popd > /dev/null
-


### PR DESCRIPTION
#### Description
Cloudsmith tool breaks on an empty extra argument when not running in dry-run mode.
This fixes this issue.
