### PR TITLE
Use profile markers API for in-game profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - `Improbable.Gdk.Core.EntityId` is now a readonly struct. [#1290](https://github.com/spatialos/gdk-for-unity/pull/1290)
 - The Playground project now uses QBI instead of CBI. [#1370](https://github.com/spatialos/gdk-for-unity/pull/1307)
 - Added `MockWorld` and `MockBase` classes to the `Improbable.Gdk.TestUtils` package. These are designed as a framework for testing Core code. [#1305](https://github.com/spatialos/gdk-for-unity/pull/1305)
+- Switched internal profiling to use new `ProfilerMarker` API. [#1311](https://github.com/spatialos/gdk-for-unity/pull/1311)
 
 ## `0.3.3` - 2020-02-14
 

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentComponent.cs
@@ -17,10 +17,68 @@ namespace Improbable.DependentSchema
 
         public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
-            public uint ComponentId => 198800;
-
             // Bit masks for tracking which component properties were changed locally and need to be synced.
             private fixed UInt32 dirtyBits[1];
+
+            internal uint aHandle;
+
+            public global::Improbable.TestSchema.ExhaustiveRepeatedData A
+            {
+                get => global::Improbable.DependentSchema.DependentComponent.ReferenceTypeProviders.AProvider.Get(aHandle);
+                set
+                {
+                    MarkDataDirty(0);
+                    global::Improbable.DependentSchema.DependentComponent.ReferenceTypeProviders.AProvider.Set(aHandle, value);
+                }
+            }
+
+            private global::Improbable.TestSchema.SomeEnum b;
+
+            public global::Improbable.TestSchema.SomeEnum B
+            {
+                get => b;
+                set
+                {
+                    MarkDataDirty(1);
+                    this.b = value;
+                }
+            }
+
+            internal uint cHandle;
+
+            public global::Improbable.TestSchema.SomeEnum? C
+            {
+                get => global::Improbable.DependentSchema.DependentComponent.ReferenceTypeProviders.CProvider.Get(cHandle);
+                set
+                {
+                    MarkDataDirty(2);
+                    global::Improbable.DependentSchema.DependentComponent.ReferenceTypeProviders.CProvider.Set(cHandle, value);
+                }
+            }
+
+            internal uint dHandle;
+
+            public global::System.Collections.Generic.List<global::Improbable.TestSchema.SomeType> D
+            {
+                get => global::Improbable.DependentSchema.DependentComponent.ReferenceTypeProviders.DProvider.Get(dHandle);
+                set
+                {
+                    MarkDataDirty(3);
+                    global::Improbable.DependentSchema.DependentComponent.ReferenceTypeProviders.DProvider.Set(dHandle, value);
+                }
+            }
+
+            internal uint eHandle;
+
+            public global::System.Collections.Generic.Dictionary<global::Improbable.TestSchema.SomeEnum, global::Improbable.TestSchema.SomeType> E
+            {
+                get => global::Improbable.DependentSchema.DependentComponent.ReferenceTypeProviders.EProvider.Get(eHandle);
+                set
+                {
+                    MarkDataDirty(4);
+                    global::Improbable.DependentSchema.DependentComponent.ReferenceTypeProviders.EProvider.Set(eHandle, value);
+                }
+            }
 
             public bool IsDataDirty()
             {
@@ -90,66 +148,6 @@ namespace Improbable.DependentSchema
                 componentDataSchema.SchemaData = null;
 
                 return snapshot;
-            }
-
-            internal uint aHandle;
-
-            public global::Improbable.TestSchema.ExhaustiveRepeatedData A
-            {
-                get => global::Improbable.DependentSchema.DependentComponent.ReferenceTypeProviders.AProvider.Get(aHandle);
-                set
-                {
-                    MarkDataDirty(0);
-                    global::Improbable.DependentSchema.DependentComponent.ReferenceTypeProviders.AProvider.Set(aHandle, value);
-                }
-            }
-
-            private global::Improbable.TestSchema.SomeEnum b;
-
-            public global::Improbable.TestSchema.SomeEnum B
-            {
-                get => b;
-                set
-                {
-                    MarkDataDirty(1);
-                    this.b = value;
-                }
-            }
-
-            internal uint cHandle;
-
-            public global::Improbable.TestSchema.SomeEnum? C
-            {
-                get => global::Improbable.DependentSchema.DependentComponent.ReferenceTypeProviders.CProvider.Get(cHandle);
-                set
-                {
-                    MarkDataDirty(2);
-                    global::Improbable.DependentSchema.DependentComponent.ReferenceTypeProviders.CProvider.Set(cHandle, value);
-                }
-            }
-
-            internal uint dHandle;
-
-            public global::System.Collections.Generic.List<global::Improbable.TestSchema.SomeType> D
-            {
-                get => global::Improbable.DependentSchema.DependentComponent.ReferenceTypeProviders.DProvider.Get(dHandle);
-                set
-                {
-                    MarkDataDirty(3);
-                    global::Improbable.DependentSchema.DependentComponent.ReferenceTypeProviders.DProvider.Set(dHandle, value);
-                }
-            }
-
-            internal uint eHandle;
-
-            public global::System.Collections.Generic.Dictionary<global::Improbable.TestSchema.SomeEnum, global::Improbable.TestSchema.SomeType> E
-            {
-                get => global::Improbable.DependentSchema.DependentComponent.ReferenceTypeProviders.EProvider.Get(eHandle);
-                set
-                {
-                    MarkDataDirty(4);
-                    global::Improbable.DependentSchema.DependentComponent.ReferenceTypeProviders.EProvider.Set(eHandle, value);
-                }
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentComponentComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentComponentComponentReaderWriter.cs
@@ -20,7 +20,7 @@ namespace Improbable.DependentSchema
 
         protected override DependentComponentReader CreateReader(Entity entity, EntityId entityId)
         {
-            return new DependentComponentReader(world, entity, entityId);
+            return new DependentComponentReader(World, entity, entityId);
         }
     }
 
@@ -33,7 +33,7 @@ namespace Improbable.DependentSchema
 
         protected override DependentComponentWriter CreateWriter(Entity entity, EntityId entityId)
         {
-            return new DependentComponentWriter(world, entity, entityId);
+            return new DependentComponentWriter(World, entity, entityId);
         }
     }
 

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentComponentUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentComponentUpdateSender.cs
@@ -2,15 +2,11 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEngine.Profiling;
-using Unity.Mathematics;
 using Unity.Entities;
 using Unity.Collections;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
+using Unity.Profiling;
 
 namespace Improbable.DependentSchema
 {
@@ -18,6 +14,8 @@ namespace Improbable.DependentSchema
     {
         internal class ComponentReplicator : IComponentReplicationHandler
         {
+            private ProfilerMarker componentMarker = new ProfilerMarker("DependentComponent");
+
             public uint ComponentId => 198800;
 
             public EntityQueryDesc ComponentUpdateQuery => new EntityQueryDesc
@@ -36,64 +34,63 @@ namespace Improbable.DependentSchema
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
-                Profiler.BeginSample("DependentComponent");
-
-                var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.DependentSchema.DependentComponent.Component>();
-                var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
-
-                foreach (var chunk in chunkArray)
+                using (componentMarker.Auto())
                 {
-                    var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
-                    var componentArray = chunk.GetNativeArray(componentType);
-                    var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
+                    var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
+                    var componentType = system.GetArchetypeChunkComponentType<global::Improbable.DependentSchema.DependentComponent.Component>();
+                    var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 
-                    if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
+                    foreach (var chunk in chunkArray)
                     {
-                        continue;
-                    }
+                        var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
+                        var componentArray = chunk.GetNativeArray(componentType);
+                        var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
 
-                    for (var i = 0; i < componentArray.Length; i++)
-                    {
-                        var data = componentArray[i];
-
-                        if (data.IsDataDirty())
+                        if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
                         {
-                            Update update = new Update();
+                            continue;
+                        }
 
-                            if (data.IsDataDirty(0))
+                        for (var i = 0; i < componentArray.Length; i++)
+                        {
+                            var data = componentArray[i];
+
+                            if (data.IsDataDirty())
                             {
-                                update.A = data.A;
-                            }
+                                var update = new Update();
 
-                            if (data.IsDataDirty(1))
-                            {
-                                update.B = data.B;
-                            }
+                                if (data.IsDataDirty(0))
+                                {
+                                    update.A = data.A;
+                                }
 
-                            if (data.IsDataDirty(2))
-                            {
-                                update.C = data.C;
-                            }
+                                if (data.IsDataDirty(1))
+                                {
+                                    update.B = data.B;
+                                }
 
-                            if (data.IsDataDirty(3))
-                            {
-                                update.D = data.D;
-                            }
+                                if (data.IsDataDirty(2))
+                                {
+                                    update.C = data.C;
+                                }
 
-                            if (data.IsDataDirty(4))
-                            {
-                                update.E = data.E;
-                            }
+                                if (data.IsDataDirty(3))
+                                {
+                                    update.D = data.D;
+                                }
 
-                            componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
-                            data.MarkDataClean();
-                            componentArray[i] = data;
+                                if (data.IsDataDirty(4))
+                                {
+                                    update.E = data.E;
+                                }
+
+                                componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
+                                data.MarkDataClean();
+                                componentArray[i] = data;
+                            }
                         }
                     }
                 }
-
-                Profiler.EndSample();
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponent.cs
@@ -17,80 +17,8 @@ namespace Improbable.DependentSchema
 
         public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
-            public uint ComponentId => 198801;
-
             // Bit masks for tracking which component properties were changed locally and need to be synced.
             private fixed UInt32 dirtyBits[1];
-
-            public bool IsDataDirty()
-            {
-                var isDataDirty = false;
-
-                isDataDirty |= (dirtyBits[0] != 0x0);
-
-                return isDataDirty;
-            }
-
-            /*
-            The propertyIndex argument counts up from 0 in the order defined in your schema component.
-            It is not the schema field number itself. For example:
-            component MyComponent
-            {
-                id = 1337;
-                bool val_a = 1;
-                bool val_b = 3;
-            }
-            In that case, val_a corresponds to propertyIndex 0 and val_b corresponds to propertyIndex 1 in this method.
-            This method throws an InvalidOperationException in case your component doesn't contain properties.
-            */
-
-            public bool IsDataDirty(int propertyIndex)
-            {
-                ValidateFieldIndex(propertyIndex);
-
-                // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex >> 4;
-                return (dirtyBits[dirtyBitsByteIndex] & (0x1 << (propertyIndex & 31))) != 0x0;
-            }
-
-            // Like the IsDataDirty() method above, the propertyIndex arguments starts counting from 0.
-            // This method throws an InvalidOperationException in case your component doesn't contain properties.
-            public void MarkDataDirty(int propertyIndex)
-            {
-                ValidateFieldIndex(propertyIndex);
-
-                // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex >> 4;
-                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
-            }
-
-            public void MarkDataClean()
-            {
-                dirtyBits[0] = 0x0;
-            }
-
-            [Conditional("DEBUG")]
-            private void ValidateFieldIndex(int propertyIndex)
-            {
-                if (propertyIndex < 0 || propertyIndex >= 18)
-                {
-                    throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
-                        "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
-                        "Please contact SpatialOS support if you encounter this issue.");
-                }
-            }
-
-            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
-            {
-                var componentDataSchema = new ComponentData(198801, SchemaComponentData.Create());
-                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
-                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields());
-
-                componentDataSchema.SchemaData?.Destroy();
-                componentDataSchema.SchemaData = null;
-
-                return snapshot;
-            }
 
             internal uint field1Handle;
 
@@ -306,6 +234,76 @@ namespace Improbable.DependentSchema
                     MarkDataDirty(17);
                     global::Improbable.DependentSchema.DependentDataComponent.ReferenceTypeProviders.Field18Provider.Set(field18Handle, value);
                 }
+            }
+
+            public bool IsDataDirty()
+            {
+                var isDataDirty = false;
+
+                isDataDirty |= (dirtyBits[0] != 0x0);
+
+                return isDataDirty;
+            }
+
+            /*
+            The propertyIndex argument counts up from 0 in the order defined in your schema component.
+            It is not the schema field number itself. For example:
+            component MyComponent
+            {
+                id = 1337;
+                bool val_a = 1;
+                bool val_b = 3;
+            }
+            In that case, val_a corresponds to propertyIndex 0 and val_b corresponds to propertyIndex 1 in this method.
+            This method throws an InvalidOperationException in case your component doesn't contain properties.
+            */
+
+            public bool IsDataDirty(int propertyIndex)
+            {
+                ValidateFieldIndex(propertyIndex);
+
+                // Retrieve the dirtyBits[0-n] field that tracks this property.
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                return (dirtyBits[dirtyBitsByteIndex] & (0x1 << (propertyIndex & 31))) != 0x0;
+            }
+
+            // Like the IsDataDirty() method above, the propertyIndex arguments starts counting from 0.
+            // This method throws an InvalidOperationException in case your component doesn't contain properties.
+            public void MarkDataDirty(int propertyIndex)
+            {
+                ValidateFieldIndex(propertyIndex);
+
+                // Retrieve the dirtyBits[0-n] field that tracks this property.
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
+            }
+
+            public void MarkDataClean()
+            {
+                dirtyBits[0] = 0x0;
+            }
+
+            [Conditional("DEBUG")]
+            private void ValidateFieldIndex(int propertyIndex)
+            {
+                if (propertyIndex < 0 || propertyIndex >= 18)
+                {
+                    throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
+                        "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
+                        "Please contact SpatialOS support if you encounter this issue.");
+                }
+            }
+
+            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
+            {
+                var componentDataSchema = new ComponentData(198801, SchemaComponentData.Create());
+                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
+                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields());
+
+                componentDataSchema.SchemaData?.Destroy();
+                componentDataSchema.SchemaData = null;
+
+                return snapshot;
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponentComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponentComponentReaderWriter.cs
@@ -20,7 +20,7 @@ namespace Improbable.DependentSchema
 
         protected override DependentDataComponentReader CreateReader(Entity entity, EntityId entityId)
         {
-            return new DependentDataComponentReader(world, entity, entityId);
+            return new DependentDataComponentReader(World, entity, entityId);
         }
     }
 
@@ -33,7 +33,7 @@ namespace Improbable.DependentSchema
 
         protected override DependentDataComponentWriter CreateWriter(Entity entity, EntityId entityId)
         {
-            return new DependentDataComponentWriter(world, entity, entityId);
+            return new DependentDataComponentWriter(World, entity, entityId);
         }
     }
 

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponentUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponentUpdateSender.cs
@@ -2,15 +2,11 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEngine.Profiling;
-using Unity.Mathematics;
 using Unity.Entities;
 using Unity.Collections;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
+using Unity.Profiling;
 
 namespace Improbable.DependentSchema
 {
@@ -18,6 +14,8 @@ namespace Improbable.DependentSchema
     {
         internal class ComponentReplicator : IComponentReplicationHandler
         {
+            private ProfilerMarker componentMarker = new ProfilerMarker("DependentDataComponent");
+
             public uint ComponentId => 198801;
 
             public EntityQueryDesc ComponentUpdateQuery => new EntityQueryDesc
@@ -36,129 +34,128 @@ namespace Improbable.DependentSchema
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
-                Profiler.BeginSample("DependentDataComponent");
-
-                var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.DependentSchema.DependentDataComponent.Component>();
-                var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
-
-                foreach (var chunk in chunkArray)
+                using (componentMarker.Auto())
                 {
-                    var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
-                    var componentArray = chunk.GetNativeArray(componentType);
-                    var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
+                    var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
+                    var componentType = system.GetArchetypeChunkComponentType<global::Improbable.DependentSchema.DependentDataComponent.Component>();
+                    var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 
-                    if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
+                    foreach (var chunk in chunkArray)
                     {
-                        continue;
-                    }
+                        var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
+                        var componentArray = chunk.GetNativeArray(componentType);
+                        var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
 
-                    for (var i = 0; i < componentArray.Length; i++)
-                    {
-                        var data = componentArray[i];
-
-                        if (data.IsDataDirty())
+                        if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
                         {
-                            Update update = new Update();
+                            continue;
+                        }
 
-                            if (data.IsDataDirty(0))
+                        for (var i = 0; i < componentArray.Length; i++)
+                        {
+                            var data = componentArray[i];
+
+                            if (data.IsDataDirty())
                             {
-                                update.Field1 = data.Field1;
-                            }
+                                var update = new Update();
 
-                            if (data.IsDataDirty(1))
-                            {
-                                update.Field2 = data.Field2;
-                            }
+                                if (data.IsDataDirty(0))
+                                {
+                                    update.Field1 = data.Field1;
+                                }
 
-                            if (data.IsDataDirty(2))
-                            {
-                                update.Field3 = data.Field3;
-                            }
+                                if (data.IsDataDirty(1))
+                                {
+                                    update.Field2 = data.Field2;
+                                }
 
-                            if (data.IsDataDirty(3))
-                            {
-                                update.Field4 = data.Field4;
-                            }
+                                if (data.IsDataDirty(2))
+                                {
+                                    update.Field3 = data.Field3;
+                                }
 
-                            if (data.IsDataDirty(4))
-                            {
-                                update.Field5 = data.Field5;
-                            }
+                                if (data.IsDataDirty(3))
+                                {
+                                    update.Field4 = data.Field4;
+                                }
 
-                            if (data.IsDataDirty(5))
-                            {
-                                update.Field6 = data.Field6;
-                            }
+                                if (data.IsDataDirty(4))
+                                {
+                                    update.Field5 = data.Field5;
+                                }
 
-                            if (data.IsDataDirty(6))
-                            {
-                                update.Field7 = data.Field7;
-                            }
+                                if (data.IsDataDirty(5))
+                                {
+                                    update.Field6 = data.Field6;
+                                }
 
-                            if (data.IsDataDirty(7))
-                            {
-                                update.Field8 = data.Field8;
-                            }
+                                if (data.IsDataDirty(6))
+                                {
+                                    update.Field7 = data.Field7;
+                                }
 
-                            if (data.IsDataDirty(8))
-                            {
-                                update.Field9 = data.Field9;
-                            }
+                                if (data.IsDataDirty(7))
+                                {
+                                    update.Field8 = data.Field8;
+                                }
 
-                            if (data.IsDataDirty(9))
-                            {
-                                update.Field10 = data.Field10;
-                            }
+                                if (data.IsDataDirty(8))
+                                {
+                                    update.Field9 = data.Field9;
+                                }
 
-                            if (data.IsDataDirty(10))
-                            {
-                                update.Field11 = data.Field11;
-                            }
+                                if (data.IsDataDirty(9))
+                                {
+                                    update.Field10 = data.Field10;
+                                }
 
-                            if (data.IsDataDirty(11))
-                            {
-                                update.Field12 = data.Field12;
-                            }
+                                if (data.IsDataDirty(10))
+                                {
+                                    update.Field11 = data.Field11;
+                                }
 
-                            if (data.IsDataDirty(12))
-                            {
-                                update.Field13 = data.Field13;
-                            }
+                                if (data.IsDataDirty(11))
+                                {
+                                    update.Field12 = data.Field12;
+                                }
 
-                            if (data.IsDataDirty(13))
-                            {
-                                update.Field14 = data.Field14;
-                            }
+                                if (data.IsDataDirty(12))
+                                {
+                                    update.Field13 = data.Field13;
+                                }
 
-                            if (data.IsDataDirty(14))
-                            {
-                                update.Field15 = data.Field15;
-                            }
+                                if (data.IsDataDirty(13))
+                                {
+                                    update.Field14 = data.Field14;
+                                }
 
-                            if (data.IsDataDirty(15))
-                            {
-                                update.Field16 = data.Field16;
-                            }
+                                if (data.IsDataDirty(14))
+                                {
+                                    update.Field15 = data.Field15;
+                                }
 
-                            if (data.IsDataDirty(16))
-                            {
-                                update.Field17 = data.Field17;
-                            }
+                                if (data.IsDataDirty(15))
+                                {
+                                    update.Field16 = data.Field16;
+                                }
 
-                            if (data.IsDataDirty(17))
-                            {
-                                update.Field18 = data.Field18;
-                            }
+                                if (data.IsDataDirty(16))
+                                {
+                                    update.Field17 = data.Field17;
+                                }
 
-                            componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
-                            data.MarkDataClean();
-                            componentArray[i] = data;
+                                if (data.IsDataDirty(17))
+                                {
+                                    update.Field18 = data.Field18;
+                                }
+
+                                componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
+                                data.MarkDataClean();
+                                componentArray[i] = data;
+                            }
                         }
                     }
                 }
-
-                Profiler.EndSample();
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTest.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTest.cs
@@ -17,10 +17,20 @@ namespace Improbable.Tests
 
         public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
-            public uint ComponentId => 11111;
-
             // Bit masks for tracking which component properties were changed locally and need to be synced.
             private fixed UInt32 dirtyBits[1];
+
+            private uint root;
+
+            public uint Root
+            {
+                get => root;
+                set
+                {
+                    MarkDataDirty(0);
+                    this.root = value;
+                }
+            }
 
             public bool IsDataDirty()
             {
@@ -90,18 +100,6 @@ namespace Improbable.Tests
                 componentDataSchema.SchemaData = null;
 
                 return snapshot;
-            }
-
-            private uint root;
-
-            public uint Root
-            {
-                get => root;
-                set
-                {
-                    MarkDataDirty(0);
-                    this.root = value;
-                }
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestChild.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestChild.cs
@@ -17,10 +17,20 @@ namespace Improbable.Tests
 
         public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
-            public uint ComponentId => 11112;
-
             // Bit masks for tracking which component properties were changed locally and need to be synced.
             private fixed UInt32 dirtyBits[1];
+
+            private uint child;
+
+            public uint Child
+            {
+                get => child;
+                set
+                {
+                    MarkDataDirty(0);
+                    this.child = value;
+                }
+            }
 
             public bool IsDataDirty()
             {
@@ -90,18 +100,6 @@ namespace Improbable.Tests
                 componentDataSchema.SchemaData = null;
 
                 return snapshot;
-            }
-
-            private uint child;
-
-            public uint Child
-            {
-                get => child;
-                set
-                {
-                    MarkDataDirty(0);
-                    this.child = value;
-                }
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestChildComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestChildComponentReaderWriter.cs
@@ -20,7 +20,7 @@ namespace Improbable.Tests
 
         protected override DependencyTestChildReader CreateReader(Entity entity, EntityId entityId)
         {
-            return new DependencyTestChildReader(world, entity, entityId);
+            return new DependencyTestChildReader(World, entity, entityId);
         }
     }
 
@@ -33,7 +33,7 @@ namespace Improbable.Tests
 
         protected override DependencyTestChildWriter CreateWriter(Entity entity, EntityId entityId)
         {
-            return new DependencyTestChildWriter(world, entity, entityId);
+            return new DependencyTestChildWriter(World, entity, entityId);
         }
     }
 

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestChildUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestChildUpdateSender.cs
@@ -2,15 +2,11 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEngine.Profiling;
-using Unity.Mathematics;
 using Unity.Entities;
 using Unity.Collections;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
+using Unity.Profiling;
 
 namespace Improbable.Tests
 {
@@ -18,6 +14,8 @@ namespace Improbable.Tests
     {
         internal class ComponentReplicator : IComponentReplicationHandler
         {
+            private ProfilerMarker componentMarker = new ProfilerMarker("DependencyTestChild");
+
             public uint ComponentId => 11112;
 
             public EntityQueryDesc ComponentUpdateQuery => new EntityQueryDesc
@@ -36,44 +34,43 @@ namespace Improbable.Tests
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
-                Profiler.BeginSample("DependencyTestChild");
-
-                var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.Tests.DependencyTestChild.Component>();
-                var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
-
-                foreach (var chunk in chunkArray)
+                using (componentMarker.Auto())
                 {
-                    var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
-                    var componentArray = chunk.GetNativeArray(componentType);
-                    var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
+                    var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
+                    var componentType = system.GetArchetypeChunkComponentType<global::Improbable.Tests.DependencyTestChild.Component>();
+                    var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 
-                    if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
+                    foreach (var chunk in chunkArray)
                     {
-                        continue;
-                    }
+                        var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
+                        var componentArray = chunk.GetNativeArray(componentType);
+                        var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
 
-                    for (var i = 0; i < componentArray.Length; i++)
-                    {
-                        var data = componentArray[i];
-
-                        if (data.IsDataDirty())
+                        if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
                         {
-                            Update update = new Update();
+                            continue;
+                        }
 
-                            if (data.IsDataDirty(0))
+                        for (var i = 0; i < componentArray.Length; i++)
+                        {
+                            var data = componentArray[i];
+
+                            if (data.IsDataDirty())
                             {
-                                update.Child = data.Child;
-                            }
+                                var update = new Update();
 
-                            componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
-                            data.MarkDataClean();
-                            componentArray[i] = data;
+                                if (data.IsDataDirty(0))
+                                {
+                                    update.Child = data.Child;
+                                }
+
+                                componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
+                                data.MarkDataClean();
+                                componentArray[i] = data;
+                            }
                         }
                     }
                 }
-
-                Profiler.EndSample();
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestComponentReaderWriter.cs
@@ -20,7 +20,7 @@ namespace Improbable.Tests
 
         protected override DependencyTestReader CreateReader(Entity entity, EntityId entityId)
         {
-            return new DependencyTestReader(world, entity, entityId);
+            return new DependencyTestReader(World, entity, entityId);
         }
     }
 
@@ -33,7 +33,7 @@ namespace Improbable.Tests
 
         protected override DependencyTestWriter CreateWriter(Entity entity, EntityId entityId)
         {
-            return new DependencyTestWriter(world, entity, entityId);
+            return new DependencyTestWriter(World, entity, entityId);
         }
     }
 

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestGrandchild.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestGrandchild.cs
@@ -17,10 +17,20 @@ namespace Improbable.Tests
 
         public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
-            public uint ComponentId => 11113;
-
             // Bit masks for tracking which component properties were changed locally and need to be synced.
             private fixed UInt32 dirtyBits[1];
+
+            private uint grandchild;
+
+            public uint Grandchild
+            {
+                get => grandchild;
+                set
+                {
+                    MarkDataDirty(0);
+                    this.grandchild = value;
+                }
+            }
 
             public bool IsDataDirty()
             {
@@ -90,18 +100,6 @@ namespace Improbable.Tests
                 componentDataSchema.SchemaData = null;
 
                 return snapshot;
-            }
-
-            private uint grandchild;
-
-            public uint Grandchild
-            {
-                get => grandchild;
-                set
-                {
-                    MarkDataDirty(0);
-                    this.grandchild = value;
-                }
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestGrandchildComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestGrandchildComponentReaderWriter.cs
@@ -20,7 +20,7 @@ namespace Improbable.Tests
 
         protected override DependencyTestGrandchildReader CreateReader(Entity entity, EntityId entityId)
         {
-            return new DependencyTestGrandchildReader(world, entity, entityId);
+            return new DependencyTestGrandchildReader(World, entity, entityId);
         }
     }
 
@@ -33,7 +33,7 @@ namespace Improbable.Tests
 
         protected override DependencyTestGrandchildWriter CreateWriter(Entity entity, EntityId entityId)
         {
-            return new DependencyTestGrandchildWriter(world, entity, entityId);
+            return new DependencyTestGrandchildWriter(World, entity, entityId);
         }
     }
 

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestGrandchildUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestGrandchildUpdateSender.cs
@@ -2,15 +2,11 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEngine.Profiling;
-using Unity.Mathematics;
 using Unity.Entities;
 using Unity.Collections;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
+using Unity.Profiling;
 
 namespace Improbable.Tests
 {
@@ -18,6 +14,8 @@ namespace Improbable.Tests
     {
         internal class ComponentReplicator : IComponentReplicationHandler
         {
+            private ProfilerMarker componentMarker = new ProfilerMarker("DependencyTestGrandchild");
+
             public uint ComponentId => 11113;
 
             public EntityQueryDesc ComponentUpdateQuery => new EntityQueryDesc
@@ -36,44 +34,43 @@ namespace Improbable.Tests
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
-                Profiler.BeginSample("DependencyTestGrandchild");
-
-                var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.Tests.DependencyTestGrandchild.Component>();
-                var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
-
-                foreach (var chunk in chunkArray)
+                using (componentMarker.Auto())
                 {
-                    var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
-                    var componentArray = chunk.GetNativeArray(componentType);
-                    var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
+                    var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
+                    var componentType = system.GetArchetypeChunkComponentType<global::Improbable.Tests.DependencyTestGrandchild.Component>();
+                    var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 
-                    if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
+                    foreach (var chunk in chunkArray)
                     {
-                        continue;
-                    }
+                        var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
+                        var componentArray = chunk.GetNativeArray(componentType);
+                        var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
 
-                    for (var i = 0; i < componentArray.Length; i++)
-                    {
-                        var data = componentArray[i];
-
-                        if (data.IsDataDirty())
+                        if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
                         {
-                            Update update = new Update();
+                            continue;
+                        }
 
-                            if (data.IsDataDirty(0))
+                        for (var i = 0; i < componentArray.Length; i++)
+                        {
+                            var data = componentArray[i];
+
+                            if (data.IsDataDirty())
                             {
-                                update.Grandchild = data.Grandchild;
-                            }
+                                var update = new Update();
 
-                            componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
-                            data.MarkDataClean();
-                            componentArray[i] = data;
+                                if (data.IsDataDirty(0))
+                                {
+                                    update.Grandchild = data.Grandchild;
+                                }
+
+                                componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
+                                data.MarkDataClean();
+                                componentArray[i] = data;
+                            }
                         }
                     }
                 }
-
-                Profiler.EndSample();
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestUpdateSender.cs
@@ -2,15 +2,11 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEngine.Profiling;
-using Unity.Mathematics;
 using Unity.Entities;
 using Unity.Collections;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
+using Unity.Profiling;
 
 namespace Improbable.Tests
 {
@@ -18,6 +14,8 @@ namespace Improbable.Tests
     {
         internal class ComponentReplicator : IComponentReplicationHandler
         {
+            private ProfilerMarker componentMarker = new ProfilerMarker("DependencyTest");
+
             public uint ComponentId => 11111;
 
             public EntityQueryDesc ComponentUpdateQuery => new EntityQueryDesc
@@ -36,44 +34,43 @@ namespace Improbable.Tests
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
-                Profiler.BeginSample("DependencyTest");
-
-                var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.Tests.DependencyTest.Component>();
-                var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
-
-                foreach (var chunk in chunkArray)
+                using (componentMarker.Auto())
                 {
-                    var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
-                    var componentArray = chunk.GetNativeArray(componentType);
-                    var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
+                    var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
+                    var componentType = system.GetArchetypeChunkComponentType<global::Improbable.Tests.DependencyTest.Component>();
+                    var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 
-                    if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
+                    foreach (var chunk in chunkArray)
                     {
-                        continue;
-                    }
+                        var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
+                        var componentArray = chunk.GetNativeArray(componentType);
+                        var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
 
-                    for (var i = 0; i < componentArray.Length; i++)
-                    {
-                        var data = componentArray[i];
-
-                        if (data.IsDataDirty())
+                        if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
                         {
-                            Update update = new Update();
+                            continue;
+                        }
 
-                            if (data.IsDataDirty(0))
+                        for (var i = 0; i < componentArray.Length; i++)
+                        {
+                            var data = componentArray[i];
+
+                            if (data.IsDataDirty())
                             {
-                                update.Root = data.Root;
-                            }
+                                var update = new Update();
 
-                            componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
-                            data.MarkDataClean();
-                            componentArray[i] = data;
+                                if (data.IsDataDirty(0))
+                                {
+                                    update.Root = data.Root;
+                                }
+
+                                componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
+                                data.MarkDataClean();
+                                componentArray[i] = data;
+                            }
                         }
                     }
                 }
-
-                Profiler.EndSample();
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/ComponentUsingNestedTypeSameName.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ComponentUsingNestedTypeSameName.cs
@@ -17,10 +17,44 @@ namespace Improbable.TestSchema
 
         public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
-            public uint ComponentId => 198730;
-
             // Bit masks for tracking which component properties were changed locally and need to be synced.
             private fixed UInt32 dirtyBits[1];
+
+            private int nestedField;
+
+            public int NestedField
+            {
+                get => nestedField;
+                set
+                {
+                    MarkDataDirty(0);
+                    this.nestedField = value;
+                }
+            }
+
+            private global::Improbable.TestSchema.NestedTypeSameName.Other.NestedTypeSameName.Other0.NestedTypeSameName other0Field;
+
+            public global::Improbable.TestSchema.NestedTypeSameName.Other.NestedTypeSameName.Other0.NestedTypeSameName Other0Field
+            {
+                get => other0Field;
+                set
+                {
+                    MarkDataDirty(1);
+                    this.other0Field = value;
+                }
+            }
+
+            private global::Improbable.TestSchema.NestedTypeSameName.Other.NestedTypeSameName.Other1.NestedTypeSameName other1Field;
+
+            public global::Improbable.TestSchema.NestedTypeSameName.Other.NestedTypeSameName.Other1.NestedTypeSameName Other1Field
+            {
+                get => other1Field;
+                set
+                {
+                    MarkDataDirty(2);
+                    this.other1Field = value;
+                }
+            }
 
             public bool IsDataDirty()
             {
@@ -90,42 +124,6 @@ namespace Improbable.TestSchema
                 componentDataSchema.SchemaData = null;
 
                 return snapshot;
-            }
-
-            private int nestedField;
-
-            public int NestedField
-            {
-                get => nestedField;
-                set
-                {
-                    MarkDataDirty(0);
-                    this.nestedField = value;
-                }
-            }
-
-            private global::Improbable.TestSchema.NestedTypeSameName.Other.NestedTypeSameName.Other0.NestedTypeSameName other0Field;
-
-            public global::Improbable.TestSchema.NestedTypeSameName.Other.NestedTypeSameName.Other0.NestedTypeSameName Other0Field
-            {
-                get => other0Field;
-                set
-                {
-                    MarkDataDirty(1);
-                    this.other0Field = value;
-                }
-            }
-
-            private global::Improbable.TestSchema.NestedTypeSameName.Other.NestedTypeSameName.Other1.NestedTypeSameName other1Field;
-
-            public global::Improbable.TestSchema.NestedTypeSameName.Other.NestedTypeSameName.Other1.NestedTypeSameName Other1Field
-            {
-                get => other1Field;
-                set
-                {
-                    MarkDataDirty(2);
-                    this.other1Field = value;
-                }
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/testschema/ComponentUsingNestedTypeSameNameComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ComponentUsingNestedTypeSameNameComponentReaderWriter.cs
@@ -20,7 +20,7 @@ namespace Improbable.TestSchema
 
         protected override ComponentUsingNestedTypeSameNameReader CreateReader(Entity entity, EntityId entityId)
         {
-            return new ComponentUsingNestedTypeSameNameReader(world, entity, entityId);
+            return new ComponentUsingNestedTypeSameNameReader(World, entity, entityId);
         }
     }
 
@@ -33,7 +33,7 @@ namespace Improbable.TestSchema
 
         protected override ComponentUsingNestedTypeSameNameWriter CreateWriter(Entity entity, EntityId entityId)
         {
-            return new ComponentUsingNestedTypeSameNameWriter(world, entity, entityId);
+            return new ComponentUsingNestedTypeSameNameWriter(World, entity, entityId);
         }
     }
 

--- a/test-project/Assets/Generated/Source/improbable/testschema/ComponentUsingNestedTypeSameNameUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ComponentUsingNestedTypeSameNameUpdateSender.cs
@@ -2,15 +2,11 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEngine.Profiling;
-using Unity.Mathematics;
 using Unity.Entities;
 using Unity.Collections;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
+using Unity.Profiling;
 
 namespace Improbable.TestSchema
 {
@@ -18,6 +14,8 @@ namespace Improbable.TestSchema
     {
         internal class ComponentReplicator : IComponentReplicationHandler
         {
+            private ProfilerMarker componentMarker = new ProfilerMarker("ComponentUsingNestedTypeSameName");
+
             public uint ComponentId => 198730;
 
             public EntityQueryDesc ComponentUpdateQuery => new EntityQueryDesc
@@ -36,54 +34,53 @@ namespace Improbable.TestSchema
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
-                Profiler.BeginSample("ComponentUsingNestedTypeSameName");
-
-                var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.TestSchema.ComponentUsingNestedTypeSameName.Component>();
-                var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
-
-                foreach (var chunk in chunkArray)
+                using (componentMarker.Auto())
                 {
-                    var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
-                    var componentArray = chunk.GetNativeArray(componentType);
-                    var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
+                    var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
+                    var componentType = system.GetArchetypeChunkComponentType<global::Improbable.TestSchema.ComponentUsingNestedTypeSameName.Component>();
+                    var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 
-                    if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
+                    foreach (var chunk in chunkArray)
                     {
-                        continue;
-                    }
+                        var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
+                        var componentArray = chunk.GetNativeArray(componentType);
+                        var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
 
-                    for (var i = 0; i < componentArray.Length; i++)
-                    {
-                        var data = componentArray[i];
-
-                        if (data.IsDataDirty())
+                        if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
                         {
-                            Update update = new Update();
+                            continue;
+                        }
 
-                            if (data.IsDataDirty(0))
+                        for (var i = 0; i < componentArray.Length; i++)
+                        {
+                            var data = componentArray[i];
+
+                            if (data.IsDataDirty())
                             {
-                                update.NestedField = data.NestedField;
-                            }
+                                var update = new Update();
 
-                            if (data.IsDataDirty(1))
-                            {
-                                update.Other0Field = data.Other0Field;
-                            }
+                                if (data.IsDataDirty(0))
+                                {
+                                    update.NestedField = data.NestedField;
+                                }
 
-                            if (data.IsDataDirty(2))
-                            {
-                                update.Other1Field = data.Other1Field;
-                            }
+                                if (data.IsDataDirty(1))
+                                {
+                                    update.Other0Field = data.Other0Field;
+                                }
 
-                            componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
-                            data.MarkDataClean();
-                            componentArray[i] = data;
+                                if (data.IsDataDirty(2))
+                                {
+                                    update.Other1Field = data.Other1Field;
+                                }
+
+                                componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
+                                data.MarkDataClean();
+                                componentArray[i] = data;
+                            }
                         }
                     }
                 }
-
-                Profiler.EndSample();
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveEntity.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveEntity.cs
@@ -17,10 +17,68 @@ namespace Improbable.TestSchema
 
         public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
-            public uint ComponentId => 197720;
-
             // Bit masks for tracking which component properties were changed locally and need to be synced.
             private fixed UInt32 dirtyBits[1];
+
+            internal uint field1Handle;
+
+            public global::Improbable.Gdk.Core.EntitySnapshot Field1
+            {
+                get => global::Improbable.TestSchema.ExhaustiveEntity.ReferenceTypeProviders.Field1Provider.Get(field1Handle);
+                set
+                {
+                    MarkDataDirty(0);
+                    global::Improbable.TestSchema.ExhaustiveEntity.ReferenceTypeProviders.Field1Provider.Set(field1Handle, value);
+                }
+            }
+
+            internal uint field2Handle;
+
+            public global::Improbable.Gdk.Core.EntitySnapshot? Field2
+            {
+                get => global::Improbable.TestSchema.ExhaustiveEntity.ReferenceTypeProviders.Field2Provider.Get(field2Handle);
+                set
+                {
+                    MarkDataDirty(1);
+                    global::Improbable.TestSchema.ExhaustiveEntity.ReferenceTypeProviders.Field2Provider.Set(field2Handle, value);
+                }
+            }
+
+            internal uint field3Handle;
+
+            public global::System.Collections.Generic.List<global::Improbable.Gdk.Core.EntitySnapshot> Field3
+            {
+                get => global::Improbable.TestSchema.ExhaustiveEntity.ReferenceTypeProviders.Field3Provider.Get(field3Handle);
+                set
+                {
+                    MarkDataDirty(2);
+                    global::Improbable.TestSchema.ExhaustiveEntity.ReferenceTypeProviders.Field3Provider.Set(field3Handle, value);
+                }
+            }
+
+            internal uint field4Handle;
+
+            public global::System.Collections.Generic.Dictionary<global::Improbable.Gdk.Core.EntitySnapshot, string> Field4
+            {
+                get => global::Improbable.TestSchema.ExhaustiveEntity.ReferenceTypeProviders.Field4Provider.Get(field4Handle);
+                set
+                {
+                    MarkDataDirty(3);
+                    global::Improbable.TestSchema.ExhaustiveEntity.ReferenceTypeProviders.Field4Provider.Set(field4Handle, value);
+                }
+            }
+
+            internal uint field5Handle;
+
+            public global::System.Collections.Generic.Dictionary<string, global::Improbable.Gdk.Core.EntitySnapshot> Field5
+            {
+                get => global::Improbable.TestSchema.ExhaustiveEntity.ReferenceTypeProviders.Field5Provider.Get(field5Handle);
+                set
+                {
+                    MarkDataDirty(4);
+                    global::Improbable.TestSchema.ExhaustiveEntity.ReferenceTypeProviders.Field5Provider.Set(field5Handle, value);
+                }
+            }
 
             public bool IsDataDirty()
             {
@@ -90,66 +148,6 @@ namespace Improbable.TestSchema
                 componentDataSchema.SchemaData = null;
 
                 return snapshot;
-            }
-
-            internal uint field1Handle;
-
-            public global::Improbable.Gdk.Core.EntitySnapshot Field1
-            {
-                get => global::Improbable.TestSchema.ExhaustiveEntity.ReferenceTypeProviders.Field1Provider.Get(field1Handle);
-                set
-                {
-                    MarkDataDirty(0);
-                    global::Improbable.TestSchema.ExhaustiveEntity.ReferenceTypeProviders.Field1Provider.Set(field1Handle, value);
-                }
-            }
-
-            internal uint field2Handle;
-
-            public global::Improbable.Gdk.Core.EntitySnapshot? Field2
-            {
-                get => global::Improbable.TestSchema.ExhaustiveEntity.ReferenceTypeProviders.Field2Provider.Get(field2Handle);
-                set
-                {
-                    MarkDataDirty(1);
-                    global::Improbable.TestSchema.ExhaustiveEntity.ReferenceTypeProviders.Field2Provider.Set(field2Handle, value);
-                }
-            }
-
-            internal uint field3Handle;
-
-            public global::System.Collections.Generic.List<global::Improbable.Gdk.Core.EntitySnapshot> Field3
-            {
-                get => global::Improbable.TestSchema.ExhaustiveEntity.ReferenceTypeProviders.Field3Provider.Get(field3Handle);
-                set
-                {
-                    MarkDataDirty(2);
-                    global::Improbable.TestSchema.ExhaustiveEntity.ReferenceTypeProviders.Field3Provider.Set(field3Handle, value);
-                }
-            }
-
-            internal uint field4Handle;
-
-            public global::System.Collections.Generic.Dictionary<global::Improbable.Gdk.Core.EntitySnapshot, string> Field4
-            {
-                get => global::Improbable.TestSchema.ExhaustiveEntity.ReferenceTypeProviders.Field4Provider.Get(field4Handle);
-                set
-                {
-                    MarkDataDirty(3);
-                    global::Improbable.TestSchema.ExhaustiveEntity.ReferenceTypeProviders.Field4Provider.Set(field4Handle, value);
-                }
-            }
-
-            internal uint field5Handle;
-
-            public global::System.Collections.Generic.Dictionary<string, global::Improbable.Gdk.Core.EntitySnapshot> Field5
-            {
-                get => global::Improbable.TestSchema.ExhaustiveEntity.ReferenceTypeProviders.Field5Provider.Get(field5Handle);
-                set
-                {
-                    MarkDataDirty(4);
-                    global::Improbable.TestSchema.ExhaustiveEntity.ReferenceTypeProviders.Field5Provider.Set(field5Handle, value);
-                }
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveEntityComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveEntityComponentReaderWriter.cs
@@ -20,7 +20,7 @@ namespace Improbable.TestSchema
 
         protected override ExhaustiveEntityReader CreateReader(Entity entity, EntityId entityId)
         {
-            return new ExhaustiveEntityReader(world, entity, entityId);
+            return new ExhaustiveEntityReader(World, entity, entityId);
         }
     }
 
@@ -33,7 +33,7 @@ namespace Improbable.TestSchema
 
         protected override ExhaustiveEntityWriter CreateWriter(Entity entity, EntityId entityId)
         {
-            return new ExhaustiveEntityWriter(world, entity, entityId);
+            return new ExhaustiveEntityWriter(World, entity, entityId);
         }
     }
 

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveEntityUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveEntityUpdateSender.cs
@@ -2,15 +2,11 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEngine.Profiling;
-using Unity.Mathematics;
 using Unity.Entities;
 using Unity.Collections;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
+using Unity.Profiling;
 
 namespace Improbable.TestSchema
 {
@@ -18,6 +14,8 @@ namespace Improbable.TestSchema
     {
         internal class ComponentReplicator : IComponentReplicationHandler
         {
+            private ProfilerMarker componentMarker = new ProfilerMarker("ExhaustiveEntity");
+
             public uint ComponentId => 197720;
 
             public EntityQueryDesc ComponentUpdateQuery => new EntityQueryDesc
@@ -36,64 +34,63 @@ namespace Improbable.TestSchema
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
-                Profiler.BeginSample("ExhaustiveEntity");
-
-                var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.TestSchema.ExhaustiveEntity.Component>();
-                var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
-
-                foreach (var chunk in chunkArray)
+                using (componentMarker.Auto())
                 {
-                    var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
-                    var componentArray = chunk.GetNativeArray(componentType);
-                    var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
+                    var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
+                    var componentType = system.GetArchetypeChunkComponentType<global::Improbable.TestSchema.ExhaustiveEntity.Component>();
+                    var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 
-                    if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
+                    foreach (var chunk in chunkArray)
                     {
-                        continue;
-                    }
+                        var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
+                        var componentArray = chunk.GetNativeArray(componentType);
+                        var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
 
-                    for (var i = 0; i < componentArray.Length; i++)
-                    {
-                        var data = componentArray[i];
-
-                        if (data.IsDataDirty())
+                        if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
                         {
-                            Update update = new Update();
+                            continue;
+                        }
 
-                            if (data.IsDataDirty(0))
+                        for (var i = 0; i < componentArray.Length; i++)
+                        {
+                            var data = componentArray[i];
+
+                            if (data.IsDataDirty())
                             {
-                                update.Field1 = data.Field1;
-                            }
+                                var update = new Update();
 
-                            if (data.IsDataDirty(1))
-                            {
-                                update.Field2 = data.Field2;
-                            }
+                                if (data.IsDataDirty(0))
+                                {
+                                    update.Field1 = data.Field1;
+                                }
 
-                            if (data.IsDataDirty(2))
-                            {
-                                update.Field3 = data.Field3;
-                            }
+                                if (data.IsDataDirty(1))
+                                {
+                                    update.Field2 = data.Field2;
+                                }
 
-                            if (data.IsDataDirty(3))
-                            {
-                                update.Field4 = data.Field4;
-                            }
+                                if (data.IsDataDirty(2))
+                                {
+                                    update.Field3 = data.Field3;
+                                }
 
-                            if (data.IsDataDirty(4))
-                            {
-                                update.Field5 = data.Field5;
-                            }
+                                if (data.IsDataDirty(3))
+                                {
+                                    update.Field4 = data.Field4;
+                                }
 
-                            componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
-                            data.MarkDataClean();
-                            componentArray[i] = data;
+                                if (data.IsDataDirty(4))
+                                {
+                                    update.Field5 = data.Field5;
+                                }
+
+                                componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
+                                data.MarkDataClean();
+                                componentArray[i] = data;
+                            }
                         }
                     }
                 }
-
-                Profiler.EndSample();
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapKey.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapKey.cs
@@ -17,80 +17,8 @@ namespace Improbable.TestSchema
 
         public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
-            public uint ComponentId => 197719;
-
             // Bit masks for tracking which component properties were changed locally and need to be synced.
             private fixed UInt32 dirtyBits[1];
-
-            public bool IsDataDirty()
-            {
-                var isDataDirty = false;
-
-                isDataDirty |= (dirtyBits[0] != 0x0);
-
-                return isDataDirty;
-            }
-
-            /*
-            The propertyIndex argument counts up from 0 in the order defined in your schema component.
-            It is not the schema field number itself. For example:
-            component MyComponent
-            {
-                id = 1337;
-                bool val_a = 1;
-                bool val_b = 3;
-            }
-            In that case, val_a corresponds to propertyIndex 0 and val_b corresponds to propertyIndex 1 in this method.
-            This method throws an InvalidOperationException in case your component doesn't contain properties.
-            */
-
-            public bool IsDataDirty(int propertyIndex)
-            {
-                ValidateFieldIndex(propertyIndex);
-
-                // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex >> 4;
-                return (dirtyBits[dirtyBitsByteIndex] & (0x1 << (propertyIndex & 31))) != 0x0;
-            }
-
-            // Like the IsDataDirty() method above, the propertyIndex arguments starts counting from 0.
-            // This method throws an InvalidOperationException in case your component doesn't contain properties.
-            public void MarkDataDirty(int propertyIndex)
-            {
-                ValidateFieldIndex(propertyIndex);
-
-                // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex >> 4;
-                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
-            }
-
-            public void MarkDataClean()
-            {
-                dirtyBits[0] = 0x0;
-            }
-
-            [Conditional("DEBUG")]
-            private void ValidateFieldIndex(int propertyIndex)
-            {
-                if (propertyIndex < 0 || propertyIndex >= 18)
-                {
-                    throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
-                        "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
-                        "Please contact SpatialOS support if you encounter this issue.");
-                }
-            }
-
-            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
-            {
-                var componentDataSchema = new ComponentData(197719, SchemaComponentData.Create());
-                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
-                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields());
-
-                componentDataSchema.SchemaData?.Destroy();
-                componentDataSchema.SchemaData = null;
-
-                return snapshot;
-            }
 
             internal uint field1Handle;
 
@@ -306,6 +234,76 @@ namespace Improbable.TestSchema
                     MarkDataDirty(17);
                     global::Improbable.TestSchema.ExhaustiveMapKey.ReferenceTypeProviders.Field18Provider.Set(field18Handle, value);
                 }
+            }
+
+            public bool IsDataDirty()
+            {
+                var isDataDirty = false;
+
+                isDataDirty |= (dirtyBits[0] != 0x0);
+
+                return isDataDirty;
+            }
+
+            /*
+            The propertyIndex argument counts up from 0 in the order defined in your schema component.
+            It is not the schema field number itself. For example:
+            component MyComponent
+            {
+                id = 1337;
+                bool val_a = 1;
+                bool val_b = 3;
+            }
+            In that case, val_a corresponds to propertyIndex 0 and val_b corresponds to propertyIndex 1 in this method.
+            This method throws an InvalidOperationException in case your component doesn't contain properties.
+            */
+
+            public bool IsDataDirty(int propertyIndex)
+            {
+                ValidateFieldIndex(propertyIndex);
+
+                // Retrieve the dirtyBits[0-n] field that tracks this property.
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                return (dirtyBits[dirtyBitsByteIndex] & (0x1 << (propertyIndex & 31))) != 0x0;
+            }
+
+            // Like the IsDataDirty() method above, the propertyIndex arguments starts counting from 0.
+            // This method throws an InvalidOperationException in case your component doesn't contain properties.
+            public void MarkDataDirty(int propertyIndex)
+            {
+                ValidateFieldIndex(propertyIndex);
+
+                // Retrieve the dirtyBits[0-n] field that tracks this property.
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
+            }
+
+            public void MarkDataClean()
+            {
+                dirtyBits[0] = 0x0;
+            }
+
+            [Conditional("DEBUG")]
+            private void ValidateFieldIndex(int propertyIndex)
+            {
+                if (propertyIndex < 0 || propertyIndex >= 18)
+                {
+                    throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
+                        "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
+                        "Please contact SpatialOS support if you encounter this issue.");
+                }
+            }
+
+            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
+            {
+                var componentDataSchema = new ComponentData(197719, SchemaComponentData.Create());
+                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
+                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields());
+
+                componentDataSchema.SchemaData?.Destroy();
+                componentDataSchema.SchemaData = null;
+
+                return snapshot;
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapKeyComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapKeyComponentReaderWriter.cs
@@ -20,7 +20,7 @@ namespace Improbable.TestSchema
 
         protected override ExhaustiveMapKeyReader CreateReader(Entity entity, EntityId entityId)
         {
-            return new ExhaustiveMapKeyReader(world, entity, entityId);
+            return new ExhaustiveMapKeyReader(World, entity, entityId);
         }
     }
 
@@ -33,7 +33,7 @@ namespace Improbable.TestSchema
 
         protected override ExhaustiveMapKeyWriter CreateWriter(Entity entity, EntityId entityId)
         {
-            return new ExhaustiveMapKeyWriter(world, entity, entityId);
+            return new ExhaustiveMapKeyWriter(World, entity, entityId);
         }
     }
 

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapKeyUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapKeyUpdateSender.cs
@@ -2,15 +2,11 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEngine.Profiling;
-using Unity.Mathematics;
 using Unity.Entities;
 using Unity.Collections;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
+using Unity.Profiling;
 
 namespace Improbable.TestSchema
 {
@@ -18,6 +14,8 @@ namespace Improbable.TestSchema
     {
         internal class ComponentReplicator : IComponentReplicationHandler
         {
+            private ProfilerMarker componentMarker = new ProfilerMarker("ExhaustiveMapKey");
+
             public uint ComponentId => 197719;
 
             public EntityQueryDesc ComponentUpdateQuery => new EntityQueryDesc
@@ -36,129 +34,128 @@ namespace Improbable.TestSchema
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
-                Profiler.BeginSample("ExhaustiveMapKey");
-
-                var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.TestSchema.ExhaustiveMapKey.Component>();
-                var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
-
-                foreach (var chunk in chunkArray)
+                using (componentMarker.Auto())
                 {
-                    var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
-                    var componentArray = chunk.GetNativeArray(componentType);
-                    var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
+                    var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
+                    var componentType = system.GetArchetypeChunkComponentType<global::Improbable.TestSchema.ExhaustiveMapKey.Component>();
+                    var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 
-                    if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
+                    foreach (var chunk in chunkArray)
                     {
-                        continue;
-                    }
+                        var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
+                        var componentArray = chunk.GetNativeArray(componentType);
+                        var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
 
-                    for (var i = 0; i < componentArray.Length; i++)
-                    {
-                        var data = componentArray[i];
-
-                        if (data.IsDataDirty())
+                        if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
                         {
-                            Update update = new Update();
+                            continue;
+                        }
 
-                            if (data.IsDataDirty(0))
+                        for (var i = 0; i < componentArray.Length; i++)
+                        {
+                            var data = componentArray[i];
+
+                            if (data.IsDataDirty())
                             {
-                                update.Field1 = data.Field1;
-                            }
+                                var update = new Update();
 
-                            if (data.IsDataDirty(1))
-                            {
-                                update.Field2 = data.Field2;
-                            }
+                                if (data.IsDataDirty(0))
+                                {
+                                    update.Field1 = data.Field1;
+                                }
 
-                            if (data.IsDataDirty(2))
-                            {
-                                update.Field3 = data.Field3;
-                            }
+                                if (data.IsDataDirty(1))
+                                {
+                                    update.Field2 = data.Field2;
+                                }
 
-                            if (data.IsDataDirty(3))
-                            {
-                                update.Field4 = data.Field4;
-                            }
+                                if (data.IsDataDirty(2))
+                                {
+                                    update.Field3 = data.Field3;
+                                }
 
-                            if (data.IsDataDirty(4))
-                            {
-                                update.Field5 = data.Field5;
-                            }
+                                if (data.IsDataDirty(3))
+                                {
+                                    update.Field4 = data.Field4;
+                                }
 
-                            if (data.IsDataDirty(5))
-                            {
-                                update.Field6 = data.Field6;
-                            }
+                                if (data.IsDataDirty(4))
+                                {
+                                    update.Field5 = data.Field5;
+                                }
 
-                            if (data.IsDataDirty(6))
-                            {
-                                update.Field7 = data.Field7;
-                            }
+                                if (data.IsDataDirty(5))
+                                {
+                                    update.Field6 = data.Field6;
+                                }
 
-                            if (data.IsDataDirty(7))
-                            {
-                                update.Field8 = data.Field8;
-                            }
+                                if (data.IsDataDirty(6))
+                                {
+                                    update.Field7 = data.Field7;
+                                }
 
-                            if (data.IsDataDirty(8))
-                            {
-                                update.Field9 = data.Field9;
-                            }
+                                if (data.IsDataDirty(7))
+                                {
+                                    update.Field8 = data.Field8;
+                                }
 
-                            if (data.IsDataDirty(9))
-                            {
-                                update.Field10 = data.Field10;
-                            }
+                                if (data.IsDataDirty(8))
+                                {
+                                    update.Field9 = data.Field9;
+                                }
 
-                            if (data.IsDataDirty(10))
-                            {
-                                update.Field11 = data.Field11;
-                            }
+                                if (data.IsDataDirty(9))
+                                {
+                                    update.Field10 = data.Field10;
+                                }
 
-                            if (data.IsDataDirty(11))
-                            {
-                                update.Field12 = data.Field12;
-                            }
+                                if (data.IsDataDirty(10))
+                                {
+                                    update.Field11 = data.Field11;
+                                }
 
-                            if (data.IsDataDirty(12))
-                            {
-                                update.Field13 = data.Field13;
-                            }
+                                if (data.IsDataDirty(11))
+                                {
+                                    update.Field12 = data.Field12;
+                                }
 
-                            if (data.IsDataDirty(13))
-                            {
-                                update.Field14 = data.Field14;
-                            }
+                                if (data.IsDataDirty(12))
+                                {
+                                    update.Field13 = data.Field13;
+                                }
 
-                            if (data.IsDataDirty(14))
-                            {
-                                update.Field15 = data.Field15;
-                            }
+                                if (data.IsDataDirty(13))
+                                {
+                                    update.Field14 = data.Field14;
+                                }
 
-                            if (data.IsDataDirty(15))
-                            {
-                                update.Field16 = data.Field16;
-                            }
+                                if (data.IsDataDirty(14))
+                                {
+                                    update.Field15 = data.Field15;
+                                }
 
-                            if (data.IsDataDirty(16))
-                            {
-                                update.Field17 = data.Field17;
-                            }
+                                if (data.IsDataDirty(15))
+                                {
+                                    update.Field16 = data.Field16;
+                                }
 
-                            if (data.IsDataDirty(17))
-                            {
-                                update.Field18 = data.Field18;
-                            }
+                                if (data.IsDataDirty(16))
+                                {
+                                    update.Field17 = data.Field17;
+                                }
 
-                            componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
-                            data.MarkDataClean();
-                            componentArray[i] = data;
+                                if (data.IsDataDirty(17))
+                                {
+                                    update.Field18 = data.Field18;
+                                }
+
+                                componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
+                                data.MarkDataClean();
+                                componentArray[i] = data;
+                            }
                         }
                     }
                 }
-
-                Profiler.EndSample();
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapValue.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapValue.cs
@@ -17,80 +17,8 @@ namespace Improbable.TestSchema
 
         public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
-            public uint ComponentId => 197718;
-
             // Bit masks for tracking which component properties were changed locally and need to be synced.
             private fixed UInt32 dirtyBits[1];
-
-            public bool IsDataDirty()
-            {
-                var isDataDirty = false;
-
-                isDataDirty |= (dirtyBits[0] != 0x0);
-
-                return isDataDirty;
-            }
-
-            /*
-            The propertyIndex argument counts up from 0 in the order defined in your schema component.
-            It is not the schema field number itself. For example:
-            component MyComponent
-            {
-                id = 1337;
-                bool val_a = 1;
-                bool val_b = 3;
-            }
-            In that case, val_a corresponds to propertyIndex 0 and val_b corresponds to propertyIndex 1 in this method.
-            This method throws an InvalidOperationException in case your component doesn't contain properties.
-            */
-
-            public bool IsDataDirty(int propertyIndex)
-            {
-                ValidateFieldIndex(propertyIndex);
-
-                // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex >> 4;
-                return (dirtyBits[dirtyBitsByteIndex] & (0x1 << (propertyIndex & 31))) != 0x0;
-            }
-
-            // Like the IsDataDirty() method above, the propertyIndex arguments starts counting from 0.
-            // This method throws an InvalidOperationException in case your component doesn't contain properties.
-            public void MarkDataDirty(int propertyIndex)
-            {
-                ValidateFieldIndex(propertyIndex);
-
-                // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex >> 4;
-                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
-            }
-
-            public void MarkDataClean()
-            {
-                dirtyBits[0] = 0x0;
-            }
-
-            [Conditional("DEBUG")]
-            private void ValidateFieldIndex(int propertyIndex)
-            {
-                if (propertyIndex < 0 || propertyIndex >= 18)
-                {
-                    throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
-                        "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
-                        "Please contact SpatialOS support if you encounter this issue.");
-                }
-            }
-
-            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
-            {
-                var componentDataSchema = new ComponentData(197718, SchemaComponentData.Create());
-                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
-                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields());
-
-                componentDataSchema.SchemaData?.Destroy();
-                componentDataSchema.SchemaData = null;
-
-                return snapshot;
-            }
 
             internal uint field1Handle;
 
@@ -306,6 +234,76 @@ namespace Improbable.TestSchema
                     MarkDataDirty(17);
                     global::Improbable.TestSchema.ExhaustiveMapValue.ReferenceTypeProviders.Field18Provider.Set(field18Handle, value);
                 }
+            }
+
+            public bool IsDataDirty()
+            {
+                var isDataDirty = false;
+
+                isDataDirty |= (dirtyBits[0] != 0x0);
+
+                return isDataDirty;
+            }
+
+            /*
+            The propertyIndex argument counts up from 0 in the order defined in your schema component.
+            It is not the schema field number itself. For example:
+            component MyComponent
+            {
+                id = 1337;
+                bool val_a = 1;
+                bool val_b = 3;
+            }
+            In that case, val_a corresponds to propertyIndex 0 and val_b corresponds to propertyIndex 1 in this method.
+            This method throws an InvalidOperationException in case your component doesn't contain properties.
+            */
+
+            public bool IsDataDirty(int propertyIndex)
+            {
+                ValidateFieldIndex(propertyIndex);
+
+                // Retrieve the dirtyBits[0-n] field that tracks this property.
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                return (dirtyBits[dirtyBitsByteIndex] & (0x1 << (propertyIndex & 31))) != 0x0;
+            }
+
+            // Like the IsDataDirty() method above, the propertyIndex arguments starts counting from 0.
+            // This method throws an InvalidOperationException in case your component doesn't contain properties.
+            public void MarkDataDirty(int propertyIndex)
+            {
+                ValidateFieldIndex(propertyIndex);
+
+                // Retrieve the dirtyBits[0-n] field that tracks this property.
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
+            }
+
+            public void MarkDataClean()
+            {
+                dirtyBits[0] = 0x0;
+            }
+
+            [Conditional("DEBUG")]
+            private void ValidateFieldIndex(int propertyIndex)
+            {
+                if (propertyIndex < 0 || propertyIndex >= 18)
+                {
+                    throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
+                        "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
+                        "Please contact SpatialOS support if you encounter this issue.");
+                }
+            }
+
+            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
+            {
+                var componentDataSchema = new ComponentData(197718, SchemaComponentData.Create());
+                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
+                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields());
+
+                componentDataSchema.SchemaData?.Destroy();
+                componentDataSchema.SchemaData = null;
+
+                return snapshot;
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapValueComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapValueComponentReaderWriter.cs
@@ -20,7 +20,7 @@ namespace Improbable.TestSchema
 
         protected override ExhaustiveMapValueReader CreateReader(Entity entity, EntityId entityId)
         {
-            return new ExhaustiveMapValueReader(world, entity, entityId);
+            return new ExhaustiveMapValueReader(World, entity, entityId);
         }
     }
 
@@ -33,7 +33,7 @@ namespace Improbable.TestSchema
 
         protected override ExhaustiveMapValueWriter CreateWriter(Entity entity, EntityId entityId)
         {
-            return new ExhaustiveMapValueWriter(world, entity, entityId);
+            return new ExhaustiveMapValueWriter(World, entity, entityId);
         }
     }
 

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapValueUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapValueUpdateSender.cs
@@ -2,15 +2,11 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEngine.Profiling;
-using Unity.Mathematics;
 using Unity.Entities;
 using Unity.Collections;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
+using Unity.Profiling;
 
 namespace Improbable.TestSchema
 {
@@ -18,6 +14,8 @@ namespace Improbable.TestSchema
     {
         internal class ComponentReplicator : IComponentReplicationHandler
         {
+            private ProfilerMarker componentMarker = new ProfilerMarker("ExhaustiveMapValue");
+
             public uint ComponentId => 197718;
 
             public EntityQueryDesc ComponentUpdateQuery => new EntityQueryDesc
@@ -36,129 +34,128 @@ namespace Improbable.TestSchema
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
-                Profiler.BeginSample("ExhaustiveMapValue");
-
-                var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.TestSchema.ExhaustiveMapValue.Component>();
-                var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
-
-                foreach (var chunk in chunkArray)
+                using (componentMarker.Auto())
                 {
-                    var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
-                    var componentArray = chunk.GetNativeArray(componentType);
-                    var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
+                    var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
+                    var componentType = system.GetArchetypeChunkComponentType<global::Improbable.TestSchema.ExhaustiveMapValue.Component>();
+                    var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 
-                    if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
+                    foreach (var chunk in chunkArray)
                     {
-                        continue;
-                    }
+                        var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
+                        var componentArray = chunk.GetNativeArray(componentType);
+                        var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
 
-                    for (var i = 0; i < componentArray.Length; i++)
-                    {
-                        var data = componentArray[i];
-
-                        if (data.IsDataDirty())
+                        if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
                         {
-                            Update update = new Update();
+                            continue;
+                        }
 
-                            if (data.IsDataDirty(0))
+                        for (var i = 0; i < componentArray.Length; i++)
+                        {
+                            var data = componentArray[i];
+
+                            if (data.IsDataDirty())
                             {
-                                update.Field1 = data.Field1;
-                            }
+                                var update = new Update();
 
-                            if (data.IsDataDirty(1))
-                            {
-                                update.Field2 = data.Field2;
-                            }
+                                if (data.IsDataDirty(0))
+                                {
+                                    update.Field1 = data.Field1;
+                                }
 
-                            if (data.IsDataDirty(2))
-                            {
-                                update.Field3 = data.Field3;
-                            }
+                                if (data.IsDataDirty(1))
+                                {
+                                    update.Field2 = data.Field2;
+                                }
 
-                            if (data.IsDataDirty(3))
-                            {
-                                update.Field4 = data.Field4;
-                            }
+                                if (data.IsDataDirty(2))
+                                {
+                                    update.Field3 = data.Field3;
+                                }
 
-                            if (data.IsDataDirty(4))
-                            {
-                                update.Field5 = data.Field5;
-                            }
+                                if (data.IsDataDirty(3))
+                                {
+                                    update.Field4 = data.Field4;
+                                }
 
-                            if (data.IsDataDirty(5))
-                            {
-                                update.Field6 = data.Field6;
-                            }
+                                if (data.IsDataDirty(4))
+                                {
+                                    update.Field5 = data.Field5;
+                                }
 
-                            if (data.IsDataDirty(6))
-                            {
-                                update.Field7 = data.Field7;
-                            }
+                                if (data.IsDataDirty(5))
+                                {
+                                    update.Field6 = data.Field6;
+                                }
 
-                            if (data.IsDataDirty(7))
-                            {
-                                update.Field8 = data.Field8;
-                            }
+                                if (data.IsDataDirty(6))
+                                {
+                                    update.Field7 = data.Field7;
+                                }
 
-                            if (data.IsDataDirty(8))
-                            {
-                                update.Field9 = data.Field9;
-                            }
+                                if (data.IsDataDirty(7))
+                                {
+                                    update.Field8 = data.Field8;
+                                }
 
-                            if (data.IsDataDirty(9))
-                            {
-                                update.Field10 = data.Field10;
-                            }
+                                if (data.IsDataDirty(8))
+                                {
+                                    update.Field9 = data.Field9;
+                                }
 
-                            if (data.IsDataDirty(10))
-                            {
-                                update.Field11 = data.Field11;
-                            }
+                                if (data.IsDataDirty(9))
+                                {
+                                    update.Field10 = data.Field10;
+                                }
 
-                            if (data.IsDataDirty(11))
-                            {
-                                update.Field12 = data.Field12;
-                            }
+                                if (data.IsDataDirty(10))
+                                {
+                                    update.Field11 = data.Field11;
+                                }
 
-                            if (data.IsDataDirty(12))
-                            {
-                                update.Field13 = data.Field13;
-                            }
+                                if (data.IsDataDirty(11))
+                                {
+                                    update.Field12 = data.Field12;
+                                }
 
-                            if (data.IsDataDirty(13))
-                            {
-                                update.Field14 = data.Field14;
-                            }
+                                if (data.IsDataDirty(12))
+                                {
+                                    update.Field13 = data.Field13;
+                                }
 
-                            if (data.IsDataDirty(14))
-                            {
-                                update.Field15 = data.Field15;
-                            }
+                                if (data.IsDataDirty(13))
+                                {
+                                    update.Field14 = data.Field14;
+                                }
 
-                            if (data.IsDataDirty(15))
-                            {
-                                update.Field16 = data.Field16;
-                            }
+                                if (data.IsDataDirty(14))
+                                {
+                                    update.Field15 = data.Field15;
+                                }
 
-                            if (data.IsDataDirty(16))
-                            {
-                                update.Field17 = data.Field17;
-                            }
+                                if (data.IsDataDirty(15))
+                                {
+                                    update.Field16 = data.Field16;
+                                }
 
-                            if (data.IsDataDirty(17))
-                            {
-                                update.Field18 = data.Field18;
-                            }
+                                if (data.IsDataDirty(16))
+                                {
+                                    update.Field17 = data.Field17;
+                                }
 
-                            componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
-                            data.MarkDataClean();
-                            componentArray[i] = data;
+                                if (data.IsDataDirty(17))
+                                {
+                                    update.Field18 = data.Field18;
+                                }
+
+                                componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
+                                data.MarkDataClean();
+                                componentArray[i] = data;
+                            }
                         }
                     }
                 }
-
-                Profiler.EndSample();
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveOptional.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveOptional.cs
@@ -17,80 +17,8 @@ namespace Improbable.TestSchema
 
         public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
-            public uint ComponentId => 197716;
-
             // Bit masks for tracking which component properties were changed locally and need to be synced.
             private fixed UInt32 dirtyBits[1];
-
-            public bool IsDataDirty()
-            {
-                var isDataDirty = false;
-
-                isDataDirty |= (dirtyBits[0] != 0x0);
-
-                return isDataDirty;
-            }
-
-            /*
-            The propertyIndex argument counts up from 0 in the order defined in your schema component.
-            It is not the schema field number itself. For example:
-            component MyComponent
-            {
-                id = 1337;
-                bool val_a = 1;
-                bool val_b = 3;
-            }
-            In that case, val_a corresponds to propertyIndex 0 and val_b corresponds to propertyIndex 1 in this method.
-            This method throws an InvalidOperationException in case your component doesn't contain properties.
-            */
-
-            public bool IsDataDirty(int propertyIndex)
-            {
-                ValidateFieldIndex(propertyIndex);
-
-                // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex >> 4;
-                return (dirtyBits[dirtyBitsByteIndex] & (0x1 << (propertyIndex & 31))) != 0x0;
-            }
-
-            // Like the IsDataDirty() method above, the propertyIndex arguments starts counting from 0.
-            // This method throws an InvalidOperationException in case your component doesn't contain properties.
-            public void MarkDataDirty(int propertyIndex)
-            {
-                ValidateFieldIndex(propertyIndex);
-
-                // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex >> 4;
-                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
-            }
-
-            public void MarkDataClean()
-            {
-                dirtyBits[0] = 0x0;
-            }
-
-            [Conditional("DEBUG")]
-            private void ValidateFieldIndex(int propertyIndex)
-            {
-                if (propertyIndex < 0 || propertyIndex >= 18)
-                {
-                    throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
-                        "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
-                        "Please contact SpatialOS support if you encounter this issue.");
-                }
-            }
-
-            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
-            {
-                var componentDataSchema = new ComponentData(197716, SchemaComponentData.Create());
-                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
-                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields());
-
-                componentDataSchema.SchemaData?.Destroy();
-                componentDataSchema.SchemaData = null;
-
-                return snapshot;
-            }
 
             internal uint field1Handle;
 
@@ -306,6 +234,76 @@ namespace Improbable.TestSchema
                     MarkDataDirty(17);
                     global::Improbable.TestSchema.ExhaustiveOptional.ReferenceTypeProviders.Field18Provider.Set(field18Handle, value);
                 }
+            }
+
+            public bool IsDataDirty()
+            {
+                var isDataDirty = false;
+
+                isDataDirty |= (dirtyBits[0] != 0x0);
+
+                return isDataDirty;
+            }
+
+            /*
+            The propertyIndex argument counts up from 0 in the order defined in your schema component.
+            It is not the schema field number itself. For example:
+            component MyComponent
+            {
+                id = 1337;
+                bool val_a = 1;
+                bool val_b = 3;
+            }
+            In that case, val_a corresponds to propertyIndex 0 and val_b corresponds to propertyIndex 1 in this method.
+            This method throws an InvalidOperationException in case your component doesn't contain properties.
+            */
+
+            public bool IsDataDirty(int propertyIndex)
+            {
+                ValidateFieldIndex(propertyIndex);
+
+                // Retrieve the dirtyBits[0-n] field that tracks this property.
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                return (dirtyBits[dirtyBitsByteIndex] & (0x1 << (propertyIndex & 31))) != 0x0;
+            }
+
+            // Like the IsDataDirty() method above, the propertyIndex arguments starts counting from 0.
+            // This method throws an InvalidOperationException in case your component doesn't contain properties.
+            public void MarkDataDirty(int propertyIndex)
+            {
+                ValidateFieldIndex(propertyIndex);
+
+                // Retrieve the dirtyBits[0-n] field that tracks this property.
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
+            }
+
+            public void MarkDataClean()
+            {
+                dirtyBits[0] = 0x0;
+            }
+
+            [Conditional("DEBUG")]
+            private void ValidateFieldIndex(int propertyIndex)
+            {
+                if (propertyIndex < 0 || propertyIndex >= 18)
+                {
+                    throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
+                        "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
+                        "Please contact SpatialOS support if you encounter this issue.");
+                }
+            }
+
+            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
+            {
+                var componentDataSchema = new ComponentData(197716, SchemaComponentData.Create());
+                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
+                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields());
+
+                componentDataSchema.SchemaData?.Destroy();
+                componentDataSchema.SchemaData = null;
+
+                return snapshot;
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveOptionalComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveOptionalComponentReaderWriter.cs
@@ -20,7 +20,7 @@ namespace Improbable.TestSchema
 
         protected override ExhaustiveOptionalReader CreateReader(Entity entity, EntityId entityId)
         {
-            return new ExhaustiveOptionalReader(world, entity, entityId);
+            return new ExhaustiveOptionalReader(World, entity, entityId);
         }
     }
 
@@ -33,7 +33,7 @@ namespace Improbable.TestSchema
 
         protected override ExhaustiveOptionalWriter CreateWriter(Entity entity, EntityId entityId)
         {
-            return new ExhaustiveOptionalWriter(world, entity, entityId);
+            return new ExhaustiveOptionalWriter(World, entity, entityId);
         }
     }
 

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveOptionalUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveOptionalUpdateSender.cs
@@ -2,15 +2,11 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEngine.Profiling;
-using Unity.Mathematics;
 using Unity.Entities;
 using Unity.Collections;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
+using Unity.Profiling;
 
 namespace Improbable.TestSchema
 {
@@ -18,6 +14,8 @@ namespace Improbable.TestSchema
     {
         internal class ComponentReplicator : IComponentReplicationHandler
         {
+            private ProfilerMarker componentMarker = new ProfilerMarker("ExhaustiveOptional");
+
             public uint ComponentId => 197716;
 
             public EntityQueryDesc ComponentUpdateQuery => new EntityQueryDesc
@@ -36,129 +34,128 @@ namespace Improbable.TestSchema
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
-                Profiler.BeginSample("ExhaustiveOptional");
-
-                var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.TestSchema.ExhaustiveOptional.Component>();
-                var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
-
-                foreach (var chunk in chunkArray)
+                using (componentMarker.Auto())
                 {
-                    var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
-                    var componentArray = chunk.GetNativeArray(componentType);
-                    var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
+                    var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
+                    var componentType = system.GetArchetypeChunkComponentType<global::Improbable.TestSchema.ExhaustiveOptional.Component>();
+                    var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 
-                    if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
+                    foreach (var chunk in chunkArray)
                     {
-                        continue;
-                    }
+                        var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
+                        var componentArray = chunk.GetNativeArray(componentType);
+                        var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
 
-                    for (var i = 0; i < componentArray.Length; i++)
-                    {
-                        var data = componentArray[i];
-
-                        if (data.IsDataDirty())
+                        if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
                         {
-                            Update update = new Update();
+                            continue;
+                        }
 
-                            if (data.IsDataDirty(0))
+                        for (var i = 0; i < componentArray.Length; i++)
+                        {
+                            var data = componentArray[i];
+
+                            if (data.IsDataDirty())
                             {
-                                update.Field1 = data.Field1;
-                            }
+                                var update = new Update();
 
-                            if (data.IsDataDirty(1))
-                            {
-                                update.Field2 = data.Field2;
-                            }
+                                if (data.IsDataDirty(0))
+                                {
+                                    update.Field1 = data.Field1;
+                                }
 
-                            if (data.IsDataDirty(2))
-                            {
-                                update.Field3 = data.Field3;
-                            }
+                                if (data.IsDataDirty(1))
+                                {
+                                    update.Field2 = data.Field2;
+                                }
 
-                            if (data.IsDataDirty(3))
-                            {
-                                update.Field4 = data.Field4;
-                            }
+                                if (data.IsDataDirty(2))
+                                {
+                                    update.Field3 = data.Field3;
+                                }
 
-                            if (data.IsDataDirty(4))
-                            {
-                                update.Field5 = data.Field5;
-                            }
+                                if (data.IsDataDirty(3))
+                                {
+                                    update.Field4 = data.Field4;
+                                }
 
-                            if (data.IsDataDirty(5))
-                            {
-                                update.Field6 = data.Field6;
-                            }
+                                if (data.IsDataDirty(4))
+                                {
+                                    update.Field5 = data.Field5;
+                                }
 
-                            if (data.IsDataDirty(6))
-                            {
-                                update.Field7 = data.Field7;
-                            }
+                                if (data.IsDataDirty(5))
+                                {
+                                    update.Field6 = data.Field6;
+                                }
 
-                            if (data.IsDataDirty(7))
-                            {
-                                update.Field8 = data.Field8;
-                            }
+                                if (data.IsDataDirty(6))
+                                {
+                                    update.Field7 = data.Field7;
+                                }
 
-                            if (data.IsDataDirty(8))
-                            {
-                                update.Field9 = data.Field9;
-                            }
+                                if (data.IsDataDirty(7))
+                                {
+                                    update.Field8 = data.Field8;
+                                }
 
-                            if (data.IsDataDirty(9))
-                            {
-                                update.Field10 = data.Field10;
-                            }
+                                if (data.IsDataDirty(8))
+                                {
+                                    update.Field9 = data.Field9;
+                                }
 
-                            if (data.IsDataDirty(10))
-                            {
-                                update.Field11 = data.Field11;
-                            }
+                                if (data.IsDataDirty(9))
+                                {
+                                    update.Field10 = data.Field10;
+                                }
 
-                            if (data.IsDataDirty(11))
-                            {
-                                update.Field12 = data.Field12;
-                            }
+                                if (data.IsDataDirty(10))
+                                {
+                                    update.Field11 = data.Field11;
+                                }
 
-                            if (data.IsDataDirty(12))
-                            {
-                                update.Field13 = data.Field13;
-                            }
+                                if (data.IsDataDirty(11))
+                                {
+                                    update.Field12 = data.Field12;
+                                }
 
-                            if (data.IsDataDirty(13))
-                            {
-                                update.Field14 = data.Field14;
-                            }
+                                if (data.IsDataDirty(12))
+                                {
+                                    update.Field13 = data.Field13;
+                                }
 
-                            if (data.IsDataDirty(14))
-                            {
-                                update.Field15 = data.Field15;
-                            }
+                                if (data.IsDataDirty(13))
+                                {
+                                    update.Field14 = data.Field14;
+                                }
 
-                            if (data.IsDataDirty(15))
-                            {
-                                update.Field16 = data.Field16;
-                            }
+                                if (data.IsDataDirty(14))
+                                {
+                                    update.Field15 = data.Field15;
+                                }
 
-                            if (data.IsDataDirty(16))
-                            {
-                                update.Field17 = data.Field17;
-                            }
+                                if (data.IsDataDirty(15))
+                                {
+                                    update.Field16 = data.Field16;
+                                }
 
-                            if (data.IsDataDirty(17))
-                            {
-                                update.Field18 = data.Field18;
-                            }
+                                if (data.IsDataDirty(16))
+                                {
+                                    update.Field17 = data.Field17;
+                                }
 
-                            componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
-                            data.MarkDataClean();
-                            componentArray[i] = data;
+                                if (data.IsDataDirty(17))
+                                {
+                                    update.Field18 = data.Field18;
+                                }
+
+                                componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
+                                data.MarkDataClean();
+                                componentArray[i] = data;
+                            }
                         }
                     }
                 }
-
-                Profiler.EndSample();
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveRepeated.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveRepeated.cs
@@ -17,80 +17,8 @@ namespace Improbable.TestSchema
 
         public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
-            public uint ComponentId => 197717;
-
             // Bit masks for tracking which component properties were changed locally and need to be synced.
             private fixed UInt32 dirtyBits[1];
-
-            public bool IsDataDirty()
-            {
-                var isDataDirty = false;
-
-                isDataDirty |= (dirtyBits[0] != 0x0);
-
-                return isDataDirty;
-            }
-
-            /*
-            The propertyIndex argument counts up from 0 in the order defined in your schema component.
-            It is not the schema field number itself. For example:
-            component MyComponent
-            {
-                id = 1337;
-                bool val_a = 1;
-                bool val_b = 3;
-            }
-            In that case, val_a corresponds to propertyIndex 0 and val_b corresponds to propertyIndex 1 in this method.
-            This method throws an InvalidOperationException in case your component doesn't contain properties.
-            */
-
-            public bool IsDataDirty(int propertyIndex)
-            {
-                ValidateFieldIndex(propertyIndex);
-
-                // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex >> 4;
-                return (dirtyBits[dirtyBitsByteIndex] & (0x1 << (propertyIndex & 31))) != 0x0;
-            }
-
-            // Like the IsDataDirty() method above, the propertyIndex arguments starts counting from 0.
-            // This method throws an InvalidOperationException in case your component doesn't contain properties.
-            public void MarkDataDirty(int propertyIndex)
-            {
-                ValidateFieldIndex(propertyIndex);
-
-                // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex >> 4;
-                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
-            }
-
-            public void MarkDataClean()
-            {
-                dirtyBits[0] = 0x0;
-            }
-
-            [Conditional("DEBUG")]
-            private void ValidateFieldIndex(int propertyIndex)
-            {
-                if (propertyIndex < 0 || propertyIndex >= 18)
-                {
-                    throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
-                        "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
-                        "Please contact SpatialOS support if you encounter this issue.");
-                }
-            }
-
-            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
-            {
-                var componentDataSchema = new ComponentData(197717, SchemaComponentData.Create());
-                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
-                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields());
-
-                componentDataSchema.SchemaData?.Destroy();
-                componentDataSchema.SchemaData = null;
-
-                return snapshot;
-            }
 
             internal uint field1Handle;
 
@@ -306,6 +234,76 @@ namespace Improbable.TestSchema
                     MarkDataDirty(17);
                     global::Improbable.TestSchema.ExhaustiveRepeated.ReferenceTypeProviders.Field18Provider.Set(field18Handle, value);
                 }
+            }
+
+            public bool IsDataDirty()
+            {
+                var isDataDirty = false;
+
+                isDataDirty |= (dirtyBits[0] != 0x0);
+
+                return isDataDirty;
+            }
+
+            /*
+            The propertyIndex argument counts up from 0 in the order defined in your schema component.
+            It is not the schema field number itself. For example:
+            component MyComponent
+            {
+                id = 1337;
+                bool val_a = 1;
+                bool val_b = 3;
+            }
+            In that case, val_a corresponds to propertyIndex 0 and val_b corresponds to propertyIndex 1 in this method.
+            This method throws an InvalidOperationException in case your component doesn't contain properties.
+            */
+
+            public bool IsDataDirty(int propertyIndex)
+            {
+                ValidateFieldIndex(propertyIndex);
+
+                // Retrieve the dirtyBits[0-n] field that tracks this property.
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                return (dirtyBits[dirtyBitsByteIndex] & (0x1 << (propertyIndex & 31))) != 0x0;
+            }
+
+            // Like the IsDataDirty() method above, the propertyIndex arguments starts counting from 0.
+            // This method throws an InvalidOperationException in case your component doesn't contain properties.
+            public void MarkDataDirty(int propertyIndex)
+            {
+                ValidateFieldIndex(propertyIndex);
+
+                // Retrieve the dirtyBits[0-n] field that tracks this property.
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
+            }
+
+            public void MarkDataClean()
+            {
+                dirtyBits[0] = 0x0;
+            }
+
+            [Conditional("DEBUG")]
+            private void ValidateFieldIndex(int propertyIndex)
+            {
+                if (propertyIndex < 0 || propertyIndex >= 18)
+                {
+                    throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
+                        "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
+                        "Please contact SpatialOS support if you encounter this issue.");
+                }
+            }
+
+            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
+            {
+                var componentDataSchema = new ComponentData(197717, SchemaComponentData.Create());
+                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
+                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields());
+
+                componentDataSchema.SchemaData?.Destroy();
+                componentDataSchema.SchemaData = null;
+
+                return snapshot;
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveRepeatedComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveRepeatedComponentReaderWriter.cs
@@ -20,7 +20,7 @@ namespace Improbable.TestSchema
 
         protected override ExhaustiveRepeatedReader CreateReader(Entity entity, EntityId entityId)
         {
-            return new ExhaustiveRepeatedReader(world, entity, entityId);
+            return new ExhaustiveRepeatedReader(World, entity, entityId);
         }
     }
 
@@ -33,7 +33,7 @@ namespace Improbable.TestSchema
 
         protected override ExhaustiveRepeatedWriter CreateWriter(Entity entity, EntityId entityId)
         {
-            return new ExhaustiveRepeatedWriter(world, entity, entityId);
+            return new ExhaustiveRepeatedWriter(World, entity, entityId);
         }
     }
 

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveRepeatedUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveRepeatedUpdateSender.cs
@@ -2,15 +2,11 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEngine.Profiling;
-using Unity.Mathematics;
 using Unity.Entities;
 using Unity.Collections;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
+using Unity.Profiling;
 
 namespace Improbable.TestSchema
 {
@@ -18,6 +14,8 @@ namespace Improbable.TestSchema
     {
         internal class ComponentReplicator : IComponentReplicationHandler
         {
+            private ProfilerMarker componentMarker = new ProfilerMarker("ExhaustiveRepeated");
+
             public uint ComponentId => 197717;
 
             public EntityQueryDesc ComponentUpdateQuery => new EntityQueryDesc
@@ -36,129 +34,128 @@ namespace Improbable.TestSchema
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
-                Profiler.BeginSample("ExhaustiveRepeated");
-
-                var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.TestSchema.ExhaustiveRepeated.Component>();
-                var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
-
-                foreach (var chunk in chunkArray)
+                using (componentMarker.Auto())
                 {
-                    var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
-                    var componentArray = chunk.GetNativeArray(componentType);
-                    var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
+                    var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
+                    var componentType = system.GetArchetypeChunkComponentType<global::Improbable.TestSchema.ExhaustiveRepeated.Component>();
+                    var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 
-                    if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
+                    foreach (var chunk in chunkArray)
                     {
-                        continue;
-                    }
+                        var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
+                        var componentArray = chunk.GetNativeArray(componentType);
+                        var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
 
-                    for (var i = 0; i < componentArray.Length; i++)
-                    {
-                        var data = componentArray[i];
-
-                        if (data.IsDataDirty())
+                        if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
                         {
-                            Update update = new Update();
+                            continue;
+                        }
 
-                            if (data.IsDataDirty(0))
+                        for (var i = 0; i < componentArray.Length; i++)
+                        {
+                            var data = componentArray[i];
+
+                            if (data.IsDataDirty())
                             {
-                                update.Field1 = data.Field1;
-                            }
+                                var update = new Update();
 
-                            if (data.IsDataDirty(1))
-                            {
-                                update.Field2 = data.Field2;
-                            }
+                                if (data.IsDataDirty(0))
+                                {
+                                    update.Field1 = data.Field1;
+                                }
 
-                            if (data.IsDataDirty(2))
-                            {
-                                update.Field3 = data.Field3;
-                            }
+                                if (data.IsDataDirty(1))
+                                {
+                                    update.Field2 = data.Field2;
+                                }
 
-                            if (data.IsDataDirty(3))
-                            {
-                                update.Field4 = data.Field4;
-                            }
+                                if (data.IsDataDirty(2))
+                                {
+                                    update.Field3 = data.Field3;
+                                }
 
-                            if (data.IsDataDirty(4))
-                            {
-                                update.Field5 = data.Field5;
-                            }
+                                if (data.IsDataDirty(3))
+                                {
+                                    update.Field4 = data.Field4;
+                                }
 
-                            if (data.IsDataDirty(5))
-                            {
-                                update.Field6 = data.Field6;
-                            }
+                                if (data.IsDataDirty(4))
+                                {
+                                    update.Field5 = data.Field5;
+                                }
 
-                            if (data.IsDataDirty(6))
-                            {
-                                update.Field7 = data.Field7;
-                            }
+                                if (data.IsDataDirty(5))
+                                {
+                                    update.Field6 = data.Field6;
+                                }
 
-                            if (data.IsDataDirty(7))
-                            {
-                                update.Field8 = data.Field8;
-                            }
+                                if (data.IsDataDirty(6))
+                                {
+                                    update.Field7 = data.Field7;
+                                }
 
-                            if (data.IsDataDirty(8))
-                            {
-                                update.Field9 = data.Field9;
-                            }
+                                if (data.IsDataDirty(7))
+                                {
+                                    update.Field8 = data.Field8;
+                                }
 
-                            if (data.IsDataDirty(9))
-                            {
-                                update.Field10 = data.Field10;
-                            }
+                                if (data.IsDataDirty(8))
+                                {
+                                    update.Field9 = data.Field9;
+                                }
 
-                            if (data.IsDataDirty(10))
-                            {
-                                update.Field11 = data.Field11;
-                            }
+                                if (data.IsDataDirty(9))
+                                {
+                                    update.Field10 = data.Field10;
+                                }
 
-                            if (data.IsDataDirty(11))
-                            {
-                                update.Field12 = data.Field12;
-                            }
+                                if (data.IsDataDirty(10))
+                                {
+                                    update.Field11 = data.Field11;
+                                }
 
-                            if (data.IsDataDirty(12))
-                            {
-                                update.Field13 = data.Field13;
-                            }
+                                if (data.IsDataDirty(11))
+                                {
+                                    update.Field12 = data.Field12;
+                                }
 
-                            if (data.IsDataDirty(13))
-                            {
-                                update.Field14 = data.Field14;
-                            }
+                                if (data.IsDataDirty(12))
+                                {
+                                    update.Field13 = data.Field13;
+                                }
 
-                            if (data.IsDataDirty(14))
-                            {
-                                update.Field15 = data.Field15;
-                            }
+                                if (data.IsDataDirty(13))
+                                {
+                                    update.Field14 = data.Field14;
+                                }
 
-                            if (data.IsDataDirty(15))
-                            {
-                                update.Field16 = data.Field16;
-                            }
+                                if (data.IsDataDirty(14))
+                                {
+                                    update.Field15 = data.Field15;
+                                }
 
-                            if (data.IsDataDirty(16))
-                            {
-                                update.Field17 = data.Field17;
-                            }
+                                if (data.IsDataDirty(15))
+                                {
+                                    update.Field16 = data.Field16;
+                                }
 
-                            if (data.IsDataDirty(17))
-                            {
-                                update.Field18 = data.Field18;
-                            }
+                                if (data.IsDataDirty(16))
+                                {
+                                    update.Field17 = data.Field17;
+                                }
 
-                            componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
-                            data.MarkDataClean();
-                            componentArray[i] = data;
+                                if (data.IsDataDirty(17))
+                                {
+                                    update.Field18 = data.Field18;
+                                }
+
+                                componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
+                                data.MarkDataClean();
+                                componentArray[i] = data;
+                            }
                         }
                     }
                 }
-
-                Profiler.EndSample();
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveSingular.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveSingular.cs
@@ -17,80 +17,8 @@ namespace Improbable.TestSchema
 
         public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
-            public uint ComponentId => 197715;
-
             // Bit masks for tracking which component properties were changed locally and need to be synced.
             private fixed UInt32 dirtyBits[1];
-
-            public bool IsDataDirty()
-            {
-                var isDataDirty = false;
-
-                isDataDirty |= (dirtyBits[0] != 0x0);
-
-                return isDataDirty;
-            }
-
-            /*
-            The propertyIndex argument counts up from 0 in the order defined in your schema component.
-            It is not the schema field number itself. For example:
-            component MyComponent
-            {
-                id = 1337;
-                bool val_a = 1;
-                bool val_b = 3;
-            }
-            In that case, val_a corresponds to propertyIndex 0 and val_b corresponds to propertyIndex 1 in this method.
-            This method throws an InvalidOperationException in case your component doesn't contain properties.
-            */
-
-            public bool IsDataDirty(int propertyIndex)
-            {
-                ValidateFieldIndex(propertyIndex);
-
-                // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex >> 4;
-                return (dirtyBits[dirtyBitsByteIndex] & (0x1 << (propertyIndex & 31))) != 0x0;
-            }
-
-            // Like the IsDataDirty() method above, the propertyIndex arguments starts counting from 0.
-            // This method throws an InvalidOperationException in case your component doesn't contain properties.
-            public void MarkDataDirty(int propertyIndex)
-            {
-                ValidateFieldIndex(propertyIndex);
-
-                // Retrieve the dirtyBits[0-n] field that tracks this property.
-                var dirtyBitsByteIndex = propertyIndex >> 4;
-                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
-            }
-
-            public void MarkDataClean()
-            {
-                dirtyBits[0] = 0x0;
-            }
-
-            [Conditional("DEBUG")]
-            private void ValidateFieldIndex(int propertyIndex)
-            {
-                if (propertyIndex < 0 || propertyIndex >= 18)
-                {
-                    throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
-                        "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
-                        "Please contact SpatialOS support if you encounter this issue.");
-                }
-            }
-
-            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
-            {
-                var componentDataSchema = new ComponentData(197715, SchemaComponentData.Create());
-                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
-                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields());
-
-                componentDataSchema.SchemaData?.Destroy();
-                componentDataSchema.SchemaData = null;
-
-                return snapshot;
-            }
 
             private bool field1;
 
@@ -306,6 +234,76 @@ namespace Improbable.TestSchema
                     MarkDataDirty(17);
                     this.field18 = value;
                 }
+            }
+
+            public bool IsDataDirty()
+            {
+                var isDataDirty = false;
+
+                isDataDirty |= (dirtyBits[0] != 0x0);
+
+                return isDataDirty;
+            }
+
+            /*
+            The propertyIndex argument counts up from 0 in the order defined in your schema component.
+            It is not the schema field number itself. For example:
+            component MyComponent
+            {
+                id = 1337;
+                bool val_a = 1;
+                bool val_b = 3;
+            }
+            In that case, val_a corresponds to propertyIndex 0 and val_b corresponds to propertyIndex 1 in this method.
+            This method throws an InvalidOperationException in case your component doesn't contain properties.
+            */
+
+            public bool IsDataDirty(int propertyIndex)
+            {
+                ValidateFieldIndex(propertyIndex);
+
+                // Retrieve the dirtyBits[0-n] field that tracks this property.
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                return (dirtyBits[dirtyBitsByteIndex] & (0x1 << (propertyIndex & 31))) != 0x0;
+            }
+
+            // Like the IsDataDirty() method above, the propertyIndex arguments starts counting from 0.
+            // This method throws an InvalidOperationException in case your component doesn't contain properties.
+            public void MarkDataDirty(int propertyIndex)
+            {
+                ValidateFieldIndex(propertyIndex);
+
+                // Retrieve the dirtyBits[0-n] field that tracks this property.
+                var dirtyBitsByteIndex = propertyIndex >> 4;
+                dirtyBits[dirtyBitsByteIndex] |= (UInt32) (0x1 << (propertyIndex & 31));
+            }
+
+            public void MarkDataClean()
+            {
+                dirtyBits[0] = 0x0;
+            }
+
+            [Conditional("DEBUG")]
+            private void ValidateFieldIndex(int propertyIndex)
+            {
+                if (propertyIndex < 0 || propertyIndex >= 18)
+                {
+                    throw new ArgumentException("\"propertyIndex\" argument out of range. Valid range is [0, 17]. " +
+                        "Unless you are using custom component replication code, this is most likely caused by a code generation bug. " +
+                        "Please contact SpatialOS support if you encounter this issue.");
+                }
+            }
+
+            public Snapshot ToComponentSnapshot(global::Unity.Entities.World world)
+            {
+                var componentDataSchema = new ComponentData(197715, SchemaComponentData.Create());
+                Serialization.SerializeComponent(this, componentDataSchema.SchemaData.Value.GetFields(), world);
+                var snapshot = Serialization.DeserializeSnapshot(componentDataSchema.SchemaData.Value.GetFields());
+
+                componentDataSchema.SchemaData?.Destroy();
+                componentDataSchema.SchemaData = null;
+
+                return snapshot;
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveSingularComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveSingularComponentReaderWriter.cs
@@ -20,7 +20,7 @@ namespace Improbable.TestSchema
 
         protected override ExhaustiveSingularReader CreateReader(Entity entity, EntityId entityId)
         {
-            return new ExhaustiveSingularReader(world, entity, entityId);
+            return new ExhaustiveSingularReader(World, entity, entityId);
         }
     }
 
@@ -33,7 +33,7 @@ namespace Improbable.TestSchema
 
         protected override ExhaustiveSingularWriter CreateWriter(Entity entity, EntityId entityId)
         {
-            return new ExhaustiveSingularWriter(world, entity, entityId);
+            return new ExhaustiveSingularWriter(World, entity, entityId);
         }
     }
 

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveSingularUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveSingularUpdateSender.cs
@@ -2,15 +2,11 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEngine.Profiling;
-using Unity.Mathematics;
 using Unity.Entities;
 using Unity.Collections;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
+using Unity.Profiling;
 
 namespace Improbable.TestSchema
 {
@@ -18,6 +14,8 @@ namespace Improbable.TestSchema
     {
         internal class ComponentReplicator : IComponentReplicationHandler
         {
+            private ProfilerMarker componentMarker = new ProfilerMarker("ExhaustiveSingular");
+
             public uint ComponentId => 197715;
 
             public EntityQueryDesc ComponentUpdateQuery => new EntityQueryDesc
@@ -36,129 +34,128 @@ namespace Improbable.TestSchema
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
-                Profiler.BeginSample("ExhaustiveSingular");
-
-                var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.TestSchema.ExhaustiveSingular.Component>();
-                var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
-
-                foreach (var chunk in chunkArray)
+                using (componentMarker.Auto())
                 {
-                    var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
-                    var componentArray = chunk.GetNativeArray(componentType);
-                    var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
+                    var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
+                    var componentType = system.GetArchetypeChunkComponentType<global::Improbable.TestSchema.ExhaustiveSingular.Component>();
+                    var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 
-                    if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
+                    foreach (var chunk in chunkArray)
                     {
-                        continue;
-                    }
+                        var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
+                        var componentArray = chunk.GetNativeArray(componentType);
+                        var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
 
-                    for (var i = 0; i < componentArray.Length; i++)
-                    {
-                        var data = componentArray[i];
-
-                        if (data.IsDataDirty())
+                        if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
                         {
-                            Update update = new Update();
+                            continue;
+                        }
 
-                            if (data.IsDataDirty(0))
+                        for (var i = 0; i < componentArray.Length; i++)
+                        {
+                            var data = componentArray[i];
+
+                            if (data.IsDataDirty())
                             {
-                                update.Field1 = data.Field1;
-                            }
+                                var update = new Update();
 
-                            if (data.IsDataDirty(1))
-                            {
-                                update.Field2 = data.Field2;
-                            }
+                                if (data.IsDataDirty(0))
+                                {
+                                    update.Field1 = data.Field1;
+                                }
 
-                            if (data.IsDataDirty(2))
-                            {
-                                update.Field3 = data.Field3;
-                            }
+                                if (data.IsDataDirty(1))
+                                {
+                                    update.Field2 = data.Field2;
+                                }
 
-                            if (data.IsDataDirty(3))
-                            {
-                                update.Field4 = data.Field4;
-                            }
+                                if (data.IsDataDirty(2))
+                                {
+                                    update.Field3 = data.Field3;
+                                }
 
-                            if (data.IsDataDirty(4))
-                            {
-                                update.Field5 = data.Field5;
-                            }
+                                if (data.IsDataDirty(3))
+                                {
+                                    update.Field4 = data.Field4;
+                                }
 
-                            if (data.IsDataDirty(5))
-                            {
-                                update.Field6 = data.Field6;
-                            }
+                                if (data.IsDataDirty(4))
+                                {
+                                    update.Field5 = data.Field5;
+                                }
 
-                            if (data.IsDataDirty(6))
-                            {
-                                update.Field7 = data.Field7;
-                            }
+                                if (data.IsDataDirty(5))
+                                {
+                                    update.Field6 = data.Field6;
+                                }
 
-                            if (data.IsDataDirty(7))
-                            {
-                                update.Field8 = data.Field8;
-                            }
+                                if (data.IsDataDirty(6))
+                                {
+                                    update.Field7 = data.Field7;
+                                }
 
-                            if (data.IsDataDirty(8))
-                            {
-                                update.Field9 = data.Field9;
-                            }
+                                if (data.IsDataDirty(7))
+                                {
+                                    update.Field8 = data.Field8;
+                                }
 
-                            if (data.IsDataDirty(9))
-                            {
-                                update.Field10 = data.Field10;
-                            }
+                                if (data.IsDataDirty(8))
+                                {
+                                    update.Field9 = data.Field9;
+                                }
 
-                            if (data.IsDataDirty(10))
-                            {
-                                update.Field11 = data.Field11;
-                            }
+                                if (data.IsDataDirty(9))
+                                {
+                                    update.Field10 = data.Field10;
+                                }
 
-                            if (data.IsDataDirty(11))
-                            {
-                                update.Field12 = data.Field12;
-                            }
+                                if (data.IsDataDirty(10))
+                                {
+                                    update.Field11 = data.Field11;
+                                }
 
-                            if (data.IsDataDirty(12))
-                            {
-                                update.Field13 = data.Field13;
-                            }
+                                if (data.IsDataDirty(11))
+                                {
+                                    update.Field12 = data.Field12;
+                                }
 
-                            if (data.IsDataDirty(13))
-                            {
-                                update.Field14 = data.Field14;
-                            }
+                                if (data.IsDataDirty(12))
+                                {
+                                    update.Field13 = data.Field13;
+                                }
 
-                            if (data.IsDataDirty(14))
-                            {
-                                update.Field15 = data.Field15;
-                            }
+                                if (data.IsDataDirty(13))
+                                {
+                                    update.Field14 = data.Field14;
+                                }
 
-                            if (data.IsDataDirty(15))
-                            {
-                                update.Field16 = data.Field16;
-                            }
+                                if (data.IsDataDirty(14))
+                                {
+                                    update.Field15 = data.Field15;
+                                }
 
-                            if (data.IsDataDirty(16))
-                            {
-                                update.Field17 = data.Field17;
-                            }
+                                if (data.IsDataDirty(15))
+                                {
+                                    update.Field16 = data.Field16;
+                                }
 
-                            if (data.IsDataDirty(17))
-                            {
-                                update.Field18 = data.Field18;
-                            }
+                                if (data.IsDataDirty(16))
+                                {
+                                    update.Field17 = data.Field17;
+                                }
 
-                            componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
-                            data.MarkDataClean();
-                            componentArray[i] = data;
+                                if (data.IsDataDirty(17))
+                                {
+                                    update.Field18 = data.Field18;
+                                }
+
+                                componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
+                                data.MarkDataClean();
+                                componentArray[i] = data;
+                            }
                         }
                     }
                 }
-
-                Profiler.EndSample();
             }
         }
     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/RecursiveComponent.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/RecursiveComponent.cs
@@ -17,10 +17,44 @@ namespace Improbable.TestSchema
 
         public unsafe struct Component : IComponentData, ISpatialComponentData, ISnapshottable<Snapshot>
         {
-            public uint ComponentId => 18800;
-
             // Bit masks for tracking which component properties were changed locally and need to be synced.
             private fixed UInt32 dirtyBits[1];
+
+            internal uint aHandle;
+
+            public global::Improbable.TestSchema.TypeA A
+            {
+                get => global::Improbable.TestSchema.RecursiveComponent.ReferenceTypeProviders.AProvider.Get(aHandle);
+                set
+                {
+                    MarkDataDirty(0);
+                    global::Improbable.TestSchema.RecursiveComponent.ReferenceTypeProviders.AProvider.Set(aHandle, value);
+                }
+            }
+
+            internal uint bHandle;
+
+            public global::Improbable.TestSchema.TypeB B
+            {
+                get => global::Improbable.TestSchema.RecursiveComponent.ReferenceTypeProviders.BProvider.Get(bHandle);
+                set
+                {
+                    MarkDataDirty(1);
+                    global::Improbable.TestSchema.RecursiveComponent.ReferenceTypeProviders.BProvider.Set(bHandle, value);
+                }
+            }
+
+            internal uint cHandle;
+
+            public global::Improbable.TestSchema.TypeC C
+            {
+                get => global::Improbable.TestSchema.RecursiveComponent.ReferenceTypeProviders.CProvider.Get(cHandle);
+                set
+                {
+                    MarkDataDirty(2);
+                    global::Improbable.TestSchema.RecursiveComponent.ReferenceTypeProviders.CProvider.Set(cHandle, value);
+                }
+            }
 
             public bool IsDataDirty()
             {
@@ -90,42 +124,6 @@ namespace Improbable.TestSchema
                 componentDataSchema.SchemaData = null;
 
                 return snapshot;
-            }
-
-            internal uint aHandle;
-
-            public global::Improbable.TestSchema.TypeA A
-            {
-                get => global::Improbable.TestSchema.RecursiveComponent.ReferenceTypeProviders.AProvider.Get(aHandle);
-                set
-                {
-                    MarkDataDirty(0);
-                    global::Improbable.TestSchema.RecursiveComponent.ReferenceTypeProviders.AProvider.Set(aHandle, value);
-                }
-            }
-
-            internal uint bHandle;
-
-            public global::Improbable.TestSchema.TypeB B
-            {
-                get => global::Improbable.TestSchema.RecursiveComponent.ReferenceTypeProviders.BProvider.Get(bHandle);
-                set
-                {
-                    MarkDataDirty(1);
-                    global::Improbable.TestSchema.RecursiveComponent.ReferenceTypeProviders.BProvider.Set(bHandle, value);
-                }
-            }
-
-            internal uint cHandle;
-
-            public global::Improbable.TestSchema.TypeC C
-            {
-                get => global::Improbable.TestSchema.RecursiveComponent.ReferenceTypeProviders.CProvider.Get(cHandle);
-                set
-                {
-                    MarkDataDirty(2);
-                    global::Improbable.TestSchema.RecursiveComponent.ReferenceTypeProviders.CProvider.Set(cHandle, value);
-                }
             }
         }
 

--- a/test-project/Assets/Generated/Source/improbable/testschema/RecursiveComponentComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/RecursiveComponentComponentReaderWriter.cs
@@ -20,7 +20,7 @@ namespace Improbable.TestSchema
 
         protected override RecursiveComponentReader CreateReader(Entity entity, EntityId entityId)
         {
-            return new RecursiveComponentReader(world, entity, entityId);
+            return new RecursiveComponentReader(World, entity, entityId);
         }
     }
 
@@ -33,7 +33,7 @@ namespace Improbable.TestSchema
 
         protected override RecursiveComponentWriter CreateWriter(Entity entity, EntityId entityId)
         {
-            return new RecursiveComponentWriter(world, entity, entityId);
+            return new RecursiveComponentWriter(World, entity, entityId);
         }
     }
 

--- a/test-project/Assets/Generated/Source/improbable/testschema/RecursiveComponentUpdateSender.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/RecursiveComponentUpdateSender.cs
@@ -2,15 +2,11 @@
 // DO NOT EDIT - this file is automatically regenerated.
 // =====================================================
 
-using System;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEngine.Profiling;
-using Unity.Mathematics;
 using Unity.Entities;
 using Unity.Collections;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
+using Unity.Profiling;
 
 namespace Improbable.TestSchema
 {
@@ -18,6 +14,8 @@ namespace Improbable.TestSchema
     {
         internal class ComponentReplicator : IComponentReplicationHandler
         {
+            private ProfilerMarker componentMarker = new ProfilerMarker("RecursiveComponent");
+
             public uint ComponentId => 18800;
 
             public EntityQueryDesc ComponentUpdateQuery => new EntityQueryDesc
@@ -36,54 +34,53 @@ namespace Improbable.TestSchema
                 EntityManager entityManager,
                 ComponentUpdateSystem componentUpdateSystem)
             {
-                Profiler.BeginSample("RecursiveComponent");
-
-                var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
-                var componentType = system.GetArchetypeChunkComponentType<global::Improbable.TestSchema.RecursiveComponent.Component>();
-                var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
-
-                foreach (var chunk in chunkArray)
+                using (componentMarker.Auto())
                 {
-                    var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
-                    var componentArray = chunk.GetNativeArray(componentType);
-                    var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
+                    var spatialOSEntityType = system.GetArchetypeChunkComponentType<SpatialEntityId>(true);
+                    var componentType = system.GetArchetypeChunkComponentType<global::Improbable.TestSchema.RecursiveComponent.Component>();
+                    var authorityType = system.GetArchetypeChunkSharedComponentType<ComponentAuthority>();
 
-                    if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
+                    foreach (var chunk in chunkArray)
                     {
-                        continue;
-                    }
+                        var entityIdArray = chunk.GetNativeArray(spatialOSEntityType);
+                        var componentArray = chunk.GetNativeArray(componentType);
+                        var authorityIndex = chunk.GetSharedComponentIndex(authorityType);
 
-                    for (var i = 0; i < componentArray.Length; i++)
-                    {
-                        var data = componentArray[i];
-
-                        if (data.IsDataDirty())
+                        if (!entityManager.GetSharedComponentData<ComponentAuthority>(authorityIndex).HasAuthority)
                         {
-                            Update update = new Update();
+                            continue;
+                        }
 
-                            if (data.IsDataDirty(0))
+                        for (var i = 0; i < componentArray.Length; i++)
+                        {
+                            var data = componentArray[i];
+
+                            if (data.IsDataDirty())
                             {
-                                update.A = data.A;
-                            }
+                                var update = new Update();
 
-                            if (data.IsDataDirty(1))
-                            {
-                                update.B = data.B;
-                            }
+                                if (data.IsDataDirty(0))
+                                {
+                                    update.A = data.A;
+                                }
 
-                            if (data.IsDataDirty(2))
-                            {
-                                update.C = data.C;
-                            }
+                                if (data.IsDataDirty(1))
+                                {
+                                    update.B = data.B;
+                                }
 
-                            componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
-                            data.MarkDataClean();
-                            componentArray[i] = data;
+                                if (data.IsDataDirty(2))
+                                {
+                                    update.C = data.C;
+                                }
+
+                                componentUpdateSystem.SendUpdate(in update, entityIdArray[i].EntityId);
+                                data.MarkDataClean();
+                                componentArray[i] = data;
+                            }
                         }
                     }
                 }
-
-                Profiler.EndSample();
             }
         }
     }

--- a/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetworkStatisticsSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/NetworkStats/NetworkStatisticsSystem.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Unity.Entities;
+using Unity.Profiling;
 using UnityEngine;
 using Debug = UnityEngine.Debug;
 
@@ -24,6 +25,7 @@ namespace Improbable.Gdk.Core.NetworkStats
         private readonly NetStats netStats = new NetStats(DefaultBufferSize);
         private readonly NetFrameStats lastIncomingData = new NetFrameStats();
         private readonly NetFrameStats lastOutgoingData = new NetFrameStats();
+        private ProfilerMarker applyDiffMarker = new ProfilerMarker("NetworkStatisticsSystem.ApplyDiff");
 
         private float lastFrameTime;
 
@@ -54,7 +56,10 @@ namespace Improbable.Gdk.Core.NetworkStats
         [Conditional("UNITY_EDITOR")]
         internal void ApplyDiff(ViewDiff diff)
         {
-            lastIncomingData.CopyFrom(diff.GetNetStats());
+            using (applyDiffMarker.Auto())
+            {
+                lastIncomingData.CopyFrom(diff.GetNetStats());
+            }
         }
 
         [Conditional("UNITY_EDITOR")]

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/CleanTemporaryComponentsSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/CleanTemporaryComponentsSystem.cs
@@ -35,7 +35,6 @@ namespace Improbable.Gdk.Core
 
         protected override void OnUpdate()
         {
-            Profiler.BeginSample("RemoveRemoveAtEndOfTick");
             foreach (var (componentGroup, componentType) in componentGroupsToRemove)
             {
                 if (componentGroup.IsEmptyIgnoreFilter)
@@ -51,8 +50,6 @@ namespace Improbable.Gdk.Core
                     }
                 }
             }
-
-            Profiler.EndSample();
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/ComponentSendSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/ComponentSendSystem.cs
@@ -7,6 +7,7 @@ using Unity.Collections;
 using Unity.Entities;
 using Unity.Jobs;
 using Unity.Jobs.LowLevel.Unsafe;
+using Unity.Profiling;
 using UnityEngine.Profiling;
 
 namespace Improbable.Gdk.Core
@@ -23,6 +24,9 @@ namespace Improbable.Gdk.Core
         private readonly List<ComponentReplicator> componentReplicators = new List<ComponentReplicator>();
         private NativeArray<ArchetypeChunk>[] chunkArrayCache;
         private NativeArray<JobHandle> gatheringJobs;
+        
+        private ProfilerMarker gatherChunksMarker = new ProfilerMarker("GatherAllChunks");
+        private ProfilerMarker executeReplication = new ProfilerMarker("ExecuteReplication");
 
         protected override void OnCreate()
         {
@@ -43,28 +47,28 @@ namespace Improbable.Gdk.Core
         {
             var componentUpdateSystem = World.GetExistingSystem<ComponentUpdateSystem>();
 
-            Profiler.BeginSample("GatherChunks");
-            for (var i = 0; i < componentReplicators.Count; i++)
+            using (gatherChunksMarker.Auto())
             {
-                var replicator = componentReplicators[i];
-                chunkArrayCache[i] = replicator.Group.CreateArchetypeChunkArray(Allocator.TempJob, out var jobHandle);
-                gatheringJobs[i] = jobHandle;
+                for (var i = 0; i < componentReplicators.Count; i++)
+                {
+                    var replicator = componentReplicators[i];
+                    chunkArrayCache[i] =
+                        replicator.Group.CreateArchetypeChunkArray(Allocator.TempJob, out var jobHandle);
+                    gatheringJobs[i] = jobHandle;
+                }
             }
 
-            Profiler.EndSample();
-
             for (var i = 0; i < componentReplicators.Count; i++)
             {
-                Profiler.BeginSample("ExecuteReplication");
+                using (executeReplication.Auto())
+                {
+                    gatheringJobs[i].Complete();
+                    var replicator = componentReplicators[i];
+                    var chunkArray = chunkArrayCache[i];
 
-                gatheringJobs[i].Complete();
-                var replicator = componentReplicators[i];
-                var chunkArray = chunkArrayCache[i];
-
-                replicator.Handler.SendUpdates(chunkArray, this, EntityManager, componentUpdateSystem);
-                chunkArray.Dispose();
-
-                Profiler.EndSample();
+                    replicator.Handler.SendUpdates(chunkArray, this, EntityManager, componentUpdateSystem);
+                    chunkArray.Dispose();
+                }
             }
         }
 

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/ComponentSendSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/ComponentSendSystem.cs
@@ -24,7 +24,7 @@ namespace Improbable.Gdk.Core
         private readonly List<ComponentReplicator> componentReplicators = new List<ComponentReplicator>();
         private NativeArray<ArchetypeChunk>[] chunkArrayCache;
         private NativeArray<JobHandle> gatheringJobs;
-        
+
         private ProfilerMarker gatherChunksMarker = new ProfilerMarker("GatherAllChunks");
         private ProfilerMarker executeReplication = new ProfilerMarker("ExecuteReplication");
 

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/EcsViewSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/EcsViewSystem.cs
@@ -16,7 +16,7 @@ namespace Improbable.Gdk.Core
             new Dictionary<uint, IEcsViewManager>();
 
         private WorkerSystem worker;
-        
+
         private ProfilerMarker applyDiffMarker = new ProfilerMarker("EcsViewSystem.ApplyDiff");
         private ProfilerMarker addEntityMarker = new ProfilerMarker("EcsViewSystem.OnAddEntity");
         private ProfilerMarker removeEntityMarker = new ProfilerMarker("EcsViewSystem.OnRemoveEntity");

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/EcsViewSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/EcsViewSystem.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Unity.Entities;
-using UnityEngine.Profiling;
+using Unity.Profiling;
 
 namespace Improbable.Gdk.Core
 {
@@ -16,6 +16,10 @@ namespace Improbable.Gdk.Core
             new Dictionary<uint, IEcsViewManager>();
 
         private WorkerSystem worker;
+        
+        private ProfilerMarker applyDiffMarker = new ProfilerMarker("EcsViewSystem.ApplyDiff");
+        private ProfilerMarker addEntityMarker = new ProfilerMarker("EcsViewSystem.OnAddEntity");
+        private ProfilerMarker removeEntityMarker = new ProfilerMarker("EcsViewSystem.OnRemoveEntity");
 
         internal ComponentType[] GetInitialComponentsToAdd(uint componentId)
         {
@@ -29,25 +33,28 @@ namespace Improbable.Gdk.Core
 
         internal void ApplyDiff(ViewDiff diff)
         {
-            if (diff.Disconnected)
+            using (applyDiffMarker.Auto())
             {
-                OnDisconnect(diff.DisconnectMessage);
-                return;
-            }
+                if (diff.Disconnected)
+                {
+                    OnDisconnect(diff.DisconnectMessage);
+                    return;
+                }
 
-            foreach (var entityId in diff.GetEntitiesAdded())
-            {
-                AddEntity(entityId);
-            }
+                foreach (var entityId in diff.GetEntitiesAdded())
+                {
+                    AddEntity(entityId);
+                }
 
-            foreach (var manager in managers)
-            {
-                manager.ApplyDiff(diff);
-            }
+                foreach (var manager in managers)
+                {
+                    manager.ApplyDiff(diff);
+                }
 
-            foreach (var entityId in diff.GetEntitiesRemoved())
-            {
-                RemoveEntity(entityId);
+                foreach (var entityId in diff.GetEntitiesRemoved())
+                {
+                    RemoveEntity(entityId);
+                }
             }
         }
 
@@ -85,39 +92,40 @@ namespace Improbable.Gdk.Core
 
         private void AddEntity(EntityId entityId)
         {
-            if (worker.EntityIdToEntity.ContainsKey(entityId))
+            using (addEntityMarker.Auto())
             {
-                throw new InvalidSpatialEntityStateException(
-                    string.Format(Errors.EntityAlreadyExistsError, entityId.Id));
+                if (worker.EntityIdToEntity.ContainsKey(entityId))
+                {
+                    throw new InvalidSpatialEntityStateException(
+                        string.Format(Errors.EntityAlreadyExistsError, entityId.Id));
+                }
+
+                var entity = EntityManager.CreateEntity();
+
+                EntityManager.AddComponentData(entity, new SpatialEntityId
+                {
+                    EntityId = entityId
+                });
+
+                EntityManager.AddComponent(entity, ComponentType.ReadWrite<NewlyAddedSpatialOSEntity>());
+
+                worker.EntityIdToEntity.Add(entityId, entity);
             }
-
-            Profiler.BeginSample("OnAddEntity");
-
-            var entity = EntityManager.CreateEntity();
-
-            EntityManager.AddComponentData(entity, new SpatialEntityId
-            {
-                EntityId = entityId
-            });
-
-            EntityManager.AddComponent(entity, ComponentType.ReadWrite<NewlyAddedSpatialOSEntity>());
-
-            worker.EntityIdToEntity.Add(entityId, entity);
-            Profiler.EndSample();
         }
 
         private void RemoveEntity(EntityId entityId)
         {
-            if (!worker.TryGetEntity(entityId, out var entity))
+            using (removeEntityMarker.Auto())
             {
-                throw new InvalidSpatialEntityStateException(
-                    string.Format(Errors.EntityNotFoundForDeleteError, entityId.Id));
-            }
+                if (!worker.TryGetEntity(entityId, out var entity))
+                {
+                    throw new InvalidSpatialEntityStateException(
+                        string.Format(Errors.EntityNotFoundForDeleteError, entityId.Id));
+                }
 
-            Profiler.BeginSample("OnRemoveEntity");
-            EntityManager.DestroyEntity(entity);
-            worker.EntityIdToEntity.Remove(entityId);
-            Profiler.EndSample();
+                EntityManager.DestroyEntity(entity);
+                worker.EntityIdToEntity.Remove(entityId);
+            }
         }
 
         private void OnDisconnect(string reason)

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/EntitySystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/EntitySystem.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Unity.Entities;
+using Unity.Profiling;
 
 namespace Improbable.Gdk.Core
 {
@@ -11,6 +12,8 @@ namespace Improbable.Gdk.Core
     {
         private readonly List<EntityId> entitiesAdded = new List<EntityId>();
         private readonly List<EntityId> entitiesRemoved = new List<EntityId>();
+        
+        private ProfilerMarker applyDiffMarker = new ProfilerMarker("EntitySystem.ApplyDiff");
 
         private WorkerSystem workerSystem;
 
@@ -31,18 +34,21 @@ namespace Improbable.Gdk.Core
 
         internal void ApplyDiff(ViewDiff diff)
         {
-            entitiesAdded.Clear();
-            entitiesRemoved.Clear();
-
-            // todo decide on a container and remove this
-            foreach (var entityId in diff.GetEntitiesAdded())
+            using (applyDiffMarker.Auto())
             {
-                entitiesAdded.Add(entityId);
-            }
+                entitiesAdded.Clear();
+                entitiesRemoved.Clear();
 
-            foreach (var entityId in diff.GetEntitiesRemoved())
-            {
-                entitiesRemoved.Add(entityId);
+                // todo decide on a container and remove this
+                foreach (var entityId in diff.GetEntitiesAdded())
+                {
+                    entitiesAdded.Add(entityId);
+                }
+
+                foreach (var entityId in diff.GetEntitiesRemoved())
+                {
+                    entitiesRemoved.Add(entityId);
+                }
             }
         }
 

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/EntitySystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/EntitySystem.cs
@@ -12,7 +12,7 @@ namespace Improbable.Gdk.Core
     {
         private readonly List<EntityId> entitiesAdded = new List<EntityId>();
         private readonly List<EntityId> entitiesRemoved = new List<EntityId>();
-        
+
         private ProfilerMarker applyDiffMarker = new ProfilerMarker("EntitySystem.ApplyDiff");
 
         private WorkerSystem workerSystem;

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
@@ -2,7 +2,6 @@ using System;
 using Improbable.Gdk.Core.NetworkStats;
 using Unity.Entities;
 using UnityEngine;
-using UnityEngine.Profiling;
 
 namespace Improbable.Gdk.Core
 {
@@ -32,23 +31,13 @@ namespace Improbable.Gdk.Core
         {
             try
             {
-                Profiler.BeginSample("GetMessages");
                 worker.Tick();
-                Profiler.EndSample();
 
                 var diff = worker.Diff;
-
-                Profiler.BeginSample("ApplyDiff ECS");
+                worker.View.ApplyDiff(diff);
                 ecsViewSystem.ApplyDiff(diff);
-                Profiler.EndSample();
-
-                Profiler.BeginSample("ApplyDiff Entity");
                 entitySystem.ApplyDiff(diff);
-                Profiler.EndSample();
-
-                Profiler.BeginSample("ApplyDiff Networking Statistics");
                 networkStatisticsSystem.ApplyDiff(diff);
-                Profiler.EndSample();
             }
             catch (Exception e)
             {

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/WorkerSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/WorkerSystem.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Improbable.Gdk.Core.NetworkStats;
 using Improbable.Worker.CInterop;
 using Unity.Entities;
+using Unity.Profiling;
 using UnityEngine;
 using Entity = Unity.Entities.Entity;
 
@@ -36,6 +37,8 @@ namespace Improbable.Gdk.Core
 
         internal ViewDiff Diff => Worker.ViewDiff;
         internal MessagesToSend MessagesToSend => Worker.MessagesToSend;
+        
+        private ProfilerMarker tickMarker = new ProfilerMarker("WorkerSystem.Tick");
 
         public WorkerSystem(WorkerInWorld worker)
         {
@@ -86,7 +89,10 @@ namespace Improbable.Gdk.Core
 
         internal void Tick()
         {
-            Worker.Tick();
+            using (tickMarker.Auto())
+            {
+                Worker.Tick();
+            }
         }
 
         internal void SendMessages(NetFrameStats frameStats)

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/WorkerSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/WorkerSystem.cs
@@ -37,7 +37,7 @@ namespace Improbable.Gdk.Core
 
         internal ViewDiff Diff => Worker.ViewDiff;
         internal MessagesToSend MessagesToSend => Worker.MessagesToSend;
-        
+
         private ProfilerMarker tickMarker = new ProfilerMarker("WorkerSystem.Tick");
 
         public WorkerSystem(WorkerInWorld worker)

--- a/workers/unity/Packages/io.improbable.gdk.core/View/View.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/View/View.cs
@@ -14,7 +14,7 @@ namespace Improbable.Gdk.Core
 
         private readonly HashSet<EntityId> entities = new HashSet<EntityId>();
         private readonly Dictionary<string, string> workerFlags = new Dictionary<string, string>();
-        
+
         private ProfilerMarker applyDiffMarker = new ProfilerMarker("View.ApplyDiff");
 
         public View()

--- a/workers/unity/Packages/io.improbable.gdk.core/View/View.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/View/View.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Improbable.Worker.CInterop;
-using UnityEngine;
+using Unity.Profiling;
 
 namespace Improbable.Gdk.Core
 {
@@ -14,6 +14,8 @@ namespace Improbable.Gdk.Core
 
         private readonly HashSet<EntityId> entities = new HashSet<EntityId>();
         private readonly Dictionary<string, string> workerFlags = new Dictionary<string, string>();
+        
+        private ProfilerMarker applyDiffMarker = new ProfilerMarker("View.ApplyDiff");
 
         public View()
         {
@@ -127,26 +129,29 @@ namespace Improbable.Gdk.Core
 
         internal void ApplyDiff(ViewDiff diff)
         {
-            var entitiesAdded = diff.GetEntitiesAdded();
-            foreach (var entity in entitiesAdded)
+            using (applyDiffMarker.Auto())
             {
-                entities.Add(entity);
-            }
+                var entitiesAdded = diff.GetEntitiesAdded();
+                foreach (var entity in entitiesAdded)
+                {
+                    entities.Add(entity);
+                }
 
-            var entitiesRemoved = diff.GetEntitiesRemoved();
-            foreach (var entity in entitiesRemoved)
-            {
-                entities.Remove(entity);
-            }
+                var entitiesRemoved = diff.GetEntitiesRemoved();
+                foreach (var entity in entitiesRemoved)
+                {
+                    entities.Remove(entity);
+                }
 
-            foreach (var storage in viewStorages)
-            {
-                storage.ApplyDiff(diff);
-            }
+                foreach (var storage in viewStorages)
+                {
+                    storage.ApplyDiff(diff);
+                }
 
-            foreach (var pair in diff.GetWorkerFlagChanges())
-            {
-                workerFlags[pair.Item1] = pair.Item2;
+                foreach (var pair in diff.GetWorkerFlagChanges())
+                {
+                    workerFlags[pair.Item1] = pair.Item2;
+                }
             }
         }
     }

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/Worker.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/Worker.cs
@@ -87,7 +87,6 @@ namespace Improbable.Gdk.Core
         public void Tick()
         {
             ConnectionHandler.GetMessagesReceived(ref ViewDiff);
-            View.ApplyDiff(ViewDiff);
         }
 
         public void EnsureMessagesFlushed(NetFrameStats frameStats)

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenDocs/3-using-the-codewriter.md
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenDocs/3-using-the-codewriter.md
@@ -570,31 +570,66 @@ using (var x = Some.RandomThing())
 }
 ```
 
-## Profiler sampling
+### Profiler sampling scopes
 
-The `ProfilerStart` and `ProfilerEnd` methods are wrappers for adding profile markers to generated code.
+The `ProfileScope` methods allow you to add Unity profiler markers to a block of code.
+
+#### Example: populate custom scope
 
 ```csharp
+
+t.Line("private ProfileMarker marker = new ProfileMarker(\"some name\");");
+
 t.Method("public void ExampleMethod()", m =>
 {
-    m.ProfilerStart("Sample name");
-
-    //define code
-
-    m.ProfilerEnd();
+    m.ProfilerScope("marker", cs => {
+        // define code here
+    })
 });
 ```
 
 Generated code:
 
 ```csharp
+private ProfileMarker marker = new ProfileMarker("some name");
+
 public void ExampleMethod()
 {
-    Profiler.BeginSample("Sample name");
+    using (marker.Auto())
+    {
+        // define code here
+    }
+}
+```
 
-    //code
 
-    Profiler.EndSample();
+#### Example: return enumerable
+
+```csharp
+
+t.Line("private ProfileMarker marker = new ProfileMarker(\"some name\");");
+
+t.Method("public void ExampleMethod()", m =>
+{
+    m.ProfilerScope("marker", () => {
+        yield return "//code goes here";
+        yield return "//more code";
+    });
+});
+```
+
+Generated code:
+
+```csharp
+private ProfileMarker marker = new ProfileMarker("some name");
+
+public void ExampleMethod()
+{
+    using (marker.Auto())
+    {
+        // code goes here
+        // more code
+    }
 }
 ```
 

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenDocs/3-using-the-codewriter.md
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenDocs/3-using-the-codewriter.md
@@ -597,7 +597,7 @@ public void ExampleMethod()
 {
     using (marker.Auto())
     {
-        // define code here
+        // code here
     }
 }
 ```
@@ -612,8 +612,8 @@ t.Line("private ProfileMarker marker = new ProfileMarker(\"some name\");");
 t.Method("public void ExampleMethod()", m =>
 {
     m.ProfilerScope("marker", () => {
-        yield return "//code goes here";
-        yield return "//more code";
+        yield return "// define code here";
+        yield return "// define more code here";
     });
 });
 ```
@@ -627,8 +627,8 @@ public void ExampleMethod()
 {
     using (marker.Auto())
     {
-        // code goes here
-        // more code
+        // code here
+        // more code here
     }
 }
 ```

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/Abstract/ScopeBody.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/Abstract/ScopeBody.cs
@@ -123,14 +123,9 @@ namespace Improbable.Gdk.CodeGeneration.CodeWriter.Scopes
             Line($"return {toReturn};");
         }
 
-        public void ProfilerStart(string name)
+        public void ProfileScope(string markerVariableName, Action<CustomScopeBlock> populate)
         {
-            Line($"Profiler.BeginSample(\"{name}\");");
-        }
-
-        public void ProfilerEnd()
-        {
-            Line("Profiler.EndSample();");
+            Add(new CustomScopeBlock($"using ({markerVariableName}.Auto())", populate));
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/Abstract/ScopeBody.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/Abstract/ScopeBody.cs
@@ -127,5 +127,10 @@ namespace Improbable.Gdk.CodeGeneration.CodeWriter.Scopes
         {
             Add(new CustomScopeBlock($"using ({markerVariableName}.Auto())", populate));
         }
+
+        public void ProfileScope(string markerVariableName, Func<IEnumerable<string>> populate)
+        {
+            Add(new CustomScopeBlock($"using ({markerVariableName}.Auto())", populate));
+        }
     }
 }


### PR DESCRIPTION
Move View.ApplyDiff to outside Worker.Tick

#### Description
This changes the use of the Profiler API in runtime code to use the ProfileMarkers.
This allows them to be used for measuring performance in the benchmark framework, and are lighter on the network when profiling remotely.

As a bonus, this moves View.ApplyDiff to its rightfull place amongst other ApplyDiff function calls.