### PR TITLE
Simplified dirtybits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
-- Generated code Assembly Definition now needs to have ` allow unsafe code` selected to compile. [#1255](https://github.com/spatialos/gdk-for-unity/pull/1255)
+- Your generated code Assembly Definition file now needs to have `allow unsafe code` selected to compile. [#1255](https://github.com/spatialos/gdk-for-unity/pull/1255)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- Generated code Assembly Definition now needs to have ` allow unsafe code` selected to compile. [#1255](https://github.com/spatialos/gdk-for-unity/pull/1255)
+
 ### Added
 
 - Added public toolkit for writing code generators. [#1240](https://github.com/spatialos/gdk-for-unity/pull/1240) [#1243](https://github.com/spatialos/gdk-for-unity/pull/1243) [#1244](https://github.com/spatialos/gdk-for-unity/pull/1244) [#1245](https://github.com/spatialos/gdk-for-unity/pull/1245) [#1250](https://github.com/spatialos/gdk-for-unity/pull/1250)
@@ -16,6 +20,7 @@
 - Ported gameobject creation module to new CodeWriter. [#1247](https://github.com/spatialos/gdk-for-unity/pull/1247)
 - Ported core module to new CodeWriter. [#1247](https://github.com/spatialos/gdk-for-unity/pull/1247) [#1248](https://github.com/spatialos/gdk-for-unity/pull/1248) [#1249](https://github.com/spatialos/gdk-for-unity/pull/1249) [#1251](https://github.com/spatialos/gdk-for-unity/pull/1251) [#1252](https://github.com/spatialos/gdk-for-unity/pull/1252) [#1253](https://github.com/spatialos/gdk-for-unity/pull/1253)
 - Removed all Text Template Transformation Toolkit (T4) references and dependencies. [#1254](https://github.com/spatialos/gdk-for-unity/pull/1254)
+- Simplified dirtyBits logic and code generation [#1255](https://github.com/spatialos/gdk-for-unity/pull/1255)
 
 ## `0.3.2` - 2019-12-23
 

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -2,10 +2,10 @@
 
 ## From `0.3.2` to `0.3.3`
 
-### Allow unsafe code in Generated Code
+### Generated code now requires unsafe
 
-Code generated from schema now contains the `unsafe` code, which needs to be specifically allowed in the relevant Assembly Definition file.
-If you follow the Blank Project, you can find this option on the `Assets\Generated\Improbable.Gdk.Generated` asset.
+Code generated from schema now contains code marked as `unsafe`, which needs to be specifically allowed in the relevant [Assembly Definition file](https://docs.unity3d.com/Manual/class-AssemblyDefinitionImporter.html).
+If you follow the Blank Project, you can find this option on the `Assets\Generated\Improbable.Gdk.Generated.asmdef` asset.
 
 ## From `0.2.10` to `0.3.0`
 

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -1,5 +1,12 @@
 # Upgrade Guide
 
+## From `0.3.2` to `0.3.3`
+
+### Allow unsafe code in Generated Code
+
+Code generated from schema now contains the `unsafe` code, which needs to be specifically allowed in the relevant Assembly Definition file.
+If you follow the Blank Project, you can find this option on the `Assets\Generated\Improbable.Gdk.Generated` asset.
+
 ## From `0.2.10` to `0.3.0`
 
 ### Reactive Components

--- a/test-project/Assets/Generated/Improbable.Gdk.Generated.asmdef
+++ b/test-project/Assets/Generated/Improbable.Gdk.Generated.asmdef
@@ -1,4 +1,4 @@
-﻿{
+{
     "name": "Improbable.Gdk.Generated",
     "references": [
         "Unity.Collections",
@@ -6,5 +6,13 @@
         "Unity.Mathematics",
         "Unity.Entities.Hybrid",
         "Improbable.Gdk.Core"
-    ]
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
 }

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentComponent.cs
@@ -6,6 +6,7 @@ using Improbable.Gdk.Core;
 using Improbable.Worker.CInterop;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Unity.Entities;
 
 namespace Improbable.DependentSchema
@@ -14,19 +15,18 @@ namespace Improbable.DependentSchema
     {
         public const uint ComponentId = 198800;
 
-        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
+        public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 198800;
 
             // Bit masks for tracking which component properties were changed locally and need to be synced.
-            // Each byte tracks 8 component properties.
-            private byte dirtyBits0;
+            private fixed UInt32 dirtyBits[1];
 
             public bool IsDataDirty()
             {
                 var isDataDirty = false;
 
-                isDataDirty |= (dirtyBits0 != 0x0);
+                isDataDirty |= (dirtyBits[0] != 0x0);
 
                 return isDataDirty;
             }
@@ -46,48 +46,38 @@ namespace Improbable.DependentSchema
 
             public bool IsDataDirty(int propertyIndex)
             {
-                if (propertyIndex < 0 || propertyIndex >= 5)
-                {
-                    throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 4]. " +
-                        "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
-                        "Please contact SpatialOS support if you encounter this issue.");
-                }
+                ValidateFieldIndex(propertyIndex);
 
                 // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex / 8;
-                switch (dirtyBitsByteIndex)
-                {
-                    case 0:
-                        return (dirtyBits0 & (0x1 << propertyIndex % 8)) != 0x0;
-                }
-
-                return false;
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                return (dirtyBits[dirtyBitsByteIndex] & (0x1 << (propertyIndex & 31))) != 0x0;
             }
 
             // Like the IsDataDirty() method above, the propertyIndex arguments starts counting from 0.
             // This method throws an InvalidOperationException in case your component doesn't contain properties.
             public void MarkDataDirty(int propertyIndex)
             {
+                ValidateFieldIndex(propertyIndex);
+
+                // Retrieve the dirtyBits[0-n] field that tracks this property.
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & 31));
+            }
+
+            public void MarkDataClean()
+            {
+                dirtyBits[0] = 0x0;
+            }
+
+            [Conditional("DEBUG")]
+            private void ValidateFieldIndex(int propertyIndex)
+            {
                 if (propertyIndex < 0 || propertyIndex >= 5)
                 {
                     throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 4]. " +
                         "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
                         "Please contact SpatialOS support if you encounter this issue.");
                 }
-
-                // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex / 8;
-                switch (dirtyBitsByteIndex)
-                {
-                    case 0:
-                        dirtyBits0 |= (byte) (0x1 << propertyIndex % 8);
-                        break;
-                }
-            }
-
-            public void MarkDataClean()
-            {
-                dirtyBits0 = 0x0;
             }
 
             public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentComponent.cs
@@ -61,7 +61,7 @@ namespace Improbable.DependentSchema
 
                 // Retrieve the dirtyBits[0-n] field that tracks this property.
                 var dirtyBitsByteIndex = propertyIndex >> 4;
-                dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & 31));
+                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
             }
 
             public void MarkDataClean()

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponent.cs
@@ -61,7 +61,7 @@ namespace Improbable.DependentSchema
 
                 // Retrieve the dirtyBits[0-n] field that tracks this property.
                 var dirtyBitsByteIndex = propertyIndex >> 4;
-                dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & 31));
+                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
             }
 
             public void MarkDataClean()

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponent.cs
@@ -6,6 +6,7 @@ using Improbable.Gdk.Core;
 using Improbable.Worker.CInterop;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Unity.Entities;
 
 namespace Improbable.DependentSchema
@@ -14,23 +15,18 @@ namespace Improbable.DependentSchema
     {
         public const uint ComponentId = 198801;
 
-        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
+        public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 198801;
 
             // Bit masks for tracking which component properties were changed locally and need to be synced.
-            // Each byte tracks 8 component properties.
-            private byte dirtyBits0;
-            private byte dirtyBits1;
-            private byte dirtyBits2;
+            private fixed UInt32 dirtyBits[1];
 
             public bool IsDataDirty()
             {
                 var isDataDirty = false;
 
-                isDataDirty |= (dirtyBits0 != 0x0);
-                isDataDirty |= (dirtyBits1 != 0x0);
-                isDataDirty |= (dirtyBits2 != 0x0);
+                isDataDirty |= (dirtyBits[0] != 0x0);
 
                 return isDataDirty;
             }
@@ -50,64 +46,38 @@ namespace Improbable.DependentSchema
 
             public bool IsDataDirty(int propertyIndex)
             {
-                if (propertyIndex < 0 || propertyIndex >= 18)
-                {
-                    throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
-                        "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
-                        "Please contact SpatialOS support if you encounter this issue.");
-                }
+                ValidateFieldIndex(propertyIndex);
 
                 // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex / 8;
-                switch (dirtyBitsByteIndex)
-                {
-                    case 0:
-                        return (dirtyBits0 & (0x1 << propertyIndex % 8)) != 0x0;
-
-                    case 1:
-                        return (dirtyBits1 & (0x1 << propertyIndex % 8)) != 0x0;
-
-                    case 2:
-                        return (dirtyBits2 & (0x1 << propertyIndex % 8)) != 0x0;
-                }
-
-                return false;
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                return (dirtyBits[dirtyBitsByteIndex] & (0x1 << (propertyIndex & 31))) != 0x0;
             }
 
             // Like the IsDataDirty() method above, the propertyIndex arguments starts counting from 0.
             // This method throws an InvalidOperationException in case your component doesn't contain properties.
             public void MarkDataDirty(int propertyIndex)
             {
+                ValidateFieldIndex(propertyIndex);
+
+                // Retrieve the dirtyBits[0-n] field that tracks this property.
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & 31));
+            }
+
+            public void MarkDataClean()
+            {
+                dirtyBits[0] = 0x0;
+            }
+
+            [Conditional("DEBUG")]
+            private void ValidateFieldIndex(int propertyIndex)
+            {
                 if (propertyIndex < 0 || propertyIndex >= 18)
                 {
                     throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
                         "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
                         "Please contact SpatialOS support if you encounter this issue.");
                 }
-
-                // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex / 8;
-                switch (dirtyBitsByteIndex)
-                {
-                    case 0:
-                        dirtyBits0 |= (byte) (0x1 << propertyIndex % 8);
-                        break;
-
-                    case 1:
-                        dirtyBits1 |= (byte) (0x1 << propertyIndex % 8);
-                        break;
-
-                    case 2:
-                        dirtyBits2 |= (byte) (0x1 << propertyIndex % 8);
-                        break;
-                }
-            }
-
-            public void MarkDataClean()
-            {
-                dirtyBits0 = 0x0;
-                dirtyBits1 = 0x0;
-                dirtyBits2 = 0x0;
             }
 
             public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTest.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTest.cs
@@ -61,7 +61,7 @@ namespace Improbable.Tests
 
                 // Retrieve the dirtyBits[0-n] field that tracks this property.
                 var dirtyBitsByteIndex = propertyIndex >> 4;
-                dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & 31));
+                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
             }
 
             public void MarkDataClean()

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTest.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTest.cs
@@ -6,6 +6,7 @@ using Improbable.Gdk.Core;
 using Improbable.Worker.CInterop;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Unity.Entities;
 
 namespace Improbable.Tests
@@ -14,19 +15,18 @@ namespace Improbable.Tests
     {
         public const uint ComponentId = 11111;
 
-        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
+        public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 11111;
 
             // Bit masks for tracking which component properties were changed locally and need to be synced.
-            // Each byte tracks 8 component properties.
-            private byte dirtyBits0;
+            private fixed UInt32 dirtyBits[1];
 
             public bool IsDataDirty()
             {
                 var isDataDirty = false;
 
-                isDataDirty |= (dirtyBits0 != 0x0);
+                isDataDirty |= (dirtyBits[0] != 0x0);
 
                 return isDataDirty;
             }
@@ -46,48 +46,38 @@ namespace Improbable.Tests
 
             public bool IsDataDirty(int propertyIndex)
             {
-                if (propertyIndex < 0 || propertyIndex >= 1)
-                {
-                    throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 0]. " +
-                        "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
-                        "Please contact SpatialOS support if you encounter this issue.");
-                }
+                ValidateFieldIndex(propertyIndex);
 
                 // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex / 8;
-                switch (dirtyBitsByteIndex)
-                {
-                    case 0:
-                        return (dirtyBits0 & (0x1 << propertyIndex % 8)) != 0x0;
-                }
-
-                return false;
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                return (dirtyBits[dirtyBitsByteIndex] & (0x1 << (propertyIndex & 31))) != 0x0;
             }
 
             // Like the IsDataDirty() method above, the propertyIndex arguments starts counting from 0.
             // This method throws an InvalidOperationException in case your component doesn't contain properties.
             public void MarkDataDirty(int propertyIndex)
             {
+                ValidateFieldIndex(propertyIndex);
+
+                // Retrieve the dirtyBits[0-n] field that tracks this property.
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & 31));
+            }
+
+            public void MarkDataClean()
+            {
+                dirtyBits[0] = 0x0;
+            }
+
+            [Conditional("DEBUG")]
+            private void ValidateFieldIndex(int propertyIndex)
+            {
                 if (propertyIndex < 0 || propertyIndex >= 1)
                 {
                     throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 0]. " +
                         "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
                         "Please contact SpatialOS support if you encounter this issue.");
                 }
-
-                // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex / 8;
-                switch (dirtyBitsByteIndex)
-                {
-                    case 0:
-                        dirtyBits0 |= (byte) (0x1 << propertyIndex % 8);
-                        break;
-                }
-            }
-
-            public void MarkDataClean()
-            {
-                dirtyBits0 = 0x0;
             }
 
             public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestChild.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestChild.cs
@@ -61,7 +61,7 @@ namespace Improbable.Tests
 
                 // Retrieve the dirtyBits[0-n] field that tracks this property.
                 var dirtyBitsByteIndex = propertyIndex >> 4;
-                dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & 31));
+                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
             }
 
             public void MarkDataClean()

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestChild.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestChild.cs
@@ -6,6 +6,7 @@ using Improbable.Gdk.Core;
 using Improbable.Worker.CInterop;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Unity.Entities;
 
 namespace Improbable.Tests
@@ -14,19 +15,18 @@ namespace Improbable.Tests
     {
         public const uint ComponentId = 11112;
 
-        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
+        public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 11112;
 
             // Bit masks for tracking which component properties were changed locally and need to be synced.
-            // Each byte tracks 8 component properties.
-            private byte dirtyBits0;
+            private fixed UInt32 dirtyBits[1];
 
             public bool IsDataDirty()
             {
                 var isDataDirty = false;
 
-                isDataDirty |= (dirtyBits0 != 0x0);
+                isDataDirty |= (dirtyBits[0] != 0x0);
 
                 return isDataDirty;
             }
@@ -46,48 +46,38 @@ namespace Improbable.Tests
 
             public bool IsDataDirty(int propertyIndex)
             {
-                if (propertyIndex < 0 || propertyIndex >= 1)
-                {
-                    throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 0]. " +
-                        "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
-                        "Please contact SpatialOS support if you encounter this issue.");
-                }
+                ValidateFieldIndex(propertyIndex);
 
                 // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex / 8;
-                switch (dirtyBitsByteIndex)
-                {
-                    case 0:
-                        return (dirtyBits0 & (0x1 << propertyIndex % 8)) != 0x0;
-                }
-
-                return false;
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                return (dirtyBits[dirtyBitsByteIndex] & (0x1 << (propertyIndex & 31))) != 0x0;
             }
 
             // Like the IsDataDirty() method above, the propertyIndex arguments starts counting from 0.
             // This method throws an InvalidOperationException in case your component doesn't contain properties.
             public void MarkDataDirty(int propertyIndex)
             {
+                ValidateFieldIndex(propertyIndex);
+
+                // Retrieve the dirtyBits[0-n] field that tracks this property.
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & 31));
+            }
+
+            public void MarkDataClean()
+            {
+                dirtyBits[0] = 0x0;
+            }
+
+            [Conditional("DEBUG")]
+            private void ValidateFieldIndex(int propertyIndex)
+            {
                 if (propertyIndex < 0 || propertyIndex >= 1)
                 {
                     throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 0]. " +
                         "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
                         "Please contact SpatialOS support if you encounter this issue.");
                 }
-
-                // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex / 8;
-                switch (dirtyBitsByteIndex)
-                {
-                    case 0:
-                        dirtyBits0 |= (byte) (0x1 << propertyIndex % 8);
-                        break;
-                }
-            }
-
-            public void MarkDataClean()
-            {
-                dirtyBits0 = 0x0;
             }
 
             public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestGrandchild.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestGrandchild.cs
@@ -61,7 +61,7 @@ namespace Improbable.Tests
 
                 // Retrieve the dirtyBits[0-n] field that tracks this property.
                 var dirtyBitsByteIndex = propertyIndex >> 4;
-                dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & 31));
+                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
             }
 
             public void MarkDataClean()

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestGrandchild.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestGrandchild.cs
@@ -6,6 +6,7 @@ using Improbable.Gdk.Core;
 using Improbable.Worker.CInterop;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Unity.Entities;
 
 namespace Improbable.Tests
@@ -14,19 +15,18 @@ namespace Improbable.Tests
     {
         public const uint ComponentId = 11113;
 
-        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
+        public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 11113;
 
             // Bit masks for tracking which component properties were changed locally and need to be synced.
-            // Each byte tracks 8 component properties.
-            private byte dirtyBits0;
+            private fixed UInt32 dirtyBits[1];
 
             public bool IsDataDirty()
             {
                 var isDataDirty = false;
 
-                isDataDirty |= (dirtyBits0 != 0x0);
+                isDataDirty |= (dirtyBits[0] != 0x0);
 
                 return isDataDirty;
             }
@@ -46,48 +46,38 @@ namespace Improbable.Tests
 
             public bool IsDataDirty(int propertyIndex)
             {
-                if (propertyIndex < 0 || propertyIndex >= 1)
-                {
-                    throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 0]. " +
-                        "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
-                        "Please contact SpatialOS support if you encounter this issue.");
-                }
+                ValidateFieldIndex(propertyIndex);
 
                 // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex / 8;
-                switch (dirtyBitsByteIndex)
-                {
-                    case 0:
-                        return (dirtyBits0 & (0x1 << propertyIndex % 8)) != 0x0;
-                }
-
-                return false;
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                return (dirtyBits[dirtyBitsByteIndex] & (0x1 << (propertyIndex & 31))) != 0x0;
             }
 
             // Like the IsDataDirty() method above, the propertyIndex arguments starts counting from 0.
             // This method throws an InvalidOperationException in case your component doesn't contain properties.
             public void MarkDataDirty(int propertyIndex)
             {
+                ValidateFieldIndex(propertyIndex);
+
+                // Retrieve the dirtyBits[0-n] field that tracks this property.
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & 31));
+            }
+
+            public void MarkDataClean()
+            {
+                dirtyBits[0] = 0x0;
+            }
+
+            [Conditional("DEBUG")]
+            private void ValidateFieldIndex(int propertyIndex)
+            {
                 if (propertyIndex < 0 || propertyIndex >= 1)
                 {
                     throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 0]. " +
                         "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
                         "Please contact SpatialOS support if you encounter this issue.");
                 }
-
-                // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex / 8;
-                switch (dirtyBitsByteIndex)
-                {
-                    case 0:
-                        dirtyBits0 |= (byte) (0x1 << propertyIndex % 8);
-                        break;
-                }
-            }
-
-            public void MarkDataClean()
-            {
-                dirtyBits0 = 0x0;
             }
 
             public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveEntity.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveEntity.cs
@@ -61,7 +61,7 @@ namespace Improbable.TestSchema
 
                 // Retrieve the dirtyBits[0-n] field that tracks this property.
                 var dirtyBitsByteIndex = propertyIndex >> 4;
-                dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & 31));
+                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
             }
 
             public void MarkDataClean()

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapKey.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapKey.cs
@@ -61,7 +61,7 @@ namespace Improbable.TestSchema
 
                 // Retrieve the dirtyBits[0-n] field that tracks this property.
                 var dirtyBitsByteIndex = propertyIndex >> 4;
-                dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & 31));
+                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
             }
 
             public void MarkDataClean()

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapKey.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapKey.cs
@@ -6,6 +6,7 @@ using Improbable.Gdk.Core;
 using Improbable.Worker.CInterop;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Unity.Entities;
 
 namespace Improbable.TestSchema
@@ -14,23 +15,18 @@ namespace Improbable.TestSchema
     {
         public const uint ComponentId = 197719;
 
-        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
+        public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 197719;
 
             // Bit masks for tracking which component properties were changed locally and need to be synced.
-            // Each byte tracks 8 component properties.
-            private byte dirtyBits0;
-            private byte dirtyBits1;
-            private byte dirtyBits2;
+            private fixed UInt32 dirtyBits[1];
 
             public bool IsDataDirty()
             {
                 var isDataDirty = false;
 
-                isDataDirty |= (dirtyBits0 != 0x0);
-                isDataDirty |= (dirtyBits1 != 0x0);
-                isDataDirty |= (dirtyBits2 != 0x0);
+                isDataDirty |= (dirtyBits[0] != 0x0);
 
                 return isDataDirty;
             }
@@ -50,64 +46,38 @@ namespace Improbable.TestSchema
 
             public bool IsDataDirty(int propertyIndex)
             {
-                if (propertyIndex < 0 || propertyIndex >= 18)
-                {
-                    throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
-                        "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
-                        "Please contact SpatialOS support if you encounter this issue.");
-                }
+                ValidateFieldIndex(propertyIndex);
 
                 // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex / 8;
-                switch (dirtyBitsByteIndex)
-                {
-                    case 0:
-                        return (dirtyBits0 & (0x1 << propertyIndex % 8)) != 0x0;
-
-                    case 1:
-                        return (dirtyBits1 & (0x1 << propertyIndex % 8)) != 0x0;
-
-                    case 2:
-                        return (dirtyBits2 & (0x1 << propertyIndex % 8)) != 0x0;
-                }
-
-                return false;
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                return (dirtyBits[dirtyBitsByteIndex] & (0x1 << (propertyIndex & 31))) != 0x0;
             }
 
             // Like the IsDataDirty() method above, the propertyIndex arguments starts counting from 0.
             // This method throws an InvalidOperationException in case your component doesn't contain properties.
             public void MarkDataDirty(int propertyIndex)
             {
+                ValidateFieldIndex(propertyIndex);
+
+                // Retrieve the dirtyBits[0-n] field that tracks this property.
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & 31));
+            }
+
+            public void MarkDataClean()
+            {
+                dirtyBits[0] = 0x0;
+            }
+
+            [Conditional("DEBUG")]
+            private void ValidateFieldIndex(int propertyIndex)
+            {
                 if (propertyIndex < 0 || propertyIndex >= 18)
                 {
                     throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
                         "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
                         "Please contact SpatialOS support if you encounter this issue.");
                 }
-
-                // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex / 8;
-                switch (dirtyBitsByteIndex)
-                {
-                    case 0:
-                        dirtyBits0 |= (byte) (0x1 << propertyIndex % 8);
-                        break;
-
-                    case 1:
-                        dirtyBits1 |= (byte) (0x1 << propertyIndex % 8);
-                        break;
-
-                    case 2:
-                        dirtyBits2 |= (byte) (0x1 << propertyIndex % 8);
-                        break;
-                }
-            }
-
-            public void MarkDataClean()
-            {
-                dirtyBits0 = 0x0;
-                dirtyBits1 = 0x0;
-                dirtyBits2 = 0x0;
             }
 
             public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapValue.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapValue.cs
@@ -61,7 +61,7 @@ namespace Improbable.TestSchema
 
                 // Retrieve the dirtyBits[0-n] field that tracks this property.
                 var dirtyBitsByteIndex = propertyIndex >> 4;
-                dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & 31));
+                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
             }
 
             public void MarkDataClean()

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapValue.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapValue.cs
@@ -6,6 +6,7 @@ using Improbable.Gdk.Core;
 using Improbable.Worker.CInterop;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Unity.Entities;
 
 namespace Improbable.TestSchema
@@ -14,23 +15,18 @@ namespace Improbable.TestSchema
     {
         public const uint ComponentId = 197718;
 
-        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
+        public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 197718;
 
             // Bit masks for tracking which component properties were changed locally and need to be synced.
-            // Each byte tracks 8 component properties.
-            private byte dirtyBits0;
-            private byte dirtyBits1;
-            private byte dirtyBits2;
+            private fixed UInt32 dirtyBits[1];
 
             public bool IsDataDirty()
             {
                 var isDataDirty = false;
 
-                isDataDirty |= (dirtyBits0 != 0x0);
-                isDataDirty |= (dirtyBits1 != 0x0);
-                isDataDirty |= (dirtyBits2 != 0x0);
+                isDataDirty |= (dirtyBits[0] != 0x0);
 
                 return isDataDirty;
             }
@@ -50,64 +46,38 @@ namespace Improbable.TestSchema
 
             public bool IsDataDirty(int propertyIndex)
             {
-                if (propertyIndex < 0 || propertyIndex >= 18)
-                {
-                    throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
-                        "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
-                        "Please contact SpatialOS support if you encounter this issue.");
-                }
+                ValidateFieldIndex(propertyIndex);
 
                 // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex / 8;
-                switch (dirtyBitsByteIndex)
-                {
-                    case 0:
-                        return (dirtyBits0 & (0x1 << propertyIndex % 8)) != 0x0;
-
-                    case 1:
-                        return (dirtyBits1 & (0x1 << propertyIndex % 8)) != 0x0;
-
-                    case 2:
-                        return (dirtyBits2 & (0x1 << propertyIndex % 8)) != 0x0;
-                }
-
-                return false;
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                return (dirtyBits[dirtyBitsByteIndex] & (0x1 << (propertyIndex & 31))) != 0x0;
             }
 
             // Like the IsDataDirty() method above, the propertyIndex arguments starts counting from 0.
             // This method throws an InvalidOperationException in case your component doesn't contain properties.
             public void MarkDataDirty(int propertyIndex)
             {
+                ValidateFieldIndex(propertyIndex);
+
+                // Retrieve the dirtyBits[0-n] field that tracks this property.
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & 31));
+            }
+
+            public void MarkDataClean()
+            {
+                dirtyBits[0] = 0x0;
+            }
+
+            [Conditional("DEBUG")]
+            private void ValidateFieldIndex(int propertyIndex)
+            {
                 if (propertyIndex < 0 || propertyIndex >= 18)
                 {
                     throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
                         "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
                         "Please contact SpatialOS support if you encounter this issue.");
                 }
-
-                // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex / 8;
-                switch (dirtyBitsByteIndex)
-                {
-                    case 0:
-                        dirtyBits0 |= (byte) (0x1 << propertyIndex % 8);
-                        break;
-
-                    case 1:
-                        dirtyBits1 |= (byte) (0x1 << propertyIndex % 8);
-                        break;
-
-                    case 2:
-                        dirtyBits2 |= (byte) (0x1 << propertyIndex % 8);
-                        break;
-                }
-            }
-
-            public void MarkDataClean()
-            {
-                dirtyBits0 = 0x0;
-                dirtyBits1 = 0x0;
-                dirtyBits2 = 0x0;
             }
 
             public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveOptional.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveOptional.cs
@@ -61,7 +61,7 @@ namespace Improbable.TestSchema
 
                 // Retrieve the dirtyBits[0-n] field that tracks this property.
                 var dirtyBitsByteIndex = propertyIndex >> 4;
-                dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & 31));
+                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
             }
 
             public void MarkDataClean()

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveOptional.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveOptional.cs
@@ -6,6 +6,7 @@ using Improbable.Gdk.Core;
 using Improbable.Worker.CInterop;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Unity.Entities;
 
 namespace Improbable.TestSchema
@@ -14,23 +15,18 @@ namespace Improbable.TestSchema
     {
         public const uint ComponentId = 197716;
 
-        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
+        public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 197716;
 
             // Bit masks for tracking which component properties were changed locally and need to be synced.
-            // Each byte tracks 8 component properties.
-            private byte dirtyBits0;
-            private byte dirtyBits1;
-            private byte dirtyBits2;
+            private fixed UInt32 dirtyBits[1];
 
             public bool IsDataDirty()
             {
                 var isDataDirty = false;
 
-                isDataDirty |= (dirtyBits0 != 0x0);
-                isDataDirty |= (dirtyBits1 != 0x0);
-                isDataDirty |= (dirtyBits2 != 0x0);
+                isDataDirty |= (dirtyBits[0] != 0x0);
 
                 return isDataDirty;
             }
@@ -50,64 +46,38 @@ namespace Improbable.TestSchema
 
             public bool IsDataDirty(int propertyIndex)
             {
-                if (propertyIndex < 0 || propertyIndex >= 18)
-                {
-                    throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
-                        "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
-                        "Please contact SpatialOS support if you encounter this issue.");
-                }
+                ValidateFieldIndex(propertyIndex);
 
                 // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex / 8;
-                switch (dirtyBitsByteIndex)
-                {
-                    case 0:
-                        return (dirtyBits0 & (0x1 << propertyIndex % 8)) != 0x0;
-
-                    case 1:
-                        return (dirtyBits1 & (0x1 << propertyIndex % 8)) != 0x0;
-
-                    case 2:
-                        return (dirtyBits2 & (0x1 << propertyIndex % 8)) != 0x0;
-                }
-
-                return false;
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                return (dirtyBits[dirtyBitsByteIndex] & (0x1 << (propertyIndex & 31))) != 0x0;
             }
 
             // Like the IsDataDirty() method above, the propertyIndex arguments starts counting from 0.
             // This method throws an InvalidOperationException in case your component doesn't contain properties.
             public void MarkDataDirty(int propertyIndex)
             {
+                ValidateFieldIndex(propertyIndex);
+
+                // Retrieve the dirtyBits[0-n] field that tracks this property.
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & 31));
+            }
+
+            public void MarkDataClean()
+            {
+                dirtyBits[0] = 0x0;
+            }
+
+            [Conditional("DEBUG")]
+            private void ValidateFieldIndex(int propertyIndex)
+            {
                 if (propertyIndex < 0 || propertyIndex >= 18)
                 {
                     throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
                         "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
                         "Please contact SpatialOS support if you encounter this issue.");
                 }
-
-                // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex / 8;
-                switch (dirtyBitsByteIndex)
-                {
-                    case 0:
-                        dirtyBits0 |= (byte) (0x1 << propertyIndex % 8);
-                        break;
-
-                    case 1:
-                        dirtyBits1 |= (byte) (0x1 << propertyIndex % 8);
-                        break;
-
-                    case 2:
-                        dirtyBits2 |= (byte) (0x1 << propertyIndex % 8);
-                        break;
-                }
-            }
-
-            public void MarkDataClean()
-            {
-                dirtyBits0 = 0x0;
-                dirtyBits1 = 0x0;
-                dirtyBits2 = 0x0;
             }
 
             public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveRepeated.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveRepeated.cs
@@ -6,6 +6,7 @@ using Improbable.Gdk.Core;
 using Improbable.Worker.CInterop;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Unity.Entities;
 
 namespace Improbable.TestSchema
@@ -14,23 +15,18 @@ namespace Improbable.TestSchema
     {
         public const uint ComponentId = 197717;
 
-        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
+        public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 197717;
 
             // Bit masks for tracking which component properties were changed locally and need to be synced.
-            // Each byte tracks 8 component properties.
-            private byte dirtyBits0;
-            private byte dirtyBits1;
-            private byte dirtyBits2;
+            private fixed UInt32 dirtyBits[1];
 
             public bool IsDataDirty()
             {
                 var isDataDirty = false;
 
-                isDataDirty |= (dirtyBits0 != 0x0);
-                isDataDirty |= (dirtyBits1 != 0x0);
-                isDataDirty |= (dirtyBits2 != 0x0);
+                isDataDirty |= (dirtyBits[0] != 0x0);
 
                 return isDataDirty;
             }
@@ -50,64 +46,38 @@ namespace Improbable.TestSchema
 
             public bool IsDataDirty(int propertyIndex)
             {
-                if (propertyIndex < 0 || propertyIndex >= 18)
-                {
-                    throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
-                        "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
-                        "Please contact SpatialOS support if you encounter this issue.");
-                }
+                ValidateFieldIndex(propertyIndex);
 
                 // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex / 8;
-                switch (dirtyBitsByteIndex)
-                {
-                    case 0:
-                        return (dirtyBits0 & (0x1 << propertyIndex % 8)) != 0x0;
-
-                    case 1:
-                        return (dirtyBits1 & (0x1 << propertyIndex % 8)) != 0x0;
-
-                    case 2:
-                        return (dirtyBits2 & (0x1 << propertyIndex % 8)) != 0x0;
-                }
-
-                return false;
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                return (dirtyBits[dirtyBitsByteIndex] & (0x1 << (propertyIndex & 31))) != 0x0;
             }
 
             // Like the IsDataDirty() method above, the propertyIndex arguments starts counting from 0.
             // This method throws an InvalidOperationException in case your component doesn't contain properties.
             public void MarkDataDirty(int propertyIndex)
             {
+                ValidateFieldIndex(propertyIndex);
+
+                // Retrieve the dirtyBits[0-n] field that tracks this property.
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & 31));
+            }
+
+            public void MarkDataClean()
+            {
+                dirtyBits[0] = 0x0;
+            }
+
+            [Conditional("DEBUG")]
+            private void ValidateFieldIndex(int propertyIndex)
+            {
                 if (propertyIndex < 0 || propertyIndex >= 18)
                 {
                     throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
                         "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
                         "Please contact SpatialOS support if you encounter this issue.");
                 }
-
-                // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex / 8;
-                switch (dirtyBitsByteIndex)
-                {
-                    case 0:
-                        dirtyBits0 |= (byte) (0x1 << propertyIndex % 8);
-                        break;
-
-                    case 1:
-                        dirtyBits1 |= (byte) (0x1 << propertyIndex % 8);
-                        break;
-
-                    case 2:
-                        dirtyBits2 |= (byte) (0x1 << propertyIndex % 8);
-                        break;
-                }
-            }
-
-            public void MarkDataClean()
-            {
-                dirtyBits0 = 0x0;
-                dirtyBits1 = 0x0;
-                dirtyBits2 = 0x0;
             }
 
             public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveRepeated.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveRepeated.cs
@@ -61,7 +61,7 @@ namespace Improbable.TestSchema
 
                 // Retrieve the dirtyBits[0-n] field that tracks this property.
                 var dirtyBitsByteIndex = propertyIndex >> 4;
-                dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & 31));
+                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
             }
 
             public void MarkDataClean()

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveSingular.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveSingular.cs
@@ -6,6 +6,7 @@ using Improbable.Gdk.Core;
 using Improbable.Worker.CInterop;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Unity.Entities;
 
 namespace Improbable.TestSchema
@@ -14,23 +15,18 @@ namespace Improbable.TestSchema
     {
         public const uint ComponentId = 197715;
 
-        public struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
+        public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
             public uint ComponentId => 197715;
 
             // Bit masks for tracking which component properties were changed locally and need to be synced.
-            // Each byte tracks 8 component properties.
-            private byte dirtyBits0;
-            private byte dirtyBits1;
-            private byte dirtyBits2;
+            private fixed UInt32 dirtyBits[1];
 
             public bool IsDataDirty()
             {
                 var isDataDirty = false;
 
-                isDataDirty |= (dirtyBits0 != 0x0);
-                isDataDirty |= (dirtyBits1 != 0x0);
-                isDataDirty |= (dirtyBits2 != 0x0);
+                isDataDirty |= (dirtyBits[0] != 0x0);
 
                 return isDataDirty;
             }
@@ -50,64 +46,38 @@ namespace Improbable.TestSchema
 
             public bool IsDataDirty(int propertyIndex)
             {
-                if (propertyIndex < 0 || propertyIndex >= 18)
-                {
-                    throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
-                        "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
-                        "Please contact SpatialOS support if you encounter this issue.");
-                }
+                ValidateFieldIndex(propertyIndex);
 
                 // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex / 8;
-                switch (dirtyBitsByteIndex)
-                {
-                    case 0:
-                        return (dirtyBits0 & (0x1 << propertyIndex % 8)) != 0x0;
-
-                    case 1:
-                        return (dirtyBits1 & (0x1 << propertyIndex % 8)) != 0x0;
-
-                    case 2:
-                        return (dirtyBits2 & (0x1 << propertyIndex % 8)) != 0x0;
-                }
-
-                return false;
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                return (dirtyBits[dirtyBitsByteIndex] & (0x1 << (propertyIndex & 31))) != 0x0;
             }
 
             // Like the IsDataDirty() method above, the propertyIndex arguments starts counting from 0.
             // This method throws an InvalidOperationException in case your component doesn't contain properties.
             public void MarkDataDirty(int propertyIndex)
             {
+                ValidateFieldIndex(propertyIndex);
+
+                // Retrieve the dirtyBits[0-n] field that tracks this property.
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & 31));
+            }
+
+            public void MarkDataClean()
+            {
+                dirtyBits[0] = 0x0;
+            }
+
+            [Conditional("DEBUG")]
+            private void ValidateFieldIndex(int propertyIndex)
+            {
                 if (propertyIndex < 0 || propertyIndex >= 18)
                 {
                     throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
                         "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
                         "Please contact SpatialOS support if you encounter this issue.");
                 }
-
-                // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex / 8;
-                switch (dirtyBitsByteIndex)
-                {
-                    case 0:
-                        dirtyBits0 |= (byte) (0x1 << propertyIndex % 8);
-                        break;
-
-                    case 1:
-                        dirtyBits1 |= (byte) (0x1 << propertyIndex % 8);
-                        break;
-
-                    case 2:
-                        dirtyBits2 |= (byte) (0x1 << propertyIndex % 8);
-                        break;
-                }
-            }
-
-            public void MarkDataClean()
-            {
-                dirtyBits0 = 0x0;
-                dirtyBits1 = 0x0;
-                dirtyBits2 = 0x0;
             }
 
             public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveSingular.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveSingular.cs
@@ -61,7 +61,7 @@ namespace Improbable.TestSchema
 
                 // Retrieve the dirtyBits[0-n] field that tracks this property.
                 var dirtyBitsByteIndex = propertyIndex >> 4;
-                dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & 31));
+                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
             }
 
             public void MarkDataClean()

--- a/workers/unity/Assets/Generated/Improbable.Gdk.Generated.asmdef
+++ b/workers/unity/Assets/Generated/Improbable.Gdk.Generated.asmdef
@@ -1,13 +1,18 @@
 {
     "name": "Improbable.Gdk.Generated",
-    "references": [ 
-        "Unity.Collections", 
-        "Unity.Entities", 
-        "Unity.Mathematics", 
+    "references": [
+        "Unity.Collections",
+        "Unity.Entities",
+        "Unity.Mathematics",
         "Unity.Entities.Hybrid",
         "Improbable.Gdk.Core"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
-    "allowUnsafeCode": false
+    "allowUnsafeCode": true,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
 }

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/UnityComponentDataGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/UnityComponentDataGenerator.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Improbable.Gdk.CodeGeneration.CodeWriter;
 using Improbable.Gdk.CodeGeneration.CodeWriter.Scopes;
 using Improbable.Gdk.CodeGeneration.Model.Details;
@@ -46,9 +47,10 @@ namespace Improbable.Gdk.CodeGenerator
             Logger.Trace($"Generating {qualifiedNamespace}.{componentDetails.ComponentName}.Component struct.");
 
             var fieldDetailsList = componentDetails.FieldDetails;
+
             var dirtyType = typeof(uint);
-            const int dirtyBytesPerEntry = sizeof(uint);
-            const int dirtyBitsPerEntry = dirtyBytesPerEntry * 8;
+            var dirtyBytesPerEntry = Marshal.SizeOf(dirtyType);
+            var dirtyBitsPerEntry = dirtyBytesPerEntry * 8;
             var dirtyBitCount = (fieldDetailsList.Count / dirtyBitsPerEntry) + 1;
 
             return Scope.Type(
@@ -128,7 +130,7 @@ public void MarkDataDirty(int propertyIndex)", m =>
                             {
                                 "// Retrieve the dirtyBits[0-n] field that tracks this property.",
                                 $"var dirtyBitsByteIndex = propertyIndex >> {dirtyBytesPerEntry};",
-                                $"dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & {dirtyBitsPerEntry - 1}));"
+                                $"dirtyBits[dirtyBitsByteIndex] |= ({dirtyType.Name}) (0x1 << (propertyIndex & {dirtyBitsPerEntry - 1}));"
                             });
                         }
                     });

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/UnityComponentDataGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/UnityComponentDataGenerator.cs
@@ -51,7 +51,6 @@ namespace Improbable.Gdk.CodeGenerator
             const int dirtyBitsPerEntry = dirtyBytesPerEntry * 8;
             var dirtyBitCount = (fieldDetailsList.Count / dirtyBitsPerEntry) + 1;
 
-
             return Scope.Type(
                 "public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>",
                 component =>
@@ -129,7 +128,7 @@ public void MarkDataDirty(int propertyIndex)", m =>
                             {
                                 "// Retrieve the dirtyBits[0-n] field that tracks this property.",
                                 $"var dirtyBitsByteIndex = propertyIndex >> {dirtyBytesPerEntry};",
-                                $"dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex % {dirtyBitsPerEntry - 1}));"
+                                $"dirtyBits[dirtyBitsByteIndex] |= (byte) (0x1 << (propertyIndex & {dirtyBitsPerEntry - 1}));"
                             });
                         }
                     });


### PR DESCRIPTION
#### Description
Simplify dirty bits by used a fixed array of uint's, instead of multiple code generated byte variables.
This change removes the need for switch based logic, and improves alignment of data in SpatialOS components.

#### Documentation
* [x] Changelog
* [x] Upgrade Guide
