### PR TITLE
[2/5] Prepare generators for new CodegenJob 

### DIFF
--- a/test-project/Packages/io.improbable.gdk.dependencytest/.codegen/Source/Generators/TestProject/ModularCodegenTestGenerator.cs
+++ b/test-project/Packages/io.improbable.gdk.dependencytest/.codegen/Source/Generators/TestProject/ModularCodegenTestGenerator.cs
@@ -4,7 +4,7 @@ namespace Improbable.Gdk.CodeGenerator
 {
     public static class ModularCodegenTestGenerator
     {
-        public static string Generate()
+        public static CodeWriter Generate()
         {
             return CodeWriter.Populate(cgw =>
             {
@@ -14,7 +14,7 @@ namespace Improbable.Gdk.CodeGenerator
                     {
                     });
                 });
-            }).Format();
+            });
         }
     }
 }

--- a/test-project/Packages/io.improbable.gdk.dependencytest/.codegen/Source/TestCodegenJob.cs
+++ b/test-project/Packages/io.improbable.gdk.dependencytest/.codegen/Source/TestCodegenJob.cs
@@ -2,7 +2,6 @@ using System.IO;
 using Improbable.Gdk.CodeGeneration.FileHandling;
 using Improbable.Gdk.CodeGeneration.Jobs;
 using Improbable.Gdk.CodeGeneration.Model.Details;
-using NLog;
 
 namespace Improbable.Gdk.CodeGenerator
 {
@@ -11,7 +10,7 @@ namespace Improbable.Gdk.CodeGenerator
         private readonly string relativeOutputPath = Path.Combine("improbable", "modular-codegen-tests", "Test.cs");
         private readonly string relativeTemplateOutputPath = Path.Combine("improbable", "modular-codegen-tests", "TemplateTest.cs");
 
-        private readonly string testContent = @"
+        private const string TestContent = @"
 namespace Improbable.Gdk.ModularCodegenTests
 {
     public class Test
@@ -30,8 +29,8 @@ namespace Improbable.Gdk.ModularCodegenTests
 
         protected override void RunImpl()
         {
-            AddContent(relativeOutputPath, testContent);
-            AddContent(relativeTemplateOutputPath, ModularCodegenTestGenerator.Generate());
+            AddContent(relativeOutputPath, TestContent);
+            AddContent(relativeTemplateOutputPath, ModularCodegenTestGenerator.Generate().Format());
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/.codegen/Source/Generators/BuildSystem/UnityWorkerMenuGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/.codegen/Source/Generators/BuildSystem/UnityWorkerMenuGenerator.cs
@@ -6,7 +6,7 @@ namespace Improbable.Gdk.CodeGenerator
 {
     public static class UnityWorkerMenuGenerator
     {
-        public static string Generate(List<string> workerTypes)
+        public static CodeWriter Generate(List<string> workerTypes)
         {
             return CodeWriter.Populate(cgw =>
             {
@@ -87,7 +87,7 @@ namespace Improbable.Gdk.CodeGenerator
                         });
                     });
                 });
-            }).Format();
+            });
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/.codegen/Source/WorkerGenerationJob.cs
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/.codegen/Source/WorkerGenerationJob.cs
@@ -43,7 +43,7 @@ namespace Improbable.Gdk.CodeGenerator
         protected override void RunImpl()
         {
             Logger.Info($"Generating {WorkerFileName}.");
-            var workerCode = UnityWorkerMenuGenerator.Generate(workerTypesToGenerate);
+            var workerCode = UnityWorkerMenuGenerator.Generate(workerTypesToGenerate).Format();
             AddContent(Path.Combine(relativeEditorPath, WorkerFileName), workerCode);
 
             Logger.Info($"Generating {BuildSystemFileName}.");

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/CoreCodegenJob.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/CoreCodegenJob.cs
@@ -131,7 +131,7 @@ namespace Improbable.Gdk.CodeGenerator.Core
                 Logger.Trace($"Generating code for {enumTarget.Content.QualifiedName}.");
 
                 var fileName = Path.ChangeExtension(enumTarget.Content.Name, FileExtension);
-                var enumCode = UnityEnumGenerator.Generate(enumTarget.Content, enumTarget.Package);
+                var enumCode = UnityEnumGenerator.Generate(enumTarget.Content).Format();
                 AddContent(Path.Combine(enumTarget.OutputPath, fileName), enumCode);
             }
 
@@ -143,7 +143,7 @@ namespace Improbable.Gdk.CodeGenerator.Core
                 Logger.Trace($"Generating code for {typeTarget.Content.QualifiedName}.");
 
                 var fileName = Path.ChangeExtension(typeTarget.Content.Name, FileExtension);
-                var typeCode = UnityTypeGenerator.Generate(typeTarget.Content, typeTarget.Package);
+                var typeCode = UnityTypeGenerator.Generate(typeTarget.Content).Format();
                 AddContent(Path.Combine(typeTarget.OutputPath, fileName), typeCode);
             }
 
@@ -159,7 +159,7 @@ namespace Improbable.Gdk.CodeGenerator.Core
                 var package = componentTarget.Package;
 
                 var componentFileName = Path.ChangeExtension(componentName, FileExtension);
-                var componentCode = UnityComponentDataGenerator.Generate(componentTarget.Content, package);
+                var componentCode = UnityComponentDataGenerator.Generate(componentTarget.Content).Format();
                 AddContent(Path.Combine(relativeOutputPath, componentFileName), componentCode);
 
                 if (componentTarget.Content.CommandDetails.Count > 0)
@@ -169,27 +169,27 @@ namespace Improbable.Gdk.CodeGenerator.Core
                     var commandPayloadsFileName =
                         Path.ChangeExtension($"{componentName}CommandPayloads", FileExtension);
                     var commandPayloadCode =
-                        UnityCommandPayloadGenerator.Generate(componentTarget.Content, package);
+                        UnityCommandPayloadGenerator.Generate(componentTarget.Content).Format();
                     AddContent(Path.Combine(relativeOutputPath, commandPayloadsFileName), commandPayloadCode);
 
                     var commandDiffDeserializerFileName =
                         Path.ChangeExtension($"{componentName}CommandDiffDeserializer", FileExtension);
                     var commandDiffDeserializerCode =
-                        CommandDiffDeserializerGenerator.Generate(componentTarget.Content, package);
+                        CommandDiffDeserializerGenerator.Generate(componentTarget.Content).Format();
                     AddContent(Path.Combine(relativeOutputPath, commandDiffDeserializerFileName),
                         commandDiffDeserializerCode);
 
                     var commandDiffStorageFileName =
                         Path.ChangeExtension($"{componentName}CommandDiffStorage", FileExtension);
                     var commandDiffStorageCode =
-                        CommandDiffStorageGenerator.Generate(componentTarget.Content, package);
+                        CommandDiffStorageGenerator.Generate(componentTarget.Content).Format();
                     AddContent(Path.Combine(relativeOutputPath, commandDiffStorageFileName),
                         commandDiffStorageCode);
 
                     var commandMetaDataStorageFileName =
                         Path.ChangeExtension($"{componentName}CommandMetaDataStorage", FileExtension);
                     var commandMetaDataStorageCode =
-                        CommandMetaDataStorageGenerator.Generate(componentTarget.Content, package);
+                        CommandMetaDataStorageGenerator.Generate(componentTarget.Content).Format();
                     AddContent(Path.Combine(relativeOutputPath, commandMetaDataStorageFileName),
                         commandMetaDataStorageCode);
                 }
@@ -199,24 +199,24 @@ namespace Improbable.Gdk.CodeGenerator.Core
                     Logger.Trace("Generating code for events.");
 
                     var eventsFileName = Path.ChangeExtension($"{componentName}Events", FileExtension);
-                    var eventsCode = UnityEventGenerator.Generate(componentTarget.Content, package);
+                    var eventsCode = UnityEventGenerator.Generate(componentTarget.Content).Format();
                     AddContent(Path.Combine(relativeOutputPath, eventsFileName), eventsCode);
                 }
 
                 var updateSenderFileName = Path.ChangeExtension($"{componentName}UpdateSender", FileExtension);
-                var updateSenderCode = UnityComponentSenderGenerator.Generate(componentTarget.Content, package);
+                var updateSenderCode = UnityComponentSenderGenerator.Generate(componentTarget.Content).Format();
                 AddContent(Path.Combine(relativeOutputPath, updateSenderFileName), updateSenderCode);
 
                 var ecsViewManagerFileName = Path.ChangeExtension($"{componentName}EcsViewManager", FileExtension);
-                var ecsViewManagerCode = UnityEcsViewManagerGenerator.Generate(componentTarget.Content, package);
+                var ecsViewManagerCode = UnityEcsViewManagerGenerator.Generate(componentTarget.Content).Format();
                 AddContent(Path.Combine(relativeOutputPath, ecsViewManagerFileName), ecsViewManagerCode);
 
                 var componentDiffStorageFileName = Path.ChangeExtension($"{componentName}ComponentDiffStorage", FileExtension);
-                var componentDiffStorageCode = ComponentDiffStorageGenerator.Generate(componentTarget.Content, package);
+                var componentDiffStorageCode = ComponentDiffStorageGenerator.Generate(componentTarget.Content).Format();
                 AddContent(Path.Combine(relativeOutputPath, componentDiffStorageFileName), componentDiffStorageCode);
 
                 var componentDiffDeserializerFileName = Path.ChangeExtension($"{componentName}ComponentDiffDeserializer", FileExtension);
-                var componentDiffDeserializerCode = ComponentDiffDeserializerGenerator.Generate(componentTarget.Content, package);
+                var componentDiffDeserializerCode = ComponentDiffDeserializerGenerator.Generate(componentTarget.Content).Format();
                 AddContent(Path.Combine(relativeOutputPath, componentDiffDeserializerFileName), componentDiffDeserializerCode);
 
                 if (componentTarget.Content.FieldDetails.Any(field => !field.IsBlittable))
@@ -225,17 +225,17 @@ namespace Improbable.Gdk.CodeGenerator.Core
 
                     var referenceProviderFileName = Path.ChangeExtension($"{componentName}Providers", FileExtension);
                     var referenceProviderTranslationCode =
-                        UnityReferenceTypeProviderGenerator.Generate(componentTarget.Content, package);
+                        UnityReferenceTypeProviderGenerator.Generate(componentTarget.Content).Format();
                     AddContent(Path.Combine(relativeOutputPath, referenceProviderFileName),
                         referenceProviderTranslationCode);
                 }
 
                 var viewStorageFileName = Path.ChangeExtension($"{componentName}ViewStorage", FileExtension);
-                var viewStorageCode = ViewStorageGenerator.Generate(componentTarget.Content, package);
+                var viewStorageCode = ViewStorageGenerator.Generate(componentTarget.Content).Format();
                 AddContent(Path.Combine(relativeOutputPath, viewStorageFileName), viewStorageCode);
 
                 var metaclassFileName = Path.ChangeExtension($"{componentName}Metaclass", FileExtension);
-                var metaclassCode = MetaclassGenerator.Generate(componentTarget.Content, package);
+                var metaclassCode = MetaclassGenerator.Generate(componentTarget.Content).Format();
                 AddContent(Path.Combine(relativeOutputPath, metaclassFileName), metaclassCode);
             }
 

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/CommandDiffDeserializerGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/CommandDiffDeserializerGenerator.cs
@@ -8,10 +8,8 @@ namespace Improbable.Gdk.CodeGenerator
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public static string Generate(UnityComponentDetails componentDetails, string package)
+        public static CodeWriter Generate(UnityComponentDetails componentDetails)
         {
-            var qualifiedNamespace = package;
-
             return CodeWriter.Populate(cgw =>
             {
                 cgw.UsingDirectives(
@@ -19,18 +17,18 @@ namespace Improbable.Gdk.CodeGenerator
                     "Improbable.Worker.CInterop"
                 );
 
-                cgw.Namespace(qualifiedNamespace, ns =>
+                cgw.Namespace(componentDetails.Namespace, ns =>
                 {
                     ns.Type($"public partial class {componentDetails.Name}", partial =>
                     {
                         foreach (var command in componentDetails.CommandDetails)
                         {
-                            partial.Text(GenerateDiffCommandDeserializer(command, qualifiedNamespace, componentDetails.Name));
-                            partial.Text(GenerateCommandSerializer(command, qualifiedNamespace, componentDetails.Name));
+                            partial.Text(GenerateDiffCommandDeserializer(command, componentDetails.Namespace, componentDetails.Name));
+                            partial.Text(GenerateCommandSerializer(command, componentDetails.Namespace, componentDetails.Name));
                         }
                     });
                 });
-            }).Format();
+            });
         }
 
         private static Text GenerateDiffCommandDeserializer(UnityCommandDetails command, string qualifiedNamespace, string componentName)

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/CommandDiffStorageGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/CommandDiffStorageGenerator.cs
@@ -8,7 +8,7 @@ namespace Improbable.Gdk.CodeGenerator
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public static string Generate(UnityComponentDetails componentDetails, string qualifiedNamespace)
+        public static CodeWriter Generate(UnityComponentDetails componentDetails)
         {
             return CodeWriter.Populate(cgw =>
             {
@@ -17,18 +17,18 @@ namespace Improbable.Gdk.CodeGenerator
                     "Improbable.Gdk.Core.Commands"
                 );
 
-                cgw.Namespace(qualifiedNamespace, ns =>
+                cgw.Namespace(componentDetails.Namespace, ns =>
                 {
                     ns.Type($"public partial class {componentDetails.Name}", partial =>
                     {
                         foreach (var command in componentDetails.CommandDetails)
                         {
-                            partial.Text(GenerateCommandStorage(command, qualifiedNamespace, componentDetails.Name));
-                            partial.Text(GenerateCommandsToSendStorage(command, qualifiedNamespace, componentDetails.Name));
+                            partial.Text(GenerateCommandStorage(command, componentDetails.Namespace, componentDetails.Name));
+                            partial.Text(GenerateCommandsToSendStorage(command, componentDetails.Namespace, componentDetails.Name));
                         }
                     });
                 });
-            }).Format();
+            });
         }
 
         private static Text GenerateCommandStorage(UnityCommandDetails command, string qualifiedNamespace, string componentName)

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/CommandMetaDataStorageGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/CommandMetaDataStorageGenerator.cs
@@ -8,7 +8,7 @@ namespace Improbable.Gdk.CodeGenerator
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public static string Generate(UnityComponentDetails componentDetails, string qualifiedNamespace)
+        public static CodeWriter Generate(UnityComponentDetails componentDetails)
         {
             return CodeWriter.Populate(cgw =>
             {
@@ -16,13 +16,13 @@ namespace Improbable.Gdk.CodeGenerator
                     "Improbable.Gdk.Core"
                 );
 
-                cgw.Namespace(qualifiedNamespace, ns =>
+                cgw.Namespace(componentDetails.Namespace, ns =>
                 {
                     ns.Type($"public partial class {componentDetails.Name}", partial =>
                     {
                         foreach (var command in componentDetails.CommandDetails)
                         {
-                            Logger.Trace($"Generating {qualifiedNamespace}.{componentDetails.Name}.{command.PascalCaseName}CommandMetaDataStorage class.");
+                            Logger.Trace($"Generating {componentDetails.Namespace}.{componentDetails.Name}.{command.PascalCaseName}CommandMetaDataStorage class.");
 
                             partial.Line($@"
 private class {command.PascalCaseName}CommandMetaDataStorage :
@@ -35,7 +35,7 @@ private class {command.PascalCaseName}CommandMetaDataStorage :
                         }
                     });
                 });
-            }).Format();
+            });
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/ComponentDiffDeserializerGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/ComponentDiffDeserializerGenerator.cs
@@ -9,7 +9,7 @@ namespace Improbable.Gdk.CodeGenerator
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public static string Generate(UnityComponentDetails componentDetails, string qualifiedNamespace)
+        public static CodeWriter Generate(UnityComponentDetails componentDetails)
         {
             return CodeWriter.Populate(cgw =>
             {
@@ -18,23 +18,23 @@ namespace Improbable.Gdk.CodeGenerator
                     "Improbable.Worker.CInterop"
                 );
 
-                cgw.Namespace(qualifiedNamespace, ns =>
+                cgw.Namespace(componentDetails.Namespace, ns =>
                 {
                     ns.Type($"public partial class {componentDetails.Name}", partial =>
                     {
-                        partial.Type(GenerateComponentDeserializer(componentDetails, qualifiedNamespace));
-                        partial.Type(GenerateComponentSerializer(componentDetails, qualifiedNamespace));
+                        partial.Type(GenerateComponentDeserializer(componentDetails));
+                        partial.Type(GenerateComponentSerializer(componentDetails));
                     });
                 });
-            }).Format();
+            });
         }
 
-        private static TypeBlock GenerateComponentDeserializer(UnityComponentDetails componentDetails, string qualifiedNamespace)
+        private static TypeBlock GenerateComponentDeserializer(UnityComponentDetails componentDetails)
         {
-            var componentNamespace = $"global::{qualifiedNamespace}.{componentDetails.Name}";
+            var componentNamespace = $"global::{componentDetails.Namespace}.{componentDetails.Name}";
             var eventDetailsList = componentDetails.EventDetails;
 
-            Logger.Trace($"Generating {qualifiedNamespace}.{componentDetails.Name}.DiffComponentDeserializer class.");
+            Logger.Trace($"Generating {componentDetails.Namespace}.{componentDetails.Name}.DiffComponentDeserializer class.");
 
             return Scope.Type("public class DiffComponentDeserializer : IComponentDiffDeserializer", deserializer =>
             {
@@ -88,7 +88,7 @@ if (eventCount > 0)
             });
         }
 
-        private static TypeBlock GenerateComponentSerializer(UnityComponentDetails componentDetails, string qualifiedNamespace)
+        private static TypeBlock GenerateComponentSerializer(UnityComponentDetails componentDetails)
         {
             var eventDetailsList = componentDetails.EventDetails;
 

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/ComponentDiffStorageGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/ComponentDiffStorageGenerator.cs
@@ -11,7 +11,7 @@ namespace Improbable.Gdk.CodeGenerator
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public static string Generate(UnityComponentDetails componentDetails, string qualifiedNamespace)
+        public static CodeWriter Generate(UnityComponentDetails componentDetails)
         {
             var eventDetailsList = componentDetails.EventDetails;
 
@@ -24,11 +24,11 @@ namespace Improbable.Gdk.CodeGenerator
                     "Improbable.Worker.CInterop"
                 );
 
-                cgw.Namespace(qualifiedNamespace, ns =>
+                cgw.Namespace(componentDetails.Namespace, ns =>
                 {
                     ns.Type($"public partial class {componentDetails.Name}", partial =>
                     {
-                        Logger.Trace($"Generating {qualifiedNamespace}.{componentDetails.Name}.DiffComponentStorage class.");
+                        Logger.Trace($"Generating {componentDetails.Namespace}.{componentDetails.Name}.DiffComponentStorage class.");
 
                         var classDefinition = new StringBuilder("public class DiffComponentStorage : IDiffUpdateStorage<Update>, IDiffComponentAddedStorage<Update>, IDiffAuthorityStorage");
 
@@ -228,7 +228,7 @@ public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entity
                         });
                     });
                 });
-            }).Format();
+            });
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/UnityCommandPayloadGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/UnityCommandPayloadGenerator.cs
@@ -8,7 +8,7 @@ namespace Improbable.Gdk.CodeGenerator
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public static string Generate(UnityComponentDetails componentDetails, string qualifiedNamespace)
+        public static CodeWriter Generate(UnityComponentDetails componentDetails)
         {
             return CodeWriter.Populate(cgw =>
             {
@@ -19,13 +19,13 @@ namespace Improbable.Gdk.CodeGenerator
                     "Improbable.Gdk.Core.Commands"
                 );
 
-                cgw.Namespace(qualifiedNamespace, ns =>
+                cgw.Namespace(componentDetails.Namespace, ns =>
                 {
                     ns.Type($"public partial class {componentDetails.Name}", partial =>
                     {
                         foreach (var commandDetails in componentDetails.CommandDetails)
                         {
-                            Logger.Trace($"Generating {qualifiedNamespace}.{componentDetails.Name}.{commandDetails.PascalCaseName} partial class.");
+                            Logger.Trace($"Generating {componentDetails.Namespace}.{componentDetails.Name}.{commandDetails.PascalCaseName} partial class.");
 
                             partial.Line($@"
 public partial class {commandDetails.PascalCaseName}
@@ -167,7 +167,7 @@ public partial class {commandDetails.PascalCaseName}
                         }
                     });
                 });
-            }).Format();
+            });
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/UnityComponentSenderGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/UnityComponentSenderGenerator.cs
@@ -8,11 +8,11 @@ namespace Improbable.Gdk.CodeGenerator
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public static string Generate(UnityComponentDetails componentDetails, string qualifiedNamespace)
+        public static CodeWriter Generate(UnityComponentDetails componentDetails)
         {
-            var componentNamespace = $"global::{qualifiedNamespace}.{componentDetails.Name}";
+            var componentNamespace = $"global::{componentDetails.Namespace}.{componentDetails.Name}";
 
-            Logger.Trace($"Generating {qualifiedNamespace}.{componentDetails.Name}.ComponentReplicator internal class.");
+            Logger.Trace($"Generating {componentDetails.Namespace}.{componentDetails.Name}.ComponentReplicator internal class.");
 
             return CodeWriter.Populate(cgw =>
             {
@@ -28,7 +28,7 @@ namespace Improbable.Gdk.CodeGenerator
                     "Improbable.Gdk.Core.CodegenAdapters"
                 );
 
-                cgw.Namespace(qualifiedNamespace, ns =>
+                cgw.Namespace(componentDetails.Namespace, ns =>
                 {
                     ns.Type($"public partial class {componentDetails.Name}", partial =>
                     {
@@ -109,7 +109,7 @@ public void SendUpdates(
                         });
                     });
                 });
-            }).Format();
+            });
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/UnityEcsViewManagerGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/UnityEcsViewManagerGenerator.cs
@@ -9,9 +9,9 @@ namespace Improbable.Gdk.CodeGenerator
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public static string Generate(UnityComponentDetails componentDetails, string qualifiedNamespace)
+        public static CodeWriter Generate(UnityComponentDetails componentDetails)
         {
-            var componentNamespace = $"global::{qualifiedNamespace}.{componentDetails.Name}";
+            var componentNamespace = $"global::{componentDetails.Namespace}.{componentDetails.Name}";
 
             return CodeWriter.Populate(cgw =>
             {
@@ -22,11 +22,11 @@ namespace Improbable.Gdk.CodeGenerator
                     "Improbable.Gdk.Core"
                 );
 
-                cgw.Namespace(qualifiedNamespace, ns =>
+                cgw.Namespace(componentDetails.Namespace, ns =>
                 {
                     ns.Type($"public partial class {componentDetails.Name}", partial =>
                     {
-                        Logger.Trace($"Generating {qualifiedNamespace}.{componentDetails.Name}.EcsViewManager class.");
+                        Logger.Trace($"Generating {componentDetails.Namespace}.{componentDetails.Name}.EcsViewManager class.");
 
                         partial.Type("public class EcsViewManager : IEcsViewManager", evm =>
                         {
@@ -195,7 +195,7 @@ private void SetAuthority(EntityId entityId, Authority authority)
                         });
                     });
                 });
-            }).Format();
+            });
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/UnityEnumContent.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/UnityEnumContent.cs
@@ -11,12 +11,10 @@ namespace Improbable.Gdk.CodeGenerator
 
         public static EnumBlock Generate(UnityEnumDetails details, string enumNamespace)
         {
-            var enumName = details.Name;
-
-            Logger.Trace($"Generating {enumNamespace}.{enumName} enum.");
+            Logger.Trace($"Generating {enumNamespace}.{details.Name} enum.");
 
             return Scope.AnnotatedEnum("global::System.Serializable",
-                $"public enum {enumName} : uint", e =>
+                $"public enum {details.Name} : uint", e =>
                 {
                     foreach (var (item1, item2) in details.Values)
                     {

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/UnityEnumGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/UnityEnumGenerator.cs
@@ -1,19 +1,24 @@
 using Improbable.Gdk.CodeGeneration.CodeWriter;
 using Improbable.Gdk.CodeGeneration.Model.Details;
+using NLog;
 
 namespace Improbable.Gdk.CodeGenerator
 {
     public static class UnityEnumGenerator
     {
-        public static string Generate(UnityEnumDetails details, string package)
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+        public static CodeWriter Generate(UnityEnumDetails details)
         {
+            Logger.Trace($"Generating code for {details.QualifiedName}.");
+
             return CodeWriter.Populate(cgw =>
             {
-                cgw.Namespace(package, ns =>
+                cgw.Namespace(details.Namespace, ns =>
                 {
-                    ns.Line(UnityEnumContent.Generate(details, package).Format());
+                    ns.Enum(UnityEnumContent.Generate(details, details.Namespace));
                 });
-            }).Format();
+            });
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/UnityEventGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/UnityEventGenerator.cs
@@ -8,9 +8,8 @@ namespace Improbable.Gdk.CodeGenerator
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public static string Generate(UnityComponentDetails details, string package)
+        public static CodeWriter Generate(UnityComponentDetails details)
         {
-            var qualifiedNamespace = package;
             var componentName = details.Name;
 
             return CodeWriter.Populate(cgw =>
@@ -22,7 +21,7 @@ namespace Improbable.Gdk.CodeGenerator
                     "Unity.Entities"
                 );
 
-                cgw.Namespace(qualifiedNamespace, ns =>
+                cgw.Namespace(details.Namespace, ns =>
                 {
                     ns.Type($"public partial class {componentName}", partial =>
                     {
@@ -31,7 +30,7 @@ namespace Improbable.Gdk.CodeGenerator
                             var eventName = eventDetail.PascalCaseName;
                             var payloadType = eventDetail.FqnPayloadType;
 
-                            Logger.Trace($"Generating {qualifiedNamespace}.{componentName}.{eventName} class.");
+                            Logger.Trace($"Generating {details.Namespace}.{componentName}.{eventName} class.");
                             partial.Line($@"
 public static class {eventName}
 {{
@@ -49,7 +48,7 @@ public static class {eventName}
                         }
                     });
                 });
-            }).Format();
+            });
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/UnityReferenceTypeProviderGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/UnityReferenceTypeProviderGenerator.cs
@@ -9,7 +9,7 @@ namespace Improbable.Gdk.CodeGenerator
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public static string Generate(UnityComponentDetails componentDetails, string qualifiedNamespace)
+        public static CodeWriter Generate(UnityComponentDetails componentDetails)
         {
             return CodeWriter.Populate(cgw =>
             {
@@ -20,7 +20,7 @@ namespace Improbable.Gdk.CodeGenerator
                     "Improbable.Gdk.Core"
                 );
 
-                cgw.Namespace(qualifiedNamespace, ns =>
+                cgw.Namespace(componentDetails.Namespace, ns =>
                 {
                     ns.Type($"public partial class {componentDetails.Name}", partial =>
                     {
@@ -28,12 +28,12 @@ namespace Improbable.Gdk.CodeGenerator
                         {
                             foreach (var fieldDetails in componentDetails.FieldDetails.Where(fd => !fd.IsBlittable))
                             {
-                                providers.Type(UnityReferenceTypeProviderContent.Generate(fieldDetails, qualifiedNamespace, componentDetails.Name));
+                                providers.Type(UnityReferenceTypeProviderContent.Generate(fieldDetails, componentDetails.Namespace, componentDetails.Name));
                             }
                         });
                     });
                 });
-            }).Format();
+            });
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/UnityTypeGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/UnityTypeGenerator.cs
@@ -8,10 +8,8 @@ namespace Improbable.Gdk.CodeGenerator
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public static string Generate(UnityTypeDetails details, string package)
+        public static CodeWriter Generate(UnityTypeDetails details)
         {
-            var qualifiedNamespace = package;
-
             return CodeWriter.Populate(cgw =>
             {
                 cgw.UsingDirectives(
@@ -20,11 +18,11 @@ namespace Improbable.Gdk.CodeGenerator
                     "UnityEngine"
                 );
 
-                cgw.Namespace(qualifiedNamespace, ns =>
+                cgw.Namespace(details.Namespace, ns =>
                 {
-                    ns.Type(UnityTypeContent.Generate(details, qualifiedNamespace));
+                    ns.Type(UnityTypeContent.Generate(details, details.Namespace));
                 });
-            }).Format();
+            });
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/ViewStorageGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/ViewStorageGenerator.cs
@@ -8,7 +8,7 @@ namespace Improbable.Gdk.CodeGenerator
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public static string Generate(UnityComponentDetails componentDetails, string qualifiedNamespace)
+        public static CodeWriter Generate(UnityComponentDetails componentDetails)
         {
             return CodeWriter.Populate(cgw =>
             {
@@ -19,11 +19,11 @@ namespace Improbable.Gdk.CodeGenerator
                     "Improbable.Worker.CInterop"
                 );
 
-                cgw.Namespace(qualifiedNamespace, ns =>
+                cgw.Namespace(componentDetails.Namespace, ns =>
                 {
                     ns.Type($"public partial class {componentDetails.Name}", partial =>
                     {
-                        Logger.Trace($"Generating {qualifiedNamespace}.{componentDetails.Name}.{componentDetails.Name}ViewStorage class.");
+                        Logger.Trace($"Generating {componentDetails.Namespace}.{componentDetails.Name}.{componentDetails.Name}ViewStorage class.");
 
                         partial.Type($"public class {componentDetails.Name}ViewStorage : IViewStorage, IViewComponentStorage<Snapshot>, IViewComponentUpdater<Update>",
                             vs =>
@@ -128,7 +128,7 @@ if (update.{fieldName}.HasValue)
                             });
                     });
                 });
-            }).Format();
+            });
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/.codegen/Source/GameObjectCodegenJob.cs
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/.codegen/Source/GameObjectCodegenJob.cs
@@ -58,21 +58,20 @@ namespace Improbable.Gdk.CodeGenerator.GameObjectCreation
 
                 var relativeOutputPath = componentTarget.OutputPath;
                 var componentName = componentTarget.Content.Name;
-                var package = componentTarget.Package;
 
                 if (componentTarget.Content.CommandDetails.Count > 0)
                 {
                     var commandSenderReceiverFileName =
                         Path.ChangeExtension($"{componentName}CommandSenderReceiver", FileExtension);
                     var commandSenderReceiverCode =
-                        UnityCommandSenderReceiverGenerator.Generate(componentTarget.Content, package);
+                        UnityCommandSenderReceiverGenerator.Generate(componentTarget.Content).Format();
                     AddContent(Path.Combine(relativeOutputPath, commandSenderReceiverFileName), commandSenderReceiverCode);
                 }
 
                 var componentReaderWriterFileName =
                     Path.ChangeExtension($"{componentName}ComponentReaderWriter", FileExtension);
                 var componentReaderWriterCode =
-                    UnityComponentReaderWriterGenerator.Generate(componentTarget.Content, package);
+                    UnityComponentReaderWriterGenerator.Generate(componentTarget.Content).Format();
                 AddContent(Path.Combine(relativeOutputPath, componentReaderWriterFileName), componentReaderWriterCode);
             }
 

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/.codegen/Source/Generators/GameObjectCreation/UnityComponentReaderWriterGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/.codegen/Source/Generators/GameObjectCreation/UnityComponentReaderWriterGenerator.cs
@@ -25,17 +25,17 @@ namespace Improbable.Gdk.CodeGenerator
 
                 cgw.Namespace(details.Namespace, ns =>
                 {
-                    ns.Type(GenerateComponentReaderSubscriptionManager(details, details.Namespace));
-                    ns.Type(GenerateComponentWriterSubscriptionManager(details, details.Namespace));
-                    ns.Type(GenerateComponentReader(details, details.Namespace));
-                    ns.Type(GenerateComponentWriter(details, details.Namespace));
+                    ns.Type(GenerateComponentReaderSubscriptionManager(details));
+                    ns.Type(GenerateComponentWriterSubscriptionManager(details));
+                    ns.Type(GenerateComponentReader(details));
+                    ns.Type(GenerateComponentWriter(details));
                 });
             });
         }
 
-        private static TypeBlock GenerateComponentReaderSubscriptionManager(UnityComponentDetails componentDetails, string qualifiedNamespace)
+        private static TypeBlock GenerateComponentReaderSubscriptionManager(UnityComponentDetails componentDetails)
         {
-            Logger.Trace($"Generating {qualifiedNamespace}.{componentDetails.Name}ReaderSubscriptionManager class.");
+            Logger.Trace($"Generating {componentDetails.Namespace}.{componentDetails.Name}ReaderSubscriptionManager class.");
 
             return Scope.AnnotatedType("AutoRegisterSubscriptionManager",
                 $"public class {componentDetails.Name}ReaderSubscriptionManager : SubscriptionManager<{componentDetails.Name}Reader>",
@@ -166,9 +166,9 @@ private void OnComponentRemoved(EntityId entityId)
                 });
         }
 
-        private static TypeBlock GenerateComponentWriterSubscriptionManager(UnityComponentDetails componentDetails, string qualifiedNamespace)
+        private static TypeBlock GenerateComponentWriterSubscriptionManager(UnityComponentDetails componentDetails)
         {
-            Logger.Trace($"Generating {qualifiedNamespace}.{componentDetails.Name}WriterSubscriptionManager class.");
+            Logger.Trace($"Generating {componentDetails.Namespace}.{componentDetails.Name}WriterSubscriptionManager class.");
 
             return Scope.AnnotatedType("AutoRegisterSubscriptionManager",
                 $"public class {componentDetails.Name}WriterSubscriptionManager : SubscriptionManager<{componentDetails.Name}Writer>",
@@ -291,9 +291,9 @@ public override void ResetValue(ISubscription subscription)
                 });
         }
 
-        private static TypeBlock GenerateComponentReader(UnityComponentDetails componentDetails, string qualifiedNamespace)
+        private static TypeBlock GenerateComponentReader(UnityComponentDetails componentDetails)
         {
-            Logger.Trace($"Generating {qualifiedNamespace}.{componentDetails.Name}Reader class.");
+            Logger.Trace($"Generating {componentDetails.Namespace}.{componentDetails.Name}Reader class.");
 
             return Scope.Type($"public class {componentDetails.Name}Reader",
                 reader =>
@@ -522,9 +522,9 @@ if ({eventDetails.CamelCaseName}EventCallbackToCallbackKey != null)
                 });
         }
 
-        private static TypeBlock GenerateComponentWriter(UnityComponentDetails componentDetails, string qualifiedNamespace)
+        private static TypeBlock GenerateComponentWriter(UnityComponentDetails componentDetails)
         {
-            Logger.Trace($"Generating {qualifiedNamespace}.{componentDetails.Name}Writer class.");
+            Logger.Trace($"Generating {componentDetails.Namespace}.{componentDetails.Name}Writer class.");
 
             return Scope.Type($"public class {componentDetails.Name}Writer : {componentDetails.Name}Reader",
                 writer =>

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/.codegen/Source/Generators/GameObjectCreation/UnityComponentReaderWriterGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/.codegen/Source/Generators/GameObjectCreation/UnityComponentReaderWriterGenerator.cs
@@ -9,7 +9,7 @@ namespace Improbable.Gdk.CodeGenerator
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public static string Generate(UnityComponentDetails details, string package)
+        public static CodeWriter Generate(UnityComponentDetails details)
         {
             return CodeWriter.Populate(cgw =>
             {
@@ -23,14 +23,14 @@ namespace Improbable.Gdk.CodeGenerator
                     "Entity = Unity.Entities.Entity"
                 );
 
-                cgw.Namespace(package, ns =>
+                cgw.Namespace(details.Namespace, ns =>
                 {
-                    ns.Type(GenerateComponentReaderSubscriptionManager(details, package));
-                    ns.Type(GenerateComponentWriterSubscriptionManager(details, package));
-                    ns.Type(GenerateComponentReader(details, package));
-                    ns.Type(GenerateComponentWriter(details, package));
+                    ns.Type(GenerateComponentReaderSubscriptionManager(details, details.Namespace));
+                    ns.Type(GenerateComponentWriterSubscriptionManager(details, details.Namespace));
+                    ns.Type(GenerateComponentReader(details, details.Namespace));
+                    ns.Type(GenerateComponentWriter(details, details.Namespace));
                 });
-            }).Format();
+            });
         }
 
         private static TypeBlock GenerateComponentReaderSubscriptionManager(UnityComponentDetails componentDetails, string qualifiedNamespace)


### PR DESCRIPTION
#### Description

- all top-level generators now require an argument to `Generate` of type `GeneratorInputDetails`
- tidied up methods within generators

#### Tests

- no change in generated code

#### Documentation

- saving changelog for future codegen details/model PR

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
