### PR TITLE
[DOCS] Build system hooks

### DIFF
--- a/docs/modules/build-system/build-config.md
+++ b/docs/modules/build-system/build-config.md
@@ -44,4 +44,4 @@ These two options describe the behaviour of a worker type, deployment target, an
 | No | Yes | Invalid state and undefined behaviour. If this state ever occurs, please [raise a bug report](https://github.com/spatialos/gdk-for-unity/issues/new). |
 | Yes | Yes | Build is run. If the build support for the platform is not installed, fail the build. |
 
-> **Note:** Running a worker build [from the CLI]({{urlRoot}}/modules/build-system/cli) ignores the Required flag. If the build support is not installed, the build will fail. 
+> **Note:** Running a worker build [from the CLI]({{urlRoot}}/modules/build-system/cli) ignores the Required flag. If the build support is not installed, the build will fail.

--- a/docs/modules/build-system/build-hooks.md
+++ b/docs/modules/build-system/build-hooks.md
@@ -1,0 +1,26 @@
+# Build hooks
+
+During a build, you can use the Unity provided callbacks to add pre- and post-processing to your worker build.
+The build system feature module provides `WorkerBuilder.CurrentContext` containing information such as worker type and build options.
+
+This context is only valid during a build.
+
+```csharp
+public class BuildPreProcessor : IPreprocessBuildWithReport, IPostprocessBuildWithReport
+{
+    public int callbackOrder => 0;
+    public void OnPreprocessBuild(BuildReport report)
+    {
+        var workerType = WorkerBuilder.CurrentContext.WorkerType;
+        Debug.Log($"Pre-processing build with worker type {workerType}");
+    }
+
+    public void OnPostprocessBuild(BuildReport report)
+    {
+        var workerType = WorkerBuilder.CurrentContext.WorkerType;
+        Debug.Log($"Post-processing build with worker type {workerType}");
+    }
+}
+```
+
+> Ensure that your Editor assembly definition references `Improbable.Gdk.BuildSystem`.

--- a/docs/modules/build-system/build-hooks.md
+++ b/docs/modules/build-system/build-hooks.md
@@ -3,7 +3,7 @@
 During a build, you can use the Unity provided callbacks to add pre-processing and/or post-processing to your worker build.
 The Build System Feature Module provides a static readonly variable, `WorkerBuilder.CurrentContext`, which contains information such as the worker type and build options.
 
-This context is only valid during a build.
+This context is only valid during a build and will throw if accessed outside of a build.
 
 ```csharp
 public class BuildProcessor : IPreprocessBuildWithReport, IPostprocessBuildWithReport

--- a/docs/modules/build-system/build-hooks.md
+++ b/docs/modules/build-system/build-hooks.md
@@ -1,12 +1,12 @@
 # Build hooks
 
-During a build, you can use the Unity provided callbacks to add pre- and post-processing to your worker build.
-The build system feature module provides `WorkerBuilder.CurrentContext` containing information such as worker type and build options.
+During a build, you can use the Unity provided callbacks to add pre-processing and/or post-processing to your worker build.
+The Build System Feature Module provides a static readonly variable, `WorkerBuilder.CurrentContext`, which contains information such as the worker type and build options.
 
 This context is only valid during a build.
 
 ```csharp
-public class BuildPreProcessor : IPreprocessBuildWithReport, IPostprocessBuildWithReport
+public class BuildProcessor : IPreprocessBuildWithReport, IPostprocessBuildWithReport
 {
     public int callbackOrder => 0;
     public void OnPreprocessBuild(BuildReport report)
@@ -23,4 +23,4 @@ public class BuildPreProcessor : IPreprocessBuildWithReport, IPostprocessBuildWi
 }
 ```
 
-> Ensure that your Editor assembly definition references `Improbable.Gdk.BuildSystem`.
+> In order to access `WorkerBuilder.CurrentContext`, you must ensure that your Editor assembly definition references `Improbable.Gdk.BuildSystem`.

--- a/docs/modules/build-system/cli.md
+++ b/docs/modules/build-system/cli.md
@@ -6,7 +6,7 @@ We expose a single static method: [`Improbable.Gdk.BuildSystem.WorkerBuilder.Bui
 
 - `buildWorkerTypes`: REQUIRED. The type of the worker to build.
 - `buildEnvironment`: REQUIRED. The target for the worker build. Either `local` or `cloud`.
-- `scriptingBackend`: Optional. Which scripting backend to use for the build. Either `mono` or `il2cpp`. If ommitted, this defaults to `mono`.
+- `scriptingBackend`: Optional. Which scripting backend to use for the build. Either `mono` or `il2cpp`. If ommitted, this defaults to your current configuration.
 - `buildTargetFilter`: Optional. A comma delimited list of build targets to filter for. For example, "win,macos". If ommitted, this defaults to all targets for the given environment.
 
 ## Example

--- a/docs/modules/build-system/cli.md
+++ b/docs/modules/build-system/cli.md
@@ -6,7 +6,7 @@ We expose a single static method: [`Improbable.Gdk.BuildSystem.WorkerBuilder.Bui
 
 - `buildWorkerTypes`: REQUIRED. The type of the worker to build.
 - `buildEnvironment`: REQUIRED. The target for the worker build. Either `local` or `cloud`.
-- `scriptingBackend`: Optional. Which scripting backend to use for the build. Either `mono` or `il2cpp`. If ommitted, this defaults to your current configuration.
+- `scriptingBackend`: Optional. Which scripting backend to use for the build. Either `mono` or `il2cpp`. If omitted, this defaults to your current configuration.
 - `buildTargetFilter`: Optional. A comma delimited list of build targets to filter for. For example, "win,macos". If ommitted, this defaults to all targets for the given environment.
 
 ## Example

--- a/docs/modules/build-system/editor-menu.md
+++ b/docs/modules/build-system/editor-menu.md
@@ -1,6 +1,6 @@
 # Editor menu
 
-The Build System Feature Module provides a set of Unity Editor menu items to build your workers from your Unity Editor. These can be accessed via the **SpatialOS** menu item. 
+The Build System Feature Module provides a set of Unity Editor menu items to build your workers from your Unity Editor. These can be accessed via the **SpatialOS** menu item.
 
 You can build for a specific target: **Build for local** and **Build for cloud** and then either select a specific worker type or build all workers for this target.
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -40,6 +40,7 @@
         - [Build configuration]({{urlRoot}}/modules/build-system/build-config)
         - [Build in the Editor]({{urlRoot}}/modules/build-system/editor-menu)
         - [Command line interface]({{urlRoot}}/modules/build-system/cli)
+        - [Build hooks]({{urlRoot}}/modules/build-system/build-hooks)
     - Debug
         - [Overview]({{urlRoot}}/modules/debug/overview)
         - [Requirable Inspector]({{urlRoot}}/modules/debug/require-inspector)


### PR DESCRIPTION
Added  page with an example using the new `WorkerBuilder.CurrentContext`.
Small linting driveby