### PR TITLE
Build deployment launcher in CI

### DIFF
--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -73,6 +73,12 @@ steps:
             type: details
     <<: *linux
 
+  - label: "build deployment launcher :rocket:"
+    command: bash -c ci/build-deployment-launcher.sh
+    <<: *common
+    artifact_paths:
+      - logs/**/*
+
   - label: "build :android:"
     command: bash -c .shared-ci/scripts/build-worker.sh
     <<: *common

--- a/ci/build-deployment-launcher.sh
+++ b/ci/build-deployment-launcher.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e -u -o pipefail
+
+if [[ -n "${DEBUG-}" ]]; then
+  set -x
+fi
+
+cd "$(dirname "$0")/../"
+
+echo "--- Building deployment launcher :shrek:"
+
+dotnet build workers/unity/Packages/io.improbable.gdk.deploymentlauncher/.DeploymentLauncher/DeploymentLauncher.csproj | tee logs/deployment-launcher-build.log


### PR DESCRIPTION
#### Description
We realised that we _weren't_ doing this and it was only getting run on our local machines & at release time. This PR adds an extra build step to build the `DeploymentLauncher.csproj` to catch any regressions.

#### Tests

Yes I am tests.

#### Documentation

N/A
