### PR TITLE
Unity 2019.3 Upgrade

### DIFF
--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -13,7 +13,7 @@ common: &common
     - "environment=production"
     - "permission_set=builder"
     - "platform=windows"
-    - "queue=${WINDOWS_BUILDER_QUEUE:-v4-2020-02-06-bk7838-a5312ac664334bca}"
+    - "queue=${WINDOWS_BUILDER_QUEUE:-v4-2020-02-17-bk8326-e10158d937b79dcb}"
     - "scaler_version=2"
     - "minimum_instances=1"
     - "agent_count=1"

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -13,7 +13,7 @@ common: &common
     - "environment=production"
     - "permission_set=builder"
     - "platform=windows"
-    - "queue=${WINDOWS_BUILDER_QUEUE:-v4-2020-02-06-bk7835-bf006eab73a51d2a}"
+    - "queue=${WINDOWS_BUILDER_QUEUE:-v4-2020-02-06-bk7838-a5312ac664334bca}"
     - "scaler_version=2"
     - "minimum_instances=1"
     - "agent_count=1"

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -13,7 +13,7 @@ common: &common
     - "environment=production"
     - "permission_set=builder"
     - "platform=windows"
-    - "queue=v3-1570547724-22c6030099a0f41d-------z"
+    - "queue=${WINDOWS_BUILDER_QUEUE:-v4-2020-02-06-bk7835-bf006eab73a51d2a}"
     - "scaler_version=2"
     - "minimum_instances=1"
     - "agent_count=1"

--- a/.buildkite/release-qa.steps.yaml
+++ b/.buildkite/release-qa.steps.yaml
@@ -13,7 +13,7 @@ common: &common
     - "environment=production"
     - "permission_set=builder"
     - "platform=windows"
-    - "queue=${WINDOWS_BUILDER_QUEUE:-v4-2020-02-06-bk7838-a5312ac664334bca}"
+    - "queue=${WINDOWS_BUILDER_QUEUE:-v4-2020-02-17-bk8326-e10158d937b79dcb}"
     - "scaler_version=2"
     - "minimum_instances=1"
     - "agent_count=1"

--- a/.buildkite/release-qa.steps.yaml
+++ b/.buildkite/release-qa.steps.yaml
@@ -13,7 +13,7 @@ common: &common
     - "environment=production"
     - "permission_set=builder"
     - "platform=windows"
-    - "queue=${WINDOWS_BUILDER_QUEUE:-v4-2020-02-06-bk7835-bf006eab73a51d2a}"
+    - "queue=${WINDOWS_BUILDER_QUEUE:-v4-2020-02-06-bk7838-a5312ac664334bca}"
     - "scaler_version=2"
     - "minimum_instances=1"
     - "agent_count=1"

--- a/.buildkite/release-qa.steps.yaml
+++ b/.buildkite/release-qa.steps.yaml
@@ -13,7 +13,7 @@ common: &common
     - "environment=production"
     - "permission_set=builder"
     - "platform=windows"
-    - "queue=v3-1570547724-22c6030099a0f41d-------z"
+    - "queue=${WINDOWS_BUILDER_QUEUE:-v4-2020-02-06-bk7835-bf006eab73a51d2a}"
     - "scaler_version=2"
     - "minimum_instances=1"
     - "agent_count=1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- The GDK for Unity now supports Unity 2019.3. You will need to upgrade your Unity project. [#1272](https://github.com/spatialos/gdk-for-unity/pull/1272)
+
 ## `0.3.3` - 2020-02-14
 
 ### Breaking Changes

--- a/test-project/Packages/io.improbable.gdk.dependencytest/package.json
+++ b/test-project/Packages/io.improbable.gdk.dependencytest/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.dependencytest",
   "displayName": "SpatialOS GDK Dependency Test",
   "version": "0.3.3",
-  "unity": "2019.2",
+  "unity": "2019.3",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Dependency Test Root.",
   "dependencies": {

--- a/test-project/Packages/io.improbable.gdk.dependencytestchild/package.json
+++ b/test-project/Packages/io.improbable.gdk.dependencytestchild/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.dependencytestchild",
   "displayName": "SpatialOS GDK Dependency Test Child",
   "version": "0.3.3",
-  "unity": "2019.2",
+  "unity": "2019.3",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Dependency Test Child.",
   "dependencies": {

--- a/test-project/Packages/io.improbable.gdk.dependencytestgrandchild/package.json
+++ b/test-project/Packages/io.improbable.gdk.dependencytestgrandchild/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.dependencytestgrandchild",
   "displayName": "SpatialOS GDK Dependency Test Grandchild",
   "version": "0.3.3",
-  "unity": "2019.2",
+  "unity": "2019.3",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Dependency Test Grandchild.",
   "type": "tests"

--- a/test-project/Packages/io.improbable.worker.sdk.testschema/package.json
+++ b/test-project/Packages/io.improbable.worker.sdk.testschema/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.worker.sdk.testschema",
   "displayName": "SpatialOS Worker SDK Exhaustive Test Schema",
   "version": "0.3.3",
-  "unity": "2019.2",
+  "unity": "2019.3",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS Worker SDK Exhaustive Test Schema",
   "dependencies": {

--- a/test-project/Packages/manifest.json
+++ b/test-project/Packages/manifest.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
     "com.unity.ext.nunit": "1.0.0",
-    "com.unity.ide.rider": "1.1.0",
-    "com.unity.test-framework": "1.0.18",
+    "com.unity.ide.rider": "1.1.4",
+    "com.unity.test-framework": "1.1.9",
     "com.unity.ugui": "1.0.0",
     "io.improbable.gdk.buildsystem": "file:../../workers/unity/Packages/io.improbable.gdk.buildsystem",
     "io.improbable.gdk.core": "file:../../workers/unity/Packages/io.improbable.gdk.core",

--- a/test-project/Packages/manifest.json
+++ b/test-project/Packages/manifest.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "com.unity.ext.nunit": "1.0.0",
     "com.unity.ide.rider": "1.1.4",
-    "com.unity.test-framework": "1.1.9",
+    "com.unity.test-framework": "1.1.11",
     "com.unity.ugui": "1.0.0",
     "io.improbable.gdk.buildsystem": "file:../../workers/unity/Packages/io.improbable.gdk.buildsystem",
     "io.improbable.gdk.core": "file:../../workers/unity/Packages/io.improbable.gdk.core",

--- a/test-project/ProjectSettings/EditorSettings.asset
+++ b/test-project/ProjectSettings/EditorSettings.asset
@@ -3,20 +3,33 @@
 --- !u!159 &1
 EditorSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 7
+  serializedVersion: 9
   m_ExternalVersionControlSupport: Visible Meta Files
   m_SerializationMode: 2
   m_LineEndingsForNewScripts: 2
   m_DefaultBehaviorMode: 0
+  m_PrefabRegularEnvironment: {fileID: 0}
+  m_PrefabUIEnvironment: {fileID: 0}
   m_SpritePackerMode: 0
   m_SpritePackerPaddingPower: 1
   m_EtcTextureCompressorBehavior: 1
   m_EtcTextureFastCompressor: 1
   m_EtcTextureNormalCompressor: 2
   m_EtcTextureBestCompressor: 4
-  m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd;asmdef
+  m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd;asmdef;asmref
   m_ProjectGenerationRootNamespace: 
-  m_UserGeneratedProjectSuffix: 
   m_CollabEditorSettings:
     inProgressEnabled: 1
+  m_EnableTextureStreamingInEditMode: 1
   m_EnableTextureStreamingInPlayMode: 1
+  m_AsyncShaderCompilation: 1
+  m_EnterPlayModeOptionsEnabled: 0
+  m_EnterPlayModeOptions: 3
+  m_ShowLightmapResolutionOverlay: 1
+  m_UseLegacyProbeSampleCount: 1
+  m_AssetPipelineMode: 1
+  m_CacheServerMode: 0
+  m_CacheServerEndpoint: 
+  m_CacheServerNamespacePrefix: default
+  m_CacheServerEnableDownload: 1
+  m_CacheServerEnableUpload: 1

--- a/test-project/ProjectSettings/ProjectVersion.txt
+++ b/test-project/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.3.0f6
-m_EditorVersionWithRevision: 2019.3.0f6 (27ab2135bccf)
+m_EditorVersion: 2019.3.1f1
+m_EditorVersionWithRevision: 2019.3.1f1 (89d6087839c2)

--- a/test-project/ProjectSettings/ProjectVersion.txt
+++ b/test-project/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.2.0f1
-m_EditorVersionWithRevision: 2019.2.0f1 (20c1667945cf)
+m_EditorVersion: 2019.3.0f6
+m_EditorVersionWithRevision: 2019.3.0f6 (27ab2135bccf)

--- a/workers/unity/Assets/Playground/Config/CubeTemplate.cs.meta
+++ b/workers/unity/Assets/Playground/Config/CubeTemplate.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: ad46ba2a366e40959d8be234504952e8
-timeCreated: 1535991104
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Playground/Editor/DisconnectOnCompilation.cs.meta
+++ b/workers/unity/Assets/Playground/Editor/DisconnectOnCompilation.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: a30ef0727dc349fdb02d7668d19db938
-timeCreated: 1536084733
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Playground/Resources/Materials/BlackMaterial.mat
+++ b/workers/unity/Assets/Playground/Resources/Materials/BlackMaterial.mat
@@ -5,7 +5,8 @@ Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: BlackMaterial
   m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
   m_ShaderKeywords: 

--- a/workers/unity/Assets/Playground/Resources/Materials/CheckerBoard.mat
+++ b/workers/unity/Assets/Playground/Resources/Materials/CheckerBoard.mat
@@ -5,7 +5,8 @@ Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: CheckerBoard
   m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
   m_ShaderKeywords: 

--- a/workers/unity/Assets/Playground/Resources/Materials/Cube.mat
+++ b/workers/unity/Assets/Playground/Resources/Materials/Cube.mat
@@ -5,7 +5,8 @@ Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: Cube
   m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
   m_ShaderKeywords: 

--- a/workers/unity/Assets/Playground/Resources/Materials/CubeKinematic.mat
+++ b/workers/unity/Assets/Playground/Resources/Materials/CubeKinematic.mat
@@ -5,7 +5,8 @@ Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: CubeKinematic
   m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
   m_ShaderKeywords: 

--- a/workers/unity/Assets/Playground/Resources/Materials/Player.mat
+++ b/workers/unity/Assets/Playground/Resources/Materials/Player.mat
@@ -5,7 +5,8 @@ Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: Player
   m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
   m_ShaderKeywords: 

--- a/workers/unity/Assets/Playground/Resources/Materials/Skybox.mat
+++ b/workers/unity/Assets/Playground/Resources/Materials/Skybox.mat
@@ -4,8 +4,9 @@
 Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: Skybox
   m_Shader: {fileID: 106, guid: 0000000000000000f000000000000000, type: 0}
   m_ShaderKeywords: _MAPPING_LATITUDE_LONGITUDE_LAYOUT _SUNDISK_HIGH_QUALITY

--- a/workers/unity/Assets/Playground/Resources/Prefabs/Common/Character.prefab
+++ b/workers/unity/Assets/Playground/Resources/Prefabs/Common/Character.prefab
@@ -203,6 +203,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -214,6 +215,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -281,6 +283,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -292,6 +295,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/workers/unity/Assets/Playground/Resources/Prefabs/Common/Character.prefab.meta
+++ b/workers/unity/Assets/Playground/Resources/Prefabs/Common/Character.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 34f6f8ff026facf49bbc20f4663b8209
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/workers/unity/Assets/Playground/Resources/Prefabs/Common/Cube.prefab
+++ b/workers/unity/Assets/Playground/Resources/Prefabs/Common/Cube.prefab
@@ -58,6 +58,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -69,6 +70,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/workers/unity/Assets/Playground/Resources/Prefabs/Common/Cube.prefab.meta
+++ b/workers/unity/Assets/Playground/Resources/Prefabs/Common/Cube.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 9b2c7df60b27d29459f566e7ca91db4b
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/workers/unity/Assets/Playground/Resources/Prefabs/Common/Spinner.prefab
+++ b/workers/unity/Assets/Playground/Resources/Prefabs/Common/Spinner.prefab
@@ -62,6 +62,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -73,6 +74,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/workers/unity/Assets/Playground/Resources/Prefabs/Common/Spinner.prefab.meta
+++ b/workers/unity/Assets/Playground/Resources/Prefabs/Common/Spinner.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 913515e03e128a0489711fdead38a227
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/workers/unity/Assets/Playground/Resources/Prefabs/Level.prefab
+++ b/workers/unity/Assets/Playground/Resources/Prefabs/Level.prefab
@@ -55,6 +55,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 0
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -66,6 +67,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/workers/unity/Assets/Playground/Resources/Prefabs/Level.prefab.meta
+++ b/workers/unity/Assets/Playground/Resources/Prefabs/Level.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 849b7fe21c599e842ae89f79f70c0f6d
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/workers/unity/Assets/Playground/Resources/Prefabs/UIGameObject.prefab
+++ b/workers/unity/Assets/Playground/Resources/Prefabs/UIGameObject.prefab
@@ -54,7 +54,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1093243929038344}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: -98529514, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -63,8 +63,6 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Texture: {fileID: 2800000, guid: 1708d8c7f90d0734fb00b1f61fd44e13, type: 3}
   m_UVRect:
     serializedVersion: 2
@@ -143,7 +141,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1161425177754576}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_UiScaleMode: 0
@@ -165,7 +163,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1161425177754576}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
@@ -227,7 +225,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1218834492251206}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -236,8 +234,6 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
     m_FontSize: 22
@@ -306,7 +302,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1577085516725578}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -315,8 +311,6 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
     m_FontSize: 22

--- a/workers/unity/Assets/Playground/Resources/Prefabs/UIGameObject.prefab.meta
+++ b/workers/unity/Assets/Playground/Resources/Prefabs/UIGameObject.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 0adfaf6f7e2705544a15cf9e489deb92
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/workers/unity/Assets/Playground/Resources/Prefabs/UnityGameLogic/Cube.prefab
+++ b/workers/unity/Assets/Playground/Resources/Prefabs/UnityGameLogic/Cube.prefab
@@ -59,6 +59,7 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
   m_RenderingLayerMask: 4294967295
   m_RendererPriority: 0
   m_Materials:
@@ -70,6 +71,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0

--- a/workers/unity/Assets/Playground/Resources/Prefabs/UnityGameLogic/Cube.prefab.meta
+++ b/workers/unity/Assets/Playground/Resources/Prefabs/UnityGameLogic/Cube.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 6c1ccb1696965344296471af11462fdd
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/workers/unity/Assets/Playground/Resources/Prefabs/Worker/ClientWorker.prefab
+++ b/workers/unity/Assets/Playground/Resources/Prefabs/Worker/ClientWorker.prefab
@@ -44,6 +44,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   MaxConnectionAttempts: 3
-  DevelopmentAuthToken: 
   UseExternalIp: 0
   level: {fileID: 1652884293046250, guid: 849b7fe21c599e842ae89f79f70c0f6d, type: 3}

--- a/workers/unity/Assets/Playground/Resources/Prefabs/Worker/ClientWorker.prefab.meta
+++ b/workers/unity/Assets/Playground/Resources/Prefabs/Worker/ClientWorker.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 5857884d058555d4282a1beb501099b9
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/workers/unity/Assets/Playground/Resources/Prefabs/Worker/GameLogicWorker.prefab
+++ b/workers/unity/Assets/Playground/Resources/Prefabs/Worker/GameLogicWorker.prefab
@@ -44,6 +44,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   MaxConnectionAttempts: 3
-  DevelopmentAuthToken: 
   UseExternalIp: 0
   level: {fileID: 1652884293046250, guid: 849b7fe21c599e842ae89f79f70c0f6d, type: 3}

--- a/workers/unity/Assets/Playground/Resources/Prefabs/Worker/GameLogicWorker.prefab.meta
+++ b/workers/unity/Assets/Playground/Resources/Prefabs/Worker/GameLogicWorker.prefab.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 6f6583327528be14686cd6a0990d11c3
-NativeFormatImporter:
+PrefabImporter:
   externalObjects: {}
-  mainObjectFileID: 100100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/workers/unity/Assets/Playground/Resources/Prefabs/Worker/MoblieClientWorker.prefab
+++ b/workers/unity/Assets/Playground/Resources/Prefabs/Worker/MoblieClientWorker.prefab
@@ -44,6 +44,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   MaxConnectionAttempts: 3
-  IpAddress: 
-  ShouldConnectLocally: 0
   level: {fileID: 1652884293046250, guid: 849b7fe21c599e842ae89f79f70c0f6d, type: 3}
+  ipAddress: 

--- a/workers/unity/Assets/Playground/Resources/Textures/DarkCheckerBoard.png.meta
+++ b/workers/unity/Assets/Playground/Resources/Textures/DarkCheckerBoard.png.meta
@@ -1,9 +1,9 @@
 fileFormatVersion: 2
 guid: a3a33bfa3f2219f4da9ea8b17959bafb
 TextureImporter:
-  fileIDToRecycleName: {}
+  internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 10
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -58,7 +58,7 @@ TextureImporter:
   compressionQualitySet: 0
   textureFormatSet: 0
   platformSettings:
-  - serializedVersion: 2
+  - serializedVersion: 3
     buildTarget: DefaultTexturePlatform
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -69,7 +69,8 @@ TextureImporter:
     allowsAlphaSplitting: 0
     overridden: 0
     androidETC2FallbackOverride: 0
-  - serializedVersion: 2
+    forceMaximumCompressionQuality_BC6H_BC7: 1
+  - serializedVersion: 3
     buildTarget: Standalone
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -80,6 +81,7 @@ TextureImporter:
     allowsAlphaSplitting: 0
     overridden: 0
     androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 1
   spriteSheet:
     serializedVersion: 2
     sprites: []
@@ -87,11 +89,15 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 
+    internalID: 0
     vertices: []
     indices: 
     edges: []
     weights: []
+    secondaryTextures: []
   spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/workers/unity/Assets/Playground/Resources/Textures/crosshair.png.meta
+++ b/workers/unity/Assets/Playground/Resources/Textures/crosshair.png.meta
@@ -1,9 +1,9 @@
 fileFormatVersion: 2
 guid: 1708d8c7f90d0734fb00b1f61fd44e13
 TextureImporter:
-  fileIDToRecycleName: {}
+  internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 5
+  serializedVersion: 10
   mipmaps:
     mipMapMode: 0
     enableMipMap: 1
@@ -21,6 +21,8 @@ TextureImporter:
     heightScale: 0.25
     normalMapFilter: 0
   isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -31,7 +33,7 @@ TextureImporter:
     serializedVersion: 2
     filterMode: -1
     aniso: -1
-    mipBias: -1
+    mipBias: -100
     wrapU: -1
     wrapV: -1
     wrapW: -1
@@ -56,7 +58,7 @@ TextureImporter:
   compressionQualitySet: 0
   textureFormatSet: 0
   platformSettings:
-  - serializedVersion: 2
+  - serializedVersion: 3
     buildTarget: DefaultTexturePlatform
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -67,6 +69,7 @@ TextureImporter:
     allowsAlphaSplitting: 0
     overridden: 0
     androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 1
   spriteSheet:
     serializedVersion: 2
     sprites: []
@@ -74,11 +77,15 @@ TextureImporter:
     physicsShape: []
     bones: []
     spriteID: 
+    internalID: 0
     vertices: []
     indices: 
     edges: []
     weights: []
+    secondaryTextures: []
   spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/workers/unity/Assets/Playground/Scenes/ClientScene.unity
+++ b/workers/unity/Assets/Playground/Scenes/ClientScene.unity
@@ -50,12 +50,11 @@ LightmapSettings:
     m_BounceScale: 1
     m_IndirectOutputScale: 1
     m_AlbedoBoost: 1
-    m_TemporalCoherenceThreshold: 1
     m_EnvironmentLightingMode: 0
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 10
+    serializedVersion: 12
     m_Resolution: 2
     m_BakeResolution: 40
     m_AtlasSize: 1024
@@ -63,6 +62,7 @@ LightmapSettings:
     m_AOMaxDistance: 1
     m_CompAOExponent: 1
     m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
     m_Padding: 2
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
@@ -77,10 +77,16 @@ LightmapSettings:
     m_PVRDirectSampleCount: 32
     m_PVRSampleCount: 500
     m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
     m_PVRFilterTypeDirect: 0
     m_PVRFilterTypeIndirect: 0
     m_PVRFilterTypeAO: 0
-    m_PVRFilteringMode: 1
+    m_PVREnvironmentMIS: 0
     m_PVRCulling: 1
     m_PVRFilteringGaussRadiusDirect: 1
     m_PVRFilteringGaussRadiusIndirect: 5
@@ -88,7 +94,9 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
-    m_ShowResolutionOverlay: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -117,7 +125,8 @@ NavMeshSettings:
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 626948024}
@@ -133,15 +142,18 @@ GameObject:
 Light:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 626948022}
   m_Enabled: 1
-  serializedVersion: 8
+  serializedVersion: 10
   m_Type: 1
+  m_Shape: 0
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
   m_Intensity: 1
   m_Range: 10
   m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
   m_CookieSize: 10
   m_Shadows:
     m_Type: 2
@@ -151,6 +163,24 @@ Light:
     m_Bias: 0.05
     m_NormalBias: 0.4
     m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
   m_Cookie: {fileID: 0}
   m_DrawHalo: 0
   m_Flare: {fileID: 0}
@@ -158,19 +188,23 @@ Light:
   m_CullingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+  m_RenderingLayerMask: 1
   m_Lightmapping: 1
   m_LightShadowCasterMode: 0
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &626948024
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 626948022}
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
   m_LocalPosition: {x: 0, y: 3, z: 0}
@@ -183,7 +217,8 @@ Transform:
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1372932564}
@@ -199,13 +234,16 @@ GameObject:
 Camera:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1372932560}
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 1
   m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
   m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
   m_FocalLength: 50
@@ -239,7 +277,8 @@ Camera:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1372932560}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 2, z: -3}
@@ -249,75 +288,74 @@ Transform:
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1620847942
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 2}
+    - target: {fileID: 1499702287310100, guid: 5857884d058555d4282a1beb501099b9, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 2}
+    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 2}
+    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 2}
+    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 2}
+    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 2}
+    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 2}
+    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 2}
+    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 3}
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 114301731887363352, guid: 5857884d058555d4282a1beb501099b9,
-        type: 2}
+        type: 3}
       propertyPath: Origin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1499702287310100, guid: 5857884d058555d4282a1beb501099b9, type: 2}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 114301731887363352, guid: 5857884d058555d4282a1beb501099b9,
-        type: 2}
+        type: 3}
       propertyPath: Level
       value: 
       objectReference: {fileID: 0}
     - target: {fileID: 114958075083198408, guid: 5857884d058555d4282a1beb501099b9,
-        type: 2}
+        type: 3}
       propertyPath: WorkerType
       value: 
       objectReference: {fileID: 0}
     - target: {fileID: 114958075083198408, guid: 5857884d058555d4282a1beb501099b9,
-        type: 2}
+        type: 3}
       propertyPath: UseExternalIp
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 114958075083198408, guid: 5857884d058555d4282a1beb501099b9,
-        type: 2}
+        type: 3}
       propertyPath: level
       value: 
       objectReference: {fileID: 1652884293046250, guid: 849b7fe21c599e842ae89f79f70c0f6d,
-        type: 2}
+        type: 3}
     m_RemovedComponents:
-    - {fileID: 114445236242016868, guid: 5857884d058555d4282a1beb501099b9, type: 2}
-  m_SourcePrefab: {fileID: 100100000, guid: 5857884d058555d4282a1beb501099b9, type: 2}
-  m_IsPrefabAsset: 0
+    - {fileID: 114445236242016868, guid: 5857884d058555d4282a1beb501099b9, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 5857884d058555d4282a1beb501099b9, type: 3}

--- a/workers/unity/Assets/Playground/Scenes/GameLogicScene.unity
+++ b/workers/unity/Assets/Playground/Scenes/GameLogicScene.unity
@@ -50,12 +50,11 @@ LightmapSettings:
     m_BounceScale: 1
     m_IndirectOutputScale: 1
     m_AlbedoBoost: 1
-    m_TemporalCoherenceThreshold: 1
     m_EnvironmentLightingMode: 0
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 10
+    serializedVersion: 12
     m_Resolution: 2
     m_BakeResolution: 40
     m_AtlasSize: 1024
@@ -63,6 +62,7 @@ LightmapSettings:
     m_AOMaxDistance: 1
     m_CompAOExponent: 1
     m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
     m_Padding: 2
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
@@ -77,10 +77,16 @@ LightmapSettings:
     m_PVRDirectSampleCount: 32
     m_PVRSampleCount: 500
     m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
     m_PVRFilterTypeDirect: 0
     m_PVRFilterTypeIndirect: 0
     m_PVRFilterTypeAO: 0
-    m_PVRFilteringMode: 1
+    m_PVREnvironmentMIS: 0
     m_PVRCulling: 1
     m_PVRFilteringGaussRadiusDirect: 1
     m_PVRFilteringGaussRadiusIndirect: 5
@@ -88,7 +94,9 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
-    m_ShowResolutionOverlay: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -114,61 +122,60 @@ NavMeshSettings:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
 --- !u!1001 &185254182
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 2}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1020770433854806, guid: 6f6583327528be14686cd6a0990d11c3, type: 2}
+    - target: {fileID: 1020770433854806, guid: 6f6583327528be14686cd6a0990d11c3, type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 114402379897910436, guid: 6f6583327528be14686cd6a0990d11c3,
-        type: 2}
+        type: 3}
       propertyPath: Level
       value: 
       objectReference: {fileID: 1652884293046250, guid: 849b7fe21c599e842ae89f79f70c0f6d,
-        type: 2}
+        type: 3}
     - target: {fileID: 114402379897910436, guid: 6f6583327528be14686cd6a0990d11c3,
-        type: 2}
+        type: 3}
       propertyPath: level
       value: 
       objectReference: {fileID: 1652884293046250, guid: 849b7fe21c599e842ae89f79f70c0f6d,
-        type: 2}
+        type: 3}
     m_RemovedComponents:
-    - {fileID: 114683898239095492, guid: 6f6583327528be14686cd6a0990d11c3, type: 2}
-  m_SourcePrefab: {fileID: 100100000, guid: 6f6583327528be14686cd6a0990d11c3, type: 2}
-  m_IsPrefabAsset: 0
+    - {fileID: 114683898239095492, guid: 6f6583327528be14686cd6a0990d11c3, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 6f6583327528be14686cd6a0990d11c3, type: 3}

--- a/workers/unity/Assets/Playground/Scenes/MobileClientScene.unity
+++ b/workers/unity/Assets/Playground/Scenes/MobileClientScene.unity
@@ -94,8 +94,9 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
-    m_ShowResolutionOverlay: 1
     m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -145,8 +146,9 @@ Light:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 626948022}
   m_Enabled: 1
-  serializedVersion: 9
+  serializedVersion: 10
   m_Type: 1
+  m_Shape: 0
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
   m_Intensity: 1
   m_Range: 10

--- a/workers/unity/Assets/Playground/Scenes/SampleScene.unity
+++ b/workers/unity/Assets/Playground/Scenes/SampleScene.unity
@@ -50,12 +50,11 @@ LightmapSettings:
     m_BounceScale: 1
     m_IndirectOutputScale: 1
     m_AlbedoBoost: 1
-    m_TemporalCoherenceThreshold: 1
     m_EnvironmentLightingMode: 0
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 10
+    serializedVersion: 12
     m_Resolution: 2
     m_BakeResolution: 40
     m_AtlasSize: 1024
@@ -63,6 +62,7 @@ LightmapSettings:
     m_AOMaxDistance: 1
     m_CompAOExponent: 1
     m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
     m_Padding: 2
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
@@ -77,10 +77,16 @@ LightmapSettings:
     m_PVRDirectSampleCount: 32
     m_PVRSampleCount: 500
     m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
     m_PVRFilterTypeDirect: 0
     m_PVRFilterTypeIndirect: 0
     m_PVRFilterTypeAO: 0
-    m_PVRFilteringMode: 1
+    m_PVREnvironmentMIS: 0
     m_PVRCulling: 1
     m_PVRFilteringGaussRadiusDirect: 1
     m_PVRFilteringGaussRadiusIndirect: 5
@@ -88,7 +94,9 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
-    m_ShowResolutionOverlay: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -117,7 +125,8 @@ NavMeshSettings:
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 626948024}
@@ -133,15 +142,18 @@ GameObject:
 Light:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 626948022}
   m_Enabled: 1
-  serializedVersion: 8
+  serializedVersion: 10
   m_Type: 1
+  m_Shape: 0
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
   m_Intensity: 1
   m_Range: 10
   m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
   m_CookieSize: 10
   m_Shadows:
     m_Type: 2
@@ -151,6 +163,24 @@ Light:
     m_Bias: 0.05
     m_NormalBias: 0.4
     m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
   m_Cookie: {fileID: 0}
   m_DrawHalo: 0
   m_Flare: {fileID: 0}
@@ -158,19 +188,23 @@ Light:
   m_CullingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+  m_RenderingLayerMask: 1
   m_Lightmapping: 1
   m_LightShadowCasterMode: 0
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &626948024
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 626948022}
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
   m_LocalPosition: {x: 0, y: 3, z: 0}
@@ -182,62 +216,68 @@ Transform:
 --- !u!114 &941066298 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 114402379897910436, guid: 6f6583327528be14686cd6a0990d11c3,
-    type: 2}
-  m_PrefabInternal: {fileID: 984009055}
+    type: 3}
+  m_PrefabInstance: {fileID: 984009055}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 75375c8be8a244a4596ad19e2798eadf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &984009055
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 2}
+    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 2}
+    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 2}
+    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 2}
+    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 2}
+    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 2}
+    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 2}
+    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 2}
+    - target: {fileID: 4223193578606268, guid: 6f6583327528be14686cd6a0990d11c3, type: 3}
       propertyPath: m_RootOrder
       value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 114402379897910436, guid: 6f6583327528be14686cd6a0990d11c3,
-        type: 2}
+        type: 3}
       propertyPath: level
       value: 
       objectReference: {fileID: 1652884293046250, guid: 849b7fe21c599e842ae89f79f70c0f6d,
-        type: 2}
+        type: 3}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 6f6583327528be14686cd6a0990d11c3, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 6f6583327528be14686cd6a0990d11c3, type: 3}
 --- !u!1 &1372932560
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1372932564}
@@ -253,13 +293,16 @@ GameObject:
 Camera:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1372932560}
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 1
   m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
   m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
   m_FocalLength: 50
@@ -293,7 +336,8 @@ Camera:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1372932560}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 2, z: -3}
@@ -303,60 +347,59 @@ Transform:
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1415879609
-Prefab:
+PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 2}
+    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 3}
       propertyPath: m_LocalPosition.x
       value: 100
       objectReference: {fileID: 0}
-    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 2}
+    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 2}
+    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 2}
+    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 2}
+    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 2}
+    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 2}
+    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 2}
+    - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 3}
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 114958075083198408, guid: 5857884d058555d4282a1beb501099b9,
-        type: 2}
+        type: 3}
       propertyPath: DependsOnWorker
       value: 
       objectReference: {fileID: 941066298}
     - target: {fileID: 114958075083198408, guid: 5857884d058555d4282a1beb501099b9,
-        type: 2}
+        type: 3}
       propertyPath: RequiredWorkerConnection
       value: 
       objectReference: {fileID: 941066298}
     - target: {fileID: 114958075083198408, guid: 5857884d058555d4282a1beb501099b9,
-        type: 2}
+        type: 3}
       propertyPath: level
       value: 
       objectReference: {fileID: 1652884293046250, guid: 849b7fe21c599e842ae89f79f70c0f6d,
-        type: 2}
+        type: 3}
     m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 5857884d058555d4282a1beb501099b9, type: 2}
-  m_IsPrefabAsset: 0
+  m_SourcePrefab: {fileID: 100100000, guid: 5857884d058555d4282a1beb501099b9, type: 3}

--- a/workers/unity/Assets/Playground/Scripts/Cubes/ColorTranslationUtil.cs.meta
+++ b/workers/unity/Assets/Playground/Scripts/Cubes/ColorTranslationUtil.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: ec2949e5a1de4fa6a3806fbf16cbfcac
-timeCreated: 1535030517
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/DeleteCubeCommandReceiver.cs.meta
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/DeleteCubeCommandReceiver.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: bd9bcf8d1e2248bc9422f7a6e14464c5
-timeCreated: 1535709268
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/UpdateSpinnerColor.cs.meta
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/UpdateSpinnerColor.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: a2cb59dc3f5a4847afc797db9ede7396
-timeCreated: 1535030559
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/WorkerIdTest.cs.meta
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/WorkerIdTest.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: 5053c3754e6a48118a61672cedc67dec
-timeCreated: 1562321330
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Playground/Scripts/OneTimeInitialisation.cs.meta
+++ b/workers/unity/Assets/Playground/Scripts/OneTimeInitialisation.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: b1fa2b08081c40388551a8ed5987fda1
-timeCreated: 1534876254
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Playground/TransformStrategies/ClientInterpolation.asset
+++ b/workers/unity/Assets/Playground/TransformStrategies/ClientInterpolation.asset
@@ -4,7 +4,8 @@
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0

--- a/workers/unity/Assets/Playground/TransformStrategies/ClientSend.asset
+++ b/workers/unity/Assets/Playground/TransformStrategies/ClientSend.asset
@@ -4,7 +4,8 @@
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -14,9 +15,3 @@ MonoBehaviour:
   WorkerType: UnityClient
   MaxTransformUpdateRateHz: 30
   MaxPositionUpdateRateHz: 1
-  MaxSquareDistanceChangedWithoutUpdate: 0.01
-  MaxSquareVelocityChangedWithoutUpdate: 0.01
-  MaxRotationWithoutUpdateDegrees: 1
-  MaxTimeForStaleTransformWithoutUpdateS: 0.5
-  MaxSquarePositionChangeWithoutUpdate: 1
-  MaxTimeForStalePositionWithoutUpdateS: 1

--- a/workers/unity/Assets/Playground/TransformStrategies/GameLogicDirectReceive.asset
+++ b/workers/unity/Assets/Playground/TransformStrategies/GameLogicDirectReceive.asset
@@ -4,7 +4,8 @@
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0

--- a/workers/unity/Assets/Playground/TransformStrategies/GameLogicSend.asset
+++ b/workers/unity/Assets/Playground/TransformStrategies/GameLogicSend.asset
@@ -4,7 +4,8 @@
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
@@ -14,9 +15,3 @@ MonoBehaviour:
   WorkerType: UnityGameLogic
   MaxTransformUpdateRateHz: 30
   MaxPositionUpdateRateHz: 1
-  MaxSquareDistanceChangedWithoutUpdate: 0.01
-  MaxSquareVelocityChangedWithoutUpdate: 0.01
-  MaxRotationWithoutUpdateDegrees: 1
-  MaxTimeForStaleTransformWithoutUpdateS: 0.5
-  MaxSquarePositionChangeWithoutUpdate: 1
-  MaxTimeForStalePositionWithoutUpdateS: 1

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration.meta
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration.meta
@@ -1,8 +1,6 @@
 fileFormatVersion: 2
 guid: 875bc38aec3bbbd40addf5e19f18c87d
 folderAsset: yes
-timeCreated: 1516879369
-licenseType: Pro
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildConfig.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildConfig.cs.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: add92caab7fb7f24589c2e7198c19491
-timeCreated: 1513698470
-licenseType: Pro
 MonoImporter:
+  externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildConfigEditor.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildConfigEditor.cs.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: 5b7f35f2a6dae6b43baacb662601de3d
-timeCreated: 1513779752
-licenseType: Pro
 MonoImporter:
+  externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildContext.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildContext.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: b3ff9aaf99fe4681ac89b707bc3103d4
-timeCreated: 1574779234
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildEnvironment.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildEnvironment.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: f0865b1f4f2046a4a480d9aef2bf6354
-timeCreated: 1515678457
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildEnvironmentConfig.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildEnvironmentConfig.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: 9b73d6e624a04708b19836efaa1b5c65
-timeCreated: 1515591603
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/WorkerBuildConfiguration.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/WorkerBuildConfiguration.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: 635648f6704340679b4166330a3d2c97
-timeCreated: 1513698790
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/WorkerBuildData.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/WorkerBuildData.cs.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: cd14637da710af84ab5725fefe45fb37
-timeCreated: 1515422041
-licenseType: Pro
 MonoImporter:
+  externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/Util/CommandlineParser.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/Util/CommandlineParser.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: aa29fe14f7ce4d2687ed1286578cda8e
-timeCreated: 1574860005
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/WorkerBuilder.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/WorkerBuilder.cs.meta
@@ -1,8 +1,7 @@
 fileFormatVersion: 2
 guid: b5b3752654112eb4e99f5ac2f71db12d
-timeCreated: 1513951010
-licenseType: Pro
 MonoImporter:
+  externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
   executionOrder: 0

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.buildsystem",
   "displayName": "SpatialOS GDK Build System",
   "version": "0.3.3",
-  "unity": "2019.2",
+  "unity": "2019.3",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Build System Module.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/package.json.meta
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/package.json.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
 guid: 516c205189cfc404d95b6d319be41456
-TextScriptImporter:
+PackageManifestImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/workers/unity/Packages/io.improbable.gdk.core/Commands/CommandSendStorage.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/Commands/CommandSendStorage.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: c428e192150b44e5bcf02768ee84fe1a
-timeCreated: 1579872855
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.core/Commands/CommandStorageBase.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/Commands/CommandStorageBase.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: bae50a8cab8947c997c3cdd4b870053f
-timeCreated: 1580471640
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/UpdateGroups.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/UpdateGroups.cs
@@ -1,5 +1,5 @@
 using Unity.Entities;
-using UnityEngine.Experimental.PlayerLoop;
+using UnityEngine.PlayerLoop;
 
 namespace Improbable.Gdk.Core
 {

--- a/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Systems.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Systems.meta
@@ -1,3 +1,8 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: f8623bbbe4364a86a60ac04ba8fe10c1
-timeCreated: 1529402469
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.core/Utility/PlayerLoopUtils.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Utility/PlayerLoopUtils.cs
@@ -4,8 +4,8 @@ using System.Linq;
 using System.Reflection;
 using Unity.Entities;
 using UnityEngine;
-using UnityEngine.Experimental.LowLevel;
-using UnityEngine.Experimental.PlayerLoop;
+using UnityEngine.LowLevel;
+using UnityEngine.PlayerLoop;
 
 namespace Improbable.Gdk.Core
 {

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker.meta
@@ -1,3 +1,8 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: a1bfce722a9146f99e2ee226fdb4f0dd
-timeCreated: 1527095326
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.core/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.core/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.core",
   "displayName": "SpatialOS GDK Core",
   "version": "0.3.3",
-  "unity": "2019.2",
+  "unity": "2019.3",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Core Module.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.gdk.debug/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.debug/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.debug",
   "displayName": "SpatialOS GDK Debug Extensions",
   "version": "0.3.3",
-  "unity": "2019.2",
+  "unity": "2019.3",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Debug Module.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.deploymentlauncher",
   "displayName": "SpatialOS GDK Deployment Launcher",
   "version": "0.3.3",
-  "unity": "2019.2",
+  "unity": "2019.3",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Deployment Launcher.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/package.json.meta
+++ b/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/package.json.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
 guid: cc444b56540c458418739eabb9cd0967
-TextScriptImporter:
+PackageManifestImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.gameobjectcreation",
   "displayName": "SpatialOS GDK GameObject Creation",
   "version": "0.3.3",
-  "unity": "2019.2",
+  "unity": "2019.3",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK GameObject Creation Module.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/package.json.meta
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/package.json.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
 guid: 7175413558e569c4eaa4b01703631357
-TextScriptImporter:
+PackageManifestImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/workers/unity/Packages/io.improbable.gdk.mobile/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.mobile/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.mobile",
   "displayName": "SpatialOS GDK Mobile Support",
   "version": "0.3.3",
-  "unity": "2019.2",
+  "unity": "2019.3",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Mobile Support Module.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.gdk.playerlifecycle/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.playerlifecycle/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.playerlifecycle",
   "displayName": "SpatialOS GDK Player Lifecycle",
   "version": "0.3.3",
-  "unity": "2019.2",
+  "unity": "2019.3",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Player Lifecycle Module.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.gdk.playerlifecycle/package.json.meta
+++ b/workers/unity/Packages/io.improbable.gdk.playerlifecycle/package.json.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
 guid: 5924877e341b7c9429260cdb1b38212d
-TextScriptImporter:
+PackageManifestImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/workers/unity/Packages/io.improbable.gdk.querybasedinteresthelper/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.querybasedinteresthelper/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.querybasedinteresthelper",
   "displayName": "SpatialOS GDK Query-based Interest Helper",
   "version": "0.3.3",
-  "unity": "2019.2",
+  "unity": "2019.3",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Query-based Interest Helper Module.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.gdk.querybasedinteresthelper/package.json.meta
+++ b/workers/unity/Packages/io.improbable.gdk.querybasedinteresthelper/package.json.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
 guid: 427918f4aff5b421b8c2afa82abc27b5
-TextScriptImporter:
+PackageManifestImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/workers/unity/Packages/io.improbable.gdk.testutils/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.testutils",
   "displayName": "SpatialOS GDK Test Utils",
   "version": "0.3.3",
-  "unity": "2019.2",
+  "unity": "2019.3",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Test Utils.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.gdk.tools/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.tools/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.tools",
   "displayName": "SpatialOS GDK Tools",
   "version": "0.3.3",
-  "unity": "2019.2",
+  "unity": "2019.3",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Support Tools.",
   "dependencies": {}

--- a/workers/unity/Packages/io.improbable.gdk.tools/package.json.meta
+++ b/workers/unity/Packages/io.improbable.gdk.tools/package.json.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: e2d528e81dca1234793d336e0dc3a270
-TextScriptImporter:
+PackageManifestImporter:
   externalObjects: {}
-  userData:
-  assetBundleName:
-  assetBundleVariant:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.transformsynchronization/Tests/Editmode/Systems/TickSystemTests.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.transformsynchronization/Tests/Editmode/Systems/TickSystemTests.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: 22075104a9a74ca286d780e9bb24a6d5
-timeCreated: 1529587366
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.transformsynchronization/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.transformsynchronization/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.transformsynchronization",
   "displayName": "SpatialOS GDK Transform Synchronization",
   "version": "0.3.3",
-  "unity": "2019.2",
+  "unity": "2019.3",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Transform Synchronization Module.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.gdk.transformsynchronization/package.json.meta
+++ b/workers/unity/Packages/io.improbable.gdk.transformsynchronization/package.json.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
 guid: 19607a94b2a8b94468cccd0ef3f8c339
-TextScriptImporter:
+PackageManifestImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/workers/unity/Packages/io.improbable.gdk.transformsynchronization2d/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.transformsynchronization2d/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.transformsynchronization2d",
   "displayName": "SpatialOS GDK Transform Synchronization 2D",
   "version": "0.3.3",
-  "unity": "2019.2",
+  "unity": "2019.3",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Transform Synchronization Module 2D.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/BuildPostProcessXCode.cs
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/BuildPostProcessXCode.cs
@@ -48,7 +48,7 @@ namespace Improbable.Gdk.Mobile
             // Get Target GUIDs
             var unityTargetName = InvokeStaticMethod<string>("GetUnityTargetName");
             var unityTestTargetName = InvokeStaticMethod<string>("GetUnityTestTargetName");
-            var targetGUID = InvokeMethod<string>(xcodeObject, "TargetGuidByName", unityTargetName);
+            var targetGUID = InvokeMethod<string>(xcodeObject, "GetUnityMainTargetGuid");
             var targetTestingGUID = InvokeMethod<string>(xcodeObject, "TargetGuidByName", unityTestTargetName);
 
             // Enumerate configGUIDs that need library path patching

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/CopyLibcpp.cs.meta
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/CopyLibcpp.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: 5fac0bb52381407fb740a745f11981ff
-timeCreated: 1580744980
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins.meta
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins.meta
@@ -3,6 +3,6 @@ guid: cd064e5d38d89884997f3436a7ea8645
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}
-  userData:
-  assetBundleName:
-  assetBundleVariant:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable.meta
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable.meta
@@ -3,6 +3,6 @@ guid: 8b061ed5a25b79f418dc0dbdc1a14dfe
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}
-  userData:
-  assetBundleName:
-  assetBundleVariant:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Core/Android/arm64/libimprobable_worker.so.meta
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Core/Android/arm64/libimprobable_worker.so.meta
@@ -12,7 +12,7 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      '': Any
+      : Any
     second:
       enabled: 0
       settings:

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Core/Android/armv7/libimprobable_worker.so.meta
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Core/Android/armv7/libimprobable_worker.so.meta
@@ -12,7 +12,7 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      '': Any
+      : Any
     second:
       enabled: 0
       settings:

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Core/iOS/arm/libRakNetLibStatic.a.meta
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Core/iOS/arm/libRakNetLibStatic.a.meta
@@ -12,7 +12,7 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      '': Any
+      : Any
     second:
       enabled: 0
       settings:

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Core/iOS/arm/libimprobable_worker.a.meta
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Core/iOS/arm/libimprobable_worker.a.meta
@@ -12,7 +12,7 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      '': Any
+      : Any
     second:
       enabled: 0
       settings:

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Core/iOS/arm/libssl.a.meta
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Core/iOS/arm/libssl.a.meta
@@ -12,7 +12,7 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      '': Any
+      : Any
     second:
       enabled: 0
       settings:

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Core/iOS/arm/libz.a.meta
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Core/iOS/arm/libz.a.meta
@@ -12,7 +12,7 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      '': Any
+      : Any
     second:
       enabled: 0
       settings:

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Core/iOS/x86_64/libRakNetLibStatic.a.meta
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Core/iOS/x86_64/libRakNetLibStatic.a.meta
@@ -12,7 +12,7 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      '': Any
+      : Any
     second:
       enabled: 0
       settings:

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Core/iOS/x86_64/libimprobable_worker.a.meta
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Core/iOS/x86_64/libimprobable_worker.a.meta
@@ -12,7 +12,7 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      '': Any
+      : Any
     second:
       enabled: 0
       settings:

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Core/iOS/x86_64/libssl.a.meta
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Core/iOS/x86_64/libssl.a.meta
@@ -12,7 +12,7 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      '': Any
+      : Any
     second:
       enabled: 0
       settings:

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Core/iOS/x86_64/libz.a.meta
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Core/iOS/x86_64/libz.a.meta
@@ -12,7 +12,7 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      '': Any
+      : Any
     second:
       enabled: 0
       settings:

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Sdk/iOS/Improbable.Worker.CInteropStatic.dll.meta
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Sdk/iOS/Improbable.Worker.CInteropStatic.dll.meta
@@ -9,6 +9,7 @@ PluginImporter:
   isPreloaded: 0
   isOverridable: 0
   isExplicitlyReferenced: 0
+  validateReferences: 1
   platformData:
   - first:
       Any: 

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Sdk/iOS/Improbable.Worker.CInteropStatic.xml.meta
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/Plugins/Improbable/Sdk/iOS/Improbable.Worker.CInteropStatic.xml.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: f5fda56aad5d91d408ff123b26ab6ade
-DefaultImporter:
+TextScriptImporter:
   externalObjects: {}
-  userData:
-  assetBundleName:
-  assetBundleVariant:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/package.json
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.worker.sdk.mobile",
   "displayName": "SpatialOS Worker Mobile SDK",
   "version": "0.3.3",
-  "unity": "2019.2",
+  "unity": "2019.3",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS Worker Mobile SDK.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/package.json.meta
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/package.json.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 3f6e3d421576ca644b07380deacd35bb
-DefaultImporter:
+PackageManifestImporter:
   externalObjects: {}
-  userData:
-  assetBundleName:
-  assetBundleVariant:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.worker.sdk/Plugins/Improbable/Core/Linux/x86_64/libimprobable_worker.so.meta
+++ b/workers/unity/Packages/io.improbable.worker.sdk/Plugins/Improbable/Core/Linux/x86_64/libimprobable_worker.so.meta
@@ -9,6 +9,7 @@ PluginImporter:
   isPreloaded: 0
   isOverridable: 0
   isExplicitlyReferenced: 0
+  validateReferences: 1
   platformData:
   - first:
       Any: 

--- a/workers/unity/Packages/io.improbable.worker.sdk/Plugins/Improbable/Core/Windows/x86_64/improbable_worker.dll.meta
+++ b/workers/unity/Packages/io.improbable.worker.sdk/Plugins/Improbable/Core/Windows/x86_64/improbable_worker.dll.meta
@@ -9,6 +9,7 @@ PluginImporter:
   isPreloaded: 0
   isOverridable: 0
   isExplicitlyReferenced: 0
+  validateReferences: 1
   platformData:
   - first:
       Any: 

--- a/workers/unity/Packages/io.improbable.worker.sdk/Plugins/Improbable/Sdk/Common/Improbable.Worker.CInterop.dll.meta
+++ b/workers/unity/Packages/io.improbable.worker.sdk/Plugins/Improbable/Sdk/Common/Improbable.Worker.CInterop.dll.meta
@@ -9,9 +9,10 @@ PluginImporter:
   isPreloaded: 0
   isOverridable: 0
   isExplicitlyReferenced: 0
+  validateReferences: 1
   platformData:
   - first:
-      '': Any
+      : Any
     second:
       enabled: 0
       settings:

--- a/workers/unity/Packages/io.improbable.worker.sdk/package.json
+++ b/workers/unity/Packages/io.improbable.worker.sdk/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.worker.sdk",
   "displayName": "SpatialOS Worker SDK",
   "version": "0.3.3",
-  "unity": "2019.2",
+  "unity": "2019.3",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS Worker SDK.",
   "dependencies": {}

--- a/workers/unity/Packages/io.improbable.worker.sdk/package.json.meta
+++ b/workers/unity/Packages/io.improbable.worker.sdk/package.json.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
 guid: e33cc20413d1ae24c872cf0660ffe7fb
-TextScriptImporter:
+PackageManifestImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/workers/unity/Packages/manifest.json
+++ b/workers/unity/Packages/manifest.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "1.1.1",
-    "com.unity.package-manager-ui": "2.2.0",
+    "com.unity.ide.rider": "1.1.4",
     "com.unity.ugui": "1.0.0",
     "com.unity.ui.builder": "0.8.2-preview",
     "io.improbable.gdk.buildsystem": "file:io.improbable.gdk.buildsystem",

--- a/workers/unity/ProjectSettings/AudioManager.asset
+++ b/workers/unity/ProjectSettings/AudioManager.asset
@@ -3,6 +3,7 @@
 --- !u!11 &1
 AudioManager:
   m_ObjectHideFlags: 0
+  serializedVersion: 2
   m_Volume: 1
   Rolloff Scale: 1
   Doppler Factor: 1
@@ -15,3 +16,4 @@ AudioManager:
   m_AmbisonicDecoderPlugin: 
   m_DisableAudio: 0
   m_VirtualizeEffects: 1
+  m_RequestedDSPBufferSize: 1024

--- a/workers/unity/ProjectSettings/DynamicsManager.asset
+++ b/workers/unity/ProjectSettings/DynamicsManager.asset
@@ -3,7 +3,7 @@
 --- !u!55 &1
 PhysicsManager:
   m_ObjectHideFlags: 0
-  serializedVersion: 7
+  serializedVersion: 13
   m_Gravity: {x: 0, y: -9.81, z: 0}
   m_DefaultMaterial: {fileID: 0}
   m_BounceThreshold: 2
@@ -20,10 +20,17 @@ PhysicsManager:
   m_LayerCollisionMatrix: fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffbfffffffdffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
   m_AutoSimulation: 1
   m_AutoSyncTransforms: 1
+  m_ReuseCollisionCallbacks: 0
   m_ClothInterCollisionSettingsToggle: 0
+  m_ClothGravity: {x: 0, y: -9.81, z: 0}
   m_ContactPairsMode: 0
   m_BroadphaseType: 0
   m_WorldBounds:
     m_Center: {x: 0, y: 0, z: 0}
     m_Extent: {x: 250, y: 250, z: 250}
   m_WorldSubdivisions: 8
+  m_FrictionType: 0
+  m_EnableEnhancedDeterminism: 0
+  m_EnableUnifiedHeightmaps: 1
+  m_SolverType: 0
+  m_DefaultMaxAngularSpeed: 7

--- a/workers/unity/ProjectSettings/EditorSettings.asset
+++ b/workers/unity/ProjectSettings/EditorSettings.asset
@@ -3,20 +3,33 @@
 --- !u!159 &1
 EditorSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 7
+  serializedVersion: 9
   m_ExternalVersionControlSupport: Visible Meta Files
   m_SerializationMode: 2
   m_LineEndingsForNewScripts: 2
   m_DefaultBehaviorMode: 0
+  m_PrefabRegularEnvironment: {fileID: 0}
+  m_PrefabUIEnvironment: {fileID: 0}
   m_SpritePackerMode: 0
   m_SpritePackerPaddingPower: 1
   m_EtcTextureCompressorBehavior: 1
   m_EtcTextureFastCompressor: 1
   m_EtcTextureNormalCompressor: 2
   m_EtcTextureBestCompressor: 4
-  m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd;asmdef
+  m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd;asmdef;asmref
   m_ProjectGenerationRootNamespace: 
-  m_UserGeneratedProjectSuffix: 
   m_CollabEditorSettings:
     inProgressEnabled: 1
+  m_EnableTextureStreamingInEditMode: 1
   m_EnableTextureStreamingInPlayMode: 1
+  m_AsyncShaderCompilation: 1
+  m_EnterPlayModeOptionsEnabled: 0
+  m_EnterPlayModeOptions: 3
+  m_ShowLightmapResolutionOverlay: 1
+  m_UseLegacyProbeSampleCount: 1
+  m_AssetPipelineMode: 1
+  m_CacheServerMode: 0
+  m_CacheServerEndpoint: 
+  m_CacheServerNamespacePrefix: default
+  m_CacheServerEnableDownload: 1
+  m_CacheServerEnableUpload: 1

--- a/workers/unity/ProjectSettings/GraphicsSettings.asset
+++ b/workers/unity/ProjectSettings/GraphicsSettings.asset
@@ -3,7 +3,7 @@
 --- !u!30 &1
 GraphicsSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 12
+  serializedVersion: 13
   m_Deferred:
     m_Mode: 1
     m_Shader: {fileID: 69, guid: 0000000000000000f000000000000000, type: 0}
@@ -113,3 +113,5 @@ GraphicsSettings:
   m_AlbedoSwatchInfos: []
   m_LightsUseLinearIntensity: 0
   m_LightsUseColorTemperature: 0
+  m_LogWhenShaderIsCompiled: 0
+  m_AllowEnlightenSupportForUpgradedProject: 1

--- a/workers/unity/ProjectSettings/Physics2DSettings.asset
+++ b/workers/unity/ProjectSettings/Physics2DSettings.asset
@@ -3,7 +3,7 @@
 --- !u!19 &1
 Physics2DSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 3
+  serializedVersion: 4
   m_Gravity: {x: 0, y: -9.81}
   m_DefaultMaterial: {fileID: 0}
   m_VelocityIterations: 8
@@ -19,11 +19,30 @@ Physics2DSettings:
   m_LinearSleepTolerance: 0.01
   m_AngularSleepTolerance: 2
   m_DefaultContactOffset: 0.01
+  m_JobOptions:
+    serializedVersion: 2
+    useMultithreading: 0
+    useConsistencySorting: 0
+    m_InterpolationPosesPerJob: 100
+    m_NewContactsPerJob: 30
+    m_CollideContactsPerJob: 100
+    m_ClearFlagsPerJob: 200
+    m_ClearBodyForcesPerJob: 200
+    m_SyncDiscreteFixturesPerJob: 50
+    m_SyncContinuousFixturesPerJob: 50
+    m_FindNearestContactsPerJob: 100
+    m_UpdateTriggerContactsPerJob: 100
+    m_IslandSolverCostThreshold: 100
+    m_IslandSolverBodyCostScale: 1
+    m_IslandSolverContactCostScale: 10
+    m_IslandSolverJointCostScale: 10
+    m_IslandSolverBodiesPerJob: 50
+    m_IslandSolverContactsPerJob: 50
   m_AutoSimulation: 1
   m_QueriesHitTriggers: 1
   m_QueriesStartInColliders: 1
-  m_ChangeStopsCallbacks: 0
   m_CallbacksOnDisable: 1
+  m_ReuseCollisionCallbacks: 0
   m_AutoSyncTransforms: 1
   m_AlwaysShowColliders: 0
   m_ShowColliderSleep: 1

--- a/workers/unity/ProjectSettings/PresetManager.asset
+++ b/workers/unity/ProjectSettings/PresetManager.asset
@@ -3,25 +3,29 @@
 --- !u!1386491679 &1
 PresetManager:
   m_ObjectHideFlags: 0
-  m_DefaultList:
-  - type:
-      m_NativeTypeID: 108
-      m_ManagedTypePPtr: {fileID: 0}
-      m_ManagedTypeFallback: 
-    defaultPresets:
-    - m_Preset: {fileID: 2655988077585873504, guid: c1cf8506f04ef2c4a88b64b6c4202eea,
-        type: 2}
-  - type:
+  serializedVersion: 2
+  m_DefaultPresets:
+  - first:
       m_NativeTypeID: 1020
       m_ManagedTypePPtr: {fileID: 0}
       m_ManagedTypeFallback: 
-    defaultPresets:
+    second:
     - m_Preset: {fileID: 2655988077585873504, guid: 0cd792cc87e492d43b4e95b205fc5cc6,
         type: 2}
-  - type:
+      m_Filter: 
+  - first:
       m_NativeTypeID: 1006
       m_ManagedTypePPtr: {fileID: 0}
       m_ManagedTypeFallback: 
-    defaultPresets:
+    second:
     - m_Preset: {fileID: 2655988077585873504, guid: 7a99f8aa944efe94cb9bd74562b7d5f9,
         type: 2}
+      m_Filter: 
+  - first:
+      m_NativeTypeID: 108
+      m_ManagedTypePPtr: {fileID: 0}
+      m_ManagedTypeFallback: 
+    second:
+    - m_Preset: {fileID: 2655988077585873504, guid: c1cf8506f04ef2c4a88b64b6c4202eea,
+        type: 2}
+      m_Filter: 

--- a/workers/unity/ProjectSettings/ProjectSettings.asset
+++ b/workers/unity/ProjectSettings/ProjectSettings.asset
@@ -3,7 +3,7 @@
 --- !u!129 &1
 PlayerSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 18
+  serializedVersion: 20
   productGUID: 00d744d32a4452244a9a72cbda2f61ff
   AndroidProfiler: 0
   AndroidFilterTouchesWhenObscured: 0
@@ -52,7 +52,6 @@ PlayerSettings:
   m_StackTraceTypes: 010000000100000001000000010000000100000001000000
   iosShowActivityIndicatorOnLoading: -1
   androidShowActivityIndicatorOnLoading: -1
-  displayResolutionDialog: 1
   iosUseCustomAppBackgroundBehavior: 0
   iosAllowHTTPDownload: 1
   allowedAutorotateToPortrait: 1
@@ -85,7 +84,6 @@ PlayerSettings:
   useMacAppStoreValidation: 0
   macAppStoreCategory: public.app-category.games
   gpuSkinning: 1
-  graphicsJobs: 1
   xboxPIXTextureCapture: 0
   xboxEnableAvatar: 0
   xboxEnableKinect: 0
@@ -93,7 +91,6 @@ PlayerSettings:
   xboxEnableFitness: 0
   visibleInBackground: 1
   allowFullscreenSwitch: 1
-  graphicsJobMode: 0
   fullscreenMode: 1
   xboxSpeechDB: 0
   xboxEnableHeadOrientation: 0
@@ -113,6 +110,7 @@ PlayerSettings:
   switchNVNShaderPoolsGranularity: 33554432
   switchNVNDefaultPoolsGranularity: 16777216
   switchNVNOtherPoolsGranularity: 16777216
+  vulkanNumSwapchainBuffers: 3
   vulkanEnableSetSRGBWrite: 0
   m_SupportedAspectRatios:
     4:3: 1
@@ -151,11 +149,13 @@ PlayerSettings:
       sharedDepthBuffer: 0
       dashSupport: 0
       lowOverheadMode: 0
+      protectedContext: 0
+      v2Signing: 1
     enable360StereoCapture: 0
   isWsaHolographicRemotingEnabled: 0
-  protectGraphicsMemory: 0
   enableFrameTimingStats: 0
   useHDRDisplay: 0
+  D3DHDRBitDepth: 0
   m_ColorGamuts: 00000000
   targetPixelDensity: 30
   resolutionScalingMode: 0
@@ -186,7 +186,7 @@ PlayerSettings:
   iOSTargetOSVersionString: 10.0
   tvOSSdkVersion: 0
   tvOSRequireExtendedGameController: 0
-  tvOSTargetOSVersionString: 9.0
+  tvOSTargetOSVersionString: 10.0
   uIPrerenderedIcon: 0
   uIRequiresPersistentWiFi: 0
   uIRequiresFullScreen: 1
@@ -276,7 +276,6 @@ PlayerSettings:
   androidGamepadSupportLevel: 0
   AndroidValidateAppBundleSize: 1
   AndroidAppBundleSizeToValidate: 150
-  resolutionDialogBanner: {fileID: 0}
   m_BuildTargetIcons: []
   m_BuildTargetPlatformIcons:
   - m_BuildTarget: Android
@@ -375,6 +374,38 @@ PlayerSettings:
   - m_BuildTarget: Standalone
     m_StaticBatching: 1
     m_DynamicBatching: 0
+  m_BuildTargetGraphicsJobs:
+  - m_BuildTarget: MacStandaloneSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: Switch
+    m_GraphicsJobs: 1
+  - m_BuildTarget: MetroSupport
+    m_GraphicsJobs: 1
+  - m_BuildTarget: AppleTVSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: BJMSupport
+    m_GraphicsJobs: 1
+  - m_BuildTarget: LinuxStandaloneSupport
+    m_GraphicsJobs: 1
+  - m_BuildTarget: PS4Player
+    m_GraphicsJobs: 1
+  - m_BuildTarget: iOSSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: WindowsStandaloneSupport
+    m_GraphicsJobs: 1
+  - m_BuildTarget: XboxOnePlayer
+    m_GraphicsJobs: 1
+  - m_BuildTarget: LuminSupport
+    m_GraphicsJobs: 0
+  - m_BuildTarget: AndroidPlayer
+    m_GraphicsJobs: 0
+  - m_BuildTarget: WebGLSupport
+    m_GraphicsJobs: 0
+  m_BuildTargetGraphicsJobMode:
+  - m_BuildTarget: PS4Player
+    m_GraphicsJobMode: 0
+  - m_BuildTarget: XboxOnePlayer
+    m_GraphicsJobMode: 0
   m_BuildTargetGraphicsAPIs: []
   m_BuildTargetVRSettings:
   - m_BuildTarget: Standalone
@@ -385,7 +416,6 @@ PlayerSettings:
   openGLRequireES31: 0
   openGLRequireES31AEP: 0
   openGLRequireES32: 0
-  vuforiaEnabled: 0
   m_TemplateCustomTags: {}
   mobileMTRendering:
     Android: 1
@@ -501,6 +531,7 @@ PlayerSettings:
   switchRatingsInt_9: 0
   switchRatingsInt_10: 0
   switchRatingsInt_11: 0
+  switchRatingsInt_12: 0
   switchLocalCommunicationIds_0: 
   switchLocalCommunicationIds_1: 
   switchLocalCommunicationIds_2: 
@@ -600,6 +631,7 @@ PlayerSettings:
   ps4contentSearchFeaturesUsed: 0
   ps4attribEyeToEyeDistanceSettingVR: 0
   ps4IncludedModules: []
+  ps4attribVROutputEnabled: 0
   monoEnv: 
   splashScreenBackgroundSourceLandscape: {fileID: 0}
   splashScreenBackgroundSourcePortrait: {fileID: 0}
@@ -701,7 +733,6 @@ PlayerSettings:
   XboxOneAllowedProductIds: []
   XboxOnePersistentLocalStorageSize: 0
   XboxOneXTitleMemory: 8
-  xboxOneScriptCompiler: 1
   XboxOneOverrideIdentityName: 
   vrEditorSettings:
     daydream:
@@ -720,13 +751,6 @@ PlayerSettings:
   luminVersion:
     m_VersionCode: 1
     m_VersionName: 
-  facebookSdkVersion: 7.9.4
-  facebookAppId: 
-  facebookCookies: 1
-  facebookLogging: 1
-  facebookStatus: 1
-  facebookXfbml: 0
-  facebookFrictionlessRequests: 1
   apiCompatibilityLevel: 3
   cloudProjectId: 
   framebufferDepthMemorylessMode: 0

--- a/workers/unity/ProjectSettings/ProjectVersion.txt
+++ b/workers/unity/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.3.0f6
-m_EditorVersionWithRevision: 2019.3.0f6 (27ab2135bccf)
+m_EditorVersion: 2019.3.1f1
+m_EditorVersionWithRevision: 2019.3.1f1 (89d6087839c2)

--- a/workers/unity/ProjectSettings/ProjectVersion.txt
+++ b/workers/unity/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.2.0f1
-m_EditorVersionWithRevision: 2019.2.0f1 (20c1667945cf)
+m_EditorVersion: 2019.3.0f6
+m_EditorVersionWithRevision: 2019.3.0f6 (27ab2135bccf)

--- a/workers/unity/ProjectSettings/QualitySettings.asset
+++ b/workers/unity/ProjectSettings/QualitySettings.asset
@@ -40,6 +40,7 @@ QualitySettings:
     asyncUploadBufferSize: 4
     asyncUploadPersistentBuffer: 1
     resolutionScalingFixedDPIFactor: 1
+    customRenderPipeline: {fileID: 0}
     excludedTargetPlatforms: []
   - serializedVersion: 2
     name: Medium
@@ -75,6 +76,7 @@ QualitySettings:
     asyncUploadBufferSize: 4
     asyncUploadPersistentBuffer: 1
     resolutionScalingFixedDPIFactor: 1
+    customRenderPipeline: {fileID: 0}
     excludedTargetPlatforms: []
   - serializedVersion: 2
     name: High
@@ -110,5 +112,6 @@ QualitySettings:
     asyncUploadBufferSize: 4
     asyncUploadPersistentBuffer: 1
     resolutionScalingFixedDPIFactor: 1
+    customRenderPipeline: {fileID: 0}
     excludedTargetPlatforms: []
   m_PerPlatformDefaultQuality: {}

--- a/workers/unity/ProjectSettings/VFXManager.asset
+++ b/workers/unity/ProjectSettings/VFXManager.asset
@@ -6,6 +6,7 @@ VFXManager:
   m_IndirectShader: {fileID: 0}
   m_CopyBufferShader: {fileID: 0}
   m_SortShader: {fileID: 0}
+  m_StripUpdateShader: {fileID: 0}
   m_RenderPipeSettingsPath: 
   m_FixedTimeStep: 0.016666668
   m_MaxDeltaTime: 0.05


### PR DESCRIPTION
#### Description

Unity 2019.3 upgrade

- Some things have moved from experimental to non-experimental
- New queue, who dis?
- Unity auto-upgraded some config files

I don't want to roll this into `develop` until we've released `v0.3.3`. That then gives us a full release cycle on 2019.3 to find any oddities/bugs in 2019.3

#### Tests

QA happening on the FPS project since its more representative --> https://buildkite.com/improbable/gdk-for-unity-fps-starter-project-release-qa/builds/87

#### Documentation

- [x] Changelog
