### PR TITLE
Events no longer trigger component updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Reactive components have been removed completely. [#1195](https://github.com/spatialos/gdk-for-unity/pull/1195)
   - If you are using reactive components, please see our documentation on the [ECS workflow](https://docs.improbable.io/unity/alpha/workflows/overview#ecs-centric-workflow).
 - Codegen for the GameObjectCreation package has been moved into the package. If the package is not used, readers and writers will no longer be generated. [#1196](https://github.com/spatialos/gdk-for-unity/pull/1196)
+- Empty component updates will no longer trigger callbacks when received. [#1211](https://github.com/spatialos/gdk-for-unity/pull/1211)
 
 ### Added
 
@@ -22,6 +23,7 @@
 
 - Fixed a bug where the Deployment Launcher window would accept tags with 33 characters. [#1202](https://github.com/spatialos/gdk-for-unity/pull/1202)
 - Fixed a small memory leak with command response callbacks using MonoBehaviours. [#1205](https://github.com/spatialos/gdk-for-unity/pull/1205)
+- Fixed events triggering the `OnUpdate` callback on readers and writers. [#1211](https://github.com/spatialos/gdk-for-unity/pull/1211)
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 - Fixed a bug where the Deployment Launcher window would accept tags with 33 characters. [#1202](https://github.com/spatialos/gdk-for-unity/pull/1202)
 - Fixed a small memory leak with command response callbacks using MonoBehaviours. [#1205](https://github.com/spatialos/gdk-for-unity/pull/1205)
-- Fixed events triggering the `OnUpdate` callback on readers and writers. [#1211](https://github.com/spatialos/gdk-for-unity/pull/1211)
+- Fixed an issue where events would trigger the `OnUpdate` callback on readers and writers. [#1211](https://github.com/spatialos/gdk-for-unity/pull/1211)
 
 ### Internal
 

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentComponentComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentComponentComponentDiffDeserializer.cs
@@ -18,8 +18,11 @@ namespace Improbable.DependentSchema
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = global::Improbable.DependentSchema.DependentComponent.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
-                diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                if (op.Update.SchemaData.Value.GetFields().GetUniqueFieldIdCount() > 0)
+                {
+                    var update = global::Improbable.DependentSchema.DependentComponent.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                    diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                }
             }
 
             public void AddComponentToDiff(AddComponentOp op, ViewDiff diff)

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponentComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponentComponentDiffDeserializer.cs
@@ -18,8 +18,11 @@ namespace Improbable.DependentSchema
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = global::Improbable.DependentSchema.DependentDataComponent.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
-                diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                if (op.Update.SchemaData.Value.GetFields().GetUniqueFieldIdCount() > 0)
+                {
+                    var update = global::Improbable.DependentSchema.DependentDataComponent.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                    diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                }
                 var eventsObject = op.Update.SchemaData.Value.GetEvents();
 
                 {

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestChildComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestChildComponentDiffDeserializer.cs
@@ -18,8 +18,11 @@ namespace Improbable.Tests
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = global::Improbable.Tests.DependencyTestChild.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
-                diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                if (op.Update.SchemaData.Value.GetFields().GetUniqueFieldIdCount() > 0)
+                {
+                    var update = global::Improbable.Tests.DependencyTestChild.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                    diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                }
             }
 
             public void AddComponentToDiff(AddComponentOp op, ViewDiff diff)

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestComponentDiffDeserializer.cs
@@ -18,8 +18,11 @@ namespace Improbable.Tests
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = global::Improbable.Tests.DependencyTest.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
-                diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                if (op.Update.SchemaData.Value.GetFields().GetUniqueFieldIdCount() > 0)
+                {
+                    var update = global::Improbable.Tests.DependencyTest.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                    diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                }
             }
 
             public void AddComponentToDiff(AddComponentOp op, ViewDiff diff)

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestGrandchildComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestGrandchildComponentDiffDeserializer.cs
@@ -18,8 +18,11 @@ namespace Improbable.Tests
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = global::Improbable.Tests.DependencyTestGrandchild.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
-                diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                if (op.Update.SchemaData.Value.GetFields().GetUniqueFieldIdCount() > 0)
+                {
+                    var update = global::Improbable.Tests.DependencyTestGrandchild.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                    diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                }
             }
 
             public void AddComponentToDiff(AddComponentOp op, ViewDiff diff)

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveEntityComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveEntityComponentDiffDeserializer.cs
@@ -18,8 +18,11 @@ namespace Improbable.TestSchema
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = global::Improbable.TestSchema.ExhaustiveEntity.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
-                diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                if (op.Update.SchemaData.Value.GetFields().GetUniqueFieldIdCount() > 0)
+                {
+                    var update = global::Improbable.TestSchema.ExhaustiveEntity.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                    diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                }
             }
 
             public void AddComponentToDiff(AddComponentOp op, ViewDiff diff)

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapKeyComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapKeyComponentDiffDeserializer.cs
@@ -18,8 +18,11 @@ namespace Improbable.TestSchema
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = global::Improbable.TestSchema.ExhaustiveMapKey.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
-                diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                if (op.Update.SchemaData.Value.GetFields().GetUniqueFieldIdCount() > 0)
+                {
+                    var update = global::Improbable.TestSchema.ExhaustiveMapKey.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                    diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                }
             }
 
             public void AddComponentToDiff(AddComponentOp op, ViewDiff diff)

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapValueComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapValueComponentDiffDeserializer.cs
@@ -18,8 +18,11 @@ namespace Improbable.TestSchema
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = global::Improbable.TestSchema.ExhaustiveMapValue.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
-                diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                if (op.Update.SchemaData.Value.GetFields().GetUniqueFieldIdCount() > 0)
+                {
+                    var update = global::Improbable.TestSchema.ExhaustiveMapValue.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                    diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                }
             }
 
             public void AddComponentToDiff(AddComponentOp op, ViewDiff diff)

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveOptionalComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveOptionalComponentDiffDeserializer.cs
@@ -18,8 +18,11 @@ namespace Improbable.TestSchema
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = global::Improbable.TestSchema.ExhaustiveOptional.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
-                diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                if (op.Update.SchemaData.Value.GetFields().GetUniqueFieldIdCount() > 0)
+                {
+                    var update = global::Improbable.TestSchema.ExhaustiveOptional.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                    diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                }
             }
 
             public void AddComponentToDiff(AddComponentOp op, ViewDiff diff)

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveRepeatedComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveRepeatedComponentDiffDeserializer.cs
@@ -18,8 +18,11 @@ namespace Improbable.TestSchema
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = global::Improbable.TestSchema.ExhaustiveRepeated.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
-                diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                if (op.Update.SchemaData.Value.GetFields().GetUniqueFieldIdCount() > 0)
+                {
+                    var update = global::Improbable.TestSchema.ExhaustiveRepeated.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                    diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                }
             }
 
             public void AddComponentToDiff(AddComponentOp op, ViewDiff diff)

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveSingularComponentDiffDeserializer.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveSingularComponentDiffDeserializer.cs
@@ -18,8 +18,11 @@ namespace Improbable.TestSchema
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = global::Improbable.TestSchema.ExhaustiveSingular.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
-                diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                if (op.Update.SchemaData.Value.GetFields().GetUniqueFieldIdCount() > 0)
+                {
+                    var update = global::Improbable.TestSchema.ExhaustiveSingular.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                    diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                }
             }
 
             public void AddComponentToDiff(AddComponentOp op, ViewDiff diff)

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Templates/ComponentDiffDeserializerGenerator.tt
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Templates/ComponentDiffDeserializerGenerator.tt
@@ -25,8 +25,11 @@ namespace <#= qualifiedNamespace #>
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                var update = <#= componentNamespace #>.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
-                diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                if (op.Update.SchemaData.Value.GetFields().GetUniqueFieldIdCount() > 0)
+                {
+                    var update = <#= componentNamespace #>.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
+                    diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);
+                }
 <# if (eventDetailsList.Count > 0) { #>
                 var eventsObject = op.Update.SchemaData.Value.GetEvents();
 <# foreach (var ev in eventDetailsList) {


### PR DESCRIPTION
#### Description
Received component ops that don't contain any field updates, no longer trigger the OnUpdate callback.

#### Documentation
* [x] Changelog
