### PR TITLE
Change default network type to ModularUDP with Compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Generated Worker ID's for local development are now smaller and easier to read for debugging. [#1197](https://github.com/spatialos/gdk-for-unity/pull/1197)
 - Upgraded to Worker SDK 14.2.1. [#1208](https://github.com/spatialos/gdk-for-unity/pull/1208)
   - Versioning scheme for the SDK and Mobile SDK packages have now changed to align with the GDK for Unity version.
+- Changed the default network type to ModularUDP with packet compression. [#1212](https://github.com/spatialos/gdk-for-unity/pull/1212)
 
 ### Fixed
 

--- a/workers/unity/Assets/Playground/Scripts/Worker/ClientWorkerConnector.cs
+++ b/workers/unity/Assets/Playground/Scripts/Worker/ClientWorkerConnector.cs
@@ -1,6 +1,5 @@
 using System;
 using Improbable.Gdk.Core;
-using Improbable.Worker.CInterop;
 using UnityEngine;
 
 namespace Playground
@@ -20,7 +19,6 @@ namespace Playground
 
             var connParams = CreateConnectionParameters(WorkerUtils.UnityClient);
             connParams.Network.UseExternalIp = UseExternalIp;
-            connParams.Network.ConnectionType = NetworkConnectionType.RakNet;
 
             var builder = new SpatialOSConnectionHandlerBuilder()
                 .SetConnectionParameters(connParams);

--- a/workers/unity/Assets/Playground/Scripts/Worker/MobileClientWorkerConnector.cs
+++ b/workers/unity/Assets/Playground/Scripts/Worker/MobileClientWorkerConnector.cs
@@ -1,7 +1,6 @@
 using System;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Mobile;
-using Improbable.Worker.CInterop;
 using UnityEngine;
 
 namespace Playground

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/WorkerConnector.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/WorkerConnector.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Improbable.Worker.CInterop;
+using Improbable.Worker.CInterop.Alpha;
 using Unity.Entities;
 using UnityEditor;
 using UnityEngine;
@@ -211,7 +212,16 @@ namespace Improbable.Gdk.Core
             var @params = new ConnectionParameters
             {
                 WorkerType = workerType,
-                DefaultComponentVtable = new ComponentVtable()
+                DefaultComponentVtable = new ComponentVtable(),
+                Network =
+                {
+                    ConnectionType = NetworkConnectionType.ModularUdp,
+                    ModularUdp =
+                    {
+                        DownstreamCompression = new CompressionParameters(),
+                        UpstreamCompression = new CompressionParameters(),
+                    }
+                }
             };
 
             initializer?.Initialize(@params);


### PR DESCRIPTION
#### Description
Changed the default network type to ModularUDP (KCP) with Compression enabled.

#### Tests
Ran this in the Playground which shows the compression working through its worker metrics.
* [x] Works with Blank Project
* [x] Works with FPS Project

#### Documentation
* [x] Changelog
