### PR TITLE
Display runtime version in deployment launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - The SpatialOS Runtime version is now pinned by the GDK. This has been initially set to `14.4.0`. [#1299](https://github.com/spatialos/gdk-for-unity/pull/1299)
     - You can override this version in the GDK Tools Configuration. [#1289](https://github.com/spatialos/gdk-for-unity/pull/1289)
     - This version (or your override) will be used in both local deployments started through the editor and cloud deployments started through the Deployment Launcher.
+    - The currently selected version will be displayed in the Deployment Launcher. [#1302](https://github.com/spatialos/gdk-for-unity/pull/1302)
 
 ### Changed
 

--- a/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
+++ b/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
@@ -22,6 +22,7 @@ namespace Improbable.Gdk.DeploymentLauncher
         private const string BuiltInErrorIcon = "console.erroricon.sml";
         private const string BuiltInRefreshIcon = "Refresh";
         private const string BuiltInWebIcon = "BuildSettings.Web.Small";
+        private const string BuiltInEditIcon = "editicon.sml";
 
         private static readonly Vector2 SmallIconSize = new Vector2(12, 12);
         private readonly Color horizontalLineColor = new Color(0.3f, 0.3f, 0.3f, 1);
@@ -245,6 +246,26 @@ namespace Improbable.Gdk.DeploymentLauncher
                     }
 
                     EditorGUILayout.LabelField("Project Name", projectName);
+                }
+
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    using (new EditorGUI.DisabledScope(manager.IsActive))
+                    {
+                        var buttonIcon = new GUIContent(EditorGUIUtility.IconContent(BuiltInEditIcon))
+                        {
+                            tooltip = "Edit the Runtime version."
+                        };
+
+                        if (GUILayout.Button(buttonIcon, EditorStyles.miniButton, GUILayout.ExpandWidth(false)))
+                        {
+                            GdkToolsConfigurationWindow.ShowWindow();
+                        }
+                    }
+
+                    var config = GdkToolsConfiguration.GetOrCreateInstance();
+
+                    EditorGUILayout.LabelField("Runtime Version", config.RuntimeVersion);
                 }
 
                 CommonUIElements.DrawHorizontalLine(5, horizontalLineColor);

--- a/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentLauncherWindowStyle.cs
+++ b/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentLauncherWindowStyle.cs
@@ -1,0 +1,68 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Improbable.Worker.CInterop
+{
+    internal class DeploymentLauncherWindowStyle
+    {
+        private const string BuiltInErrorIcon = "console.erroricon.sml";
+        private const string BuiltInRefreshIcon = "Refresh";
+        private const string BuiltInWebIcon = "BuildSettings.Web.Small";
+        private const string BuiltInEditIcon = "editicon.sml";
+
+        public readonly Vector2 SmallIconSize = new Vector2(x: 12, y: 12);
+        public readonly Color HorizontalLineColor = new Color(r: 0.3f, g: 0.3f, b: 0.3f, a: 1);
+
+        public readonly GUIContent ProjectRefreshButtonContents;
+        public readonly GUIContent EditRuntimeVersionButtonContents;
+        public readonly GUIContent DeploymentConfigurationErrorContents;
+        public readonly GUIContent OpenDeploymentButtonContents;
+        public readonly GUIContent RemoveDeploymentConfigurationButtonContents;
+        public readonly GUIContent RemoveSimPlayerDeploymentButtonContents;
+
+        private Material spinnerMaterial;
+
+        public DeploymentLauncherWindowStyle()
+        {
+            ProjectRefreshButtonContents = new GUIContent(EditorGUIUtility.IconContent(BuiltInRefreshIcon))
+            {
+                tooltip = "Refresh your project name."
+            };
+
+            EditRuntimeVersionButtonContents = new GUIContent(EditorGUIUtility.IconContent(BuiltInEditIcon))
+            {
+                tooltip = "Edit the Runtime version."
+            };
+
+            DeploymentConfigurationErrorContents = new GUIContent(EditorGUIUtility.IconContent(BuiltInErrorIcon))
+            {
+                tooltip = "One or more errors in deployment configuration."
+            };
+
+            OpenDeploymentButtonContents = new GUIContent(EditorGUIUtility.IconContent(BuiltInWebIcon))
+            {
+                tooltip = "Open this deployment in your browser."
+            };
+
+            RemoveDeploymentConfigurationButtonContents = new GUIContent(EditorGUIUtility.IconContent("Toolbar Minus"))
+            {
+                tooltip = "Remove deployment configuration"
+            };
+
+            RemoveSimPlayerDeploymentButtonContents = new GUIContent(EditorGUIUtility.IconContent("Toolbar Minus"))
+            {
+                tooltip = "Remove simulated player deployment"
+            };
+
+            spinnerMaterial = new Material(Shader.Find("UI/Default"));
+        }
+
+        public void DrawSpinner(float value, Rect rect)
+        {
+            // There are 11 frames in the spinner animation, 0 till 11.
+            var imageId = Mathf.RoundToInt(value) % 12;
+            var icon = EditorGUIUtility.IconContent($"d_WaitSpin{imageId:D2}");
+            EditorGUI.DrawPreviewTexture(rect, icon.image, spinnerMaterial, ScaleMode.ScaleToFit, imageAspect: 1);
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentLauncherWindowStyle.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentLauncherWindowStyle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c4dbe0128bd8ab48b1fbb76895983e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#### Description
Added a label which diplays the current runtime version & a button which opens the GDK Tools Configuration window to the deployment launcher. 

![image](https://user-images.githubusercontent.com/13353733/75155721-86bb5400-5708-11ea-9bfa-15c3e1014179.png)

#### Tests

- [x] Changed the runtime override and observed the change in the deployment launcher.

#### Documentation

- [x] Changelog
- [x] Probably some docs updates --> #1303 
