### PR TITLE
Deployment Launcher editor performance improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 ### Fixed
 
-- The Deployment Launcher window no longer saves changes after every input. [#1219](https://github.com/spatialos/gdk-for-unity/pull/1219)
-    - It will now wait for at least 1 second to elapse after the last change before writing the config back to disk.
+- Fixed an issue where the Deployment Launcher window would feel unresponsive due to saving changes after every input. [#1219](https://github.com/spatialos/gdk-for-unity/pull/1219)
+    - It will now wait for at least 1 second to elapse after the last change before writing the configuration back to disk.
 
 ## `0.3.0` - 2019-11-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - A `WorkerSystem` now exposes the underlying Worker's `IsConnected` property. [#1217](https://github.com/spatialos/gdk-for-unity/pull/1217)
 
+### Fixed
+
+- The Deployment Launcher window no longer saves changes after every input. [#1219](https://github.com/spatialos/gdk-for-unity/pull/1219)
+    - It will now wait for at least 1 second to elapse after the last change before writing the config back to disk.
+
 ## `0.3.0` - 2019-11-11
 
 ### Breaking Changes

--- a/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
+++ b/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
@@ -78,7 +78,6 @@ namespace Improbable.Gdk.DeploymentLauncher
 
         private void OnExit()
         {
-            Debug.Log("Saving Deployment Launcher configuration before closing.");
             AssetDatabase.SaveAssets();
 
             manager.Cancel();

--- a/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
+++ b/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
@@ -86,7 +86,7 @@ namespace Improbable.Gdk.DeploymentLauncher
 
         private void Update()
         {
-            SaveChanges();
+            TrySaveChanges();
 
             manager.Update();
 
@@ -894,7 +894,7 @@ namespace Improbable.Gdk.DeploymentLauncher
             lastEditTime = DateTime.Now;
         }
 
-        private void SaveChanges()
+        private void TrySaveChanges()
         {
             var timeSinceLastEdit = DateTime.Now - lastEditTime;
             if (EditorUtility.GetDirtyCount(launcherConfig) <= 0 || timeSinceLastEdit <= FileSavingInterval)

--- a/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
+++ b/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
@@ -902,7 +902,6 @@ namespace Improbable.Gdk.DeploymentLauncher
                 return;
             }
 
-            Debug.Log("Saving Deployment Launcher configuration.");
             AssetDatabase.SaveAssets();
         }
 


### PR DESCRIPTION
#### Description

- stop saving to disk on every change
	- only write unsaved changes if it's been more than 1 second since the last change
	- also write to disk if the window is being closed

#### Tests

- feels a lot nicer
- profile before/after

#### Documentation

probably worth adding a note in the deployment launcher docs about the save interval

- [x] changelog

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
