### PR TITLE
Quick code snippets fixes

### DIFF
--- a/docs/projects/fps/tutorial.md
+++ b/docs/projects/fps/tutorial.md
@@ -488,12 +488,16 @@ namespace Fps
         [Require] private HealthComponentCommandSender healthCommandRequestSender;
 
         private Coroutine respawnCoroutine;
+        private Collider collider;
 
         private void OnEnable()
         {
+            collider = gameObject.GetComponentInChildren<Collider>();
+
             // If the pickup is inactive on initial checkout - turn off collisions and start the respawning process.
             if (!healthPickupWriter.Data.IsActive)
             {
+                collider.enabled = false;
                 respawnCoroutine = StartCoroutine(RespawnHealthPackRoutine());
             }
         }
@@ -524,10 +528,11 @@ namespace Fps
 
         private void SetIsActive(bool isActive)
         {
+            collider.enabled = isActive;
             healthPickupWriter?.SendUpdate(new HealthPickup.Update
-                {
-                    IsActive = new Option<bool>(isActive)
-                });
+            {
+                IsActive = new Option<bool>(isActive)
+            });
         }
 
         private void HandleCollisionWithPlayer(GameObject player)

--- a/docs/workflows/monobehaviour/interaction/commands/component-commands.md
+++ b/docs/workflows/monobehaviour/interaction/commands/component-commands.md
@@ -35,12 +35,15 @@ We use the following [schema]({{urlRoot}}/reference/glossary#schema) for all exa
 ```schemalang
 package playground;
 
+import "improbable/gdk/core/common.schema";
+
 component CubeSpawner
 {
     id = 12002;
-    command improbable.common.Empty spawn_cube(improbable.common.Empty);
+    command improbable.gdk.core.Empty spawn_cube(improbable.gdk.core.Empty);
 }
 ```
+
 The GDK generates the following classes in the `Playground` namespace:
 
   * `CubeSpawner.SpawnCube.Request`


### PR DESCRIPTION
#### Description

- turn off colliders in HealthPickupServerBehaviour (UTY-1977)
- fix missing schema import for `Empty` (UTY-2099)

#### Tests

- not regaining health anymore when pickup is disabled
- codegen broke without import, works fine now

#### Documentation

- yes this is docs

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
