### PR TITLE
The beginnings of a useful testing framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - De-duplicated code for generated `ComponentDiffStorage` instances. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
 - `Improbable.Gdk.Core.EntityId` is now a readonly struct. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
 - The Playground project now uses QBI instead of CBI. [#1370](https://github.com/spatialos/gdk-for-unity/pull/1307)
+- Added `MockWorld` and `MockBase` classes to the `Improbable.Gdk.TestUtils` package. These are designed as a framework for testing Core code. [#1305](https://github.com/spatialos/gdk-for-unity/pull/1305)
 
 ## `0.3.3` - 2020-02-14
 

--- a/test-project/Assets/EditmodeTests/Improbable.Gdk.EditModeTests.asmdef
+++ b/test-project/Assets/EditmodeTests/Improbable.Gdk.EditModeTests.asmdef
@@ -10,7 +10,8 @@
         "Improbable.Gdk.TransformSynchronization",
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
-        "Improbable.Gdk.TestBases"
+        "Improbable.Gdk.TestBases",
+        "Improbable.Gdk.TestUtils"
     ],
     "includePlatforms": [
         "Editor"

--- a/test-project/Assets/EditmodeTests/Subscriptions/RequireablesUnlinkTests.cs
+++ b/test-project/Assets/EditmodeTests/Subscriptions/RequireablesUnlinkTests.cs
@@ -1,94 +1,125 @@
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Subscriptions;
 using Improbable.Gdk.Test;
-using Improbable.Gdk.TestBases;
+using Improbable.Gdk.TestUtils;
 using Improbable.Worker.CInterop;
 using NUnit.Framework;
 using UnityEngine;
 
 namespace Improbable.Gdk.EditmodeTests.Subscriptions
 {
-    public class RequireablesUnlinkTests : SubscriptionsTestBase
+    public class RequireablesUnlinkTests : MockBase
     {
         private const long EntityId = 100;
-        private GameObject createdGameObject;
 
-        [SetUp]
-        public override void Setup()
+        private static EntityTemplate GetTemplate()
         {
-            base.Setup();
             var template = new EntityTemplate();
             template.AddComponent(new Position.Snapshot(), "worker");
             template.AddComponent(new TestCommands.Snapshot(), "worker");
-            ConnectionHandler.CreateEntity(EntityId, template);
-            Update();
-        }
-
-        [TearDown]
-        public override void TearDown()
-        {
-            base.TearDown();
-            Object.DestroyImmediate(createdGameObject);
+            return template;
         }
 
         [Test]
         public void Reader_is_disabled_if_gameobject_unlinked()
         {
-            createdGameObject = CreateAndLinkGameObjectWithComponent<PositionReaderBehaviour>(EntityId);
-            var reader = createdGameObject.GetComponent<PositionReaderBehaviour>().Reader;
-
-            Linker.UnlinkGameObjectFromEntity(new EntityId(EntityId), createdGameObject);
-
-            Assert.IsNull(createdGameObject.GetComponent<PositionReaderBehaviour>().Reader);
-            Assert.IsFalse(reader.IsValid);
+            World
+                .Step(world =>
+                {
+                    world.Connection.CreateEntity(EntityId, GetTemplate());
+                })
+                .Step(world =>
+                {
+                    var (go, readerBehaviour) = world.CreateGameObject<PositionReaderBehaviour>(EntityId);
+                    return (gameObject: go, reader: readerBehaviour.Reader);
+                })
+                .Step((world, context) =>
+                {
+                    world.Linker.UnlinkGameObjectFromEntity(new EntityId(EntityId), context.gameObject);
+                })
+                .Step((world, context) =>
+                {
+                    var (gameObject, positionReader) = context;
+                    Assert.IsNull(gameObject.GetComponent<PositionReaderBehaviour>().Reader);
+                    Assert.IsFalse(positionReader.IsValid);
+                });
         }
 
         [Test]
         public void Writer_is_disabled_if_gameobject_unlinked()
         {
-            ConnectionHandler.ChangeAuthority(EntityId, Position.ComponentId, Authority.Authoritative);
-            Update();
-
-            createdGameObject = CreateAndLinkGameObjectWithComponent<PositionWriterBehaviour>(EntityId);
-            var writer = createdGameObject.GetComponent<PositionWriterBehaviour>().Writer;
-
-            Linker.UnlinkGameObjectFromEntity(new EntityId(EntityId), createdGameObject);
-
-            Assert.IsNull(createdGameObject.GetComponent<PositionWriterBehaviour>().Writer);
-            Assert.IsFalse(writer.IsValid);
+            World
+                .Step(world =>
+                {
+                    world.Connection.CreateEntity(EntityId, GetTemplate());
+                    World.Connection.ChangeAuthority(EntityId, Position.ComponentId, Authority.Authoritative);
+                })
+                .Step(world =>
+                {
+                    var (go, writerBehaviour) = world.CreateGameObject<PositionWriterBehaviour>(EntityId);
+                    return (gameObject: go, writer: writerBehaviour.Writer);
+                })
+                .Step((world, context) =>
+                {
+                    world.Linker.UnlinkGameObjectFromEntity(new EntityId(EntityId), context.gameObject);
+                })
+                .Step((world, context) =>
+                {
+                    var (gameObject, writer) = context;
+                    Assert.IsNull(gameObject.GetComponent<PositionWriterBehaviour>().Writer);
+                    Assert.IsFalse(writer.IsValid);
+                });
         }
 
         [Test]
         public void CommandSender_is_disabled_if_gameobject_unlinked()
         {
-            createdGameObject = CreateAndLinkGameObjectWithComponent<CommandSender>(EntityId);
-            var sender = createdGameObject.GetComponent<CommandSender>().Sender;
-
-            Linker.UnlinkGameObjectFromEntity(new EntityId(EntityId), createdGameObject);
-
-            Assert.IsNull(createdGameObject.GetComponent<CommandSender>().Sender);
-            Assert.IsFalse(sender.IsValid);
+            World
+                .Step(world =>
+                {
+                    world.Connection.CreateEntity(EntityId, GetTemplate());
+                })
+                .Step(world =>
+                {
+                    var (go, commandSender) = world.CreateGameObject<CommandSender>(EntityId);
+                    return (gameObject: go, sender: commandSender.Sender);
+                })
+                .Step((world, context) =>
+                {
+                    world.Linker.UnlinkGameObjectFromEntity(new EntityId(EntityId), context.gameObject);
+                })
+                .Step((world, context) =>
+                {
+                    var (gameObject, commandSender) = context;
+                    Assert.IsNull(gameObject.GetComponent<CommandSender>().Sender);
+                    Assert.IsFalse(commandSender.IsValid);
+                });
         }
 
         [Test]
         public void CommandReceiver_is_disabled_if_gameobject_unlinked()
         {
-            ConnectionHandler.ChangeAuthority(EntityId, TestCommands.ComponentId, Authority.Authoritative);
-            Update();
-
-            createdGameObject = CreateAndLinkGameObjectWithComponent<CommandReceiver>(EntityId);
-            var receiver = createdGameObject.GetComponent<CommandReceiver>().Receiver;
-
-            Linker.UnlinkGameObjectFromEntity(new EntityId(EntityId), createdGameObject);
-
-            Assert.IsNull(createdGameObject.GetComponent<CommandReceiver>().Receiver);
-            Assert.IsFalse(receiver.IsValid);
-        }
-
-        private void Update()
-        {
-            ReceiveSystem.Update();
-            RequireLifecycleSystem.Update();
+            World
+                .Step(world =>
+                {
+                    world.Connection.CreateEntity(EntityId, GetTemplate());
+                    World.Connection.ChangeAuthority(EntityId, TestCommands.ComponentId, Authority.Authoritative);
+                })
+                .Step(world =>
+                {
+                    var (go, commandReceiver) = world.CreateGameObject<CommandReceiver>(EntityId);
+                    return (gameObject: go, receiver: commandReceiver.Receiver);
+                })
+                .Step((world, context) =>
+                {
+                    world.Linker.UnlinkGameObjectFromEntity(new EntityId(EntityId), context.gameObject);
+                })
+                .Step((world, context) =>
+                {
+                    var (gameObject, receiver) = context;
+                    Assert.IsNull(gameObject.GetComponent<CommandReceiver>().Receiver);
+                    Assert.IsFalse(receiver.IsValid);
+                });
         }
 
         private class PositionReaderBehaviour : MonoBehaviour

--- a/workers/unity/Packages/io.improbable.gdk.core/AssemblyInfo.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/AssemblyInfo.cs
@@ -5,3 +5,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Improbable.Gdk.EditmodeTests")]
 [assembly: InternalsVisibleTo("Improbable.Gdk.PlaymodeTests")]
 [assembly: InternalsVisibleTo("Improbable.Gdk.Debug")]
+[assembly: InternalsVisibleTo("Improbable.Gdk.TestUtils")]

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs
@@ -114,7 +114,6 @@ namespace Improbable.Gdk.Core
 
         public void PushMessagesToSend(MessagesToSend messages, NetFrameStats netFrameStats)
         {
-            throw new System.NotImplementedException();
         }
 
         public bool IsConnected()

--- a/workers/unity/Packages/io.improbable.gdk.testutils/Improbable.Gdk.TestUtils.asmdef
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/Improbable.Gdk.TestUtils.asmdef
@@ -1,9 +1,12 @@
 {
     "name": "Improbable.Gdk.TestUtils",
     "references": [
-        "Improbable.Gdk.Core"
+        "Improbable.Gdk.Core",
+        "Unity.Entities"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,
@@ -11,8 +14,6 @@
         "nunit.framework.dll"
     ],
     "autoReferenced": true,
-    "defineConstraints": [
-        "UNITY_INCLUDE_TESTS"
-    ],
+    "defineConstraints": [],
     "versionDefines": []
 }

--- a/workers/unity/Packages/io.improbable.gdk.testutils/MockBase.cs
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/MockBase.cs
@@ -1,0 +1,26 @@
+using NUnit.Framework;
+
+namespace Improbable.Gdk.TestUtils
+{
+    public abstract class MockBase
+    {
+        protected MockWorld World;
+
+        protected virtual MockWorld.Options GetOptions()
+        {
+            return new MockWorld.Options();
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            World = MockWorld.Create(GetOptions());
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            World.Dispose();
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.testutils/MockBase.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/MockBase.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0839e3f40c8543958ccbf3a11314f052
+timeCreated: 1582637051

--- a/workers/unity/Packages/io.improbable.gdk.testutils/MockWorld.cs
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/MockWorld.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Subscriptions;
+using Unity.Entities;
+using UnityEditor;
+using UnityEngine;
+
+namespace Improbable.Gdk.TestUtils
+{
+    public class MockWorld : IDisposable
+    {
+        public struct Options
+        {
+            public string WorkerType;
+            public Type[] AdditionalSystems;
+            public ILogDispatcher Logger;
+        }
+
+        public WorkerInWorld Worker { get; private set; }
+        public MockConnectionHandler Connection { get; private set; }
+
+        public EntityGameObjectLinker Linker { get; private set; }
+
+        private readonly HashSet<GameObject> gameObjects = new HashSet<GameObject>();
+
+        public static MockWorld Create(Options options)
+        {
+            var mockWorld = new MockWorld();
+
+            var connectionBuilder = new MockConnectionHandlerBuilder();
+            mockWorld.Connection = connectionBuilder.ConnectionHandler;
+
+            mockWorld.Worker = WorkerInWorld
+                .CreateWorkerInWorldAsync(connectionBuilder,
+                    options.WorkerType ?? "TestWorkerType",
+                    options.Logger ?? new LoggingDispatcher(),
+                    Vector3.zero)
+                .Result;
+
+            foreach (var type in options.AdditionalSystems ?? new Type[] { })
+            {
+                mockWorld.Worker.World.CreateSystem(type);
+            }
+
+            mockWorld.Linker = new EntityGameObjectLinker(mockWorld.Worker.World);
+
+            PlayerLoopUtils.ResolveSystemGroups(mockWorld.Worker.World);
+
+            return mockWorld;
+        }
+
+        public T GetSystem<T>() where T : ComponentSystemBase
+        {
+            return Worker.World.GetExistingSystem<T>();
+        }
+
+        public MockWorldWithContext<T> Step<T>(Func<MockWorld, T> frame)
+        {
+            var context = frame(this);
+            Update();
+            return new MockWorldWithContext<T>(this, context);
+        }
+
+        public MockWorld Step(Action<MockWorld> frame)
+        {
+            frame(this);
+            Update();
+            return this;
+        }
+
+        private void Update()
+        {
+            Worker.World.Update();
+        }
+
+        public (GameObject, T) CreateGameObject<T>(long entityId) where T : MonoBehaviour
+        {
+            var gameObject = new GameObject("TestGameObject");
+            gameObjects.Add(gameObject);
+
+            var component = gameObject.AddComponent<T>();
+            component.enabled = false;
+
+            Linker.LinkGameObjectToSpatialOSEntity(new EntityId(entityId), gameObject);
+            return (gameObject, component);
+        }
+
+        public void Dispose()
+        {
+            foreach (var go in gameObjects)
+            {
+                UnityEngine.Object.DestroyImmediate(go);
+            }
+
+            Worker?.Dispose();
+            Connection?.Dispose();
+        }
+
+        public readonly struct MockWorldWithContext<T>
+        {
+            private readonly T context;
+            private readonly MockWorld world;
+
+            public MockWorldWithContext(MockWorld world, T context)
+            {
+                this.world = world;
+                this.context = context;
+            }
+
+            public MockWorldWithContext<U> Step<U>(Func<MockWorld, T, U> frame)
+            {
+                var newContext = frame(world, context);
+                world.Update();
+
+                return new MockWorldWithContext<U>(world, newContext);
+            }
+
+            public MockWorldWithContext<T> Step(Action<MockWorld> frame)
+            {
+                frame(world);
+                world.Update();
+
+                return this;
+            }
+
+            public MockWorldWithContext<T> Step(Action<MockWorld, T> frame)
+            {
+                frame(world, context);
+                world.Update();
+
+                return this;
+            }
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.testutils/MockWorld.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/MockWorld.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1903c4204261ae745ae52f2c29a95cf6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#### Description

This PR condenses some of the patterns we've used in testing into a `MockWorld` class which helps you write integration tests in a fluent and easy to understand way. The goal of this was to make it very easy to spin up the full stack with a mock connection and tick through frames. This is visible in the API which looks something like:

```csharp
MockWorld.Create(new MockWorld.Options())
	.Step(world => /* first frame */)
	.Step(world => /* second frame */)
	...
```

The `MockWorld` classes has a minimal feature set, and can be extended in the future:

- Handling the creation and management of the world & player loop. 
- Create and link GameObjects (with a given component), a future extension could be adding a `<T1, T2>` & `<T1, T2, T3>` version.
- Passing arbitrary context through 'frames' simply by returning an object in the lambda. This context will be passed through any number of frames until it is replaced:
	```csharp
	MockWorld.Create(new MockWorld.Options())
		.Step(world => 10)
		.Step((world, number) => /* do something with number */)
		.Step(world => /* do something without number */)
		.Step((world, number) => { /* do something with number */ return "foo"; })
		.Step((world, str) => /* do something with string */);
	```

This is all wrapped up in the `MockBase` abstract class which test fixtures can inherit from. This has a simple `SetUp` and `TearDown` where the World is created and then disposed so each test can have a fresh world to start with. 

I've ported the existing tests in the Test Project to this new paradigm, there are tests in `Core` that would benefit from this API but we may want to move around the location of the `Mock*` objects in order to use them there. 

**Commits are ordered!**

#### Tests

Old tests ported & still passing.

#### Documentation

- [x] Changelog