### PR TITLE
Events also update entities!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed a bug where code generation would happen on every Unity compilation, despite the code generator returning successfully. [#1294](https://github.com/spatialos/gdk-for-unity/pull/1294)
 - Fixed a bug where dotnet output from the code generator would cause exceptions to be thrown. [#1294](https://github.com/spatialos/gdk-for-unity/pull/1294)
 - Fixed a bug where the Mobile Launcher window wouldn't find Android devices that contained hyphens in their product name. [#1288](https://github.com/spatialos/gdk-for-unity/issues/1288) [#1296](https://github.com/spatialos/gdk-for-unity/pull/1296)
+- Fixed a bug where component events were not dropped properly when the entity-component pair was removed from the View. [#1298])(https://github.com/spatialos/gdk-for-unity/pull/1298)
 
 ### Removed
 

--- a/test-project/Assets/EditmodeTests/Core.meta
+++ b/test-project/Assets/EditmodeTests/Core.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 962ea040e7824ccd8861d73fdeae5acb
+timeCreated: 1582127273

--- a/test-project/Assets/EditmodeTests/Core/ComponentDiffStorageTests.cs
+++ b/test-project/Assets/EditmodeTests/Core/ComponentDiffStorageTests.cs
@@ -1,0 +1,157 @@
+using Improbable.DependentSchema;
+using Improbable.Gdk.Core;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Improbable.Gdk.EditmodeTests.Core
+{
+    [TestFixture]
+    public class ComponentDiffStorageTests
+    {
+        private const long EntityId = 10;
+
+        private WorkerInWorld workerInWorld;
+        private SpatialOSReceiveSystem receiveSystem;
+        private ComponentUpdateSystem componentUpdateSystem;
+        private MockConnectionHandler connectionHandler;
+
+        [SetUp]
+        public void Setup()
+        {
+            var connectionBuilder = new MockConnectionHandlerBuilder();
+            connectionHandler = connectionBuilder.ConnectionHandler;
+
+            workerInWorld = WorkerInWorld
+                .CreateWorkerInWorldAsync(connectionBuilder, "TestWorkerType", new LoggingDispatcher(), Vector3.zero)
+                .Result;
+
+            var world = workerInWorld.World;
+            receiveSystem = world.GetExistingSystem<SpatialOSReceiveSystem>();
+            componentUpdateSystem = world.GetExistingSystem<ComponentUpdateSystem>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            workerInWorld.Dispose();
+        }
+
+        [Test]
+        public void Component_updates_are_available_immediately()
+        {
+            CreateEntity();
+            Update();
+
+            UpdatePosition();
+            Update();
+
+            var updates = componentUpdateSystem.GetComponentUpdatesReceived<Position.Update>();
+            Assert.AreEqual(expected: 1, updates.Count);
+
+            var entitySpecificUpdates =
+                componentUpdateSystem.GetEntityComponentUpdatesReceived<Position.Update>(new EntityId(10));
+            Assert.AreEqual(expected: 1, entitySpecificUpdates.Count);
+        }
+
+        [Test]
+        public void Component_updates_are_dropped_if_component_removed()
+        {
+            CreateEntity();
+            Update();
+
+            UpdatePosition();
+            connectionHandler.RemoveComponent(entityId: 10, Position.ComponentId);
+            Update();
+
+            var updates = componentUpdateSystem.GetComponentUpdatesReceived<Position.Update>();
+            Assert.AreEqual(expected: 0, updates.Count);
+
+            var entitySpecificUpdates =
+                componentUpdateSystem.GetEntityComponentUpdatesReceived<Position.Update>(new EntityId(10));
+            Assert.AreEqual(expected: 0, entitySpecificUpdates.Count);
+        }
+
+        [Test]
+        public void Events_are_available_immediately()
+        {
+            CreateEntity();
+            Update();
+
+            SendDependentDataEvent();
+            Update();
+
+            var events = componentUpdateSystem.GetEventsReceived<DependentDataComponent.FooEvent.Event>();
+            Assert.AreEqual(1, events.Count);
+
+            var entitySpecificEvents =
+                componentUpdateSystem.GetEventsReceived<DependentDataComponent.FooEvent.Event>(new EntityId(EntityId));
+            Assert.AreEqual(1, entitySpecificEvents.Count);
+        }
+
+        [Test]
+        public void Events_are_dropped_if_component_removed()
+        {
+            CreateEntity();
+            Update();
+
+            SendDependentDataEvent();
+            connectionHandler.RemoveComponent(EntityId, DependentDataComponent.ComponentId);
+            Update();
+
+            var events = componentUpdateSystem.GetEventsReceived<DependentDataComponent.FooEvent.Event>();
+            Assert.AreEqual(0, events.Count);
+
+            var entitySpecificEvents =
+                componentUpdateSystem.GetEventsReceived<DependentDataComponent.FooEvent.Event>(new EntityId(EntityId));
+            Assert.AreEqual(0, entitySpecificEvents.Count);
+        }
+
+        [Test]
+        public void Messages_on_different_components_are_not_coupled()
+        {
+            CreateEntity();
+            Update();
+
+            SendDependentDataEvent();
+            UpdatePosition();
+            connectionHandler.RemoveComponent(EntityId, DependentDataComponent.ComponentId);
+            Update();
+
+            var updates = componentUpdateSystem.GetComponentUpdatesReceived<Position.Update>();
+            Assert.AreEqual(expected: 1, updates.Count);
+
+            var entitySpecificUpdates =
+                componentUpdateSystem.GetEntityComponentUpdatesReceived<Position.Update>(new EntityId(10));
+            Assert.AreEqual(expected: 1, entitySpecificUpdates.Count);
+        }
+
+        private void CreateEntity()
+        {
+            var template = new EntityTemplate();
+            template.AddComponent(new Position.Snapshot(), "worker");
+            template.AddComponent(new DependentDataComponent.Snapshot(), "worker");
+            connectionHandler.CreateEntity(EntityId, template);
+        }
+
+        private void UpdatePosition()
+        {
+            const float coordsValue = 5.0f;
+
+            connectionHandler.UpdateComponent(EntityId, Position.ComponentId, new Position.Update
+            {
+                Coords = new Coordinates(coordsValue, coordsValue, coordsValue)
+            });
+        }
+
+        private void SendDependentDataEvent()
+        {
+            connectionHandler.AddEvent(EntityId, DependentDataComponent.ComponentId,
+                new DependentDataComponent.FooEvent.Event());
+        }
+
+        private void Update()
+        {
+            receiveSystem.Update();
+        }
+    }
+}

--- a/test-project/Assets/EditmodeTests/Core/ComponentDiffStorageTests.cs.meta
+++ b/test-project/Assets/EditmodeTests/Core/ComponentDiffStorageTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 529733f105cb49d6bc59881beb289409
+timeCreated: 1582127285

--- a/test-project/Assets/EditmodeTests/DisableAutoCreationSystemsTests.cs
+++ b/test-project/Assets/EditmodeTests/DisableAutoCreationSystemsTests.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using NUnit.Framework;
 using Unity.Entities;
 
-namespace Improbable.Gdk.Core.EditmodeTests
+namespace Improbable.Gdk.EditmodeTests
 {
     [TestFixture]
     public class DisableAutoCreationSystemsTests

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponentComponentDiffStorage.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponentComponentDiffStorage.cs
@@ -52,6 +52,7 @@ namespace Improbable.DependentSchema
             void IDiffEventStorage<FooEvent.Event>.AddEvent(ComponentEventReceived<FooEvent.Event> ev)
             {
                 fooEventEventStorage.InsertSorted(ev, fooEventComparer);
+                EntitiesUpdated.Add(ev.EntityId);
             }
         }
     }

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/ComponentDiffStorageGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/ComponentDiffStorageGenerator.cs
@@ -89,7 +89,8 @@ private readonly EventComparer<{eventType}> {ev.CamelCaseName}Comparer =
 
                                 storage.Method($"void IDiffEventStorage<{eventType}>.AddEvent(ComponentEventReceived<{eventType}> ev)", () => new[]
                                 {
-                                    $"{ev.CamelCaseName}EventStorage.InsertSorted(ev, {ev.CamelCaseName}Comparer);"
+                                    $"{ev.CamelCaseName}EventStorage.InsertSorted(ev, {ev.CamelCaseName}Comparer);",
+                                    "EntitiesUpdated.Add(ev.EntityId);"
                                 });
                             }
                         });


### PR DESCRIPTION
#### Description

Encountered a bug where receiving a series of ops like:

```
ComponentUpdate(eid: 100, cid: 100, fields: empty, events: list<ev>)
RemoveComponent(eid: 100, cid: 100) 
```

would leave leftover events in the `ViewDiff` for entities-components which have left your view.

This PR fixes this bug by properly marking entities as changed when we receive an event and adds some test coverage for this behaviour.

#### Tests

- [x] Write some test cases for this

#### Documentation
 
- [x] Changelog
