### PR TITLE
Requireable constraint tweaks & bugfixing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 - Fixed a bug where dotnet output from the code generator would cause exceptions to be thrown. [#1294](https://github.com/spatialos/gdk-for-unity/pull/1294)
 - Fixed a bug where the Mobile Launcher window wouldn't find Android devices that contained hyphens in their product name. [#1288](https://github.com/spatialos/gdk-for-unity/issues/1288) [#1296](https://github.com/spatialos/gdk-for-unity/pull/1296)
 - Fixed a bug where component events were not dropped properly when the entity-component pair was removed from the View. [#1298])(https://github.com/spatialos/gdk-for-unity/pull/1298)
+- Fixed a bug where Reader/Writer/CommandSender/CommandReceiver fields would not have their state set to invalid when the underlying constraints were not met. [#1297](https://github.com/spatialos/gdk-for-unity/pull/1297)
+    - This bug would manifest itself in situations like a `Reader` reference attempting to read data that does not exist in your worker's view anymore.
 
 ### Removed
 

--- a/test-project/Assets/EditmodeTests/Subscriptions/RequireablesDisableTests.cs
+++ b/test-project/Assets/EditmodeTests/Subscriptions/RequireablesDisableTests.cs
@@ -1,0 +1,142 @@
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Subscriptions;
+using Improbable.Gdk.Test;
+using Improbable.Gdk.TestBases;
+using Improbable.Worker.CInterop;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Improbable.Gdk.EditmodeTests.Subscriptions
+{
+    public class RequireablesDisableTests : SubscriptionsTestBase
+    {
+        private const long EntityId = 100;
+        private GameObject createdGameObject;
+
+        [SetUp]
+        public override void Setup()
+        {
+            base.Setup();
+            var template = new EntityTemplate();
+            template.AddComponent(new Position.Snapshot(), "worker");
+            template.AddComponent(new TestCommands.Snapshot(), "worker");
+            ConnectionHandler.CreateEntity(EntityId, template);
+            Update();
+        }
+
+        [Test]
+        public void Reader_is_disabled_if_component_removed()
+        {
+            createdGameObject = CreateAndLinkGameObjectWithComponent<PositionReaderBehaviour>(EntityId);
+            var reader = createdGameObject.GetComponent<PositionReaderBehaviour>().Reader;
+
+            ConnectionHandler.RemoveComponent(EntityId, Position.ComponentId);
+            Update();
+
+            Assert.IsNull(createdGameObject.GetComponent<PositionReaderBehaviour>().Reader);
+            Assert.IsFalse(reader.IsValid);
+        }
+
+        [Test]
+        public void Writer_is_disabled_if_loses_auth()
+        {
+            ConnectionHandler.ChangeAuthority(EntityId, Position.ComponentId, Authority.Authoritative);
+            Update();
+
+            createdGameObject = CreateAndLinkGameObjectWithComponent<PositionWriterBehaviour>(EntityId);
+            var writer = createdGameObject.GetComponent<PositionWriterBehaviour>().Writer;
+
+            ConnectionHandler.ChangeAuthority(EntityId, Position.ComponentId, Authority.NotAuthoritative);
+            Update();
+
+            Assert.IsNull(createdGameObject.GetComponent<PositionWriterBehaviour>().Writer);
+            Assert.IsFalse(writer.IsValid);
+        }
+
+        [Test]
+        public void CommandSender_is_disabled_if_entity_removed()
+        {
+            createdGameObject = CreateAndLinkGameObjectWithComponent<CommandSender>(EntityId);
+            var sender = createdGameObject.GetComponent<CommandSender>().Sender;
+
+            ConnectionHandler.RemoveComponent(EntityId, Position.ComponentId);
+            ConnectionHandler.RemoveComponent(EntityId, TestCommands.ComponentId);
+            ConnectionHandler.RemoveEntity(EntityId);
+            Update();
+
+            Assert.IsNull(createdGameObject.GetComponent<CommandSender>().Sender);
+            Assert.IsFalse(sender.IsValid);
+        }
+
+        [Test]
+        public void CommandReceiver_is_disabled_if_loses_auth()
+        {
+            ConnectionHandler.ChangeAuthority(EntityId, TestCommands.ComponentId, Authority.Authoritative);
+            Update();
+
+            createdGameObject = CreateAndLinkGameObjectWithComponent<CommandReceiver>(EntityId);
+            var receiver = createdGameObject.GetComponent<CommandReceiver>().Receiver;
+
+            ConnectionHandler.ChangeAuthority(EntityId, TestCommands.ComponentId, Authority.NotAuthoritative);
+            Update();
+
+            Assert.IsNull(createdGameObject.GetComponent<CommandReceiver>().Receiver);
+            Assert.IsFalse(receiver.IsValid);
+        }
+
+        [Test]
+        public void Only_field_which_lost_constraints_is_invalid()
+        {
+            createdGameObject = CreateAndLinkGameObjectWithComponent<MultipleReaderBehaviour>(EntityId);
+            var component = createdGameObject.GetComponent<MultipleReaderBehaviour>();
+            var position = component.PositionReader;
+            var testCommands = component.TestCommandsReader;
+
+            ConnectionHandler.RemoveComponent(EntityId, TestCommands.ComponentId);
+            Update();
+
+            Assert.IsNull(component.PositionReader);
+            Assert.IsNull(component.TestCommandsReader);
+            Assert.IsFalse(position.IsValid);
+            Assert.IsFalse(testCommands.IsValid);
+        }
+
+        public override void TearDown()
+        {
+            base.TearDown();
+            Object.DestroyImmediate(createdGameObject);
+        }
+
+        private void Update()
+        {
+            ReceiveSystem.Update();
+            RequireLifecycleSystem.Update();
+        }
+
+        private class PositionReaderBehaviour : MonoBehaviour
+        {
+            [Require] public PositionReader Reader;
+        }
+
+        private class PositionWriterBehaviour : MonoBehaviour
+        {
+            [Require] public PositionWriter Writer;
+        }
+
+        private class CommandSender : MonoBehaviour
+        {
+            [Require] public TestCommandsCommandSender Sender;
+        }
+
+        private class CommandReceiver : MonoBehaviour
+        {
+            [Require] public TestCommandsCommandReceiver Receiver;
+        }
+
+        private class MultipleReaderBehaviour : MonoBehaviour
+        {
+            [Require] public PositionReader PositionReader;
+            [Require] public TestCommandsReader TestCommandsReader;
+        }
+    }
+}

--- a/test-project/Assets/EditmodeTests/Subscriptions/RequireablesDisableTests.cs.meta
+++ b/test-project/Assets/EditmodeTests/Subscriptions/RequireablesDisableTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 30255483dd374ed690c001057c0f7e81
+timeCreated: 1582031667

--- a/test-project/Assets/EditmodeTests/Subscriptions/RequireablesUnlinkTests.cs.meta
+++ b/test-project/Assets/EditmodeTests/Subscriptions/RequireablesUnlinkTests.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
-guid: 30255483dd374ed690c001057c0f7e81
-timeCreated: 1582031667
+fileFormatVersion: 2
+guid: 1a35b1fbc85257447981c3839bdaa1b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentComponentComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentComponentComponentReaderWriter.cs
@@ -102,12 +102,7 @@ namespace Improbable.DependentSchema
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<DependentComponentReader>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToReaderSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -124,7 +119,9 @@ namespace Improbable.DependentSchema
             var sub = ((Subscription<DependentComponentReader>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
 
@@ -227,12 +224,7 @@ namespace Improbable.DependentSchema
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<DependentComponentWriter>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToWriterSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -249,7 +241,9 @@ namespace Improbable.DependentSchema
             var sub = ((Subscription<DependentComponentWriter>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
     }
@@ -270,7 +264,7 @@ namespace Improbable.DependentSchema
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read component data when Reader is not valid.");
                 }
 
                 return EntityManager.GetComponentData<DependentComponent.Component>(Entity);
@@ -283,7 +277,7 @@ namespace Improbable.DependentSchema
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read authority when Reader is not valid");
                 }
 
                 return ComponentUpdateSystem.GetAuthority(EntityId, DependentComponent.ComponentId);

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponentComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponentComponentReaderWriter.cs
@@ -102,12 +102,7 @@ namespace Improbable.DependentSchema
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<DependentDataComponentReader>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToReaderSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -124,7 +119,9 @@ namespace Improbable.DependentSchema
             var sub = ((Subscription<DependentDataComponentReader>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
 
@@ -227,12 +224,7 @@ namespace Improbable.DependentSchema
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<DependentDataComponentWriter>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToWriterSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -249,7 +241,9 @@ namespace Improbable.DependentSchema
             var sub = ((Subscription<DependentDataComponentWriter>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
     }
@@ -270,7 +264,7 @@ namespace Improbable.DependentSchema
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read component data when Reader is not valid.");
                 }
 
                 return EntityManager.GetComponentData<DependentDataComponent.Component>(Entity);
@@ -283,7 +277,7 @@ namespace Improbable.DependentSchema
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read authority when Reader is not valid");
                 }
 
                 return ComponentUpdateSystem.GetAuthority(EntityId, DependentDataComponent.ComponentId);

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestChildComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestChildComponentReaderWriter.cs
@@ -102,12 +102,7 @@ namespace Improbable.Tests
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<DependencyTestChildReader>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToReaderSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -124,7 +119,9 @@ namespace Improbable.Tests
             var sub = ((Subscription<DependencyTestChildReader>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
 
@@ -227,12 +224,7 @@ namespace Improbable.Tests
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<DependencyTestChildWriter>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToWriterSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -249,7 +241,9 @@ namespace Improbable.Tests
             var sub = ((Subscription<DependencyTestChildWriter>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
     }
@@ -270,7 +264,7 @@ namespace Improbable.Tests
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read component data when Reader is not valid.");
                 }
 
                 return EntityManager.GetComponentData<DependencyTestChild.Component>(Entity);
@@ -283,7 +277,7 @@ namespace Improbable.Tests
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read authority when Reader is not valid");
                 }
 
                 return ComponentUpdateSystem.GetAuthority(EntityId, DependencyTestChild.ComponentId);

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestComponentReaderWriter.cs
@@ -102,12 +102,7 @@ namespace Improbable.Tests
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<DependencyTestReader>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToReaderSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -124,7 +119,9 @@ namespace Improbable.Tests
             var sub = ((Subscription<DependencyTestReader>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
 
@@ -227,12 +224,7 @@ namespace Improbable.Tests
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<DependencyTestWriter>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToWriterSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -249,7 +241,9 @@ namespace Improbable.Tests
             var sub = ((Subscription<DependencyTestWriter>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
     }
@@ -270,7 +264,7 @@ namespace Improbable.Tests
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read component data when Reader is not valid.");
                 }
 
                 return EntityManager.GetComponentData<DependencyTest.Component>(Entity);
@@ -283,7 +277,7 @@ namespace Improbable.Tests
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read authority when Reader is not valid");
                 }
 
                 return ComponentUpdateSystem.GetAuthority(EntityId, DependencyTest.ComponentId);

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestGrandchildComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestGrandchildComponentReaderWriter.cs
@@ -102,12 +102,7 @@ namespace Improbable.Tests
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<DependencyTestGrandchildReader>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToReaderSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -124,7 +119,9 @@ namespace Improbable.Tests
             var sub = ((Subscription<DependencyTestGrandchildReader>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
 
@@ -227,12 +224,7 @@ namespace Improbable.Tests
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<DependencyTestGrandchildWriter>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToWriterSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -249,7 +241,9 @@ namespace Improbable.Tests
             var sub = ((Subscription<DependencyTestGrandchildWriter>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
     }
@@ -270,7 +264,7 @@ namespace Improbable.Tests
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read component data when Reader is not valid.");
                 }
 
                 return EntityManager.GetComponentData<DependencyTestGrandchild.Component>(Entity);
@@ -283,7 +277,7 @@ namespace Improbable.Tests
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read authority when Reader is not valid");
                 }
 
                 return ComponentUpdateSystem.GetAuthority(EntityId, DependencyTestGrandchild.ComponentId);

--- a/test-project/Assets/Generated/Source/improbable/testschema/ComponentUsingNestedTypeSameNameComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ComponentUsingNestedTypeSameNameComponentReaderWriter.cs
@@ -102,12 +102,7 @@ namespace Improbable.TestSchema
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<ComponentUsingNestedTypeSameNameReader>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToReaderSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -124,7 +119,9 @@ namespace Improbable.TestSchema
             var sub = ((Subscription<ComponentUsingNestedTypeSameNameReader>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
 
@@ -227,12 +224,7 @@ namespace Improbable.TestSchema
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<ComponentUsingNestedTypeSameNameWriter>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToWriterSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -249,7 +241,9 @@ namespace Improbable.TestSchema
             var sub = ((Subscription<ComponentUsingNestedTypeSameNameWriter>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
     }
@@ -270,7 +264,7 @@ namespace Improbable.TestSchema
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read component data when Reader is not valid.");
                 }
 
                 return EntityManager.GetComponentData<ComponentUsingNestedTypeSameName.Component>(Entity);
@@ -283,7 +277,7 @@ namespace Improbable.TestSchema
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read authority when Reader is not valid");
                 }
 
                 return ComponentUpdateSystem.GetAuthority(EntityId, ComponentUsingNestedTypeSameName.ComponentId);

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveEntityComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveEntityComponentReaderWriter.cs
@@ -102,12 +102,7 @@ namespace Improbable.TestSchema
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<ExhaustiveEntityReader>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToReaderSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -124,7 +119,9 @@ namespace Improbable.TestSchema
             var sub = ((Subscription<ExhaustiveEntityReader>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
 
@@ -227,12 +224,7 @@ namespace Improbable.TestSchema
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<ExhaustiveEntityWriter>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToWriterSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -249,7 +241,9 @@ namespace Improbable.TestSchema
             var sub = ((Subscription<ExhaustiveEntityWriter>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
     }
@@ -270,7 +264,7 @@ namespace Improbable.TestSchema
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read component data when Reader is not valid.");
                 }
 
                 return EntityManager.GetComponentData<ExhaustiveEntity.Component>(Entity);
@@ -283,7 +277,7 @@ namespace Improbable.TestSchema
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read authority when Reader is not valid");
                 }
 
                 return ComponentUpdateSystem.GetAuthority(EntityId, ExhaustiveEntity.ComponentId);

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapKeyComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapKeyComponentReaderWriter.cs
@@ -102,12 +102,7 @@ namespace Improbable.TestSchema
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<ExhaustiveMapKeyReader>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToReaderSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -124,7 +119,9 @@ namespace Improbable.TestSchema
             var sub = ((Subscription<ExhaustiveMapKeyReader>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
 
@@ -227,12 +224,7 @@ namespace Improbable.TestSchema
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<ExhaustiveMapKeyWriter>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToWriterSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -249,7 +241,9 @@ namespace Improbable.TestSchema
             var sub = ((Subscription<ExhaustiveMapKeyWriter>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
     }
@@ -270,7 +264,7 @@ namespace Improbable.TestSchema
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read component data when Reader is not valid.");
                 }
 
                 return EntityManager.GetComponentData<ExhaustiveMapKey.Component>(Entity);
@@ -283,7 +277,7 @@ namespace Improbable.TestSchema
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read authority when Reader is not valid");
                 }
 
                 return ComponentUpdateSystem.GetAuthority(EntityId, ExhaustiveMapKey.ComponentId);

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapValueComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapValueComponentReaderWriter.cs
@@ -102,12 +102,7 @@ namespace Improbable.TestSchema
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<ExhaustiveMapValueReader>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToReaderSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -124,7 +119,9 @@ namespace Improbable.TestSchema
             var sub = ((Subscription<ExhaustiveMapValueReader>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
 
@@ -227,12 +224,7 @@ namespace Improbable.TestSchema
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<ExhaustiveMapValueWriter>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToWriterSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -249,7 +241,9 @@ namespace Improbable.TestSchema
             var sub = ((Subscription<ExhaustiveMapValueWriter>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
     }
@@ -270,7 +264,7 @@ namespace Improbable.TestSchema
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read component data when Reader is not valid.");
                 }
 
                 return EntityManager.GetComponentData<ExhaustiveMapValue.Component>(Entity);
@@ -283,7 +277,7 @@ namespace Improbable.TestSchema
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read authority when Reader is not valid");
                 }
 
                 return ComponentUpdateSystem.GetAuthority(EntityId, ExhaustiveMapValue.ComponentId);

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveOptionalComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveOptionalComponentReaderWriter.cs
@@ -102,12 +102,7 @@ namespace Improbable.TestSchema
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<ExhaustiveOptionalReader>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToReaderSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -124,7 +119,9 @@ namespace Improbable.TestSchema
             var sub = ((Subscription<ExhaustiveOptionalReader>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
 
@@ -227,12 +224,7 @@ namespace Improbable.TestSchema
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<ExhaustiveOptionalWriter>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToWriterSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -249,7 +241,9 @@ namespace Improbable.TestSchema
             var sub = ((Subscription<ExhaustiveOptionalWriter>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
     }
@@ -270,7 +264,7 @@ namespace Improbable.TestSchema
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read component data when Reader is not valid.");
                 }
 
                 return EntityManager.GetComponentData<ExhaustiveOptional.Component>(Entity);
@@ -283,7 +277,7 @@ namespace Improbable.TestSchema
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read authority when Reader is not valid");
                 }
 
                 return ComponentUpdateSystem.GetAuthority(EntityId, ExhaustiveOptional.ComponentId);

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveRepeatedComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveRepeatedComponentReaderWriter.cs
@@ -102,12 +102,7 @@ namespace Improbable.TestSchema
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<ExhaustiveRepeatedReader>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToReaderSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -124,7 +119,9 @@ namespace Improbable.TestSchema
             var sub = ((Subscription<ExhaustiveRepeatedReader>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
 
@@ -227,12 +224,7 @@ namespace Improbable.TestSchema
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<ExhaustiveRepeatedWriter>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToWriterSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -249,7 +241,9 @@ namespace Improbable.TestSchema
             var sub = ((Subscription<ExhaustiveRepeatedWriter>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
     }
@@ -270,7 +264,7 @@ namespace Improbable.TestSchema
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read component data when Reader is not valid.");
                 }
 
                 return EntityManager.GetComponentData<ExhaustiveRepeated.Component>(Entity);
@@ -283,7 +277,7 @@ namespace Improbable.TestSchema
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read authority when Reader is not valid");
                 }
 
                 return ComponentUpdateSystem.GetAuthority(EntityId, ExhaustiveRepeated.ComponentId);

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveSingularComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveSingularComponentReaderWriter.cs
@@ -102,12 +102,7 @@ namespace Improbable.TestSchema
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<ExhaustiveSingularReader>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToReaderSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -124,7 +119,9 @@ namespace Improbable.TestSchema
             var sub = ((Subscription<ExhaustiveSingularReader>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
 
@@ -227,12 +224,7 @@ namespace Improbable.TestSchema
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<ExhaustiveSingularWriter>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToWriterSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -249,7 +241,9 @@ namespace Improbable.TestSchema
             var sub = ((Subscription<ExhaustiveSingularWriter>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
     }
@@ -270,7 +264,7 @@ namespace Improbable.TestSchema
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read component data when Reader is not valid.");
                 }
 
                 return EntityManager.GetComponentData<ExhaustiveSingular.Component>(Entity);
@@ -283,7 +277,7 @@ namespace Improbable.TestSchema
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read authority when Reader is not valid");
                 }
 
                 return ComponentUpdateSystem.GetAuthority(EntityId, ExhaustiveSingular.ComponentId);

--- a/test-project/Assets/Generated/Source/improbable/testschema/RecursiveComponentComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/RecursiveComponentComponentReaderWriter.cs
@@ -102,12 +102,7 @@ namespace Improbable.TestSchema
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<RecursiveComponentReader>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToReaderSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -124,7 +119,9 @@ namespace Improbable.TestSchema
             var sub = ((Subscription<RecursiveComponentReader>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
 
@@ -227,12 +224,7 @@ namespace Improbable.TestSchema
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<RecursiveComponentWriter>) subscription);
-            if (sub.HasValue)
-            {
-                var reader = sub.Value;
-                reader.IsValid = false;
-                reader.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToWriterSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -249,7 +241,9 @@ namespace Improbable.TestSchema
             var sub = ((Subscription<RecursiveComponentWriter>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var reader = sub.Value;
+                reader.IsValid = false;
+                reader.RemoveAllCallbacks();
             }
         }
     }
@@ -270,7 +264,7 @@ namespace Improbable.TestSchema
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read component data when Reader is not valid.");
                 }
 
                 return EntityManager.GetComponentData<RecursiveComponent.Component>(Entity);
@@ -283,7 +277,7 @@ namespace Improbable.TestSchema
             {
                 if (!IsValid)
                 {
-                    throw new InvalidOperationException("Oh noes!");
+                    throw new InvalidOperationException("Cannot read authority when Reader is not valid");
                 }
 
                 return ComponentUpdateSystem.GetAuthority(EntityId, RecursiveComponent.ComponentId);

--- a/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/CommandSenderReceiverSubscriptionManagerBase.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/CommandSenderReceiverSubscriptionManagerBase.cs
@@ -103,11 +103,7 @@ namespace Improbable.Gdk.Subscriptions
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<T>) subscription);
-            if (sub.HasValue)
-            {
-                var sender = sub.Value;
-                sender.IsValid = false;
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToSenderSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -122,7 +118,8 @@ namespace Improbable.Gdk.Subscriptions
             var sub = ((Subscription<T>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var sender = sub.Value;
+                sender.IsValid = false;
             }
         }
     }
@@ -222,12 +219,7 @@ namespace Improbable.Gdk.Subscriptions
         public override void Cancel(ISubscription subscription)
         {
             var sub = ((Subscription<T>) subscription);
-            if (sub.HasValue)
-            {
-                var receiver = sub.Value;
-                receiver.IsValid = false;
-                receiver.RemoveAllCallbacks();
-            }
+            ResetValue(sub);
 
             var subscriptions = entityIdToReceiveSubscriptions[sub.EntityId];
             subscriptions.Remove(sub);
@@ -244,7 +236,9 @@ namespace Improbable.Gdk.Subscriptions
             var sub = ((Subscription<T>) subscription);
             if (sub.HasValue)
             {
-                sub.Value.RemoveAllCallbacks();
+                var receiver = sub.Value;
+                receiver.IsValid = false;
+                receiver.RemoveAllCallbacks();
             }
         }
     }

--- a/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/RequiredSubscriptionsInjector.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/RequiredSubscriptionsInjector.cs
@@ -57,10 +57,7 @@ namespace Improbable.Gdk.Subscriptions
 
             foreach (var field in info.RequiredFields)
             {
-                if (!field.FieldType.IsValueType)
-                {
-                    field.SetValue(target, null);
-                }
+                field.SetValue(target, null);
             }
         }
 
@@ -77,6 +74,11 @@ namespace Improbable.Gdk.Subscriptions
         private void HandleSubscriptionsNoLongerSatisfied()
         {
             onDisable?.Invoke();
+
+            foreach (var field in info.RequiredFields)
+            {
+                field.SetValue(target, null);
+            }
         }
 
         private class Handler : ISubscriptionAvailabilityHandler

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/.codegen/Source/Generators/GameObjectCreation/UnityComponentReaderWriterGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/.codegen/Source/Generators/GameObjectCreation/UnityComponentReaderWriterGenerator.cs
@@ -129,12 +129,7 @@ public override Subscription<{componentDetails.Name}Reader> Subscribe(EntityId e
 public override void Cancel(ISubscription subscription)
 {{
     var sub = ((Subscription<{componentDetails.Name}Reader>) subscription);
-    if (sub.HasValue)
-    {{
-        var reader = sub.Value;
-        reader.IsValid = false;
-        reader.RemoveAllCallbacks();
-    }}
+    ResetValue(sub);
 
     var subscriptions = entityIdToReaderSubscriptions[sub.EntityId];
     subscriptions.Remove(sub);
@@ -151,7 +146,9 @@ public override void ResetValue(ISubscription subscription)
     var sub = ((Subscription<{componentDetails.Name}Reader>) subscription);
     if (sub.HasValue)
     {{
-        sub.Value.RemoveAllCallbacks();
+        var reader = sub.Value;
+        reader.IsValid = false;
+        reader.RemoveAllCallbacks();
     }}
 }}
 
@@ -262,12 +259,7 @@ public override Subscription<{componentDetails.Name}Writer> Subscribe(EntityId e
 public override void Cancel(ISubscription subscription)
 {{
     var sub = ((Subscription<{componentDetails.Name}Writer>) subscription);
-    if (sub.HasValue)
-    {{
-        var reader = sub.Value;
-        reader.IsValid = false;
-        reader.RemoveAllCallbacks();
-    }}
+    ResetValue(sub);
 
     var subscriptions = entityIdToWriterSubscriptions[sub.EntityId];
     subscriptions.Remove(sub);
@@ -284,7 +276,9 @@ public override void ResetValue(ISubscription subscription)
     var sub = ((Subscription<{componentDetails.Name}Writer>) subscription);
     if (sub.HasValue)
     {{
-        sub.Value.RemoveAllCallbacks();
+        var reader = sub.Value;
+        reader.IsValid = false;
+        reader.RemoveAllCallbacks();
     }}
 }}
 ");

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/.codegen/Source/Generators/GameObjectCreation/UnityComponentReaderWriterGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/.codegen/Source/Generators/GameObjectCreation/UnityComponentReaderWriterGenerator.cs
@@ -307,7 +307,7 @@ public {componentDetails.Name}.Component Data
     {{
         if (!IsValid)
         {{
-            throw new InvalidOperationException(""Oh noes!"");
+            throw new InvalidOperationException(""Cannot read component data when Reader is not valid."");
         }}
 
         return EntityManager.GetComponentData<{componentDetails.Name}.Component>(Entity);
@@ -320,7 +320,7 @@ public Authority Authority
     {{
         if (!IsValid)
         {{
-            throw new InvalidOperationException(""Oh noes!"");
+            throw new InvalidOperationException(""Cannot read authority when Reader is not valid"");
         }}
 
         return ComponentUpdateSystem.GetAuthority(EntityId, {componentDetails.Name}.ComponentId);


### PR DESCRIPTION
#### Description

This PR makes some changes to when a field annotated with `[Require]` have `IsValid` set to `false` and the value set to `null`. 

Previously this would only happen when a GameObject was unlinked from the underlying entity, typically when the entity had left the worker's view (unless a user had some custom logic). This means that if you had a MonoBehaviour like:

```csharp
public MyBehaviour : MonoBehaviour {
    [Require] public HealthReader HealthReader;
}
```

if the underlying Health component left your view, say through a QBI query the `HealthReader` field would be left injected _and_ `IsValid` would still be true. If you copied the reference or captured it in a closure, this could result in bad behaviour. 

Now, when the required field's constraints are no longer met, `HealthReader.IsValid` is set to `false` and the MonoBehaviour's field is nulled out. 

---

A consequence of this change in behaviour is that now if you have multiple required fields on a single behaviour, if one of them no longer matches the constraints, every field will be `null`-ed out and `IsValid` will be set to false

#### Tests

- [x] Tests which cover the behaviour with a single field on a MonoBehaviour.
- [x] Tests which cover the behaviour with multiple fields on a MonoBehaviour.
- [x] Tested the FPS with multi-worker.

#### Documentation

- [x] Changelog
