### PR TITLE
Fixup changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 
 - Fixed a bug where empty list, maps, or options in a component update would not be applied correctly. [#1229](https://github.com/spatialos/gdk-for-unity/pull/1229)
+- Fixed missing log path error when printing the Unity PlayerConnection debug port. [#1232](https://github.com/spatialos/gdk-for-unity/pull/1232)
 
 ## `0.3.1` - 2019-11-25
 
@@ -27,7 +28,6 @@
     - It will now wait for at least 1 second to elapse after the last change before writing the configuration back to disk.
 - Fixed issues ([#957](https://github.com/spatialos/gdk-for-unity/issues/957), [#958](https://github.com/spatialos/gdk-for-unity/issues/958)) where valid schema would generate invalid code due to name clashes. [#1222](https://github.com/spatialos/gdk-for-unity/pull/1222)
     - The offending schema properties will no longer be generated and are now logged in the Unity Editor.
-- Fixed missing log path error when printing the Unity PlayerConnection debug port. [#1232](https://github.com/spatialos/gdk-for-unity/pull/1232)
 
 ### Internal
 


### PR DESCRIPTION
While updating the status of #1226, I noticed that the changelog entry for #1232 was placed into the wrong release bucket. This PR corrects that.

I've already adjusted the published release notes. 
