### PR TITLE
Fix CopyTemplate for downloaded package.

### DIFF
--- a/workers/unity/Packages/io.improbable.gdk.tools/GenerateCode.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/GenerateCode.cs
@@ -332,7 +332,10 @@ namespace Improbable.Gdk.Tools
 
             foreach (var file in dirInfo.GetFiles())
             {
-                file.CopyTo(Path.Combine(dest, file.Name));
+                var filePath = Path.Combine(dest, file.Name);
+                file.CopyTo(filePath);
+                var fileInfo = new FileInfo(filePath);
+                fileInfo.IsReadOnly = false;
             }
 
             foreach (var dir in dirInfo.GetDirectories())


### PR DESCRIPTION
Downloaded package files are all read-only, and copying the template files kept this attribute.
This made it impossible to alter the csproj for the generators.

All copied files are now read-write.
