### PR TITLE
Copy `libc++_shared.so` for Android builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Your generated code Assembly Definition file now needs to have `allow unsafe code` selected to compile. [#1255](https://github.com/spatialos/gdk-for-unity/pull/1255)
 - The `RedirectedProcess.WithArgs` API will now concatenate arguments, instead of replacing the previously provided arguments. [#1260](https://github.com/spatialos/gdk-for-unity/pull/1260)
+- Building for Android clients now requires the Android NDK to be installed and configured on your machine. [#1265](https://github.com/spatialos/gdk-for-unity/pull/1265)
 
 ### Added
 

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -2,6 +2,12 @@
 
 ## From `0.3.2` to `0.3.3`
 
+### Building for Android now requires the NDK
+
+You can install the NDK from within the Unity Hub. Select "Add Modules" for your Unity install and ensure that the "Unity SDK & NDK" is ticked under the "Android Build Support".
+
+See [Unity's documentation](https://docs.unity3d.com/Manual/android-sdksetup.html) for more information.
+
 ### Generated code now requires unsafe
 
 Code generated from schema now contains code marked as `unsafe`, which needs to be specifically allowed in the relevant [Assembly Definition file](https://docs.unity3d.com/Manual/class-AssemblyDefinitionImporter.html).

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -4,7 +4,7 @@
 
 ### Building for Android now requires the NDK
 
-You can install the NDK from within the Unity Hub. Select "Add Modules" for your Unity install and ensure that the "Unity SDK & NDK" is ticked under the "Android Build Support".
+You can install the NDK from within the Unity Hub. Select "Add Modules" for your Unity install and ensure that the "Unity SDK & NDK" option is ticked underneath "Android Build Support".
 
 See [Unity's documentation](https://docs.unity3d.com/Manual/android-sdksetup.html) for more information.
 

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/CopyLibcpp.cs
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/CopyLibcpp.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEditor.Android;
+
+namespace Improbable.Gdk.Mobile
+{
+    // It seems that since 14.4.0, the Worker SDK no longer links in libc++_shared.so and Gradle doesn't
+    // properly link it in either.
+    // So we just manually copy it across.
+    // ¯\_(ツ)_/¯
+    internal class CopyLibcpp : IPostGenerateGradleAndroidProject
+    {
+        public int callbackOrder { get; }
+
+        private static readonly string NdkLibRoot = Path.Combine(EditorPrefs.GetString("AndroidNdkRootR16b"), "sources",
+            "cxx-stl", "llvm-libc++", "libs");
+
+        public void OnPostGenerateGradleAndroidProject(string path)
+        {
+            foreach (var arch in GetTargetArchitectures(path))
+            {
+                CopyLibcppSo(arch);
+            }
+        }
+
+        private static IEnumerable<DirectoryInfo> GetTargetArchitectures(string gradleRootPath)
+        {
+            var jniLibsPath = Path.Combine(gradleRootPath, "src", "main", "jniLibs");
+            var dirInfo = new DirectoryInfo(jniLibsPath);
+            return dirInfo.EnumerateDirectories();
+        }
+
+        private static void CopyLibcppSo(DirectoryInfo architectureFolder)
+        {
+            var architecture = architectureFolder.Name;
+            File.Copy(Path.Combine(NdkLibRoot, architecture, "libc++_shared.so"), Path.Combine(architectureFolder.FullName, "libc++_shared.so"));
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/CopyLibcpp.cs
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/CopyLibcpp.cs
@@ -5,7 +5,7 @@ using UnityEditor.Android;
 
 namespace Improbable.Gdk.Mobile
 {
-    // It seems that since 14.4.0, the Worker SDK no longer links in libc++_shared.so and Gradle doesn't
+    // Since 14.4.0, the Worker SDK no longer links 'libc++_shared.so' and Gradle doesn't seem to
     // properly link it in either.
     // So we just manually copy it across.
     // ¯\_(ツ)_/¯

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/CopyLibcpp.cs.meta
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/CopyLibcpp.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 5fac0bb52381407fb740a745f11981ff
+timeCreated: 1580744980


### PR DESCRIPTION
#### Description

The Worker SDK no longer links this library. Gradle doesn't link it properly. So we manually copy it across from the NDK. 

#### Tests

- [x] Windows w/ built in NDK
- [x] MacOS w/ built in NDK

#### Documentation

This is a breaking change since the NDK is required:

- [x] Changelog
- [x] Upgrade Guide
