### PR TITLE
Redirect schema compiler output to the codegen log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 - Fixed a bug where build targets which were _not_ marked as required were not skipped if the user did not have the build support installed. [#1257](https://github.com/spatialos/gdk-for-unity/pull/1257)
 - Fixed a bug where code generation would fail due to `dotnet new` failing to run. [#1262](https://github.com/spatialos/gdk-for-unity/pull/1262)
+- Fixed a bug where `schema_compiler` errors would be swallowed by the code generator. These should now appear in the Unity Editor and the log file as expected. [#1266](https://github.com/spatialos/gdk-for-unity/pull/1266)
 
 ### Internal
 

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Utils/SystemTools.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Utils/SystemTools.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using NLog;
 
 namespace Improbable.Gdk.CodeGeneration.Utils
 {
@@ -20,6 +21,9 @@ namespace Improbable.Gdk.CodeGeneration.Utils
 
         public static void RunRedirected(string command, List<string> arguments)
         {
+            var exe = Path.GetFileNameWithoutExtension(command);
+            var logger = LogManager.GetLogger($"Command: {exe}");
+
             command = Environment.ExpandEnvironmentVariables(command);
             command = Path.GetFullPath(command);
             arguments = arguments.Select(Environment.ExpandEnvironmentVariables).ToList();
@@ -47,14 +51,14 @@ namespace Improbable.Gdk.CodeGeneration.Utils
                     {
                         if (!string.IsNullOrEmpty(e.Data))
                         {
-                            Console.WriteLine("{0}", e.Data);
+                            logger.Info(e.Data);
                         }
                     };
                     process.ErrorDataReceived += (sender, e) =>
                     {
                         if (!string.IsNullOrEmpty(e.Data))
                         {
-                            Console.Error.WriteLine("{0}", e.Data);
+                            logger.Error(e.Data);
                         }
                     };
 


### PR DESCRIPTION
#### Description

We no longer print schema compiler errors to stdout/stderr. Instead they are redirected to the logger.

The logger name is derived from the executable that is ran.

![image](https://user-images.githubusercontent.com/13353733/73677512-5276e980-46ae-11ea-845d-d6e3e3a2111c.png)

Fixes the known issue https://github.com/spatialos/gdk-for-unity/issues/1259

#### Tests

Made some bad schema. Tried to generate code. The errors appear in both the editor and the log file.

#### Documentation

- [x] Changelog

