### PR TITLE
Add requireables <-> unlink tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 - Ported all modules to the new `CodegenJob` model. [#1276](https://github.com/spatialos/gdk-for-unity/pull/1276)
 - Running forced code generation now deletes the `ImprobableCodegen.marker` file. [#1294](https://github.com/spatialos/gdk-for-unity/pull/1294)
+- Added tests coverage for the interaction between unlinking a GameObject and Reader/Writer/CommandSender/CommandReceiver state. [#1295](https://github.com/spatialos/gdk-for-unity/pull/1295)
 
 ## `0.3.3` - 2020-02-14
 

--- a/test-project/Assets/.schema/commands.schema
+++ b/test-project/Assets/.schema/commands.schema
@@ -1,0 +1,8 @@
+package improbable.gdk.test;
+import "improbable/gdk/core/common.schema";
+
+component TestCommands {
+    id = 12699;
+
+    command improbable.gdk.core.Empty test(improbable.gdk.core.Empty);
+}

--- a/test-project/Assets/EditmodeTests/Subscriptions/RequireablesUnlinkTests.cs
+++ b/test-project/Assets/EditmodeTests/Subscriptions/RequireablesUnlinkTests.cs
@@ -32,7 +32,7 @@ namespace Improbable.Gdk.EditmodeTests.Subscriptions
         }
 
         [Test]
-        public void Reader_is_disabled_if_component_removed()
+        public void Reader_is_disabled_if_gameobject_unlinked()
         {
             createdGameObject = CreateAndLinkGameObjectWithComponent<PositionReaderBehaviour>(EntityId);
             var reader = createdGameObject.GetComponent<PositionReaderBehaviour>().Reader;
@@ -44,7 +44,7 @@ namespace Improbable.Gdk.EditmodeTests.Subscriptions
         }
 
         [Test]
-        public void Writer_is_disabled_if_loses_auth()
+        public void Writer_is_disabled_if_gameobject_unlinked()
         {
             ConnectionHandler.ChangeAuthority(EntityId, Position.ComponentId, Authority.Authoritative);
             Update();
@@ -59,7 +59,7 @@ namespace Improbable.Gdk.EditmodeTests.Subscriptions
         }
 
         [Test]
-        public void CommandSender_is_disabled_if_entity_removed()
+        public void CommandSender_is_disabled_if_gameobject_unlinked()
         {
             createdGameObject = CreateAndLinkGameObjectWithComponent<CommandSender>(EntityId);
             var sender = createdGameObject.GetComponent<CommandSender>().Sender;
@@ -71,7 +71,7 @@ namespace Improbable.Gdk.EditmodeTests.Subscriptions
         }
 
         [Test]
-        public void CommandReceiver_is_disabled_if_loses_auth()
+        public void CommandReceiver_is_disabled_if_gameobject_unlinked()
         {
             ConnectionHandler.ChangeAuthority(EntityId, TestCommands.ComponentId, Authority.Authoritative);
             Update();
@@ -93,22 +93,31 @@ namespace Improbable.Gdk.EditmodeTests.Subscriptions
 
         private class PositionReaderBehaviour : MonoBehaviour
         {
+#pragma warning disable 649
             [Require] public PositionReader Reader;
+#pragma warning restore 649
         }
 
         private class PositionWriterBehaviour : MonoBehaviour
         {
+#pragma warning disable 649
             [Require] public PositionWriter Writer;
+#pragma warning restore 649
         }
 
         private class CommandSender : MonoBehaviour
         {
+#pragma warning disable 649
+
             [Require] public TestCommandsCommandSender Sender;
+#pragma warning restore 649
         }
 
         private class CommandReceiver : MonoBehaviour
         {
+#pragma warning disable 649
             [Require] public TestCommandsCommandReceiver Receiver;
+#pragma warning restore 649
         }
     }
 }

--- a/test-project/Assets/EditmodeTests/Subscriptions/RequireablesUnlinkTests.cs
+++ b/test-project/Assets/EditmodeTests/Subscriptions/RequireablesUnlinkTests.cs
@@ -1,0 +1,114 @@
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Subscriptions;
+using Improbable.Gdk.Test;
+using Improbable.Gdk.TestBases;
+using Improbable.Worker.CInterop;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Improbable.Gdk.EditmodeTests.Subscriptions
+{
+    public class RequireablesUnlinkTests : SubscriptionsTestBase
+    {
+        private const long EntityId = 100;
+        private GameObject createdGameObject;
+
+        [SetUp]
+        public override void Setup()
+        {
+            base.Setup();
+            var template = new EntityTemplate();
+            template.AddComponent(new Position.Snapshot(), "worker");
+            template.AddComponent(new TestCommands.Snapshot(), "worker");
+            ConnectionHandler.CreateEntity(EntityId, template);
+            Update();
+        }
+
+        [TearDown]
+        public override void TearDown()
+        {
+            base.TearDown();
+            Object.DestroyImmediate(createdGameObject);
+        }
+
+        [Test]
+        public void Reader_is_disabled_if_component_removed()
+        {
+            createdGameObject = CreateAndLinkGameObjectWithComponent<PositionReaderBehaviour>(EntityId);
+            var reader = createdGameObject.GetComponent<PositionReaderBehaviour>().Reader;
+
+            Linker.UnlinkGameObjectFromEntity(new EntityId(EntityId), createdGameObject);
+
+            Assert.IsNull(createdGameObject.GetComponent<PositionReaderBehaviour>().Reader);
+            Assert.IsFalse(reader.IsValid);
+        }
+
+        [Test]
+        public void Writer_is_disabled_if_loses_auth()
+        {
+            ConnectionHandler.ChangeAuthority(EntityId, Position.ComponentId, Authority.Authoritative);
+            Update();
+
+            createdGameObject = CreateAndLinkGameObjectWithComponent<PositionWriterBehaviour>(EntityId);
+            var writer = createdGameObject.GetComponent<PositionWriterBehaviour>().Writer;
+
+            Linker.UnlinkGameObjectFromEntity(new EntityId(EntityId), createdGameObject);
+
+            Assert.IsNull(createdGameObject.GetComponent<PositionWriterBehaviour>().Writer);
+            Assert.IsFalse(writer.IsValid);
+        }
+
+        [Test]
+        public void CommandSender_is_disabled_if_entity_removed()
+        {
+            createdGameObject = CreateAndLinkGameObjectWithComponent<CommandSender>(EntityId);
+            var sender = createdGameObject.GetComponent<CommandSender>().Sender;
+
+            Linker.UnlinkGameObjectFromEntity(new EntityId(EntityId), createdGameObject);
+
+            Assert.IsNull(createdGameObject.GetComponent<CommandSender>().Sender);
+            Assert.IsFalse(sender.IsValid);
+        }
+
+        [Test]
+        public void CommandReceiver_is_disabled_if_loses_auth()
+        {
+            ConnectionHandler.ChangeAuthority(EntityId, TestCommands.ComponentId, Authority.Authoritative);
+            Update();
+
+            createdGameObject = CreateAndLinkGameObjectWithComponent<CommandReceiver>(EntityId);
+            var receiver = createdGameObject.GetComponent<CommandReceiver>().Receiver;
+
+            Linker.UnlinkGameObjectFromEntity(new EntityId(EntityId), createdGameObject);
+
+            Assert.IsNull(createdGameObject.GetComponent<CommandReceiver>().Receiver);
+            Assert.IsFalse(receiver.IsValid);
+        }
+
+        private void Update()
+        {
+            ReceiveSystem.Update();
+            RequireLifecycleSystem.Update();
+        }
+
+        private class PositionReaderBehaviour : MonoBehaviour
+        {
+            [Require] public PositionReader Reader;
+        }
+
+        private class PositionWriterBehaviour : MonoBehaviour
+        {
+            [Require] public PositionWriter Writer;
+        }
+
+        private class CommandSender : MonoBehaviour
+        {
+            [Require] public TestCommandsCommandSender Sender;
+        }
+
+        private class CommandReceiver : MonoBehaviour
+        {
+            [Require] public TestCommandsCommandReceiver Receiver;
+        }
+    }
+}

--- a/test-project/Assets/EditmodeTests/Subscriptions/RequireablesUnlinkTests.cs.meta
+++ b/test-project/Assets/EditmodeTests/Subscriptions/RequireablesUnlinkTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 30255483dd374ed690c001057c0f7e81
+timeCreated: 1582031667


### PR DESCRIPTION
#### Description
Added some tests to ensure that the state of reader/writer/commandxyz objects is correctly managed when a GameObject is unlinked from an entity.

#### Tests

Yes these are tests.

#### Documentation

- [x] Changelog

