### PR TITLE
Shrink local worker names for local development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 - Added the ability to select which Android device or emulator to launch an application on. [#1194](https://github.com/spatialos/gdk-for-unity/pull/1194)
 
+### Changed
+
+- Generated Worker ID's for local development are now smaller and easier to read for debugging. [#1197](https://github.com/spatialos/gdk-for-unity/pull/1197)
+
 ## `0.2.10` - 2019-10-14
 
 ### Breaking Changes

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/WorkerConnector.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/WorkerConnector.cs
@@ -203,7 +203,7 @@ namespace Improbable.Gdk.Core
 
         protected static string CreateNewWorkerId(string workerType)
         {
-            return $"{workerType}-{Guid.NewGuid()}";
+            return $"{workerType}-{Guid.NewGuid().GetHashCode():x}";
         }
 
         protected ConnectionParameters CreateConnectionParameters(string workerType, IConnectionParameterInitializer initializer = null)


### PR DESCRIPTION
#### Description
Worker names for local development are no longer appended with massive GUID's, but instead have a smaller string based on the hash for the GUID.
This technically increases the chance of a clash, but considering we make so few local workers (2) it really doesn't matter.

This looks significantly better in the Profiler/Net Analyzer/Entity Debugger

#### Documentation
* [x] Changelog
