### PR TITLE
Fix command response key leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Fixed
 
 - Fixed a bug where the Deployment Launcher window would accept tags with 33 characters. [#1202](https://github.com/spatialos/gdk-for-unity/pull/1202)
+- Fixed small memory leak with command response callbacks using Monobehaviours. [#1205](https://github.com/spatialos/gdk-for-unity/pull/1205)
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 ### Fixed
 
 - Fixed a bug where the Deployment Launcher window would accept tags with 33 characters. [#1202](https://github.com/spatialos/gdk-for-unity/pull/1202)
-- Fixed small memory leak with command response callbacks using Monobehaviours. [#1205](https://github.com/spatialos/gdk-for-unity/pull/1205)
+- Fixed a small memory leak with command response callbacks using MonoBehaviours. [#1205](https://github.com/spatialos/gdk-for-unity/pull/1205)
 
 ### Internal
 

--- a/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/Systems/CommandCallbackSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/Systems/CommandCallbackSystem.cs
@@ -35,7 +35,7 @@ namespace Improbable.Gdk.Subscriptions
             return callbacksRegistered++;
         }
 
-        public ulong RegisterCommandResponseCallback<T>(long requestId, Action<T> callback)
+        public void RegisterCommandResponseCallback<T>(long requestId, Action<T> callback)
             where T : struct, IReceivedCommandResponse
         {
             if (!callbackManagers.TryGetManager(typeof(T), out var manager))
@@ -44,9 +44,7 @@ namespace Improbable.Gdk.Subscriptions
                 callbackManagers.AddCallbackManager(typeof(T), manager);
             }
 
-            var key = ((CommandResponseCallbackManager<T>) manager).RegisterCallback(requestId, callback);
-            keyToInternalKeyAndManager.Add(callbacksRegistered, (key, manager));
-            return callbacksRegistered++;
+            ((CommandResponseCallbackManager<T>) manager).RegisterCallback(requestId, callback);
         }
 
         public bool UnregisterCommandRequestCallback(ulong callbackKey)


### PR DESCRIPTION
#### Description
Command response callbacks were registering a key with the system, but these were never cleared.
The key itself isn't actually used, since response callbacks will always clean up after sending.

This PR removes the key registration for response callbacks.
