### PR TITLE
Cleared field bugfix of #1211

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     - It will now wait for at least 1 second to elapse after the last change before writing the configuration back to disk.
 - Fixed issues ([#957](https://github.com/spatialos/gdk-for-unity/issues/957), [#958](https://github.com/spatialos/gdk-for-unity/issues/958)) where valid schema would generate invalid code due to name clashes. [#1222](https://github.com/spatialos/gdk-for-unity/pull/1222)
     - The offending schema properties will no longer be generated and are now logged in the Unity Editor.
+- Fixed a bug where cleared fields in a received update would not be applied to the diff. [#1229](https://github.com/spatialos/gdk-for-unity/pull/1229)
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
 - Fixed issues ([#957](https://github.com/spatialos/gdk-for-unity/issues/957), [#958](https://github.com/spatialos/gdk-for-unity/issues/958)) where valid schema would generate invalid code due to name clashes. [#1222](https://github.com/spatialos/gdk-for-unity/pull/1222)
     - The offending schema properties will no longer be generated and are now logged in the Unity Editor.
 
-
 ### Internal
 
 - Changed the default Locator port from 444 to 443. [#1220](https://github.com/spatialos/gdk-for-unity/pull/1220)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed a bug where cleared fields in a received update would not be applied to the diff. [#1229](https://github.com/spatialos/gdk-for-unity/pull/1229)
+
 ## `0.3.1` - 2019-11-25
 
 ### Added
@@ -14,7 +18,7 @@
     - It will now wait for at least 1 second to elapse after the last change before writing the configuration back to disk.
 - Fixed issues ([#957](https://github.com/spatialos/gdk-for-unity/issues/957), [#958](https://github.com/spatialos/gdk-for-unity/issues/958)) where valid schema would generate invalid code due to name clashes. [#1222](https://github.com/spatialos/gdk-for-unity/pull/1222)
     - The offending schema properties will no longer be generated and are now logged in the Unity Editor.
-- Fixed a bug where cleared fields in a received update would not be applied to the diff. [#1229](https://github.com/spatialos/gdk-for-unity/pull/1229)
+
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed a bug where cleared fields in a received update would not be applied to the diff. [#1229](https://github.com/spatialos/gdk-for-unity/pull/1229)
+- Fixed a bug where empty list, maps, or options in a component update would not be applied correctly. [#1229](https://github.com/spatialos/gdk-for-unity/pull/1229)
 
 ## `0.3.1` - 2019-11-25
 

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Templates/ComponentDiffDeserializerGenerator.tt
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Templates/ComponentDiffDeserializerGenerator.tt
@@ -25,7 +25,7 @@ namespace <#= qualifiedNamespace #>
 
             public void AddUpdateToDiff(ComponentUpdateOp op, ViewDiff diff, uint updateId)
             {
-                if (op.Update.SchemaData.Value.GetFields().GetUniqueFieldIdCount() > 0)
+                if (op.Update.SchemaData.Value.GetFields().GetUniqueFieldIdCount() + op.Update.SchemaData.Value.GetClearedFieldCount() > 0)
                 {
                     var update = <#= componentNamespace #>.Serialization.DeserializeUpdate(op.Update.SchemaData.Value);
                     diff.AddComponentUpdate(update, op.EntityId, op.Update.ComponentId, updateId);


### PR DESCRIPTION
#### Description

- UTY-2382
- Check cleared field count as well when applying update to diff
- Fixes bug introduced in #1211 

#### Tests

- removed 1 map element every second on server, received updated on client
- logged map count on server/client
- observed client never made it to 0 before bugfix
- correct behaviour observed after bugfix

#### Documentation

- [x] changelog

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
