### PR TITLE
Fix bug where mobile launcher wouldn't find Android devices with hyphens in their product name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 - Fixed a bug where code generation would happen on every Unity compilation, despite the code generator returning successfully. [#1294](https://github.com/spatialos/gdk-for-unity/pull/1294)
 - Fixed a bug where dotnet output from the code generator would cause exceptions to be thrown. [#1294](https://github.com/spatialos/gdk-for-unity/pull/1294)
-- Fixed a bug where the Mobile Launcher window wouldn't find Android devices that contained hyphens in their name. [#1288](https://github.com/spatialos/gdk-for-unity/issues/1288) [#1296](https://github.com/spatialos/gdk-for-unity/pull/1296)
+- Fixed a bug where the Mobile Launcher window wouldn't find Android devices that contained hyphens in their product name. [#1288](https://github.com/spatialos/gdk-for-unity/issues/1288) [#1296](https://github.com/spatialos/gdk-for-unity/pull/1296)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Fixed a bug where code generation would happen on every Unity compilation, despite the code generator returning successfully. [#1294](https://github.com/spatialos/gdk-for-unity/pull/1294)
 - Fixed a bug where dotnet output from the code generator would cause exceptions to be thrown. [#1294](https://github.com/spatialos/gdk-for-unity/pull/1294)
+- Fixed a bug where the Mobile Launcher window wouldn't find Android devices that contained hyphens in their name. [#1288](https://github.com/spatialos/gdk-for-unity/issues/1288) [#1296](https://github.com/spatialos/gdk-for-unity/pull/1296)
 
 ### Removed
 

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/.codegen/Source/Generators/BuildSystem/BuildSystemAssemblyGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/.codegen/Source/Generators/BuildSystem/BuildSystemAssemblyGenerator.cs
@@ -14,7 +14,12 @@ namespace Improbable.Gdk.CodeGenerator
         ""Editor""
     ],
     ""excludePlatforms"": [],
-    ""allowUnsafeCode"": false
+    ""allowUnsafeCode"": false,
+    ""overrideReferences"": false,
+    ""precompiledReferences"": [],
+    ""autoReferenced"": true,
+    ""defineConstraints"": [],
+    ""versionDefines"": []
 }
 ";
         }

--- a/workers/unity/Packages/io.improbable.gdk.mobile/Editor/AndroidUtils.cs
+++ b/workers/unity/Packages/io.improbable.gdk.mobile/Editor/AndroidUtils.cs
@@ -26,10 +26,10 @@ namespace Improbable.Gdk.Mobile
             the "product" capture would be "starltexx", "model" would be "SM_G960F" and "device" would be "starlte".
         */
         private static readonly Regex DeviceMatchRegex = new Regex(pattern:
-            "(?:(?<id>[\\w_\\d-]+)\\s*device).*" +
-            "(?:product:(?<product>[\\w_\\d]+))\\s*" +
-            "(?:model:(?<model>[\\w_\\d]+))\\s*" +
-            "(?:device:(?<device>[\\w_\\d]+)).*");
+            "(?:(?<id>[\\w\\d_-]+)\\s*device).*" +
+            "(?:product:(?<product>[\\w\\d_-]+))\\s*" +
+            "(?:model:(?<model>[\\w\\d_-]+))\\s*" +
+            "(?:device:(?<device>[\\w\\d_-]+)).*");
 
         public static (List<DeviceLaunchConfig> emulators, List<DeviceLaunchConfig> devices) RetrieveAvailableEmulatorsAndDevices()
         {


### PR DESCRIPTION
#### Description

Fix bug where mobile launcher wouldn't find Android devices with hyphens in their product name #1288 

+ drive-by update to build system asmdef generator

#### Tests

- regex101

#### Documentation

- [x] changelog

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
