### PR TITLE
Simplify components, step 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Added tests coverage for the interaction between unlinking a GameObject and Reader/Writer/CommandSender/CommandReceiver state. [#1295](https://github.com/spatialos/gdk-for-unity/pull/1295)
 - Reduce complexity in ViewDiff and MessagesToSend classes. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
 - De-duplicate code for generated ComponentDiffStorage instances. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
-- Improbable.Gdk.Core.EntityId is now a readonly struct. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
+- `Improbable.Gdk.Core.EntityId` is now a readonly struct. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
 
 ## `0.3.3` - 2020-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Added tests coverage for the interaction between unlinking a GameObject and Reader/Writer/CommandSender/CommandReceiver state. [#1295](https://github.com/spatialos/gdk-for-unity/pull/1295)
 - Reduce complexity in ViewDiff and MessagesToSend classes. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
 - De-duplicate code for generated ComponentDiffStorage instances. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
+- Improbable.Gdk.Core.EntityId is now a readonly struct. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
 
 ## `0.3.3` - 2020-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Running forced code generation now deletes the `ImprobableCodegen.marker` file. [#1294](https://github.com/spatialos/gdk-for-unity/pull/1294)
 - Added tests coverage for the interaction between unlinking a GameObject and Reader/Writer/CommandSender/CommandReceiver state. [#1295](https://github.com/spatialos/gdk-for-unity/pull/1295)
 - Reduce complexity in `ViewDiff` and `MessagesToSend` classes. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
-- De-duplicate code for generated `ComponentDiffStorage` instances. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
+- De-duplicated code for generated `ComponentDiffStorage` instances. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
 - `Improbable.Gdk.Core.EntityId` is now a readonly struct. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
 
 ## `0.3.3` - 2020-02-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 ### Internal
 
 - Ported all modules to the new `CodegenJob` model. [#1276](https://github.com/spatialos/gdk-for-unity/pull/1276)
+- Running forced code generation now deletes the `ImprobableCodegen.marker` file. [#1294](https://github.com/spatialos/gdk-for-unity/pull/1294)
+- Added tests coverage for the interaction between unlinking a GameObject and Reader/Writer/CommandSender/CommandReceiver state. [#1295](https://github.com/spatialos/gdk-for-unity/pull/1295)
 - Reduce complexity in ViewDiff and MessagesToSend classes. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
 - De-duplicate code for generated ComponentDiffStorage instances. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@
 - Ported all modules to the new `CodegenJob` model. [#1276](https://github.com/spatialos/gdk-for-unity/pull/1276)
 - Running forced code generation now deletes the `ImprobableCodegen.marker` file. [#1294](https://github.com/spatialos/gdk-for-unity/pull/1294)
 - Added tests coverage for the interaction between unlinking a GameObject and Reader/Writer/CommandSender/CommandReceiver state. [#1295](https://github.com/spatialos/gdk-for-unity/pull/1295)
-- Reduce complexity in ViewDiff and MessagesToSend classes. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
-- De-duplicate code for generated ComponentDiffStorage instances. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
+- Reduce complexity in `ViewDiff` and `MessagesToSend` classes. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
+- De-duplicate code for generated `ComponentDiffStorage` instances. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
 - `Improbable.Gdk.Core.EntityId` is now a readonly struct. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
 
 ## `0.3.3` - 2020-02-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@
 ### Internal
 
 - Ported all modules to the new `CodegenJob` model. [#1276](https://github.com/spatialos/gdk-for-unity/pull/1276)
-- Running forced code generation now deletes the `ImprobableCodegen.marker` file. [#1294](https://github.com/spatialos/gdk-for-unity/pull/1294)
-- Added tests coverage for the interaction between unlinking a GameObject and Reader/Writer/CommandSender/CommandReceiver state. [#1295](https://github.com/spatialos/gdk-for-unity/pull/1295)
+- Reduce complexity in ViewDiff and MessagesToSend classes. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
+- De-duplicate code for generated ComponentDiffStorage instances. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
 
 ## `0.3.3` - 2020-02-14
 

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentComponentComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentComponentComponentDiffStorage.cs
@@ -2,155 +2,24 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System.Collections.Generic;
 using System;
 using Improbable.Gdk.Core;
-using Improbable.Worker.CInterop;
 
 namespace Improbable.DependentSchema
 {
     public partial class DependentComponent
     {
-        public class DiffComponentStorage : IDiffUpdateStorage<Update>, IDiffComponentAddedStorage<Update>, IDiffAuthorityStorage
+        public class DiffComponentStorage : DiffComponentStorage<Update>
         {
-            private readonly HashSet<EntityId> entitiesUpdated = new HashSet<EntityId>();
-
-            private List<EntityId> componentsAdded = new List<EntityId>();
-            private List<EntityId> componentsRemoved = new List<EntityId>();
-
-            private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
-            private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
-
-            // Used to represent a state machine of authority changes. Valid state changes are:
-            // authority lost -> authority lost temporarily
-            // authority lost temporarily -> authority lost
-            // authority gained -> authority gained
-            // Creating the authority lost temporarily set is the aim as it signifies authority epoch changes
-            private readonly HashSet<EntityId> authorityLost = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityGained = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityLostTemporary = new HashSet<EntityId>();
-
-            private MessageList<ComponentUpdateReceived<Update>> updateStorage =
-                new MessageList<ComponentUpdateReceived<Update>>();
-
-            private MessageList<AuthorityChangeReceived> authorityChanges =
-                new MessageList<AuthorityChangeReceived>();
-
-            public Type[] GetEventTypes()
+            public override Type[] GetEventTypes()
             {
                 return new Type[]
                 {
                 };
             }
 
-            public Type GetUpdateType()
+            protected override void ClearEventStorage(long entityId)
             {
-                return typeof(Update);
-            }
-
-            public uint GetComponentId()
-            {
-                return ComponentId;
-            }
-
-            public void Clear()
-            {
-                entitiesUpdated.Clear();
-                updateStorage.Clear();
-                authorityChanges.Clear();
-                componentsAdded.Clear();
-                componentsRemoved.Clear();
-            }
-
-            public void RemoveEntityComponent(long entityId)
-            {
-                var id = new EntityId(entityId);
-
-                // Adding a component always updates it, so this will catch the case where the component was just added
-
-                if (entitiesUpdated.Remove(id))
-                {
-                    updateStorage.RemoveAll(update => update.EntityId.Id == entityId);
-                    authorityChanges.RemoveAll(change => change.EntityId.Id == entityId);
-                }
-
-                if (!componentsAdded.Remove(id))
-                {
-                    componentsRemoved.Add(id);
-                }
-            }
-
-            public void AddEntityComponent(long entityId, Update component)
-            {
-                var id = new EntityId(entityId);
-                if (!componentsRemoved.Remove(id))
-                {
-                    componentsAdded.Add(id);
-                }
-
-                AddUpdate(new ComponentUpdateReceived<Update>(component, id, 0));
-            }
-
-            public void AddUpdate(ComponentUpdateReceived<Update> update)
-            {
-                entitiesUpdated.Add(update.EntityId);
-                updateStorage.InsertSorted(update, updateComparer);
-            }
-
-            public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
-            {
-                if (authorityChange.Authority == Authority.NotAuthoritative)
-                {
-                    if (authorityLostTemporary.Remove(authorityChange.EntityId) || !authorityGained.Contains(authorityChange.EntityId))
-                    {
-                        authorityLost.Add(authorityChange.EntityId);
-                    }
-                }
-                else if (authorityChange.Authority == Authority.Authoritative)
-                {
-                    if (authorityLost.Remove(authorityChange.EntityId))
-                    {
-                        authorityLostTemporary.Add(authorityChange.EntityId);
-                    }
-                    else
-                    {
-                        authorityGained.Add(authorityChange.EntityId);
-                    }
-                }
-
-                authorityChanges.InsertSorted(authorityChange, authorityComparer);
-            }
-
-            public List<EntityId> GetComponentsAdded()
-            {
-                return componentsAdded;
-            }
-
-            public List<EntityId> GetComponentsRemoved()
-            {
-                return componentsRemoved;
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
-            {
-                return updateStorage.Slice();
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
-            {
-                var range = updateStorage.GetEntityRange(entityId);
-                return updateStorage.Slice(range.FirstIndex, range.Count);
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
-            {
-                return authorityChanges.Slice();
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
-            {
-                var range = authorityChanges.GetEntityRange(entityId);
-                return authorityChanges.Slice(range.FirstIndex, range.Count);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponentComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponentComponentDiffStorage.cs
@@ -2,48 +2,23 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System.Collections.Generic;
 using System;
 using Improbable.Gdk.Core;
-using Improbable.Worker.CInterop;
 
 namespace Improbable.DependentSchema
 {
     public partial class DependentDataComponent
     {
-        public class DiffComponentStorage : IDiffUpdateStorage<Update>, IDiffComponentAddedStorage<Update>, IDiffAuthorityStorage
+        public class DiffComponentStorage : DiffComponentStorage<Update>
             , IDiffEventStorage<FooEvent.Event>
         {
-            private readonly HashSet<EntityId> entitiesUpdated = new HashSet<EntityId>();
-
-            private List<EntityId> componentsAdded = new List<EntityId>();
-            private List<EntityId> componentsRemoved = new List<EntityId>();
-
-            private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
-            private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
-
-            // Used to represent a state machine of authority changes. Valid state changes are:
-            // authority lost -> authority lost temporarily
-            // authority lost temporarily -> authority lost
-            // authority gained -> authority gained
-            // Creating the authority lost temporarily set is the aim as it signifies authority epoch changes
-            private readonly HashSet<EntityId> authorityLost = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityGained = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityLostTemporary = new HashSet<EntityId>();
-
-            private MessageList<ComponentUpdateReceived<Update>> updateStorage =
-                new MessageList<ComponentUpdateReceived<Update>>();
-
-            private MessageList<AuthorityChangeReceived> authorityChanges =
-                new MessageList<AuthorityChangeReceived>();
-
             private MessageList<ComponentEventReceived<FooEvent.Event>> fooEventEventStorage =
                 new MessageList<ComponentEventReceived<FooEvent.Event>>();
 
             private readonly EventComparer<FooEvent.Event> fooEventComparer =
                 new EventComparer<FooEvent.Event>();
 
-            public Type[] GetEventTypes()
+            public override Type[] GetEventTypes()
             {
                 return new Type[]
                 {
@@ -51,124 +26,22 @@ namespace Improbable.DependentSchema
                 };
             }
 
-            public Type GetUpdateType()
+            public override void Clear()
             {
-                return typeof(Update);
-            }
-
-            public uint GetComponentId()
-            {
-                return ComponentId;
-            }
-
-            public void Clear()
-            {
-                entitiesUpdated.Clear();
-                updateStorage.Clear();
-                authorityChanges.Clear();
-                componentsAdded.Clear();
-                componentsRemoved.Clear();
+                base.Clear();
 
                 fooEventEventStorage.Clear();
             }
 
-            public void RemoveEntityComponent(long entityId)
+            protected override void ClearEventStorage(long entityId)
             {
-                var id = new EntityId(entityId);
-
-                // Adding a component always updates it, so this will catch the case where the component was just added
-
-                if (entitiesUpdated.Remove(id))
-                {
-                    updateStorage.RemoveAll(update => update.EntityId.Id == entityId);
-                    authorityChanges.RemoveAll(change => change.EntityId.Id == entityId);
-
-                    fooEventEventStorage.RemoveAll(change => change.EntityId.Id == entityId);
-                }
-
-                if (!componentsAdded.Remove(id))
-                {
-                    componentsRemoved.Add(id);
-                }
-            }
-
-            public void AddEntityComponent(long entityId, Update component)
-            {
-                var id = new EntityId(entityId);
-                if (!componentsRemoved.Remove(id))
-                {
-                    componentsAdded.Add(id);
-                }
-
-                AddUpdate(new ComponentUpdateReceived<Update>(component, id, 0));
-            }
-
-            public void AddUpdate(ComponentUpdateReceived<Update> update)
-            {
-                entitiesUpdated.Add(update.EntityId);
-                updateStorage.InsertSorted(update, updateComparer);
-            }
-
-            public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
-            {
-                if (authorityChange.Authority == Authority.NotAuthoritative)
-                {
-                    if (authorityLostTemporary.Remove(authorityChange.EntityId) || !authorityGained.Contains(authorityChange.EntityId))
-                    {
-                        authorityLost.Add(authorityChange.EntityId);
-                    }
-                }
-                else if (authorityChange.Authority == Authority.Authoritative)
-                {
-                    if (authorityLost.Remove(authorityChange.EntityId))
-                    {
-                        authorityLostTemporary.Add(authorityChange.EntityId);
-                    }
-                    else
-                    {
-                        authorityGained.Add(authorityChange.EntityId);
-                    }
-                }
-
-                authorityChanges.InsertSorted(authorityChange, authorityComparer);
-            }
-
-            public List<EntityId> GetComponentsAdded()
-            {
-                return componentsAdded;
-            }
-
-            public List<EntityId> GetComponentsRemoved()
-            {
-                return componentsRemoved;
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
-            {
-                return updateStorage.Slice();
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
-            {
-                var range = updateStorage.GetEntityRange(entityId);
-                return updateStorage.Slice(range.FirstIndex, range.Count);
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
-            {
-                return authorityChanges.Slice();
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
-            {
-                var range = authorityChanges.GetEntityRange(entityId);
-                return authorityChanges.Slice(range.FirstIndex, range.Count);
+                fooEventEventStorage.RemoveAll(change => change.EntityId.Id == entityId);
             }
 
             MessagesSpan<ComponentEventReceived<FooEvent.Event>> IDiffEventStorage<FooEvent.Event>.GetEvents(EntityId entityId)
             {
-                var range = fooEventEventStorage.GetEntityRange(entityId);
-                return fooEventEventStorage.Slice(range.FirstIndex, range.Count);
+                var (firstIndex, count) = fooEventEventStorage.GetEntityRange(entityId);
+                return fooEventEventStorage.Slice(firstIndex, count);
             }
 
             MessagesSpan<ComponentEventReceived<FooEvent.Event>> IDiffEventStorage<FooEvent.Event>.GetEvents()

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestChildComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestChildComponentDiffStorage.cs
@@ -2,155 +2,24 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System.Collections.Generic;
 using System;
 using Improbable.Gdk.Core;
-using Improbable.Worker.CInterop;
 
 namespace Improbable.Tests
 {
     public partial class DependencyTestChild
     {
-        public class DiffComponentStorage : IDiffUpdateStorage<Update>, IDiffComponentAddedStorage<Update>, IDiffAuthorityStorage
+        public class DiffComponentStorage : DiffComponentStorage<Update>
         {
-            private readonly HashSet<EntityId> entitiesUpdated = new HashSet<EntityId>();
-
-            private List<EntityId> componentsAdded = new List<EntityId>();
-            private List<EntityId> componentsRemoved = new List<EntityId>();
-
-            private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
-            private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
-
-            // Used to represent a state machine of authority changes. Valid state changes are:
-            // authority lost -> authority lost temporarily
-            // authority lost temporarily -> authority lost
-            // authority gained -> authority gained
-            // Creating the authority lost temporarily set is the aim as it signifies authority epoch changes
-            private readonly HashSet<EntityId> authorityLost = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityGained = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityLostTemporary = new HashSet<EntityId>();
-
-            private MessageList<ComponentUpdateReceived<Update>> updateStorage =
-                new MessageList<ComponentUpdateReceived<Update>>();
-
-            private MessageList<AuthorityChangeReceived> authorityChanges =
-                new MessageList<AuthorityChangeReceived>();
-
-            public Type[] GetEventTypes()
+            public override Type[] GetEventTypes()
             {
                 return new Type[]
                 {
                 };
             }
 
-            public Type GetUpdateType()
+            protected override void ClearEventStorage(long entityId)
             {
-                return typeof(Update);
-            }
-
-            public uint GetComponentId()
-            {
-                return ComponentId;
-            }
-
-            public void Clear()
-            {
-                entitiesUpdated.Clear();
-                updateStorage.Clear();
-                authorityChanges.Clear();
-                componentsAdded.Clear();
-                componentsRemoved.Clear();
-            }
-
-            public void RemoveEntityComponent(long entityId)
-            {
-                var id = new EntityId(entityId);
-
-                // Adding a component always updates it, so this will catch the case where the component was just added
-
-                if (entitiesUpdated.Remove(id))
-                {
-                    updateStorage.RemoveAll(update => update.EntityId.Id == entityId);
-                    authorityChanges.RemoveAll(change => change.EntityId.Id == entityId);
-                }
-
-                if (!componentsAdded.Remove(id))
-                {
-                    componentsRemoved.Add(id);
-                }
-            }
-
-            public void AddEntityComponent(long entityId, Update component)
-            {
-                var id = new EntityId(entityId);
-                if (!componentsRemoved.Remove(id))
-                {
-                    componentsAdded.Add(id);
-                }
-
-                AddUpdate(new ComponentUpdateReceived<Update>(component, id, 0));
-            }
-
-            public void AddUpdate(ComponentUpdateReceived<Update> update)
-            {
-                entitiesUpdated.Add(update.EntityId);
-                updateStorage.InsertSorted(update, updateComparer);
-            }
-
-            public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
-            {
-                if (authorityChange.Authority == Authority.NotAuthoritative)
-                {
-                    if (authorityLostTemporary.Remove(authorityChange.EntityId) || !authorityGained.Contains(authorityChange.EntityId))
-                    {
-                        authorityLost.Add(authorityChange.EntityId);
-                    }
-                }
-                else if (authorityChange.Authority == Authority.Authoritative)
-                {
-                    if (authorityLost.Remove(authorityChange.EntityId))
-                    {
-                        authorityLostTemporary.Add(authorityChange.EntityId);
-                    }
-                    else
-                    {
-                        authorityGained.Add(authorityChange.EntityId);
-                    }
-                }
-
-                authorityChanges.InsertSorted(authorityChange, authorityComparer);
-            }
-
-            public List<EntityId> GetComponentsAdded()
-            {
-                return componentsAdded;
-            }
-
-            public List<EntityId> GetComponentsRemoved()
-            {
-                return componentsRemoved;
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
-            {
-                return updateStorage.Slice();
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
-            {
-                var range = updateStorage.GetEntityRange(entityId);
-                return updateStorage.Slice(range.FirstIndex, range.Count);
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
-            {
-                return authorityChanges.Slice();
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
-            {
-                var range = authorityChanges.GetEntityRange(entityId);
-                return authorityChanges.Slice(range.FirstIndex, range.Count);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestComponentDiffStorage.cs
@@ -2,155 +2,24 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System.Collections.Generic;
 using System;
 using Improbable.Gdk.Core;
-using Improbable.Worker.CInterop;
 
 namespace Improbable.Tests
 {
     public partial class DependencyTest
     {
-        public class DiffComponentStorage : IDiffUpdateStorage<Update>, IDiffComponentAddedStorage<Update>, IDiffAuthorityStorage
+        public class DiffComponentStorage : DiffComponentStorage<Update>
         {
-            private readonly HashSet<EntityId> entitiesUpdated = new HashSet<EntityId>();
-
-            private List<EntityId> componentsAdded = new List<EntityId>();
-            private List<EntityId> componentsRemoved = new List<EntityId>();
-
-            private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
-            private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
-
-            // Used to represent a state machine of authority changes. Valid state changes are:
-            // authority lost -> authority lost temporarily
-            // authority lost temporarily -> authority lost
-            // authority gained -> authority gained
-            // Creating the authority lost temporarily set is the aim as it signifies authority epoch changes
-            private readonly HashSet<EntityId> authorityLost = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityGained = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityLostTemporary = new HashSet<EntityId>();
-
-            private MessageList<ComponentUpdateReceived<Update>> updateStorage =
-                new MessageList<ComponentUpdateReceived<Update>>();
-
-            private MessageList<AuthorityChangeReceived> authorityChanges =
-                new MessageList<AuthorityChangeReceived>();
-
-            public Type[] GetEventTypes()
+            public override Type[] GetEventTypes()
             {
                 return new Type[]
                 {
                 };
             }
 
-            public Type GetUpdateType()
+            protected override void ClearEventStorage(long entityId)
             {
-                return typeof(Update);
-            }
-
-            public uint GetComponentId()
-            {
-                return ComponentId;
-            }
-
-            public void Clear()
-            {
-                entitiesUpdated.Clear();
-                updateStorage.Clear();
-                authorityChanges.Clear();
-                componentsAdded.Clear();
-                componentsRemoved.Clear();
-            }
-
-            public void RemoveEntityComponent(long entityId)
-            {
-                var id = new EntityId(entityId);
-
-                // Adding a component always updates it, so this will catch the case where the component was just added
-
-                if (entitiesUpdated.Remove(id))
-                {
-                    updateStorage.RemoveAll(update => update.EntityId.Id == entityId);
-                    authorityChanges.RemoveAll(change => change.EntityId.Id == entityId);
-                }
-
-                if (!componentsAdded.Remove(id))
-                {
-                    componentsRemoved.Add(id);
-                }
-            }
-
-            public void AddEntityComponent(long entityId, Update component)
-            {
-                var id = new EntityId(entityId);
-                if (!componentsRemoved.Remove(id))
-                {
-                    componentsAdded.Add(id);
-                }
-
-                AddUpdate(new ComponentUpdateReceived<Update>(component, id, 0));
-            }
-
-            public void AddUpdate(ComponentUpdateReceived<Update> update)
-            {
-                entitiesUpdated.Add(update.EntityId);
-                updateStorage.InsertSorted(update, updateComparer);
-            }
-
-            public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
-            {
-                if (authorityChange.Authority == Authority.NotAuthoritative)
-                {
-                    if (authorityLostTemporary.Remove(authorityChange.EntityId) || !authorityGained.Contains(authorityChange.EntityId))
-                    {
-                        authorityLost.Add(authorityChange.EntityId);
-                    }
-                }
-                else if (authorityChange.Authority == Authority.Authoritative)
-                {
-                    if (authorityLost.Remove(authorityChange.EntityId))
-                    {
-                        authorityLostTemporary.Add(authorityChange.EntityId);
-                    }
-                    else
-                    {
-                        authorityGained.Add(authorityChange.EntityId);
-                    }
-                }
-
-                authorityChanges.InsertSorted(authorityChange, authorityComparer);
-            }
-
-            public List<EntityId> GetComponentsAdded()
-            {
-                return componentsAdded;
-            }
-
-            public List<EntityId> GetComponentsRemoved()
-            {
-                return componentsRemoved;
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
-            {
-                return updateStorage.Slice();
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
-            {
-                var range = updateStorage.GetEntityRange(entityId);
-                return updateStorage.Slice(range.FirstIndex, range.Count);
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
-            {
-                return authorityChanges.Slice();
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
-            {
-                var range = authorityChanges.GetEntityRange(entityId);
-                return authorityChanges.Slice(range.FirstIndex, range.Count);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestGrandchildComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestGrandchildComponentDiffStorage.cs
@@ -2,155 +2,24 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System.Collections.Generic;
 using System;
 using Improbable.Gdk.Core;
-using Improbable.Worker.CInterop;
 
 namespace Improbable.Tests
 {
     public partial class DependencyTestGrandchild
     {
-        public class DiffComponentStorage : IDiffUpdateStorage<Update>, IDiffComponentAddedStorage<Update>, IDiffAuthorityStorage
+        public class DiffComponentStorage : DiffComponentStorage<Update>
         {
-            private readonly HashSet<EntityId> entitiesUpdated = new HashSet<EntityId>();
-
-            private List<EntityId> componentsAdded = new List<EntityId>();
-            private List<EntityId> componentsRemoved = new List<EntityId>();
-
-            private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
-            private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
-
-            // Used to represent a state machine of authority changes. Valid state changes are:
-            // authority lost -> authority lost temporarily
-            // authority lost temporarily -> authority lost
-            // authority gained -> authority gained
-            // Creating the authority lost temporarily set is the aim as it signifies authority epoch changes
-            private readonly HashSet<EntityId> authorityLost = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityGained = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityLostTemporary = new HashSet<EntityId>();
-
-            private MessageList<ComponentUpdateReceived<Update>> updateStorage =
-                new MessageList<ComponentUpdateReceived<Update>>();
-
-            private MessageList<AuthorityChangeReceived> authorityChanges =
-                new MessageList<AuthorityChangeReceived>();
-
-            public Type[] GetEventTypes()
+            public override Type[] GetEventTypes()
             {
                 return new Type[]
                 {
                 };
             }
 
-            public Type GetUpdateType()
+            protected override void ClearEventStorage(long entityId)
             {
-                return typeof(Update);
-            }
-
-            public uint GetComponentId()
-            {
-                return ComponentId;
-            }
-
-            public void Clear()
-            {
-                entitiesUpdated.Clear();
-                updateStorage.Clear();
-                authorityChanges.Clear();
-                componentsAdded.Clear();
-                componentsRemoved.Clear();
-            }
-
-            public void RemoveEntityComponent(long entityId)
-            {
-                var id = new EntityId(entityId);
-
-                // Adding a component always updates it, so this will catch the case where the component was just added
-
-                if (entitiesUpdated.Remove(id))
-                {
-                    updateStorage.RemoveAll(update => update.EntityId.Id == entityId);
-                    authorityChanges.RemoveAll(change => change.EntityId.Id == entityId);
-                }
-
-                if (!componentsAdded.Remove(id))
-                {
-                    componentsRemoved.Add(id);
-                }
-            }
-
-            public void AddEntityComponent(long entityId, Update component)
-            {
-                var id = new EntityId(entityId);
-                if (!componentsRemoved.Remove(id))
-                {
-                    componentsAdded.Add(id);
-                }
-
-                AddUpdate(new ComponentUpdateReceived<Update>(component, id, 0));
-            }
-
-            public void AddUpdate(ComponentUpdateReceived<Update> update)
-            {
-                entitiesUpdated.Add(update.EntityId);
-                updateStorage.InsertSorted(update, updateComparer);
-            }
-
-            public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
-            {
-                if (authorityChange.Authority == Authority.NotAuthoritative)
-                {
-                    if (authorityLostTemporary.Remove(authorityChange.EntityId) || !authorityGained.Contains(authorityChange.EntityId))
-                    {
-                        authorityLost.Add(authorityChange.EntityId);
-                    }
-                }
-                else if (authorityChange.Authority == Authority.Authoritative)
-                {
-                    if (authorityLost.Remove(authorityChange.EntityId))
-                    {
-                        authorityLostTemporary.Add(authorityChange.EntityId);
-                    }
-                    else
-                    {
-                        authorityGained.Add(authorityChange.EntityId);
-                    }
-                }
-
-                authorityChanges.InsertSorted(authorityChange, authorityComparer);
-            }
-
-            public List<EntityId> GetComponentsAdded()
-            {
-                return componentsAdded;
-            }
-
-            public List<EntityId> GetComponentsRemoved()
-            {
-                return componentsRemoved;
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
-            {
-                return updateStorage.Slice();
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
-            {
-                var range = updateStorage.GetEntityRange(entityId);
-                return updateStorage.Slice(range.FirstIndex, range.Count);
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
-            {
-                return authorityChanges.Slice();
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
-            {
-                var range = authorityChanges.GetEntityRange(entityId);
-                return authorityChanges.Slice(range.FirstIndex, range.Count);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/ComponentUsingNestedTypeSameNameComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ComponentUsingNestedTypeSameNameComponentDiffStorage.cs
@@ -2,155 +2,24 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System.Collections.Generic;
 using System;
 using Improbable.Gdk.Core;
-using Improbable.Worker.CInterop;
 
 namespace Improbable.TestSchema
 {
     public partial class ComponentUsingNestedTypeSameName
     {
-        public class DiffComponentStorage : IDiffUpdateStorage<Update>, IDiffComponentAddedStorage<Update>, IDiffAuthorityStorage
+        public class DiffComponentStorage : DiffComponentStorage<Update>
         {
-            private readonly HashSet<EntityId> entitiesUpdated = new HashSet<EntityId>();
-
-            private List<EntityId> componentsAdded = new List<EntityId>();
-            private List<EntityId> componentsRemoved = new List<EntityId>();
-
-            private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
-            private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
-
-            // Used to represent a state machine of authority changes. Valid state changes are:
-            // authority lost -> authority lost temporarily
-            // authority lost temporarily -> authority lost
-            // authority gained -> authority gained
-            // Creating the authority lost temporarily set is the aim as it signifies authority epoch changes
-            private readonly HashSet<EntityId> authorityLost = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityGained = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityLostTemporary = new HashSet<EntityId>();
-
-            private MessageList<ComponentUpdateReceived<Update>> updateStorage =
-                new MessageList<ComponentUpdateReceived<Update>>();
-
-            private MessageList<AuthorityChangeReceived> authorityChanges =
-                new MessageList<AuthorityChangeReceived>();
-
-            public Type[] GetEventTypes()
+            public override Type[] GetEventTypes()
             {
                 return new Type[]
                 {
                 };
             }
 
-            public Type GetUpdateType()
+            protected override void ClearEventStorage(long entityId)
             {
-                return typeof(Update);
-            }
-
-            public uint GetComponentId()
-            {
-                return ComponentId;
-            }
-
-            public void Clear()
-            {
-                entitiesUpdated.Clear();
-                updateStorage.Clear();
-                authorityChanges.Clear();
-                componentsAdded.Clear();
-                componentsRemoved.Clear();
-            }
-
-            public void RemoveEntityComponent(long entityId)
-            {
-                var id = new EntityId(entityId);
-
-                // Adding a component always updates it, so this will catch the case where the component was just added
-
-                if (entitiesUpdated.Remove(id))
-                {
-                    updateStorage.RemoveAll(update => update.EntityId.Id == entityId);
-                    authorityChanges.RemoveAll(change => change.EntityId.Id == entityId);
-                }
-
-                if (!componentsAdded.Remove(id))
-                {
-                    componentsRemoved.Add(id);
-                }
-            }
-
-            public void AddEntityComponent(long entityId, Update component)
-            {
-                var id = new EntityId(entityId);
-                if (!componentsRemoved.Remove(id))
-                {
-                    componentsAdded.Add(id);
-                }
-
-                AddUpdate(new ComponentUpdateReceived<Update>(component, id, 0));
-            }
-
-            public void AddUpdate(ComponentUpdateReceived<Update> update)
-            {
-                entitiesUpdated.Add(update.EntityId);
-                updateStorage.InsertSorted(update, updateComparer);
-            }
-
-            public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
-            {
-                if (authorityChange.Authority == Authority.NotAuthoritative)
-                {
-                    if (authorityLostTemporary.Remove(authorityChange.EntityId) || !authorityGained.Contains(authorityChange.EntityId))
-                    {
-                        authorityLost.Add(authorityChange.EntityId);
-                    }
-                }
-                else if (authorityChange.Authority == Authority.Authoritative)
-                {
-                    if (authorityLost.Remove(authorityChange.EntityId))
-                    {
-                        authorityLostTemporary.Add(authorityChange.EntityId);
-                    }
-                    else
-                    {
-                        authorityGained.Add(authorityChange.EntityId);
-                    }
-                }
-
-                authorityChanges.InsertSorted(authorityChange, authorityComparer);
-            }
-
-            public List<EntityId> GetComponentsAdded()
-            {
-                return componentsAdded;
-            }
-
-            public List<EntityId> GetComponentsRemoved()
-            {
-                return componentsRemoved;
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
-            {
-                return updateStorage.Slice();
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
-            {
-                var range = updateStorage.GetEntityRange(entityId);
-                return updateStorage.Slice(range.FirstIndex, range.Count);
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
-            {
-                return authorityChanges.Slice();
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
-            {
-                var range = authorityChanges.GetEntityRange(entityId);
-                return authorityChanges.Slice(range.FirstIndex, range.Count);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveEntityComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveEntityComponentDiffStorage.cs
@@ -2,155 +2,24 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System.Collections.Generic;
 using System;
 using Improbable.Gdk.Core;
-using Improbable.Worker.CInterop;
 
 namespace Improbable.TestSchema
 {
     public partial class ExhaustiveEntity
     {
-        public class DiffComponentStorage : IDiffUpdateStorage<Update>, IDiffComponentAddedStorage<Update>, IDiffAuthorityStorage
+        public class DiffComponentStorage : DiffComponentStorage<Update>
         {
-            private readonly HashSet<EntityId> entitiesUpdated = new HashSet<EntityId>();
-
-            private List<EntityId> componentsAdded = new List<EntityId>();
-            private List<EntityId> componentsRemoved = new List<EntityId>();
-
-            private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
-            private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
-
-            // Used to represent a state machine of authority changes. Valid state changes are:
-            // authority lost -> authority lost temporarily
-            // authority lost temporarily -> authority lost
-            // authority gained -> authority gained
-            // Creating the authority lost temporarily set is the aim as it signifies authority epoch changes
-            private readonly HashSet<EntityId> authorityLost = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityGained = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityLostTemporary = new HashSet<EntityId>();
-
-            private MessageList<ComponentUpdateReceived<Update>> updateStorage =
-                new MessageList<ComponentUpdateReceived<Update>>();
-
-            private MessageList<AuthorityChangeReceived> authorityChanges =
-                new MessageList<AuthorityChangeReceived>();
-
-            public Type[] GetEventTypes()
+            public override Type[] GetEventTypes()
             {
                 return new Type[]
                 {
                 };
             }
 
-            public Type GetUpdateType()
+            protected override void ClearEventStorage(long entityId)
             {
-                return typeof(Update);
-            }
-
-            public uint GetComponentId()
-            {
-                return ComponentId;
-            }
-
-            public void Clear()
-            {
-                entitiesUpdated.Clear();
-                updateStorage.Clear();
-                authorityChanges.Clear();
-                componentsAdded.Clear();
-                componentsRemoved.Clear();
-            }
-
-            public void RemoveEntityComponent(long entityId)
-            {
-                var id = new EntityId(entityId);
-
-                // Adding a component always updates it, so this will catch the case where the component was just added
-
-                if (entitiesUpdated.Remove(id))
-                {
-                    updateStorage.RemoveAll(update => update.EntityId.Id == entityId);
-                    authorityChanges.RemoveAll(change => change.EntityId.Id == entityId);
-                }
-
-                if (!componentsAdded.Remove(id))
-                {
-                    componentsRemoved.Add(id);
-                }
-            }
-
-            public void AddEntityComponent(long entityId, Update component)
-            {
-                var id = new EntityId(entityId);
-                if (!componentsRemoved.Remove(id))
-                {
-                    componentsAdded.Add(id);
-                }
-
-                AddUpdate(new ComponentUpdateReceived<Update>(component, id, 0));
-            }
-
-            public void AddUpdate(ComponentUpdateReceived<Update> update)
-            {
-                entitiesUpdated.Add(update.EntityId);
-                updateStorage.InsertSorted(update, updateComparer);
-            }
-
-            public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
-            {
-                if (authorityChange.Authority == Authority.NotAuthoritative)
-                {
-                    if (authorityLostTemporary.Remove(authorityChange.EntityId) || !authorityGained.Contains(authorityChange.EntityId))
-                    {
-                        authorityLost.Add(authorityChange.EntityId);
-                    }
-                }
-                else if (authorityChange.Authority == Authority.Authoritative)
-                {
-                    if (authorityLost.Remove(authorityChange.EntityId))
-                    {
-                        authorityLostTemporary.Add(authorityChange.EntityId);
-                    }
-                    else
-                    {
-                        authorityGained.Add(authorityChange.EntityId);
-                    }
-                }
-
-                authorityChanges.InsertSorted(authorityChange, authorityComparer);
-            }
-
-            public List<EntityId> GetComponentsAdded()
-            {
-                return componentsAdded;
-            }
-
-            public List<EntityId> GetComponentsRemoved()
-            {
-                return componentsRemoved;
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
-            {
-                return updateStorage.Slice();
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
-            {
-                var range = updateStorage.GetEntityRange(entityId);
-                return updateStorage.Slice(range.FirstIndex, range.Count);
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
-            {
-                return authorityChanges.Slice();
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
-            {
-                var range = authorityChanges.GetEntityRange(entityId);
-                return authorityChanges.Slice(range.FirstIndex, range.Count);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapKeyComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapKeyComponentDiffStorage.cs
@@ -2,155 +2,24 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System.Collections.Generic;
 using System;
 using Improbable.Gdk.Core;
-using Improbable.Worker.CInterop;
 
 namespace Improbable.TestSchema
 {
     public partial class ExhaustiveMapKey
     {
-        public class DiffComponentStorage : IDiffUpdateStorage<Update>, IDiffComponentAddedStorage<Update>, IDiffAuthorityStorage
+        public class DiffComponentStorage : DiffComponentStorage<Update>
         {
-            private readonly HashSet<EntityId> entitiesUpdated = new HashSet<EntityId>();
-
-            private List<EntityId> componentsAdded = new List<EntityId>();
-            private List<EntityId> componentsRemoved = new List<EntityId>();
-
-            private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
-            private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
-
-            // Used to represent a state machine of authority changes. Valid state changes are:
-            // authority lost -> authority lost temporarily
-            // authority lost temporarily -> authority lost
-            // authority gained -> authority gained
-            // Creating the authority lost temporarily set is the aim as it signifies authority epoch changes
-            private readonly HashSet<EntityId> authorityLost = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityGained = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityLostTemporary = new HashSet<EntityId>();
-
-            private MessageList<ComponentUpdateReceived<Update>> updateStorage =
-                new MessageList<ComponentUpdateReceived<Update>>();
-
-            private MessageList<AuthorityChangeReceived> authorityChanges =
-                new MessageList<AuthorityChangeReceived>();
-
-            public Type[] GetEventTypes()
+            public override Type[] GetEventTypes()
             {
                 return new Type[]
                 {
                 };
             }
 
-            public Type GetUpdateType()
+            protected override void ClearEventStorage(long entityId)
             {
-                return typeof(Update);
-            }
-
-            public uint GetComponentId()
-            {
-                return ComponentId;
-            }
-
-            public void Clear()
-            {
-                entitiesUpdated.Clear();
-                updateStorage.Clear();
-                authorityChanges.Clear();
-                componentsAdded.Clear();
-                componentsRemoved.Clear();
-            }
-
-            public void RemoveEntityComponent(long entityId)
-            {
-                var id = new EntityId(entityId);
-
-                // Adding a component always updates it, so this will catch the case where the component was just added
-
-                if (entitiesUpdated.Remove(id))
-                {
-                    updateStorage.RemoveAll(update => update.EntityId.Id == entityId);
-                    authorityChanges.RemoveAll(change => change.EntityId.Id == entityId);
-                }
-
-                if (!componentsAdded.Remove(id))
-                {
-                    componentsRemoved.Add(id);
-                }
-            }
-
-            public void AddEntityComponent(long entityId, Update component)
-            {
-                var id = new EntityId(entityId);
-                if (!componentsRemoved.Remove(id))
-                {
-                    componentsAdded.Add(id);
-                }
-
-                AddUpdate(new ComponentUpdateReceived<Update>(component, id, 0));
-            }
-
-            public void AddUpdate(ComponentUpdateReceived<Update> update)
-            {
-                entitiesUpdated.Add(update.EntityId);
-                updateStorage.InsertSorted(update, updateComparer);
-            }
-
-            public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
-            {
-                if (authorityChange.Authority == Authority.NotAuthoritative)
-                {
-                    if (authorityLostTemporary.Remove(authorityChange.EntityId) || !authorityGained.Contains(authorityChange.EntityId))
-                    {
-                        authorityLost.Add(authorityChange.EntityId);
-                    }
-                }
-                else if (authorityChange.Authority == Authority.Authoritative)
-                {
-                    if (authorityLost.Remove(authorityChange.EntityId))
-                    {
-                        authorityLostTemporary.Add(authorityChange.EntityId);
-                    }
-                    else
-                    {
-                        authorityGained.Add(authorityChange.EntityId);
-                    }
-                }
-
-                authorityChanges.InsertSorted(authorityChange, authorityComparer);
-            }
-
-            public List<EntityId> GetComponentsAdded()
-            {
-                return componentsAdded;
-            }
-
-            public List<EntityId> GetComponentsRemoved()
-            {
-                return componentsRemoved;
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
-            {
-                return updateStorage.Slice();
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
-            {
-                var range = updateStorage.GetEntityRange(entityId);
-                return updateStorage.Slice(range.FirstIndex, range.Count);
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
-            {
-                return authorityChanges.Slice();
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
-            {
-                var range = authorityChanges.GetEntityRange(entityId);
-                return authorityChanges.Slice(range.FirstIndex, range.Count);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapValueComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapValueComponentDiffStorage.cs
@@ -2,155 +2,24 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System.Collections.Generic;
 using System;
 using Improbable.Gdk.Core;
-using Improbable.Worker.CInterop;
 
 namespace Improbable.TestSchema
 {
     public partial class ExhaustiveMapValue
     {
-        public class DiffComponentStorage : IDiffUpdateStorage<Update>, IDiffComponentAddedStorage<Update>, IDiffAuthorityStorage
+        public class DiffComponentStorage : DiffComponentStorage<Update>
         {
-            private readonly HashSet<EntityId> entitiesUpdated = new HashSet<EntityId>();
-
-            private List<EntityId> componentsAdded = new List<EntityId>();
-            private List<EntityId> componentsRemoved = new List<EntityId>();
-
-            private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
-            private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
-
-            // Used to represent a state machine of authority changes. Valid state changes are:
-            // authority lost -> authority lost temporarily
-            // authority lost temporarily -> authority lost
-            // authority gained -> authority gained
-            // Creating the authority lost temporarily set is the aim as it signifies authority epoch changes
-            private readonly HashSet<EntityId> authorityLost = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityGained = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityLostTemporary = new HashSet<EntityId>();
-
-            private MessageList<ComponentUpdateReceived<Update>> updateStorage =
-                new MessageList<ComponentUpdateReceived<Update>>();
-
-            private MessageList<AuthorityChangeReceived> authorityChanges =
-                new MessageList<AuthorityChangeReceived>();
-
-            public Type[] GetEventTypes()
+            public override Type[] GetEventTypes()
             {
                 return new Type[]
                 {
                 };
             }
 
-            public Type GetUpdateType()
+            protected override void ClearEventStorage(long entityId)
             {
-                return typeof(Update);
-            }
-
-            public uint GetComponentId()
-            {
-                return ComponentId;
-            }
-
-            public void Clear()
-            {
-                entitiesUpdated.Clear();
-                updateStorage.Clear();
-                authorityChanges.Clear();
-                componentsAdded.Clear();
-                componentsRemoved.Clear();
-            }
-
-            public void RemoveEntityComponent(long entityId)
-            {
-                var id = new EntityId(entityId);
-
-                // Adding a component always updates it, so this will catch the case where the component was just added
-
-                if (entitiesUpdated.Remove(id))
-                {
-                    updateStorage.RemoveAll(update => update.EntityId.Id == entityId);
-                    authorityChanges.RemoveAll(change => change.EntityId.Id == entityId);
-                }
-
-                if (!componentsAdded.Remove(id))
-                {
-                    componentsRemoved.Add(id);
-                }
-            }
-
-            public void AddEntityComponent(long entityId, Update component)
-            {
-                var id = new EntityId(entityId);
-                if (!componentsRemoved.Remove(id))
-                {
-                    componentsAdded.Add(id);
-                }
-
-                AddUpdate(new ComponentUpdateReceived<Update>(component, id, 0));
-            }
-
-            public void AddUpdate(ComponentUpdateReceived<Update> update)
-            {
-                entitiesUpdated.Add(update.EntityId);
-                updateStorage.InsertSorted(update, updateComparer);
-            }
-
-            public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
-            {
-                if (authorityChange.Authority == Authority.NotAuthoritative)
-                {
-                    if (authorityLostTemporary.Remove(authorityChange.EntityId) || !authorityGained.Contains(authorityChange.EntityId))
-                    {
-                        authorityLost.Add(authorityChange.EntityId);
-                    }
-                }
-                else if (authorityChange.Authority == Authority.Authoritative)
-                {
-                    if (authorityLost.Remove(authorityChange.EntityId))
-                    {
-                        authorityLostTemporary.Add(authorityChange.EntityId);
-                    }
-                    else
-                    {
-                        authorityGained.Add(authorityChange.EntityId);
-                    }
-                }
-
-                authorityChanges.InsertSorted(authorityChange, authorityComparer);
-            }
-
-            public List<EntityId> GetComponentsAdded()
-            {
-                return componentsAdded;
-            }
-
-            public List<EntityId> GetComponentsRemoved()
-            {
-                return componentsRemoved;
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
-            {
-                return updateStorage.Slice();
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
-            {
-                var range = updateStorage.GetEntityRange(entityId);
-                return updateStorage.Slice(range.FirstIndex, range.Count);
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
-            {
-                return authorityChanges.Slice();
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
-            {
-                var range = authorityChanges.GetEntityRange(entityId);
-                return authorityChanges.Slice(range.FirstIndex, range.Count);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveOptionalComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveOptionalComponentDiffStorage.cs
@@ -2,155 +2,24 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System.Collections.Generic;
 using System;
 using Improbable.Gdk.Core;
-using Improbable.Worker.CInterop;
 
 namespace Improbable.TestSchema
 {
     public partial class ExhaustiveOptional
     {
-        public class DiffComponentStorage : IDiffUpdateStorage<Update>, IDiffComponentAddedStorage<Update>, IDiffAuthorityStorage
+        public class DiffComponentStorage : DiffComponentStorage<Update>
         {
-            private readonly HashSet<EntityId> entitiesUpdated = new HashSet<EntityId>();
-
-            private List<EntityId> componentsAdded = new List<EntityId>();
-            private List<EntityId> componentsRemoved = new List<EntityId>();
-
-            private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
-            private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
-
-            // Used to represent a state machine of authority changes. Valid state changes are:
-            // authority lost -> authority lost temporarily
-            // authority lost temporarily -> authority lost
-            // authority gained -> authority gained
-            // Creating the authority lost temporarily set is the aim as it signifies authority epoch changes
-            private readonly HashSet<EntityId> authorityLost = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityGained = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityLostTemporary = new HashSet<EntityId>();
-
-            private MessageList<ComponentUpdateReceived<Update>> updateStorage =
-                new MessageList<ComponentUpdateReceived<Update>>();
-
-            private MessageList<AuthorityChangeReceived> authorityChanges =
-                new MessageList<AuthorityChangeReceived>();
-
-            public Type[] GetEventTypes()
+            public override Type[] GetEventTypes()
             {
                 return new Type[]
                 {
                 };
             }
 
-            public Type GetUpdateType()
+            protected override void ClearEventStorage(long entityId)
             {
-                return typeof(Update);
-            }
-
-            public uint GetComponentId()
-            {
-                return ComponentId;
-            }
-
-            public void Clear()
-            {
-                entitiesUpdated.Clear();
-                updateStorage.Clear();
-                authorityChanges.Clear();
-                componentsAdded.Clear();
-                componentsRemoved.Clear();
-            }
-
-            public void RemoveEntityComponent(long entityId)
-            {
-                var id = new EntityId(entityId);
-
-                // Adding a component always updates it, so this will catch the case where the component was just added
-
-                if (entitiesUpdated.Remove(id))
-                {
-                    updateStorage.RemoveAll(update => update.EntityId.Id == entityId);
-                    authorityChanges.RemoveAll(change => change.EntityId.Id == entityId);
-                }
-
-                if (!componentsAdded.Remove(id))
-                {
-                    componentsRemoved.Add(id);
-                }
-            }
-
-            public void AddEntityComponent(long entityId, Update component)
-            {
-                var id = new EntityId(entityId);
-                if (!componentsRemoved.Remove(id))
-                {
-                    componentsAdded.Add(id);
-                }
-
-                AddUpdate(new ComponentUpdateReceived<Update>(component, id, 0));
-            }
-
-            public void AddUpdate(ComponentUpdateReceived<Update> update)
-            {
-                entitiesUpdated.Add(update.EntityId);
-                updateStorage.InsertSorted(update, updateComparer);
-            }
-
-            public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
-            {
-                if (authorityChange.Authority == Authority.NotAuthoritative)
-                {
-                    if (authorityLostTemporary.Remove(authorityChange.EntityId) || !authorityGained.Contains(authorityChange.EntityId))
-                    {
-                        authorityLost.Add(authorityChange.EntityId);
-                    }
-                }
-                else if (authorityChange.Authority == Authority.Authoritative)
-                {
-                    if (authorityLost.Remove(authorityChange.EntityId))
-                    {
-                        authorityLostTemporary.Add(authorityChange.EntityId);
-                    }
-                    else
-                    {
-                        authorityGained.Add(authorityChange.EntityId);
-                    }
-                }
-
-                authorityChanges.InsertSorted(authorityChange, authorityComparer);
-            }
-
-            public List<EntityId> GetComponentsAdded()
-            {
-                return componentsAdded;
-            }
-
-            public List<EntityId> GetComponentsRemoved()
-            {
-                return componentsRemoved;
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
-            {
-                return updateStorage.Slice();
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
-            {
-                var range = updateStorage.GetEntityRange(entityId);
-                return updateStorage.Slice(range.FirstIndex, range.Count);
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
-            {
-                return authorityChanges.Slice();
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
-            {
-                var range = authorityChanges.GetEntityRange(entityId);
-                return authorityChanges.Slice(range.FirstIndex, range.Count);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveRepeatedComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveRepeatedComponentDiffStorage.cs
@@ -2,155 +2,24 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System.Collections.Generic;
 using System;
 using Improbable.Gdk.Core;
-using Improbable.Worker.CInterop;
 
 namespace Improbable.TestSchema
 {
     public partial class ExhaustiveRepeated
     {
-        public class DiffComponentStorage : IDiffUpdateStorage<Update>, IDiffComponentAddedStorage<Update>, IDiffAuthorityStorage
+        public class DiffComponentStorage : DiffComponentStorage<Update>
         {
-            private readonly HashSet<EntityId> entitiesUpdated = new HashSet<EntityId>();
-
-            private List<EntityId> componentsAdded = new List<EntityId>();
-            private List<EntityId> componentsRemoved = new List<EntityId>();
-
-            private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
-            private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
-
-            // Used to represent a state machine of authority changes. Valid state changes are:
-            // authority lost -> authority lost temporarily
-            // authority lost temporarily -> authority lost
-            // authority gained -> authority gained
-            // Creating the authority lost temporarily set is the aim as it signifies authority epoch changes
-            private readonly HashSet<EntityId> authorityLost = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityGained = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityLostTemporary = new HashSet<EntityId>();
-
-            private MessageList<ComponentUpdateReceived<Update>> updateStorage =
-                new MessageList<ComponentUpdateReceived<Update>>();
-
-            private MessageList<AuthorityChangeReceived> authorityChanges =
-                new MessageList<AuthorityChangeReceived>();
-
-            public Type[] GetEventTypes()
+            public override Type[] GetEventTypes()
             {
                 return new Type[]
                 {
                 };
             }
 
-            public Type GetUpdateType()
+            protected override void ClearEventStorage(long entityId)
             {
-                return typeof(Update);
-            }
-
-            public uint GetComponentId()
-            {
-                return ComponentId;
-            }
-
-            public void Clear()
-            {
-                entitiesUpdated.Clear();
-                updateStorage.Clear();
-                authorityChanges.Clear();
-                componentsAdded.Clear();
-                componentsRemoved.Clear();
-            }
-
-            public void RemoveEntityComponent(long entityId)
-            {
-                var id = new EntityId(entityId);
-
-                // Adding a component always updates it, so this will catch the case where the component was just added
-
-                if (entitiesUpdated.Remove(id))
-                {
-                    updateStorage.RemoveAll(update => update.EntityId.Id == entityId);
-                    authorityChanges.RemoveAll(change => change.EntityId.Id == entityId);
-                }
-
-                if (!componentsAdded.Remove(id))
-                {
-                    componentsRemoved.Add(id);
-                }
-            }
-
-            public void AddEntityComponent(long entityId, Update component)
-            {
-                var id = new EntityId(entityId);
-                if (!componentsRemoved.Remove(id))
-                {
-                    componentsAdded.Add(id);
-                }
-
-                AddUpdate(new ComponentUpdateReceived<Update>(component, id, 0));
-            }
-
-            public void AddUpdate(ComponentUpdateReceived<Update> update)
-            {
-                entitiesUpdated.Add(update.EntityId);
-                updateStorage.InsertSorted(update, updateComparer);
-            }
-
-            public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
-            {
-                if (authorityChange.Authority == Authority.NotAuthoritative)
-                {
-                    if (authorityLostTemporary.Remove(authorityChange.EntityId) || !authorityGained.Contains(authorityChange.EntityId))
-                    {
-                        authorityLost.Add(authorityChange.EntityId);
-                    }
-                }
-                else if (authorityChange.Authority == Authority.Authoritative)
-                {
-                    if (authorityLost.Remove(authorityChange.EntityId))
-                    {
-                        authorityLostTemporary.Add(authorityChange.EntityId);
-                    }
-                    else
-                    {
-                        authorityGained.Add(authorityChange.EntityId);
-                    }
-                }
-
-                authorityChanges.InsertSorted(authorityChange, authorityComparer);
-            }
-
-            public List<EntityId> GetComponentsAdded()
-            {
-                return componentsAdded;
-            }
-
-            public List<EntityId> GetComponentsRemoved()
-            {
-                return componentsRemoved;
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
-            {
-                return updateStorage.Slice();
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
-            {
-                var range = updateStorage.GetEntityRange(entityId);
-                return updateStorage.Slice(range.FirstIndex, range.Count);
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
-            {
-                return authorityChanges.Slice();
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
-            {
-                var range = authorityChanges.GetEntityRange(entityId);
-                return authorityChanges.Slice(range.FirstIndex, range.Count);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveSingularComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveSingularComponentDiffStorage.cs
@@ -2,155 +2,24 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System.Collections.Generic;
 using System;
 using Improbable.Gdk.Core;
-using Improbable.Worker.CInterop;
 
 namespace Improbable.TestSchema
 {
     public partial class ExhaustiveSingular
     {
-        public class DiffComponentStorage : IDiffUpdateStorage<Update>, IDiffComponentAddedStorage<Update>, IDiffAuthorityStorage
+        public class DiffComponentStorage : DiffComponentStorage<Update>
         {
-            private readonly HashSet<EntityId> entitiesUpdated = new HashSet<EntityId>();
-
-            private List<EntityId> componentsAdded = new List<EntityId>();
-            private List<EntityId> componentsRemoved = new List<EntityId>();
-
-            private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
-            private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
-
-            // Used to represent a state machine of authority changes. Valid state changes are:
-            // authority lost -> authority lost temporarily
-            // authority lost temporarily -> authority lost
-            // authority gained -> authority gained
-            // Creating the authority lost temporarily set is the aim as it signifies authority epoch changes
-            private readonly HashSet<EntityId> authorityLost = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityGained = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityLostTemporary = new HashSet<EntityId>();
-
-            private MessageList<ComponentUpdateReceived<Update>> updateStorage =
-                new MessageList<ComponentUpdateReceived<Update>>();
-
-            private MessageList<AuthorityChangeReceived> authorityChanges =
-                new MessageList<AuthorityChangeReceived>();
-
-            public Type[] GetEventTypes()
+            public override Type[] GetEventTypes()
             {
                 return new Type[]
                 {
                 };
             }
 
-            public Type GetUpdateType()
+            protected override void ClearEventStorage(long entityId)
             {
-                return typeof(Update);
-            }
-
-            public uint GetComponentId()
-            {
-                return ComponentId;
-            }
-
-            public void Clear()
-            {
-                entitiesUpdated.Clear();
-                updateStorage.Clear();
-                authorityChanges.Clear();
-                componentsAdded.Clear();
-                componentsRemoved.Clear();
-            }
-
-            public void RemoveEntityComponent(long entityId)
-            {
-                var id = new EntityId(entityId);
-
-                // Adding a component always updates it, so this will catch the case where the component was just added
-
-                if (entitiesUpdated.Remove(id))
-                {
-                    updateStorage.RemoveAll(update => update.EntityId.Id == entityId);
-                    authorityChanges.RemoveAll(change => change.EntityId.Id == entityId);
-                }
-
-                if (!componentsAdded.Remove(id))
-                {
-                    componentsRemoved.Add(id);
-                }
-            }
-
-            public void AddEntityComponent(long entityId, Update component)
-            {
-                var id = new EntityId(entityId);
-                if (!componentsRemoved.Remove(id))
-                {
-                    componentsAdded.Add(id);
-                }
-
-                AddUpdate(new ComponentUpdateReceived<Update>(component, id, 0));
-            }
-
-            public void AddUpdate(ComponentUpdateReceived<Update> update)
-            {
-                entitiesUpdated.Add(update.EntityId);
-                updateStorage.InsertSorted(update, updateComparer);
-            }
-
-            public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
-            {
-                if (authorityChange.Authority == Authority.NotAuthoritative)
-                {
-                    if (authorityLostTemporary.Remove(authorityChange.EntityId) || !authorityGained.Contains(authorityChange.EntityId))
-                    {
-                        authorityLost.Add(authorityChange.EntityId);
-                    }
-                }
-                else if (authorityChange.Authority == Authority.Authoritative)
-                {
-                    if (authorityLost.Remove(authorityChange.EntityId))
-                    {
-                        authorityLostTemporary.Add(authorityChange.EntityId);
-                    }
-                    else
-                    {
-                        authorityGained.Add(authorityChange.EntityId);
-                    }
-                }
-
-                authorityChanges.InsertSorted(authorityChange, authorityComparer);
-            }
-
-            public List<EntityId> GetComponentsAdded()
-            {
-                return componentsAdded;
-            }
-
-            public List<EntityId> GetComponentsRemoved()
-            {
-                return componentsRemoved;
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
-            {
-                return updateStorage.Slice();
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
-            {
-                var range = updateStorage.GetEntityRange(entityId);
-                return updateStorage.Slice(range.FirstIndex, range.Count);
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
-            {
-                return authorityChanges.Slice();
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
-            {
-                var range = authorityChanges.GetEntityRange(entityId);
-                return authorityChanges.Slice(range.FirstIndex, range.Count);
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/RecursiveComponentComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/RecursiveComponentComponentDiffStorage.cs
@@ -2,155 +2,24 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System.Collections.Generic;
 using System;
 using Improbable.Gdk.Core;
-using Improbable.Worker.CInterop;
 
 namespace Improbable.TestSchema
 {
     public partial class RecursiveComponent
     {
-        public class DiffComponentStorage : IDiffUpdateStorage<Update>, IDiffComponentAddedStorage<Update>, IDiffAuthorityStorage
+        public class DiffComponentStorage : DiffComponentStorage<Update>
         {
-            private readonly HashSet<EntityId> entitiesUpdated = new HashSet<EntityId>();
-
-            private List<EntityId> componentsAdded = new List<EntityId>();
-            private List<EntityId> componentsRemoved = new List<EntityId>();
-
-            private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
-            private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
-
-            // Used to represent a state machine of authority changes. Valid state changes are:
-            // authority lost -> authority lost temporarily
-            // authority lost temporarily -> authority lost
-            // authority gained -> authority gained
-            // Creating the authority lost temporarily set is the aim as it signifies authority epoch changes
-            private readonly HashSet<EntityId> authorityLost = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityGained = new HashSet<EntityId>();
-            private readonly HashSet<EntityId> authorityLostTemporary = new HashSet<EntityId>();
-
-            private MessageList<ComponentUpdateReceived<Update>> updateStorage =
-                new MessageList<ComponentUpdateReceived<Update>>();
-
-            private MessageList<AuthorityChangeReceived> authorityChanges =
-                new MessageList<AuthorityChangeReceived>();
-
-            public Type[] GetEventTypes()
+            public override Type[] GetEventTypes()
             {
                 return new Type[]
                 {
                 };
             }
 
-            public Type GetUpdateType()
+            protected override void ClearEventStorage(long entityId)
             {
-                return typeof(Update);
-            }
-
-            public uint GetComponentId()
-            {
-                return ComponentId;
-            }
-
-            public void Clear()
-            {
-                entitiesUpdated.Clear();
-                updateStorage.Clear();
-                authorityChanges.Clear();
-                componentsAdded.Clear();
-                componentsRemoved.Clear();
-            }
-
-            public void RemoveEntityComponent(long entityId)
-            {
-                var id = new EntityId(entityId);
-
-                // Adding a component always updates it, so this will catch the case where the component was just added
-
-                if (entitiesUpdated.Remove(id))
-                {
-                    updateStorage.RemoveAll(update => update.EntityId.Id == entityId);
-                    authorityChanges.RemoveAll(change => change.EntityId.Id == entityId);
-                }
-
-                if (!componentsAdded.Remove(id))
-                {
-                    componentsRemoved.Add(id);
-                }
-            }
-
-            public void AddEntityComponent(long entityId, Update component)
-            {
-                var id = new EntityId(entityId);
-                if (!componentsRemoved.Remove(id))
-                {
-                    componentsAdded.Add(id);
-                }
-
-                AddUpdate(new ComponentUpdateReceived<Update>(component, id, 0));
-            }
-
-            public void AddUpdate(ComponentUpdateReceived<Update> update)
-            {
-                entitiesUpdated.Add(update.EntityId);
-                updateStorage.InsertSorted(update, updateComparer);
-            }
-
-            public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
-            {
-                if (authorityChange.Authority == Authority.NotAuthoritative)
-                {
-                    if (authorityLostTemporary.Remove(authorityChange.EntityId) || !authorityGained.Contains(authorityChange.EntityId))
-                    {
-                        authorityLost.Add(authorityChange.EntityId);
-                    }
-                }
-                else if (authorityChange.Authority == Authority.Authoritative)
-                {
-                    if (authorityLost.Remove(authorityChange.EntityId))
-                    {
-                        authorityLostTemporary.Add(authorityChange.EntityId);
-                    }
-                    else
-                    {
-                        authorityGained.Add(authorityChange.EntityId);
-                    }
-                }
-
-                authorityChanges.InsertSorted(authorityChange, authorityComparer);
-            }
-
-            public List<EntityId> GetComponentsAdded()
-            {
-                return componentsAdded;
-            }
-
-            public List<EntityId> GetComponentsRemoved()
-            {
-                return componentsRemoved;
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
-            {
-                return updateStorage.Slice();
-            }
-
-            public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
-            {
-                var range = updateStorage.GetEntityRange(entityId);
-                return updateStorage.Slice(range.FirstIndex, range.Count);
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
-            {
-                return authorityChanges.Slice();
-            }
-
-            public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
-            {
-                var range = authorityChanges.GetEntityRange(entityId);
-                return authorityChanges.Slice(range.FirstIndex, range.Count);
             }
         }
     }

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/ComponentDiffStorageGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/ComponentDiffStorageGenerator.cs
@@ -57,9 +57,19 @@ private readonly EventComparer<{eventType}> {ev.CamelCaseName}Comparer =
                                 });
                             });
 
+                            if (eventDetailsList.Count > 0)
+                            {
+                                storage.Method("public override void Clear()", m =>
+                                {
+                                    m.Line("base.Clear();");
+                                    m.Line(eventDetailsList
+                                        .Select(ev => $"{ev.CamelCaseName}EventStorage.Clear();").ToList());
+                                });
+                            }
+
                             storage.Method("protected override void ClearEventStorage(long entityId)", m =>
                             {
-                                m.Line(eventDetailsList.Select(ev => $"{ev.CamelCaseName}EventStorage.Clear();").ToList());
+                                m.Line(eventDetailsList.Select(ev => $"{ev.CamelCaseName}EventStorage.RemoveAll(change => change.EntityId.Id == entityId);").ToList());
                             });
 
                             foreach (var ev in eventDetailsList)

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/ComponentDiffStorageGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/ComponentDiffStorageGenerator.cs
@@ -18,10 +18,8 @@ namespace Improbable.Gdk.CodeGenerator
             return CodeWriter.Populate(cgw =>
             {
                 cgw.UsingDirectives(
-                    "System.Collections.Generic",
                     "System",
-                    "Improbable.Gdk.Core",
-                    "Improbable.Worker.CInterop"
+                    "Improbable.Gdk.Core"
                 );
 
                 cgw.Namespace(componentDetails.Namespace, ns =>
@@ -30,7 +28,7 @@ namespace Improbable.Gdk.CodeGenerator
                     {
                         Logger.Trace($"Generating {componentDetails.Namespace}.{componentDetails.Name}.DiffComponentStorage class.");
 
-                        var classDefinition = new StringBuilder("public class DiffComponentStorage : IDiffUpdateStorage<Update>, IDiffComponentAddedStorage<Update>, IDiffAuthorityStorage");
+                        var classDefinition = new StringBuilder("public class DiffComponentStorage : DiffComponentStorage<Update>");
 
                         foreach (var ev in eventDetailsList)
                         {
@@ -39,31 +37,6 @@ namespace Improbable.Gdk.CodeGenerator
 
                         partial.Type(classDefinition.ToString(), storage =>
                         {
-                            storage.Line(@"
-private readonly HashSet<EntityId> entitiesUpdated = new HashSet<EntityId>();
-
-private List<EntityId> componentsAdded = new List<EntityId>();
-private List<EntityId> componentsRemoved = new List<EntityId>();
-
-private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
-private readonly UpdateComparer<Update> updateComparer = new UpdateComparer<Update>();
-
-// Used to represent a state machine of authority changes. Valid state changes are:
-// authority lost -> authority lost temporarily
-// authority lost temporarily -> authority lost
-// authority gained -> authority gained
-// Creating the authority lost temporarily set is the aim as it signifies authority epoch changes
-private readonly HashSet<EntityId> authorityLost = new HashSet<EntityId>();
-private readonly HashSet<EntityId> authorityGained = new HashSet<EntityId>();
-private readonly HashSet<EntityId> authorityLostTemporary = new HashSet<EntityId>();
-
-private MessageList<ComponentUpdateReceived<Update>> updateStorage =
-    new MessageList<ComponentUpdateReceived<Update>>();
-
-private MessageList<AuthorityChangeReceived> authorityChanges =
-    new MessageList<AuthorityChangeReceived>();
-");
-
                             foreach (var ev in eventDetailsList)
                             {
                                 var eventType = $"{ev.PascalCaseName}.Event";
@@ -76,7 +49,7 @@ private readonly EventComparer<{eventType}> {ev.CamelCaseName}Comparer =
 ");
                             }
 
-                            storage.Method("public Type[] GetEventTypes()", m =>
+                            storage.Method("public override Type[] GetEventTypes()", m =>
                             {
                                 m.Initializer("return new Type[]", () =>
                                 {
@@ -84,135 +57,19 @@ private readonly EventComparer<{eventType}> {ev.CamelCaseName}Comparer =
                                 });
                             });
 
-                            storage.Method("public Type GetUpdateType()", m =>
+                            storage.Method("protected override void ClearEventStorage(long entityId)", m =>
                             {
-                                m.Return("typeof(Update)");
-                            });
-
-                            storage.Method("public uint GetComponentId()", m =>
-                            {
-                                m.Return("ComponentId");
-                            });
-
-                            storage.Method("public void Clear()", m =>
-                            {
-                                m.Line(new[]
-                                {
-                                    "entitiesUpdated.Clear();",
-                                    "updateStorage.Clear();",
-                                    "authorityChanges.Clear();",
-                                    "componentsAdded.Clear();",
-                                    "componentsRemoved.Clear();"
-                                });
-
                                 m.Line(eventDetailsList.Select(ev => $"{ev.CamelCaseName}EventStorage.Clear();").ToList());
                             });
 
-                            storage.Method("public void RemoveEntityComponent(long entityId)", m =>
-                            {
-                                m.Line("var id = new EntityId(entityId);");
-
-                                m.Line("// Adding a component always updates it, so this will catch the case where the component was just added");
-                                m.If("entitiesUpdated.Remove(id)", then =>
-                                {
-                                    then.Line(new[]
-                                    {
-                                        "updateStorage.RemoveAll(update => update.EntityId.Id == entityId);",
-                                        "authorityChanges.RemoveAll(change => change.EntityId.Id == entityId);"
-                                    });
-
-                                    then.Line(eventDetailsList.Select(ev =>
-                                        $"{ev.CamelCaseName}EventStorage.RemoveAll(change => change.EntityId.Id == entityId);").ToList());
-                                });
-
-                                m.If("!componentsAdded.Remove(id)", () => new[]
-                                {
-                                    "componentsRemoved.Add(id);"
-                                });
-                            });
-
-                            storage.Line(@"
-public void AddEntityComponent(long entityId, Update component)
-{
-    var id = new EntityId(entityId);
-    if (!componentsRemoved.Remove(id))
-    {
-        componentsAdded.Add(id);
-    }
-
-    AddUpdate(new ComponentUpdateReceived<Update>(component, id, 0));
-}
-
-public void AddUpdate(ComponentUpdateReceived<Update> update)
-{
-    entitiesUpdated.Add(update.EntityId);
-    updateStorage.InsertSorted(update, updateComparer);
-}
-
-public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
-{
-    if (authorityChange.Authority == Authority.NotAuthoritative)
-    {
-        if (authorityLostTemporary.Remove(authorityChange.EntityId) || !authorityGained.Contains(authorityChange.EntityId))
-        {
-            authorityLost.Add(authorityChange.EntityId);
-        }
-    }
-    else if (authorityChange.Authority == Authority.Authoritative)
-    {
-        if (authorityLost.Remove(authorityChange.EntityId))
-        {
-            authorityLostTemporary.Add(authorityChange.EntityId);
-        }
-        else
-        {
-            authorityGained.Add(authorityChange.EntityId);
-        }
-    }
-
-    authorityChanges.InsertSorted(authorityChange, authorityComparer);
-}
-
-public List<EntityId> GetComponentsAdded()
-{
-    return componentsAdded;
-}
-
-public List<EntityId> GetComponentsRemoved()
-{
-    return componentsRemoved;
-}
-
-public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates()
-{
-    return updateStorage.Slice();
-}
-
-public MessagesSpan<ComponentUpdateReceived<Update>> GetUpdates(EntityId entityId)
-{
-    var range = updateStorage.GetEntityRange(entityId);
-    return updateStorage.Slice(range.FirstIndex, range.Count);
-}
-
-public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
-{
-    return authorityChanges.Slice();
-}
-
-public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
-{
-    var range = authorityChanges.GetEntityRange(entityId);
-    return authorityChanges.Slice(range.FirstIndex, range.Count);
-}
-");
                             foreach (var ev in eventDetailsList)
                             {
                                 var eventType = $"{ev.PascalCaseName}.Event";
 
                                 storage.Method($"MessagesSpan<ComponentEventReceived<{eventType}>> IDiffEventStorage<{eventType}>.GetEvents(EntityId entityId)", () => new[]
                                 {
-                                    $"var range = {ev.CamelCaseName}EventStorage.GetEntityRange(entityId);",
-                                    $"return {ev.CamelCaseName}EventStorage.Slice(range.FirstIndex, range.Count);"
+                                    $"var (firstIndex, count) = {ev.CamelCaseName}EventStorage.GetEntityRange(entityId);",
+                                    $"return {ev.CamelCaseName}EventStorage.Slice(firstIndex, count);"
                                 });
 
                                 storage.Method($"MessagesSpan<ComponentEventReceived<{eventType}>> IDiffEventStorage<{eventType}>.GetEvents()", () => new[]

--- a/workers/unity/Packages/io.improbable.gdk.core/EntityId.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/EntityId.cs
@@ -9,7 +9,7 @@ namespace Improbable.Gdk.Core
     ///     Instances of this type should be treated as transient identifiers that will not be
     ///     consistent between different runs of the same simulation.
     /// </remarks>
-    public struct EntityId : IEquatable<EntityId>
+    public readonly struct EntityId : IEquatable<EntityId>
     {
         /// <summary>
         ///     The value of the EntityId.

--- a/workers/unity/Packages/io.improbable.gdk.core/View/DiffComponentStorage.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/View/DiffComponentStorage.cs
@@ -7,7 +7,7 @@ namespace Improbable.Gdk.Core
     public abstract class DiffComponentStorage<TUpdate> : IDiffUpdateStorage<TUpdate>, IDiffComponentAddedStorage<TUpdate>, IDiffAuthorityStorage
         where TUpdate : ISpatialComponentUpdate
     {
-        private readonly HashSet<EntityId> entitiesUpdated = new HashSet<EntityId>();
+        protected readonly HashSet<EntityId> EntitiesUpdated = new HashSet<EntityId>();
         private readonly uint componentId;
 
         private readonly List<EntityId> componentsAdded = new List<EntityId>();
@@ -37,7 +37,7 @@ namespace Improbable.Gdk.Core
 
         public virtual void Clear()
         {
-            entitiesUpdated.Clear();
+            EntitiesUpdated.Clear();
             updateStorage.Clear();
             authorityChanges.Clear();
             componentsAdded.Clear();
@@ -49,7 +49,7 @@ namespace Improbable.Gdk.Core
             var id = new EntityId(entityId);
 
             // Adding a component always updates it, so this will catch the case where the component was just added
-            if (entitiesUpdated.Remove(id))
+            if (EntitiesUpdated.Remove(id))
             {
                 updateStorage.RemoveAll(update => update.EntityId.Id == entityId);
                 authorityChanges.RemoveAll(change => change.EntityId.Id == entityId);
@@ -80,7 +80,7 @@ namespace Improbable.Gdk.Core
 
         public void AddUpdate(ComponentUpdateReceived<TUpdate> update)
         {
-            entitiesUpdated.Add(update.EntityId);
+            EntitiesUpdated.Add(update.EntityId);
             updateStorage.InsertSorted(update, updateComparer);
         }
 

--- a/workers/unity/Packages/io.improbable.gdk.core/View/DiffComponentStorage.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/View/DiffComponentStorage.cs
@@ -54,7 +54,6 @@ namespace Improbable.Gdk.Core
                 updateStorage.RemoveAll(update => update.EntityId.Id == entityId);
                 authorityChanges.RemoveAll(change => change.EntityId.Id == entityId);
 
-                //playerCollidedEventStorage.RemoveAll(change => change.EntityId.Id == entityId);
                 ClearEventStorage(entityId);
             }
 
@@ -65,7 +64,6 @@ namespace Improbable.Gdk.Core
         }
 
         protected abstract void ClearEventStorage(long entityId);
-
 
         public void AddEntityComponent(long entityId, TUpdate component)
         {

--- a/workers/unity/Packages/io.improbable.gdk.core/View/DiffComponentStorage.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/View/DiffComponentStorage.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using Improbable.Worker.CInterop;
+
+namespace Improbable.Gdk.Core
+{
+    public abstract class DiffComponentStorage<TUpdate> : IDiffUpdateStorage<TUpdate>, IDiffComponentAddedStorage<TUpdate>, IDiffAuthorityStorage
+        where TUpdate : ISpatialComponentUpdate
+    {
+        private readonly HashSet<EntityId> entitiesUpdated = new HashSet<EntityId>();
+        private readonly uint componentId;
+
+        private readonly List<EntityId> componentsAdded = new List<EntityId>();
+        private readonly List<EntityId> componentsRemoved = new List<EntityId>();
+
+        private readonly AuthorityComparer authorityComparer = new AuthorityComparer();
+        private readonly UpdateComparer<TUpdate> updateComparer = new UpdateComparer<TUpdate>();
+
+        // Used to represent a state machine of authority changes. Valid state changes are:
+        // authority lost -> authority lost temporarily
+        // authority lost temporarily -> authority lost
+        // authority gained -> authority gained
+        // Creating the authority lost temporarily set is the aim as it signifies authority epoch changes
+        private readonly HashSet<EntityId> authorityLost = new HashSet<EntityId>();
+        private readonly HashSet<EntityId> authorityGained = new HashSet<EntityId>();
+        private readonly HashSet<EntityId> authorityLostTemporary = new HashSet<EntityId>();
+
+        private readonly MessageList<ComponentUpdateReceived<TUpdate>> updateStorage =
+            new MessageList<ComponentUpdateReceived<TUpdate>>();
+
+        private readonly MessageList<AuthorityChangeReceived> authorityChanges =
+            new MessageList<AuthorityChangeReceived>();
+
+        public abstract Type[] GetEventTypes();
+
+        public Type GetUpdateType() => typeof(TUpdate);
+
+        public virtual void Clear()
+        {
+            entitiesUpdated.Clear();
+            updateStorage.Clear();
+            authorityChanges.Clear();
+            componentsAdded.Clear();
+            componentsRemoved.Clear();
+        }
+
+        public void RemoveEntityComponent(long entityId)
+        {
+            var id = new EntityId(entityId);
+
+            // Adding a component always updates it, so this will catch the case where the component was just added
+            if (entitiesUpdated.Remove(id))
+            {
+                updateStorage.RemoveAll(update => update.EntityId.Id == entityId);
+                authorityChanges.RemoveAll(change => change.EntityId.Id == entityId);
+
+                //playerCollidedEventStorage.RemoveAll(change => change.EntityId.Id == entityId);
+                ClearEventStorage(entityId);
+            }
+
+            if (!componentsAdded.Remove(id))
+            {
+                componentsRemoved.Add(id);
+            }
+        }
+
+        protected abstract void ClearEventStorage(long entityId);
+
+
+        public void AddEntityComponent(long entityId, TUpdate component)
+        {
+            var id = new EntityId(entityId);
+            if (!componentsRemoved.Remove(id))
+            {
+                componentsAdded.Add(id);
+            }
+
+            AddUpdate(new ComponentUpdateReceived<TUpdate>(component, id, 0));
+        }
+
+        public void AddUpdate(ComponentUpdateReceived<TUpdate> update)
+        {
+            entitiesUpdated.Add(update.EntityId);
+            updateStorage.InsertSorted(update, updateComparer);
+        }
+
+        public void AddAuthorityChange(AuthorityChangeReceived authorityChange)
+        {
+            if (authorityChange.Authority == Authority.NotAuthoritative)
+            {
+                if (authorityLostTemporary.Remove(authorityChange.EntityId) || !authorityGained.Contains(authorityChange.EntityId))
+                {
+                    authorityLost.Add(authorityChange.EntityId);
+                }
+            }
+            else if (authorityChange.Authority == Authority.Authoritative)
+            {
+                if (authorityLost.Remove(authorityChange.EntityId))
+                {
+                    authorityLostTemporary.Add(authorityChange.EntityId);
+                }
+                else
+                {
+                    authorityGained.Add(authorityChange.EntityId);
+                }
+            }
+
+            authorityChanges.InsertSorted(authorityChange, authorityComparer);
+        }
+
+        public List<EntityId> GetComponentsAdded()
+        {
+            return componentsAdded;
+        }
+
+        public List<EntityId> GetComponentsRemoved()
+        {
+            return componentsRemoved;
+        }
+
+        public MessagesSpan<ComponentUpdateReceived<TUpdate>> GetUpdates()
+        {
+            return updateStorage.Slice();
+        }
+
+        public MessagesSpan<ComponentUpdateReceived<TUpdate>> GetUpdates(EntityId entityId)
+        {
+            var (firstIndex, count) = updateStorage.GetEntityRange(entityId);
+            return updateStorage.Slice(firstIndex, count);
+        }
+
+        public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges()
+        {
+            return authorityChanges.Slice();
+        }
+
+        public MessagesSpan<AuthorityChangeReceived> GetAuthorityChanges(EntityId entityId)
+        {
+            var (firstIndex, count) = authorityChanges.GetEntityRange(entityId);
+            return authorityChanges.Slice(firstIndex, count);
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/View/DiffComponentStorage.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/View/DiffComponentStorage.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0fe1b90bad6f416083ddd28c383ba4f9
+timeCreated: 1581705886

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/DiffStorage.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/DiffStorage.cs
@@ -8,7 +8,6 @@ namespace Improbable.Gdk.Core
     {
         Type[] GetEventTypes();
         Type GetUpdateType();
-        uint GetComponentId();
 
         void Clear();
         void RemoveEntityComponent(long entityId);

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/MessagesToSend.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/MessagesToSend.cs
@@ -11,7 +11,7 @@ namespace Improbable.Gdk.Core
         internal static IEnumerable<(uint componentId, Type diffStorageType)> ComponentTypes => ComponentDatabase.Metaclasses
             .Select(pair => (pair.Key, pair.Value.DiffStorage));
 
-        internal static IEnumerable<(uint componentId, IEnumerable<Type> storageTypes)> CommandTypes => ComponentDatabase.Metaclasses
+        internal static IEnumerable<(uint componentId, IEnumerable<Type> storageTypes)> CommandSendStorageTypes => ComponentDatabase.Metaclasses
             .Select(componentCommands => (componentCommands.Key,
                 componentCommands.Value.Commands.Select(m => m.SendStorage)));
     }
@@ -59,7 +59,7 @@ namespace Improbable.Gdk.Core
                 }
             }
 
-            foreach (var (componentId, storageTypes) in MessagesToSendMetadata.CommandTypes)
+            foreach (var (componentId, storageTypes) in MessagesToSendMetadata.CommandSendStorageTypes)
             {
                 foreach (var sendStorageType in storageTypes)
                 {

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/MessagesToSend.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/MessagesToSend.cs
@@ -14,8 +14,7 @@ namespace Improbable.Gdk.Core
                 .Select(pair => (pair.Key, pair.Value.DiffStorage));
 
             internal static IEnumerable<(uint componentId, IEnumerable<Type> storageTypes)> CommandSendStorageTypes => ComponentDatabase.Metaclasses
-                .Select(componentCommands => (componentCommands.Key,
-                    componentCommands.Value.Commands.Select(m => m.SendStorage)));
+                .Select(componentCommands => (componentCommands.Key, componentCommands.Value.Commands.Select(m => m.SendStorage)));
         }
 
         private readonly Dictionary<uint, IComponentDiffStorage> componentIdToComponentStorage =

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/MessagesToSend.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/MessagesToSend.cs
@@ -6,18 +6,18 @@ using Improbable.Worker.CInterop;
 
 namespace Improbable.Gdk.Core
 {
-    internal static class MessagesToSendMetadata
-    {
-        internal static IEnumerable<(uint componentId, Type diffStorageType)> ComponentTypes => ComponentDatabase.Metaclasses
-            .Select(pair => (pair.Key, pair.Value.DiffStorage));
-
-        internal static IEnumerable<(uint componentId, IEnumerable<Type> storageTypes)> CommandSendStorageTypes => ComponentDatabase.Metaclasses
-            .Select(componentCommands => (componentCommands.Key,
-                componentCommands.Value.Commands.Select(m => m.SendStorage)));
-    }
-
     public class MessagesToSend
     {
+        private static class MessagesToSendMetadata
+        {
+            internal static IEnumerable<(uint componentId, Type diffStorageType)> ComponentTypes => ComponentDatabase.Metaclasses
+                .Select(pair => (pair.Key, pair.Value.DiffStorage));
+
+            internal static IEnumerable<(uint componentId, IEnumerable<Type> storageTypes)> CommandSendStorageTypes => ComponentDatabase.Metaclasses
+                .Select(componentCommands => (componentCommands.Key,
+                    componentCommands.Value.Commands.Select(m => m.SendStorage)));
+        }
+
         private readonly Dictionary<uint, IComponentDiffStorage> componentIdToComponentStorage =
             new Dictionary<uint, IComponentDiffStorage>();
 

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/MessagesToSend.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/MessagesToSend.cs
@@ -3,15 +3,21 @@ using System.Collections.Generic;
 using System.Linq;
 using Improbable.Gdk.Core.Commands;
 using Improbable.Worker.CInterop;
-using UnityEngine;
 
 namespace Improbable.Gdk.Core
 {
+    internal static class MessagesToSendMetadata
+    {
+        internal static IEnumerable<(uint componentId, Type diffStorageType)> ComponentTypes => ComponentDatabase.Metaclasses
+            .Select(pair => (pair.Key, pair.Value.DiffStorage));
+
+        internal static IEnumerable<(uint componentId, IEnumerable<Type> storageTypes)> CommandTypes => ComponentDatabase.Metaclasses
+            .Select(componentCommands => (componentCommands.Key,
+                componentCommands.Value.Commands.Select(m => m.SendStorage)));
+    }
+
     public class MessagesToSend
     {
-        private static List<Type> componentTypes;
-        private static List<Type> commandTypes;
-
         private readonly Dictionary<uint, IComponentDiffStorage> componentIdToComponentStorage =
             new Dictionary<uint, IComponentDiffStorage>();
 
@@ -20,8 +26,8 @@ namespace Improbable.Gdk.Core
 
         private readonly List<IComponentDiffStorage> componentStorageList = new List<IComponentDiffStorage>();
 
-        private readonly Dictionary<uint, Dictionary<uint, IComponentCommandSendStorage>> componentIdToCommandIdToStorage =
-            new Dictionary<uint, Dictionary<uint, IComponentCommandSendStorage>>();
+        private readonly Dictionary<(uint componentId, uint commandId), IComponentCommandSendStorage> componentCommandToStorage =
+            new Dictionary<(uint componentId, uint commandId), IComponentCommandSendStorage>();
 
         private readonly Dictionary<Type, ICommandSendStorage> typeToCommandStorage =
             new Dictionary<Type, ICommandSendStorage>();
@@ -39,27 +45,12 @@ namespace Improbable.Gdk.Core
 
         public MessagesToSend()
         {
-            if (componentTypes == null)
+            foreach (var (componentId, diffStorageType) in MessagesToSendMetadata.ComponentTypes)
             {
-                componentTypes = ComponentDatabase.Metaclasses
-                    .Select(pair => pair.Value.DiffStorage)
-                    .ToList();
-            }
-
-            if (commandTypes == null)
-            {
-                commandTypes = ComponentDatabase.Metaclasses
-                    .SelectMany(pair => pair.Value.Commands)
-                    .Select(metaclass => metaclass.SendStorage)
-                    .ToList();
-            }
-
-            foreach (var type in componentTypes)
-            {
-                var instance = (IComponentDiffStorage) Activator.CreateInstance(type);
+                var instance = (IComponentDiffStorage) Activator.CreateInstance(diffStorageType);
 
                 componentStorageList.Add(instance);
-                componentIdToComponentStorage.Add(instance.GetComponentId(), instance);
+                componentIdToComponentStorage.Add(componentId, instance);
 
                 typeToComponentStorage.Add(instance.GetUpdateType(), instance);
                 foreach (var eventType in instance.GetEventTypes())
@@ -68,21 +59,17 @@ namespace Improbable.Gdk.Core
                 }
             }
 
-            foreach (var type in commandTypes)
+            foreach (var (componentId, storageTypes) in MessagesToSendMetadata.CommandTypes)
             {
-                var instance = (IComponentCommandSendStorage) Activator.CreateInstance(type);
-
-                commandStorageList.Add(instance);
-                if (!componentIdToCommandIdToStorage.TryGetValue(instance.ComponentId,
-                    out var commandIdToStorage))
+                foreach (var sendStorageType in storageTypes)
                 {
-                    commandIdToStorage = new Dictionary<uint, IComponentCommandSendStorage>();
-                    componentIdToCommandIdToStorage.Add(instance.ComponentId, commandIdToStorage);
-                }
+                    var instance = (IComponentCommandSendStorage) Activator.CreateInstance(sendStorageType);
 
-                commandIdToStorage.Add(instance.CommandId, instance);
-                typeToCommandStorage.Add(instance.RequestType, instance);
-                typeToCommandStorage.Add(instance.ResponseType, instance);
+                    commandStorageList.Add(instance);
+                    componentCommandToStorage.Add((componentId, instance.CommandId), instance);
+                    typeToCommandStorage.Add(instance.RequestType, instance);
+                    typeToCommandStorage.Add(instance.ResponseType, instance);
+                }
             }
 
             commandStorageList.Add(worldCommandStorage);
@@ -203,17 +190,12 @@ namespace Improbable.Gdk.Core
 
         internal IComponentCommandSendStorage GetCommandSendStorage(uint componentId, uint commandId)
         {
-            if (!componentIdToCommandIdToStorage.TryGetValue(componentId, out var commandIdToStorage))
+            if (!componentCommandToStorage.TryGetValue((componentId, commandId), out var commandSendStorage))
             {
-                throw new ArgumentException($"Can not find command send storage. Unknown component ID {componentId}");
+                throw new ArgumentException($"Can not find command send storage. Could not find Command ID {commandId} for Component ID {componentId}");
             }
 
-            if (!commandIdToStorage.TryGetValue(commandId, out var storage))
-            {
-                throw new ArgumentException($"Can not find command send storage. Unknown command ID {commandId}");
-            }
-
-            return storage;
+            return commandSendStorage;
         }
 
         internal WorldCommandsToSendStorage GetWorldCommandStorage()

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/ViewDiff.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/ViewDiff.cs
@@ -4,25 +4,19 @@ using System.Linq;
 using Improbable.Gdk.Core.Commands;
 using Improbable.Gdk.Core.NetworkStats;
 using Improbable.Worker.CInterop;
+using UnityEngine;
 
 namespace Improbable.Gdk.Core
 {
     internal static class ViewDiffMetadata
     {
-        internal static readonly List<(uint ComponentId, Type DiffStorageType)> ComponentStorageTypes;
-        internal static readonly List<Type> CommandStorageTypes;
+        internal static IEnumerable<(uint componentId, Type diffStorageType)> ComponentStorageTypes => ComponentDatabase
+            .Metaclasses
+            .Select(pair => (pair.Key, pair.Value.DiffStorage));
 
-        static ViewDiffMetadata()
-        {
-            ComponentStorageTypes = ComponentDatabase.Metaclasses
-                .Select(pair => (pair.Key, pair.Value.DiffStorage))
-                .ToList();
-
-            CommandStorageTypes = ComponentDatabase.Metaclasses
-                .SelectMany(pair => pair.Value.Commands)
-                .Select(metaclass => metaclass.DiffStorage)
-                .ToList();
-        }
+        internal static IEnumerable<(uint Key, IEnumerable<Type> storageTypes)> CommandDiffStorageTypes => ComponentDatabase.Metaclasses
+            .Select(componentCommands => (componentCommands.Key,
+                componentCommands.Value.Commands.Select(m => m.DiffStorage)));
     }
 
     public class ViewDiff
@@ -48,13 +42,16 @@ namespace Improbable.Gdk.Core
 
         private readonly List<IComponentDiffStorage> componentStorageList = new List<IComponentDiffStorage>();
 
-        private readonly Dictionary<uint, Dictionary<uint, IComponentCommandDiffStorage>> componentIdToCommandIdToStorage =
-            new Dictionary<uint, Dictionary<uint, IComponentCommandDiffStorage>>();
+        private readonly Dictionary<uint, (int firstIndex, int count)> componentIdStorageRange =
+            new Dictionary<uint, (int firstIndex, int count)>();
+
+        private readonly Dictionary<(uint componentId, uint commandId), IComponentCommandDiffStorage> componentCommandToStorage =
+            new Dictionary<(uint componentId, uint commandId), IComponentCommandDiffStorage>();
 
         private readonly Dictionary<Type, ICommandDiffStorage> typeToCommandStorage =
             new Dictionary<Type, ICommandDiffStorage>();
 
-        private readonly List<ICommandDiffStorage> commandStorageList = new List<ICommandDiffStorage>();
+        private readonly List<IComponentCommandDiffStorage> commandStorageList = new List<IComponentCommandDiffStorage>();
 
         private readonly WorldCommandsReceivedStorage worldCommandsReceivedStorage = new WorldCommandsReceivedStorage();
 
@@ -76,25 +73,25 @@ namespace Improbable.Gdk.Core
                 }
             }
 
-            foreach (var type in ViewDiffMetadata.CommandStorageTypes)
+            var storageIndex = 0;
+            foreach (var (componentId, storageTypes) in ViewDiffMetadata.CommandDiffStorageTypes)
             {
-                var instance = (IComponentCommandDiffStorage) Activator.CreateInstance(type);
+                var firstIndex = storageIndex;
 
-                commandStorageList.Add(instance);
-                if (!componentIdToCommandIdToStorage.TryGetValue(instance.ComponentId,
-                    out var commandIdToStorage))
+                foreach (var diffStorageType in storageTypes)
                 {
-                    commandIdToStorage = new Dictionary<uint, IComponentCommandDiffStorage>();
-                    componentIdToCommandIdToStorage.Add(instance.ComponentId, commandIdToStorage);
+                    var instance = (IComponentCommandDiffStorage) Activator.CreateInstance(diffStorageType);
+
+                    commandStorageList.Add(instance);
+                    componentCommandToStorage.Add((componentId, instance.CommandId), instance);
+                    typeToCommandStorage.Add(instance.RequestType, instance);
+                    typeToCommandStorage.Add(instance.ResponseType, instance);
+                    storageIndex++;
                 }
 
-                commandIdToStorage.Add(instance.CommandId, instance);
-
-                typeToCommandStorage.Add(instance.RequestType, instance);
-                typeToCommandStorage.Add(instance.ResponseType, instance);
+                componentIdStorageRange.Add(componentId, (firstIndex, storageIndex - firstIndex));
             }
 
-            commandStorageList.Add(worldCommandsReceivedStorage);
             typeToCommandStorage.Add(typeof(WorldCommands.CreateEntity.ReceivedResponse), worldCommandsReceivedStorage);
             typeToCommandStorage.Add(typeof(WorldCommands.DeleteEntity.ReceivedResponse), worldCommandsReceivedStorage);
             typeToCommandStorage.Add(typeof(WorldCommands.ReserveEntityIds.ReceivedResponse), worldCommandsReceivedStorage);
@@ -112,6 +109,8 @@ namespace Improbable.Gdk.Core
             {
                 storage.Clear();
             }
+
+            worldCommandsReceivedStorage.Clear();
 
             entitiesAdded.Clear();
             entitiesRemoved.Clear();
@@ -180,12 +179,10 @@ namespace Improbable.Gdk.Core
             // Remove received command requests if authority has been lost
             if (authority == Authority.NotAuthoritative)
             {
-                if (componentIdToCommandIdToStorage.TryGetValue(componentId, out var commandIdToStorage))
+                var (firstIndex, count) = componentIdStorageRange[componentId];
+                for (var i = 0; i < count; i++)
                 {
-                    foreach (var storage in commandIdToStorage)
-                    {
-                        storage.Value.RemoveRequests(entityId);
-                    }
+                    commandStorageList[firstIndex + i].RemoveRequests(entityId);
                 }
             }
         }
@@ -219,33 +216,17 @@ namespace Improbable.Gdk.Core
 
         public void AddCommandRequest<T>(T request, uint componentId, uint commandId) where T : struct, IReceivedCommandRequest
         {
-            if (!componentIdToCommandIdToStorage.TryGetValue(componentId, out var commandIdToStorage))
-            {
-                throw new ArgumentException($"Can not find component diff storage. Unknown component ID {componentId}");
-            }
+            var storage = (IDiffCommandRequestStorage<T>) GetComponentCommandDiffStorage(componentId, commandId);
 
-            if (!commandIdToStorage.TryGetValue(commandId, out var storage))
-            {
-                throw new ArgumentException($"Can not find component diff storage. Unknown command ID {commandId}");
-            }
-
-            ((IDiffCommandRequestStorage<T>) storage).AddRequest(request);
+            storage.AddRequest(request);
         }
 
         public void AddCommandResponse<T>(T response, uint componentId, uint commandId)
             where T : struct, IReceivedCommandResponse
         {
-            if (!componentIdToCommandIdToStorage.TryGetValue(componentId, out var commandIdToStorage))
-            {
-                throw new ArgumentException($"Can not find component diff storage. Unknown component ID {componentId}");
-            }
+            var storage = (IDiffCommandResponseStorage<T>) GetComponentCommandDiffStorage(componentId, commandId);
 
-            if (!commandIdToStorage.TryGetValue(commandId, out var storage))
-            {
-                throw new ArgumentException($"Can not find component diff storage. Unknown command ID {commandId}");
-            }
-
-            ((IDiffCommandResponseStorage<T>) storage).AddResponse(response);
+            storage.AddResponse(response);
         }
 
         public void AddCreateEntityResponse(WorldCommands.CreateEntity.ReceivedResponse response)
@@ -338,14 +319,9 @@ namespace Improbable.Gdk.Core
 
         internal IComponentCommandDiffStorage GetComponentCommandDiffStorage(uint componentId, uint commandId)
         {
-            if (!componentIdToCommandIdToStorage.TryGetValue(componentId, out var commandIdToStorage))
+            if (!componentCommandToStorage.TryGetValue((componentId, commandId), out var storage))
             {
-                throw new ArgumentException($"Can not find command diff storage. Unknown component ID {componentId}");
-            }
-
-            if (!commandIdToStorage.TryGetValue(commandId, out var storage))
-            {
-                throw new ArgumentException($"Can not find command diff storage. Unknown command ID {commandId}");
+                throw new ArgumentException($"Can not find CommandDiffStorage. Unknown component ID {componentId} with command ID {commandId}");
             }
 
             return storage;

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/ViewDiff.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/ViewDiff.cs
@@ -4,23 +4,23 @@ using System.Linq;
 using Improbable.Gdk.Core.Commands;
 using Improbable.Gdk.Core.NetworkStats;
 using Improbable.Worker.CInterop;
-using UnityEngine;
 
 namespace Improbable.Gdk.Core
 {
-    internal static class ViewDiffMetadata
-    {
-        internal static IEnumerable<(uint componentId, Type diffStorageType)> ComponentStorageTypes => ComponentDatabase
-            .Metaclasses
-            .Select(pair => (pair.Key, pair.Value.DiffStorage));
-
-        internal static IEnumerable<(uint Key, IEnumerable<Type> storageTypes)> CommandDiffStorageTypes => ComponentDatabase.Metaclasses
-            .Select(componentCommands => (componentCommands.Key,
-                componentCommands.Value.Commands.Select(m => m.DiffStorage)));
-    }
-
     public class ViewDiff
     {
+        private static class ViewDiffMetadata
+        {
+            internal static IEnumerable<(uint componentId, Type diffStorageType)> ComponentStorageTypes => ComponentDatabase
+                .Metaclasses
+                .Select(pair => (pair.Key, pair.Value.DiffStorage));
+
+            internal static IEnumerable<(uint Key, IEnumerable<Type> storageTypes)> CommandDiffStorageTypes => ComponentDatabase.Metaclasses
+                .Select(componentCommands => (componentCommands.Key,
+                    componentCommands.Value.Commands.Select(m => m.DiffStorage)));
+        }
+
+
         public string DisconnectMessage;
 
         public bool Disconnected { get; private set; }

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/ViewDiff.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/ViewDiff.cs
@@ -11,15 +11,13 @@ namespace Improbable.Gdk.Core
     {
         private static class ViewDiffMetadata
         {
-            internal static IEnumerable<(uint componentId, Type diffStorageType)> ComponentStorageTypes => ComponentDatabase
-                .Metaclasses
+            internal static IEnumerable<(uint componentId, Type diffStorageType)> ComponentStorageTypes => ComponentDatabase.Metaclasses
                 .Select(pair => (pair.Key, pair.Value.DiffStorage));
 
             internal static IEnumerable<(uint Key, IEnumerable<Type> storageTypes)> CommandDiffStorageTypes => ComponentDatabase.Metaclasses
                 .Select(componentCommands => (componentCommands.Key,
                     componentCommands.Value.Commands.Select(m => m.DiffStorage)));
         }
-
 
         public string DisconnectMessage;
 


### PR DESCRIPTION
#### Description
First iteration of simplifications in the Component section of code generation.
Includes an improvement in the ViewDiff and MessagesToSend, reducing a double lookup for storage instances to a single lookup.