### PR TITLE
Revert "Release 0.3.3 - Pre-Validation"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-## `0.3.3` - 2020-02-14
-
 ### Breaking Changes
 
 - Your generated code Assembly Definition file now needs to have `allow unsafe code` selected to compile. [#1255](https://github.com/spatialos/gdk-for-unity/pull/1255)

--- a/packer.config.json
+++ b/packer.config.json
@@ -1,6 +1,6 @@
 {
   "package_name": "gdk-for-unity",
-  "version": "0.3.3",
+  "version": "0.3.2",
   "git_packages": [
     {
       "clone_url": "git@github.com:spatialos/gdk-for-unity.git",

--- a/test-project/Packages/io.improbable.gdk.dependencytest/package.json
+++ b/test-project/Packages/io.improbable.gdk.dependencytest/package.json
@@ -1,12 +1,12 @@
 {
   "name": "io.improbable.gdk.dependencytest",
   "displayName": "SpatialOS GDK Dependency Test",
-  "version": "0.3.3",
+  "version": "0.3.2",
   "unity": "2019.2",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Dependency Test Root.",
   "dependencies": {
-    "io.improbable.gdk.dependencytestchild": "0.3.3"
+    "io.improbable.gdk.dependencytestchild": "0.3.2"
   },
   "type": "tests"
 }

--- a/test-project/Packages/io.improbable.gdk.dependencytestchild/package.json
+++ b/test-project/Packages/io.improbable.gdk.dependencytestchild/package.json
@@ -1,12 +1,12 @@
 {
   "name": "io.improbable.gdk.dependencytestchild",
   "displayName": "SpatialOS GDK Dependency Test Child",
-  "version": "0.3.3",
+  "version": "0.3.2",
   "unity": "2019.2",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Dependency Test Child.",
   "dependencies": {
-    "io.improbable.gdk.dependencytestgrandchild": "0.3.3"
+    "io.improbable.gdk.dependencytestgrandchild": "0.3.2"
   },
   "type": "tests"
 }

--- a/test-project/Packages/io.improbable.gdk.dependencytestgrandchild/package.json
+++ b/test-project/Packages/io.improbable.gdk.dependencytestgrandchild/package.json
@@ -1,7 +1,7 @@
 {
   "name": "io.improbable.gdk.dependencytestgrandchild",
   "displayName": "SpatialOS GDK Dependency Test Grandchild",
-  "version": "0.3.3",
+  "version": "0.3.2",
   "unity": "2019.2",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Dependency Test Grandchild.",

--- a/test-project/Packages/io.improbable.worker.sdk.testschema/package.json
+++ b/test-project/Packages/io.improbable.worker.sdk.testschema/package.json
@@ -1,11 +1,11 @@
 {
   "name": "io.improbable.worker.sdk.testschema",
   "displayName": "SpatialOS Worker SDK Exhaustive Test Schema",
-  "version": "0.3.3",
+  "version": "0.3.2",
   "unity": "2019.2",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS Worker SDK Exhaustive Test Schema",
   "dependencies": {
-    "io.improbable.gdk.core": "0.3.3"
+    "io.improbable.gdk.core": "0.3.2"
   }
 }

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/package.json
@@ -1,11 +1,11 @@
 {
   "name": "io.improbable.gdk.buildsystem",
   "displayName": "SpatialOS GDK Build System",
-  "version": "0.3.3",
+  "version": "0.3.2",
   "unity": "2019.2",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Build System Module.",
   "dependencies": {
-    "io.improbable.gdk.core": "0.3.3"
+    "io.improbable.gdk.core": "0.3.2"
   }
 }

--- a/workers/unity/Packages/io.improbable.gdk.core/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.core/package.json
@@ -1,14 +1,14 @@
 {
   "name": "io.improbable.gdk.core",
   "displayName": "SpatialOS GDK Core",
-  "version": "0.3.3",
+  "version": "0.3.2",
   "unity": "2019.2",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Core Module.",
   "dependencies": {
-    "io.improbable.worker.sdk": "0.3.3",
-    "io.improbable.gdk.tools": "0.3.3",
-    "io.improbable.gdk.testutils": "0.3.3",
+    "io.improbable.worker.sdk": "0.3.2",
+    "io.improbable.gdk.tools": "0.3.2",
+    "io.improbable.gdk.testutils": "0.3.2",
     "com.unity.entities": "0.1.1-preview"
   }
 }

--- a/workers/unity/Packages/io.improbable.gdk.debug/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.debug/package.json
@@ -1,11 +1,11 @@
 {
   "name": "io.improbable.gdk.debug",
   "displayName": "SpatialOS GDK Debug Extensions",
-  "version": "0.3.3",
+  "version": "0.3.2",
   "unity": "2019.2",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Debug Module.",
   "dependencies": {
-    "io.improbable.gdk.core": "0.3.3"
+    "io.improbable.gdk.core": "0.3.2"
   }
 }

--- a/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/package.json
@@ -1,12 +1,12 @@
 {
   "name": "io.improbable.gdk.deploymentlauncher",
   "displayName": "SpatialOS GDK Deployment Launcher",
-  "version": "0.3.3",
+  "version": "0.3.2",
   "unity": "2019.2",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Deployment Launcher.",
   "dependencies": {
-    "io.improbable.gdk.core": "0.3.3",
-    "io.improbable.gdk.tools": "0.3.3"
+    "io.improbable.gdk.core": "0.3.2",
+    "io.improbable.gdk.tools": "0.3.2"
   }
 }

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/package.json
@@ -1,11 +1,11 @@
 {
   "name": "io.improbable.gdk.gameobjectcreation",
   "displayName": "SpatialOS GDK GameObject Creation",
-  "version": "0.3.3",
+  "version": "0.3.2",
   "unity": "2019.2",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK GameObject Creation Module.",
   "dependencies": {
-    "io.improbable.gdk.core": "0.3.3"
+    "io.improbable.gdk.core": "0.3.2"
   }
 }

--- a/workers/unity/Packages/io.improbable.gdk.mobile/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.mobile/package.json
@@ -1,13 +1,13 @@
 {
   "name": "io.improbable.gdk.mobile",
   "displayName": "SpatialOS GDK Mobile Support",
-  "version": "0.3.3",
+  "version": "0.3.2",
   "unity": "2019.2",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Mobile Support Module.",
   "dependencies": {
-    "io.improbable.gdk.core": "0.3.3",
-    "io.improbable.worker.sdk.mobile": "0.3.3",
+    "io.improbable.gdk.core": "0.3.2",
+    "io.improbable.worker.sdk.mobile": "0.3.2",
     "com.unity.modules.androidjni": "1.0.0"
   }
 }

--- a/workers/unity/Packages/io.improbable.gdk.playerlifecycle/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.playerlifecycle/package.json
@@ -1,11 +1,11 @@
 {
   "name": "io.improbable.gdk.playerlifecycle",
   "displayName": "SpatialOS GDK Player Lifecycle",
-  "version": "0.3.3",
+  "version": "0.3.2",
   "unity": "2019.2",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Player Lifecycle Module.",
   "dependencies": {
-    "io.improbable.gdk.core": "0.3.3"
+    "io.improbable.gdk.core": "0.3.2"
   }
 }

--- a/workers/unity/Packages/io.improbable.gdk.querybasedinteresthelper/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.querybasedinteresthelper/package.json
@@ -1,11 +1,11 @@
 {
   "name": "io.improbable.gdk.querybasedinteresthelper",
   "displayName": "SpatialOS GDK Query-based Interest Helper",
-  "version": "0.3.3",
+  "version": "0.3.2",
   "unity": "2019.2",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Query-based Interest Helper Module.",
   "dependencies": {
-    "io.improbable.gdk.core": "0.3.3"
+    "io.improbable.gdk.core": "0.3.2"
   }
 }

--- a/workers/unity/Packages/io.improbable.gdk.testutils/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/package.json
@@ -1,12 +1,12 @@
 {
   "name": "io.improbable.gdk.testutils",
   "displayName": "SpatialOS GDK Test Utils",
-  "version": "0.3.3",
+  "version": "0.3.2",
   "unity": "2019.2",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Test Utils.",
   "dependencies": {
-    "io.improbable.gdk.core": "0.3.3",
+    "io.improbable.gdk.core": "0.3.2",
     "com.unity.ext.nunit": "1.0.0"
   }
 }

--- a/workers/unity/Packages/io.improbable.gdk.tools/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "io.improbable.gdk.tools",
   "displayName": "SpatialOS GDK Tools",
-  "version": "0.3.3",
+  "version": "0.3.2",
   "unity": "2019.2",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Support Tools.",

--- a/workers/unity/Packages/io.improbable.gdk.transformsynchronization/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.transformsynchronization/package.json
@@ -1,12 +1,12 @@
 {
   "name": "io.improbable.gdk.transformsynchronization",
   "displayName": "SpatialOS GDK Transform Synchronization",
-  "version": "0.3.3",
+  "version": "0.3.2",
   "unity": "2019.2",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Transform Synchronization Module.",
   "dependencies": {
-    "io.improbable.gdk.core": "0.3.3",
-    "io.improbable.gdk.gameobjectcreation": "0.3.3"
+    "io.improbable.gdk.core": "0.3.2",
+    "io.improbable.gdk.gameobjectcreation": "0.3.2"
   }
 }

--- a/workers/unity/Packages/io.improbable.gdk.transformsynchronization2d/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.transformsynchronization2d/package.json
@@ -1,13 +1,13 @@
 {
   "name": "io.improbable.gdk.transformsynchronization2d",
   "displayName": "SpatialOS GDK Transform Synchronization 2D",
-  "version": "0.3.3",
+  "version": "0.3.2",
   "unity": "2019.2",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Transform Synchronization Module 2D.",
   "dependencies": {
-    "io.improbable.gdk.core": "0.3.3",
-    "io.improbable.gdk.transformsynchronization": "0.3.3",
+    "io.improbable.gdk.core": "0.3.2",
+    "io.improbable.gdk.transformsynchronization": "0.3.2",
     "com.unity.modules.physics2d": "1.0.0"
   }
 }

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/package.json
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/package.json
@@ -1,11 +1,11 @@
 {
   "name": "io.improbable.worker.sdk.mobile",
   "displayName": "SpatialOS Worker Mobile SDK",
-  "version": "0.3.3",
+  "version": "0.3.2",
   "unity": "2019.2",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS Worker Mobile SDK.",
   "dependencies": {
-    "io.improbable.worker.sdk": "0.3.3"
+    "io.improbable.worker.sdk": "0.3.2"
   }
 }

--- a/workers/unity/Packages/io.improbable.worker.sdk/package.json
+++ b/workers/unity/Packages/io.improbable.worker.sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "io.improbable.worker.sdk",
   "displayName": "SpatialOS Worker SDK",
-  "version": "0.3.3",
+  "version": "0.3.2",
   "unity": "2019.2",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS Worker SDK.",


### PR DESCRIPTION
Reverts spatialos/gdk-for-unity#1264, as we found a bug generating code when running QA on FPS