### PR TITLE
Expose `IsConnected` in WorkerSystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Expose a Worker's `IsConnected` property in the `WorkerSystem`. [#1217](https://github.com/spatialos/gdk-for-unity/pull/1217)
+
 ## `0.3.0` - 2019-11-11
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Expose a Worker's `IsConnected` property in the `WorkerSystem`. [#1217](https://github.com/spatialos/gdk-for-unity/pull/1217)
+- A `WorkerSystem` now exposes the underlying Worker's `IsConnected` property. [#1217](https://github.com/spatialos/gdk-for-unity/pull/1217)
 
 ## `0.3.0` - 2019-11-11
 

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/WorkerSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/WorkerSystem.cs
@@ -23,6 +23,11 @@ namespace Improbable.Gdk.Core
         public readonly string WorkerId;
         public readonly Vector3 Origin;
 
+        /// <summary>
+        ///     Denotes whether the underlying worker is connected or not.
+        /// </summary>
+        public bool IsConnected => Worker.IsConnected;
+
         internal readonly View View;
 
         internal readonly Dictionary<EntityId, Entity> EntityIdToEntity = new Dictionary<EntityId, Entity>();


### PR DESCRIPTION
#### Description
- Expose IsConnected in WorkerSystem

#### Tests
- can access IsConnected field from both ECS and MonoBehaviours

#### Documentation
- changelog on the way

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
