### PR TITLE
UTY-2381 Fix log path for port forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
     - It will now wait for at least 1 second to elapse after the last change before writing the configuration back to disk.
 - Fixed issues ([#957](https://github.com/spatialos/gdk-for-unity/issues/957), [#958](https://github.com/spatialos/gdk-for-unity/issues/958)) where valid schema would generate invalid code due to name clashes. [#1222](https://github.com/spatialos/gdk-for-unity/pull/1222)
     - The offending schema properties will no longer be generated and are now logged in the Unity Editor.
+- Fixed missing log path error when printing the Unity PlayerConnection debug port. [#1232](https://github.com/spatialos/gdk-for-unity/pull/1232)
 
 ### Internal
 

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/WorkerConnector.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/WorkerConnector.cs
@@ -265,35 +265,9 @@ namespace Improbable.Gdk.Core
 
         private static ushort GetPlayerConnectionPort()
         {
-            var companyName = Application.companyName;
-            var productName = Application.productName;
-
-            string logPath;
-
-            switch (Application.platform)
-            {
-                case RuntimePlatform.WindowsPlayer:
-                    logPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "AppData", "LocalLow", companyName, productName,
-                        "Player.log");
-                    break;
-                case RuntimePlatform.OSXPlayer:
-                    // On MacOS it always goes in the Unity folder regardless of what companyName and productName are set to.
-                    logPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Logs", "Unity", "Player.log");
-                    break;
-                case RuntimePlatform.LinuxPlayer:
-                    logPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config", "unity3d", companyName, productName, "Player.log");
-                    break;
-                default:
-                    throw new InvalidOperationException($"Cannot find log file on platform: {Application.platform}");
-            }
-
-            CommandLineArgs.FromCommandLine().TryGetCommandLineValue("logfile", ref logPath);
-
-            logPath = Path.GetFullPath(logPath);
-
             // We need to open the File as ReadWrite since this process _already_ has it open as ReadWrite.
             // Attempting to open it as Read only results in IO exceptions due to permissions. Go figure.
-            using (var stream = new FileStream(logPath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
+            using (var stream = new FileStream(Application.consoleLogPath, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
             using (var readStream = new StreamReader(stream))
             {
                 var logContents = readStream.ReadToEnd();


### PR DESCRIPTION
#### Description
Smallest bugfix ever.
Unity provides the log location, so no need to guess.

#### Documentation
 * [x] Changelog
