### PR TITLE
Update init scripts for cn-production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Removed all Text Template Transformation Toolkit (T4) references and dependencies. [#1254](https://github.com/spatialos/gdk-for-unity/pull/1254)
 - Simplified dirtyBits logic and code generation [#1255](https://github.com/spatialos/gdk-for-unity/pull/1255)
 - The DeploymentLauncher now uses Platform SDK v14.4.0. [#1260](https://github.com/spatialos/gdk-for-unity/pull/1260)
+- `init.sh` and `init.ps1` now support the `--china` and `-china` flag respectively to download from the cn-production environment. [#1261](https://github.com/spatialos/gdk-for-unity/pull/1261)
 
 ## `0.3.2` - 2019-12-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Removed all Text Template Transformation Toolkit (T4) references and dependencies. [#1254](https://github.com/spatialos/gdk-for-unity/pull/1254)
 - Simplified dirtyBits logic and code generation [#1255](https://github.com/spatialos/gdk-for-unity/pull/1255)
 - The DeploymentLauncher now uses Platform SDK v14.4.0. [#1260](https://github.com/spatialos/gdk-for-unity/pull/1260)
-- `init.sh` and `init.ps1` now support the `--china` and `-china` flag respectively to download from the cn-production environment. [#1261](https://github.com/spatialos/gdk-for-unity/pull/1261)
+- `init.sh` and `init.ps1` now support the `--china` and `-china` flag respectively to download from the `cn-production` environment. [#1261](https://github.com/spatialos/gdk-for-unity/pull/1261)
 
 ## `0.3.2` - 2019-12-23
 

--- a/init.ps1
+++ b/init.ps1
@@ -1,4 +1,14 @@
-cd $PSScriptRoot
+param (
+    [switch]$china=$false
+)
+
+Set-Location $PSScriptRoot
+
+$EnvironmentArgs = ""
+if($china) {
+    Write-Host "Downloading with cn-production environment"
+    $EnvironmentArgs="--environment=cn-production"
+}
 
 $PkgRoot = $PSScriptRoot + "/workers/unity/Packages"
 $SdkPath = $PkgRoot + "/io.improbable.worker.sdk"
@@ -10,26 +20,26 @@ $SpotVersion = Get-Content ($SdkPath + "/.spot.version")
 
 function UpdatePackage($type, $identifier, $path, $removes)
 {
-    spatial package get $type $identifier $SdkVersion "$path" --unzip --force --json_output
+    spatial package get $type $identifier $SdkVersion "$path" --unzip --force --json_output $EnvironmentArgs
 
-    if ($removes -ne $null)
+    if ($null -ne $removes)
     {
-        $removes.Split(";") | ForEach {
-            rm "$path/$_"
+        $removes.Split(";") | ForEach-Object {
+            Remove-Item "$path/$_"
         }
     }
 }
 
 function UpdateSpot($identifier, $path)
 {
-    spatial package get spot $identifier $SpotVersion "$path" --force --json_output
+    spatial package get spot $identifier $SpotVersion "$path" --force --json_output $EnvironmentArgs
 }
 
 UpdatePackage worker_sdk c-dynamic-x86_64-gcc510-linux "$SdkPath/Plugins/Improbable/Core/Linux/x86_64"
 UpdatePackage worker_sdk c-bundle-x86_64-clang-macos "$SdkPath/Plugins/Improbable/Core/OSX"
 UpdatePackage worker_sdk c-dynamic-x86_64-vc140_mt-win32 "$SdkPath/Plugins/Improbable/Core/Windows/x86_64" "improbable_worker.lib"
 
-UpdatePackage worker_sdk csharp_cinterop "$SdkPath/Plugins/Improbable/Sdk/Common" "Improbable.Worker.CInterop.pdb"
+UpdatePackage worker_sdk csharp_cinterop "$SdkPath/Plugins/Improbable/Sdk/Common"
 
 UpdatePackage schema standard_library "$SdkPath/.schema"
 UpdatePackage schema test_schema_library "$TestSdkPath/.schema"
@@ -41,11 +51,10 @@ UpdateSpot spot-win64 "$SdkPath/.spot/spot.exe"
 UpdateSpot spot-macos "$SdkPath/.spot/spot"
 
 #Update Mobile SDK
-UpdatePackage worker_sdk c-static-fullylinked-arm-clang-ios "$SdkMobilePath/Plugins/Improbable/Core/iOS/arm" "improbable_worker_static.lib;libimprobable_worker_static.a.pic"
-UpdatePackage worker_sdk c-static-fullylinked-x86_64-clang-ios "$SdkMobilePath/Plugins/Improbable/Core/iOS/x86_64" "improbable_worker_static.lib;libimprobable_worker_static.a.pic"
+UpdatePackage worker_sdk c-static-fullylinked-arm-clang-ios "$SdkMobilePath/Plugins/Improbable/Core/iOS/arm"
+UpdatePackage worker_sdk c-static-fullylinked-x86_64-clang-ios "$SdkMobilePath/Plugins/Improbable/Core/iOS/x86_64"
 
 UpdatePackage worker_sdk c-dynamic-arm64v8a-clang_ndk16b-android "$SdkMobilePath/Plugins/Improbable/Core/Android/arm64"
 UpdatePackage worker_sdk c-dynamic-armv7a-clang_ndk16b-android "$SdkMobilePath/Plugins/Improbable/Core/Android/armv7"
-UpdatePackage worker_sdk c-dynamic-x86-clang_ndk16b-android "$SdkMobilePath/Plugins/Improbable/Core/Android/x86"
 
-UpdatePackage worker_sdk csharp_cinterop_static "$SdkMobilePath/Plugins/Improbable/Sdk/iOS" "Improbable.Worker.CInteropStatic.pdb"
+UpdatePackage worker_sdk csharp_cinterop_static "$SdkMobilePath/Plugins/Improbable/Sdk/iOS"

--- a/init.sh
+++ b/init.sh
@@ -3,6 +3,19 @@ set -e -u -o pipefail
 
 cd "$(dirname "$0")"
 
+if [[ -n "${1:-}" ]]; then
+    case "$1" in
+    --china)
+        echo "Downloading with cn-production environment"
+        ENVIRONMENT_ARGS="--environment=cn-production"
+        ;;
+    *)
+        echo "Unknown flag $1"
+        exit 1
+        ;;
+    esac
+fi
+
 PKG_ROOT="workers/unity/Packages"
 SDK_PATH="${PKG_ROOT}/io.improbable.worker.sdk"
 SDK_MOBILE_PATH="${PKG_ROOT}/io.improbable.worker.sdk.mobile"
@@ -16,7 +29,7 @@ update_package() {
     local identifier=$2
     local path=$3
 
-    spatial package get $type $identifier $SDK_VERSION "${path}" --unzip --force --json_output
+    spatial package get "${type}" "${identifier}" "${SDK_VERSION}" "${path}" --unzip --force --json_output ${ENVIRONMENT_ARGS:-}
 
     local files=${4:-""}
     for file in $(echo $files | tr ";" "\n"); do
@@ -28,7 +41,7 @@ update_spot() {
     local identifer=$1
     local path=$2
 
-    spatial package get spot $identifer $SPOT_VERSION "${path}" --force --json_output
+    spatial package get spot "${identifer}" "${SPOT_VERSION}" "${path}" --force --json_output ${ENVIRONMENT_ARGS:-}
 }
 
 # Update Core SDK


### PR DESCRIPTION
#### Description
Add support for downloading the packages through the cn-production environment in `init.sh` and `init.ps1` through the `--china` and `-china` flag respectively.

This is only needed for the maintainers of the GDK for Unity in China.

#### Documentation
* [x] Changelog
