### PR TITLE
Actually skip missing, non-required build targets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Added public toolkit for writing code generators. [#1240](https://github.com/spatialos/gdk-for-unity/pull/1240) [#1243](https://github.com/spatialos/gdk-for-unity/pull/1243) [#1244](https://github.com/spatialos/gdk-for-unity/pull/1244) [#1245](https://github.com/spatialos/gdk-for-unity/pull/1245) [#1250](https://github.com/spatialos/gdk-for-unity/pull/1250)
 
+### Fixed
+
+- Fixed a bug where build targets which were _not_ marked as required were not skipped if the user did not have the build support installed. [#1257](https://github.com/spatialos/gdk-for-unity/pull/1257)
+
 ### Internal
 
 - Implemented a new CodeWriter in the code generator which provides a fluent interface for generating C# code. [#1237](https://github.com/spatialos/gdk-for-unity/pull/1237)

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildContext.cs
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildContext.cs
@@ -51,6 +51,8 @@ namespace Improbable.Gdk.BuildSystem.Configuration
                     var targetNames = string.Join(", ", missingTargets.Select(c => c.Target.ToString()));
                     Debug.LogWarning(
                         $"Skipping ({targetNames}) because build support is not installed in the Unity Editor and the build target is not marked as 'Required'.");
+
+                    targetConfigs.RemoveAll(t => missingTargets.Contains(t));
                 }
 
                 result.AddRange(targetConfigs.Select(targetConfig => new BuildContext


### PR DESCRIPTION
#### Description

Tiny bug fix to the build system. Previously we would call out missing targets, but then try to build them anyway 😬 

#### Tests

- [x] Uninstall build support on my machine and try to build.

#### Documentation

- [x] Changelog

