### PR TITLE
Entity reservation system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
     - This version (or your override) will be used in both local deployments started through the editor and cloud deployments started through the Deployment Launcher.
     - The currently selected version will be displayed in the Deployment Launcher. [#1302](https://github.com/spatialos/gdk-for-unity/pull/1302)
 - Added a `Dump()` method to `CommandLineArgs` to format all the parsed command line arguments into a string. This can aid you in debugging issues relating to command line args. [#1312](https://github.com/spatialos/gdk-for-unity/pull/1312)
+- Added the `EntityReservationSystem` which automatically keeps a pool of reserved entity IDs. [#1314](https://github.com/spatialos/gdk-for-unity/pull/1314)
+    - The system's `TakeAsync(count)` and `GetAsync()` API can be used to obtain entity IDs for spawning, without needing callbacks.
+    - There is also a non-async `TryTake(count, out EntityId[])` and `TryGet(out EntityId)` version which allows for reservations to fail.
 
 ### Changed
 

--- a/workers/unity/Assets/Playground/Config/WorkerUtils.cs
+++ b/workers/unity/Assets/Playground/Config/WorkerUtils.cs
@@ -36,6 +36,7 @@ namespace Playground
             PlayerLifecycleHelper.AddServerSystems(world);
             GameObjectCreationHelper.EnableStandardGameObjectCreation(world);
 
+            world.GetOrCreateSystem<EntityReservationSystem>();
             world.GetOrCreateSystem<TriggerColorChangeSystem>();
             world.GetOrCreateSystem<ProcessLaunchCommandSystem>();
             world.GetOrCreateSystem<ProcessRechargeSystem>();

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/SpawnCubeCommandReceiver.cs
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/SpawnCubeCommandReceiver.cs
@@ -37,8 +37,8 @@ namespace Playground.MonoBehaviours
                 new CubeSpawner.SpawnCube.Response(requestReceived.RequestId, new Empty()));
 
             var entityReservationSystem = world.GetExistingSystem<EntityReservationSystem>();
-            var entityIds = await entityReservationSystem.Take(1);
-            SpawnCube(entityIds[0]);
+            var entityId = await entityReservationSystem.GetAsync();
+            SpawnCube(entityId);
         }
 
         private void SpawnCube(EntityId entityId)

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/EntityReservationSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/EntityReservationSystem.cs
@@ -196,7 +196,7 @@ namespace Improbable.Gdk.Core
 
             public QueuedReservation(TaskCompletionSource<EntityId> taskCompletionSource)
             {
-                MultiTcs = default;
+                MultiTcs = null;
                 SingleTcs = taskCompletionSource;
                 Count = 1;
                 Type = QueuedReservationType.Single;

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/EntityReservationSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/EntityReservationSystem.cs
@@ -5,13 +5,12 @@ using System.Threading.Tasks;
 using Improbable.Gdk.Core.Commands;
 using Improbable.Worker.CInterop;
 using Unity.Entities;
-using UnityEngine;
 
 namespace Improbable.Gdk.Core
 {
     public class EntityReservationSystem : ComponentSystem
     {
-        public uint TargetEntityIdCount = 0;
+        public uint TargetEntityIdCount = 100;
         public uint MinimumReservationCount = 10;
 
         // Actual entities left on stack
@@ -50,10 +49,10 @@ namespace Improbable.Gdk.Core
             {
                 requestCount = Math.Max(requestCount, MinimumReservationCount);
                 inFlightCount += requestCount;
+
                 var reserveEntityIdsRequest = new WorldCommands.ReserveEntityIds.Request((uint) requestCount);
                 var requestId = commandSystem.SendCommand(reserveEntityIdsRequest);
                 requestIds.Add(requestId);
-                Debug.Log($"Requesting {requestCount} Entity IDs");
             }
         }
 
@@ -73,7 +72,6 @@ namespace Improbable.Gdk.Core
                     //Add range to queue
                     var range = new EntityRangeCollection.EntityIdRange(request.FirstEntityId.Value, (uint) request.NumberOfEntityIds);
                     entityIdQueue.Add(range);
-                    Debug.Log($"Now have {entityIdQueue.Count} Entity IDs");
                 }
 
                 inFlightCount -= request.RequestPayload.NumberOfEntityIds;
@@ -122,12 +120,10 @@ namespace Improbable.Gdk.Core
         {
             if (entityIdQueue.Count >= count)
             {
-                Debug.Log($"Taking {count} Entity ID");
                 return Task.FromResult(entityIdQueue.Take(count));
             }
             else
             {
-                Debug.Log($"Queueing {count} Entity IDs");
                 queuedReservationCount += count;
 
                 var tcs = new TaskCompletionSource<EntityId[]>();

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/EntityReservationSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/EntityReservationSystem.cs
@@ -106,7 +106,7 @@ namespace Improbable.Gdk.Core
                         queuedReservation.SingleTcs.TrySetResult(entityIdQueue.Dequeue());
                         break;
                     case QueuedReservationType.Multi:
-                        queuedReservation.MultiTcs.SetResult(entityIdQueue.Take(queuedReservation.Count));
+                        queuedReservation.MultiTcs.TrySetResult(entityIdQueue.Take(queuedReservation.Count));
                         break;
                 }
             }

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/EntityReservationSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/EntityReservationSystem.cs
@@ -8,6 +8,7 @@ using Unity.Entities;
 
 namespace Improbable.Gdk.Core
 {
+    [DisableAutoCreation]
     public class EntityReservationSystem : ComponentSystem
     {
         public uint TargetEntityIdCount = 100;

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/EntityReservationSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/EntityReservationSystem.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using Improbable.Gdk.Core.Commands;
+using Improbable.Worker.CInterop;
+using Unity.Entities;
+
+namespace Improbable.Gdk.Core
+{
+    public class EntityReservationSystem : ComponentSystem
+    {
+        // Some sort of range queue
+        // private EntityRangeQueue queue;
+
+        public long TargetEntityIdCount = 200;
+
+        // Actual entities left on stack
+        private long count;
+        private long inFlightCount;
+
+        private readonly HashSet<long> requestIds = new HashSet<long>();
+        private CommandSystem commandSystem;
+
+        protected override void OnCreate()
+        {
+            commandSystem = World.GetExistingSystem<CommandSystem>();
+        }
+
+        protected override void OnUpdate()
+        {
+            // If there are outstanding requests, receive them
+            HandleReservationRequests();
+
+            // If there are queued ranges, attempt to resolve them
+            ResolveQueuedRequests();
+
+            // Request new entity id's? (Maybe move to another system)
+            RefillQueue();
+        }
+
+        private void RefillQueue()
+        {
+            var requestCount = (uint) (count - TargetEntityIdCount + inFlightCount);
+            var reserveEntityIdsRequest = new WorldCommands.ReserveEntityIds.Request(requestCount);
+            commandSystem.SendCommand(reserveEntityIdsRequest);
+        }
+
+        private void HandleReservationRequests()
+        {
+            var incomingRequests = commandSystem.GetResponses<WorldCommands.ReserveEntityIds.ReceivedResponse>();
+            for (var i = 0; i < incomingRequests.Count; i++)
+            {
+                ref readonly var request = ref incomingRequests[i];
+                if (!requestIds.Contains(request.RequestId))
+                {
+                    continue;
+                }
+
+                if (request.StatusCode == StatusCode.Success)
+                {
+                    //Add range to queue
+                }
+
+                inFlightCount += request.RequestPayload.NumberOfEntityIds;
+
+                // Remove ID from the set as it has been handled.
+                requestIds.Remove(request.RequestId);
+            }
+        }
+
+        private void ResolveQueuedRequests()
+        {
+            // Loop over queued request, check if we have enough, and call them
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/EntityReservationSystem.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/EntityReservationSystem.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fede3ca307244904bf02c08a5a22ace9
+timeCreated: 1583749671


### PR DESCRIPTION
#### Description
Create an Entity Reservation System.
This system will allow users to obtain reserved entity id's which are backed by an internal pool.
Uses awaitable tasks.

#### Tests
Unit tests and integrated into Playground cube spawning.

#### Documentation
 - [x] Changelog
