### PR TITLE
Mimic CodeWriter methods API with enums/ifelse/trycatch/custom blocks

### DIFF
--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scope.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scope.cs
@@ -11,7 +11,17 @@ namespace Improbable.Gdk.CodeGeneration.CodeWriter
             return new CustomScopeBlock(populate);
         }
 
+        public static CustomScopeBlock Custom(Func<IEnumerable<string>> populate)
+        {
+            return new CustomScopeBlock(populate);
+        }
+
         public static CustomScopeBlock Custom(string declaration, Action<CustomScopeBlock> populate)
+        {
+            return new CustomScopeBlock(declaration, populate);
+        }
+
+        public static CustomScopeBlock Custom(string declaration, Func<IEnumerable<string>> populate)
         {
             return new CustomScopeBlock(declaration, populate);
         }
@@ -21,12 +31,27 @@ namespace Improbable.Gdk.CodeGeneration.CodeWriter
             return new LoopBlock(declaration, populate);
         }
 
+        public static LoopBlock Loop(string declaration, Func<IEnumerable<string>> populate)
+        {
+            return new LoopBlock(declaration, populate);
+        }
+
         public static IfElseBlock IfElse(string declaration, Action<ScopeBody> populate)
         {
             return new IfElseBlock(declaration, populate);
         }
 
+        public static IfElseBlock IfElse(string declaration, Func<IEnumerable<string>> populate)
+        {
+            return new IfElseBlock(declaration, populate);
+        }
+
         public static TryCatchBlock TryCatch(Action<ScopeBody> populate)
+        {
+            return new TryCatchBlock(populate);
+        }
+
+        public static TryCatchBlock TryCatch(Func<IEnumerable<string>> populate)
         {
             return new TryCatchBlock(populate);
         }
@@ -42,6 +67,11 @@ namespace Improbable.Gdk.CodeGeneration.CodeWriter
         }
 
         public static EnumBlock Enum(string declaration, Action<EnumBlock> populate)
+        {
+            return new EnumBlock(declaration, populate);
+        }
+
+        public static EnumBlock Enum(string declaration, Func<IEnumerable<string>> populate)
         {
             return new EnumBlock(declaration, populate);
         }

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/Abstract/ScopeBody.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/Abstract/ScopeBody.cs
@@ -60,6 +60,11 @@ namespace Improbable.Gdk.CodeGeneration.CodeWriter.Scopes
             Add(new LoopBlock(declaration, populate));
         }
 
+        public void Loop(string declaration, Func<IEnumerable<string>> populate)
+        {
+            Add(new LoopBlock(declaration, populate));
+        }
+
         public IfElseBlock If(string declaration, Action<ScopeBody> populate)
         {
             var ifElseBlock = new IfElseBlock(declaration, populate);
@@ -67,7 +72,21 @@ namespace Improbable.Gdk.CodeGeneration.CodeWriter.Scopes
             return ifElseBlock;
         }
 
+        public IfElseBlock If(string declaration, Func<IEnumerable<string>> populate)
+        {
+            var ifElseBlock = new IfElseBlock(declaration, populate);
+            Add(ifElseBlock);
+            return ifElseBlock;
+        }
+
         public TryCatchBlock Try(Action<ScopeBody> populate)
+        {
+            var tryCatchBlock = new TryCatchBlock(populate);
+            Add(tryCatchBlock);
+            return tryCatchBlock;
+        }
+
+        public TryCatchBlock Try(Func<IEnumerable<string>> populate)
         {
             var tryCatchBlock = new TryCatchBlock(populate);
             Add(tryCatchBlock);

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/Abstract/ScopeBody.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/Abstract/ScopeBody.cs
@@ -50,7 +50,17 @@ namespace Improbable.Gdk.CodeGeneration.CodeWriter.Scopes
             Add(new CustomScopeBlock(populate));
         }
 
+        public void CustomScope(Func<IEnumerable<string>> populate)
+        {
+            Add(new CustomScopeBlock(populate));
+        }
+
         public void CustomScope(string declaration, Action<CustomScopeBlock> populate)
+        {
+            Add(new CustomScopeBlock(declaration, populate));
+        }
+
+        public void CustomScope(string declaration, Func<IEnumerable<string>> populate)
         {
             Add(new CustomScopeBlock(declaration, populate));
         }

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/Abstract/ScopeBodyList.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/Abstract/ScopeBodyList.cs
@@ -17,7 +17,17 @@ namespace Improbable.Gdk.CodeGeneration.CodeWriter.Scopes
             AddScope(declaration, populate);
         }
 
+        protected ScopeBodyList(string declaration, Func<IEnumerable<string>> populate)
+        {
+            AddScope(declaration, populate);
+        }
+
         protected void AddScope(string declaration, Action<ScopeBody> populate)
+        {
+            scopeBodies.Add(new CustomScopeBlock(declaration, populate));
+        }
+
+        protected void AddScope(string declaration, Func<IEnumerable<string>> populate)
         {
             scopeBodies.Add(new CustomScopeBlock(declaration, populate));
         }

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/CustomScopeBlock.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/CustomScopeBlock.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Improbable.Gdk.CodeGeneration.CodeWriter.Scopes
 {
@@ -12,9 +14,19 @@ namespace Improbable.Gdk.CodeGeneration.CodeWriter.Scopes
             populate(this);
         }
 
+        internal CustomScopeBlock(Func<IEnumerable<string>> populate) : base(string.Empty)
+        {
+            Line(populate().ToList());
+        }
+
         internal CustomScopeBlock(string declaration, Action<CustomScopeBlock> populate) : base(declaration)
         {
             populate(this);
+        }
+
+        internal CustomScopeBlock(string declaration, Func<IEnumerable<string>> populate) : base(declaration)
+        {
+            Line(populate().ToList());
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/EnumBlock.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/EnumBlock.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Improbable.Gdk.CodeGeneration.CodeWriter.Scopes
 {
@@ -11,6 +12,15 @@ namespace Improbable.Gdk.CodeGeneration.CodeWriter.Scopes
         {
             Annotation = annotation;
             populate(this);
+        }
+
+        internal EnumBlock(string declaration, Func<IEnumerable<string>> populate, string annotation = "") : base(declaration)
+        {
+            Annotation = annotation;
+            foreach (var member in populate())
+            {
+                Member(member);
+            }
         }
 
         public void Member(string snippet)

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/IfElseBlock.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/IfElseBlock.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Improbable.Gdk.CodeGeneration.CodeWriter.Scopes
 {
@@ -11,13 +12,28 @@ namespace Improbable.Gdk.CodeGeneration.CodeWriter.Scopes
         {
         }
 
+        internal IfElseBlock(string declaration, Func<IEnumerable<string>> populate) : base($"if ({declaration})", populate)
+        {
+        }
+
         public IfElseBlock ElseIf(string declaration, Action<ScopeBody> populate)
         {
             AddScope($"else if ({declaration})", populate);
             return this;
         }
 
+        public IfElseBlock ElseIf(string declaration, Func<IEnumerable<string>> populate)
+        {
+            AddScope($"else if ({declaration})", populate);
+            return this;
+        }
+
         public void Else(Action<ScopeBody> populate)
+        {
+            AddScope("else", populate);
+        }
+
+        public void Else(Func<IEnumerable<string>> populate)
         {
             AddScope("else", populate);
         }

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/LoopBlock.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/LoopBlock.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Improbable.Gdk.CodeGeneration.CodeWriter.Scopes
 {
@@ -10,6 +12,11 @@ namespace Improbable.Gdk.CodeGeneration.CodeWriter.Scopes
         internal LoopBlock(string declaration, Action<LoopBlock> populate) : base(declaration)
         {
             populate(this);
+        }
+
+        internal LoopBlock(string declaration, Func<IEnumerable<string>> populate) : base(declaration)
+        {
+            Line(populate().ToList());
         }
 
         public void Continue()

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/NamespaceBlock.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/NamespaceBlock.cs
@@ -44,7 +44,17 @@ namespace Improbable.Gdk.CodeGeneration.CodeWriter.Scopes
             Add(new CustomScopeBlock(populate));
         }
 
+        public void CustomScope(Func<IEnumerable<string>> populate)
+        {
+            Add(new CustomScopeBlock(populate));
+        }
+
         public void CustomScope(string declaration, Action<CustomScopeBlock> populate)
+        {
+            Add(new CustomScopeBlock(declaration, populate));
+        }
+
+        public void CustomScope(string declaration, Func<IEnumerable<string>> populate)
         {
             Add(new CustomScopeBlock(declaration, populate));
         }
@@ -55,6 +65,11 @@ namespace Improbable.Gdk.CodeGeneration.CodeWriter.Scopes
         }
 
         public void Enum(string declaration, Action<EnumBlock> populate)
+        {
+            Add(new EnumBlock(declaration, populate));
+        }
+
+        public void Enum(string declaration, Func<IEnumerable<string>> populate)
         {
             Add(new EnumBlock(declaration, populate));
         }

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/TryCatchBlock.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/TryCatchBlock.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Improbable.Gdk.CodeGeneration.CodeWriter.Scopes
 {
@@ -11,13 +12,28 @@ namespace Improbable.Gdk.CodeGeneration.CodeWriter.Scopes
         {
         }
 
+        internal TryCatchBlock(Func<IEnumerable<string>> populate) : base("try", populate)
+        {
+        }
+
         public TryCatchBlock Catch(string declaration, Action<ScopeBody> populate)
         {
             AddScope($"catch ({declaration})", populate);
             return this;
         }
 
+        public TryCatchBlock Catch(string declaration, Func<IEnumerable<string>> populate)
+        {
+            AddScope($"catch ({declaration})", populate);
+            return this;
+        }
+
         public void Finally(Action<ScopeBody> populate)
+        {
+            AddScope("finally", populate);
+        }
+
+        public void Finally(Func<IEnumerable<string>> populate)
         {
             AddScope("finally", populate);
         }

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/TypeBlock.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/TypeBlock.cs
@@ -50,7 +50,17 @@ namespace Improbable.Gdk.CodeGeneration.CodeWriter.Scopes
             Add(new CustomScopeBlock(populate));
         }
 
+        public void CustomScope(Func<IEnumerable<string>> populate)
+        {
+            Add(new CustomScopeBlock(populate));
+        }
+
         public void CustomScope(string declaration, Action<CustomScopeBlock> populate)
+        {
+            Add(new CustomScopeBlock(declaration, populate));
+        }
+
+        public void CustomScope(string declaration, Func<IEnumerable<string>> populate)
         {
             Add(new CustomScopeBlock(declaration, populate));
         }
@@ -71,6 +81,11 @@ namespace Improbable.Gdk.CodeGeneration.CodeWriter.Scopes
         }
 
         public void Enum(string declaration, Action<EnumBlock> populate)
+        {
+            Add(new EnumBlock(declaration, populate));
+        }
+
+        public void Enum(string declaration, Func<IEnumerable<string>> populate)
         {
             Add(new EnumBlock(declaration, populate));
         }


### PR DESCRIPTION
#### Description

allow you to pass `Func<IEnumerable<string>>` to more blocks:
- ifelse
- loop
- trycatch
- custom
- enum

#### Tests

- very useful when porting across gameobject creation module

#### Documentation

- n/a

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
