### PR TITLE
Change zip download references to auto generated zips

### DIFF
--- a/docs/projects/blank/tutorial/1/project-walkthrough.md
+++ b/docs/projects/blank/tutorial/1/project-walkthrough.md
@@ -19,7 +19,7 @@ Before exploring the contents of the Blank Project, we recommend you first downl
 
 <%(#Expandable title="Zip file download")%>
 
- While we recommend using Git, if you prefer to, you can get the source code for the Blank Project by downloading one zip file <a href="https://github.com/spatialos/gdk-for-unity-blank-project/releases" target="_blank">here</a>. Please download the latest release, the file should be called something like `gdk-for-unity-blank-project-x.y.z.zip`.
+ While we recommend using Git, if you prefer to, you can get the source code for the Blank Project by downloading one zip file <a href="https://github.com/spatialos/gdk-for-unity-blank-project/releases" target="_blank">here</a>. Please download the latest release, the file should be called `Source code`.
 
 <%(/Expandable)%>
 

--- a/docs/projects/fps/get-started/set-up.md
+++ b/docs/projects/fps/get-started/set-up.md
@@ -10,7 +10,7 @@ To run the the FPS Starter Project, you need to download the source code. There 
 
 <%(#Expandable title="Zip file download")%>
 
- While we recommend using Git, if you prefer to, you can get the source code for the FPS Starter Project by downloading one zip file <a href="https://github.com/spatialos/gdk-for-unity-fps-starter-project/releases" data-track-link="Starter Project Zip Clicked|product=Docs" target="_blank">here</a>. Please download the latest release, the file should be called something like `gdk-for-unity-fps-starter-project-x.y.z.zip`.
+ While we recommend using Git, if you prefer to, you can get the source code for the FPS Starter Project by downloading a zip file <a href="https://github.com/spatialos/gdk-for-unity-fps-starter-project/releases" data-track-link="Starter Project Zip Clicked|product=Docs" target="_blank">here</a>. Please download the latest release, the file should be called `Source code`.
 
 <%(Callout message="If you have downloaded the source code via a zip file move on to the next section of this page: [Open the FPS Starter Project in your Unity Editor](#open-in-editor).")%>
 


### PR DESCRIPTION
The packer generated zips aren't being done correctly. We've decided to remove packer and swap to the source generated ones since we no longer sideload.