### PR TITLE
Add `Dump()` method to `CommandLineArgs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
     - You can override this version in the GDK Tools Configuration. [#1289](https://github.com/spatialos/gdk-for-unity/pull/1289)
     - This version (or your override) will be used in both local deployments started through the editor and cloud deployments started through the Deployment Launcher.
     - The currently selected version will be displayed in the Deployment Launcher. [#1302](https://github.com/spatialos/gdk-for-unity/pull/1302)
+- Added a `Dump()` method to `CommandLineArgs` to format all the parsed command line arguments into a string. This can aid you in debugging issues relating to command line args. [#1312](https://github.com/spatialos/gdk-for-unity/pull/1312)
 
 ### Changed
 

--- a/workers/unity/Packages/io.improbable.gdk.core/Utility/CommandLineUtility.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Utility/CommandLineUtility.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
 namespace Improbable.Gdk.Core
 {
@@ -31,6 +33,13 @@ namespace Improbable.Gdk.Core
             {
                 arguments = ParseCommandLineArgs(args)
             };
+        }
+
+        public string Dump()
+        {
+            return arguments
+                .Aggregate(new StringBuilder(), (builder, pair) => builder.AppendLine($"{pair.Key}={pair.Value}"))
+                .ToString();
         }
 
         public bool Contains(string key)


### PR DESCRIPTION
#### Description
While debugging an issue related to command line args, I found that we had no way of nicely printing all the arguments collected by `CommandLineArgs`.

This PR adds a method to allow you to dump all the arguments into a single string.

#### Tests

- [x] Used it in debugging

#### Documentation

- [x] Changelog
