### PR TITLE
CORE-1340 Change locator port 444 -> 443

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Internal
 
-- Updated port to connect to locator on from 444 -> 443
+- Updated port to connect to locator on from 444 -> 443. [#1220](https://github.com/spatialos/gdk-for-unity/pull/1220)
 
 ## `0.3.0` - 2019-11-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Fixed an issue where the Deployment Launcher window would feel unresponsive due to saving changes after every input. [#1219](https://github.com/spatialos/gdk-for-unity/pull/1219)
     - It will now wait for at least 1 second to elapse after the last change before writing the configuration back to disk.
 
+### Internal
+
+- Updated port to connect to locator on from 444 -> 443
+
 ## `0.3.0` - 2019-11-11
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Internal
 
-- Updated port to connect to locator on from 444 -> 443. [#1220](https://github.com/spatialos/gdk-for-unity/pull/1220)
+- Changed the default Locator port from 444 to 443. [#1220](https://github.com/spatialos/gdk-for-unity/pull/1220)
 
 ## `0.3.0` - 2019-11-11
 

--- a/workers/unity/Packages/io.improbable.gdk.core/Config/RuntimeConfig.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Config/RuntimeConfig.cs
@@ -13,7 +13,7 @@ namespace Improbable.Gdk.Core
         public const string LocalEnvironment = "local";
         public const string CloudEnvironment = "cloud";
         public const ushort ReceptionistPort = 7777;
-        public const ushort LocatorPort = 444;
+        public const ushort LocatorPort = 443;
     }
 
     /// <summary>


### PR DESCRIPTION
#### Description

As part of protecting the platform from DDoS attacks, we will be moving locator (xavier) behind a Google Global Load Balancer. These GLBs only support serving TLS traffic on port 443. Locator already supports serving gRPC traffic on port 443, so we can make this patch immediately, and it will be a seamless transition when the DNS for locator starts pointing to the GLB (which exposes port 443) instead of our current load balancer (which exposes port 443 and 444).

#### Tests
I have manually confirmed that Xavier is serving on 443 and 444 just like all other base servers. I have also confirmed that no additional steps are required to serve gRPC TLS on HTTP TLS ports for our base servers.

I have also run the QA pipeline on this branch and successfully connected to the resulting deployment: https://buildkite.com/improbable/gdk-for-unity-release-qa/builds/75

#### Documentation
Internal release note in the changelog.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
