### PR TITLE
PlayerLifecycle integration with the EntityReservationSystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Schema components in ECS no longer have a `ComponentId` property. [#1308](https://github.com/spatialos/gdk-for-unity/pull/1308)
     - You should use `ComponentDatabase.GetComponentId<T>()` instead.
 - `CustomSpatialOSSendSystem` is no longer available. [#1308](https://github.com/spatialos/gdk-for-unity/pull/1308)
+- The PlayerLifecycle feature module now provides an `EntityId` in it's CreatePlayerEntityTemplate callback. [#1315](https://github.com/spatialos/gdk-for-unity/pull/1315)
+    - You will have to change your callback from `(string clientWorkerId, byte[] serializedArguments)` to `(EntityId entityId, string clientWorkerId, byte[] serializedArguments)`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Schema components in ECS no longer have a `ComponentId` property. [#1308](https://github.com/spatialos/gdk-for-unity/pull/1308)
     - You should use `ComponentDatabase.GetComponentId<T>()` instead.
 - `CustomSpatialOSSendSystem` is no longer available. [#1308](https://github.com/spatialos/gdk-for-unity/pull/1308)
-- The PlayerLifecycle feature module now provides an `EntityId` in it's CreatePlayerEntityTemplate callback. [#1315](https://github.com/spatialos/gdk-for-unity/pull/1315)
+- The Player Lifecycle feature module now provides an `EntityId` in its `CreatePlayerEntityTemplate` callback. [#1315](https://github.com/spatialos/gdk-for-unity/pull/1315)
     - You will have to change your callback from `(string clientWorkerId, byte[] serializedArguments)` to `(EntityId entityId, string clientWorkerId, byte[] serializedArguments)`.
 
 ### Added

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -1,5 +1,34 @@
 # Upgrade Guide
 
+## From `0.3.3` to `0.3.4`
+
+### PlayerLifecycle feature module now provides an EntityId
+
+The callback used for creating a player `EntityTemplate` has changed to provide an `EntityId` up front.
+This will be the `EntityId` the player's Entity will have after it is successfully spawned, and can be usefull for QBI.
+
+```csharp
+// Previously
+public static EntityTemplate Player(string workerId, byte[] args)
+{
+    var template = new EntityTemplate();
+    // ...
+    return template;
+}
+
+PlayerLifecycleConfig.CreatePlayerEntityTemplate = FpsEntityTemplates.Player;
+
+// Now
+public static EntityTemplate Player(EntityId entityId, string workerId, byte[] args)
+{
+    var template = new EntityTemplate();
+    // ...
+    return template;
+}
+
+PlayerLifecycleConfig.CreatePlayerEntityTemplate = FpsEntityTemplates.Player;
+```
+
 ## From `0.3.2` to `0.3.3`
 
 ### Building for Android now requires the NDK

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -5,28 +5,28 @@
 ### PlayerLifecycle feature module now provides an EntityId
 
 The callback used for creating a player `EntityTemplate` has changed to provide an `EntityId` up front.
-This will be the `EntityId` the player's Entity will have after it is successfully spawned, and can be usefull for QBI.
+This player's Entity will have this `EntityId` after it is successfully spawned, and can be useful for defining QBI queries.
+
+For example:
 
 ```csharp
-// Previously
 public static EntityTemplate Player(string workerId, byte[] args)
 {
     var template = new EntityTemplate();
     // ...
     return template;
 }
+```
 
-PlayerLifecycleConfig.CreatePlayerEntityTemplate = FpsEntityTemplates.Player;
+Would change into:
 
-// Now
+```csharp
 public static EntityTemplate Player(EntityId entityId, string workerId, byte[] args)
 {
     var template = new EntityTemplate();
     // ...
     return template;
 }
-
-PlayerLifecycleConfig.CreatePlayerEntityTemplate = FpsEntityTemplates.Player;
 ```
 
 ## From `0.3.2` to `0.3.3`

--- a/workers/unity/Assets/Playground/Config/PlayerTemplate.cs
+++ b/workers/unity/Assets/Playground/Config/PlayerTemplate.cs
@@ -9,7 +9,7 @@ namespace Playground
 {
     public static class PlayerTemplate
     {
-        public static EntityTemplate CreatePlayerEntityTemplate(string clientWorkerId, byte[] playerCreationArguments)
+        public static EntityTemplate CreatePlayerEntityTemplate(EntityId entityId, string clientWorkerId, byte[] playerCreationArguments)
         {
             var clientAttribute = EntityTemplate.GetWorkerAccessAttribute(clientWorkerId);
 

--- a/workers/unity/Assets/Playground/Config/WorkerUtils.cs
+++ b/workers/unity/Assets/Playground/Config/WorkerUtils.cs
@@ -36,7 +36,6 @@ namespace Playground
             PlayerLifecycleHelper.AddServerSystems(world);
             GameObjectCreationHelper.EnableStandardGameObjectCreation(world);
 
-            world.GetOrCreateSystem<EntityReservationSystem>();
             world.GetOrCreateSystem<TriggerColorChangeSystem>();
             world.GetOrCreateSystem<ProcessLaunchCommandSystem>();
             world.GetOrCreateSystem<ProcessRechargeSystem>();

--- a/workers/unity/Packages/io.improbable.gdk.playerlifecycle/Config/PlayerLifecycleConfig.cs
+++ b/workers/unity/Packages/io.improbable.gdk.playerlifecycle/Config/PlayerLifecycleConfig.cs
@@ -20,6 +20,7 @@ namespace Improbable.Gdk.PlayerLifecycle
     ///     An <see cref="EntityTemplate"/> to create a SpatialOS player entity from.
     /// </returns>
     public delegate EntityTemplate GetPlayerEntityTemplateDelegate(
+        EntityId entityId,
         string clientWorkerId,
         byte[] serializedArguments);
 

--- a/workers/unity/Packages/io.improbable.gdk.playerlifecycle/PlayerLifecycleHelper.cs
+++ b/workers/unity/Packages/io.improbable.gdk.playerlifecycle/PlayerLifecycleHelper.cs
@@ -65,6 +65,7 @@ namespace Improbable.Gdk.PlayerLifecycle
         /// <param name="world">A world that belongs to a server-worker.</param>
         public static void AddServerSystems(World world)
         {
+            world.GetOrCreateSystem<EntityReservationSystem>();
             world.GetOrCreateSystem<HandleCreatePlayerRequestSystem>();
             world.GetOrCreateSystem<PlayerHeartbeatInitializationSystem>();
             world.GetOrCreateSystem<SendPlayerHeartbeatRequestSystem>();

--- a/workers/unity/Packages/io.improbable.gdk.playerlifecycle/Systems/PlayerCreation/HandleCreatePlayerRequestSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.playerlifecycle/Systems/PlayerCreation/HandleCreatePlayerRequestSystem.cs
@@ -17,7 +17,7 @@ namespace Improbable.Gdk.PlayerLifecycle
         {
             base.OnCreate();
             commandSystem = World.GetExistingSystem<CommandSystem>();
-            entityReservationSystem = World.GetOrCreateSystem<EntityReservationSystem>();
+            entityReservationSystem = World.GetExistingSystem<EntityReservationSystem>();
         }
 
         private class PlayerCreationRequestContext

--- a/workers/unity/Packages/io.improbable.gdk.playerlifecycle/Systems/PlayerCreation/HandleCreatePlayerRequestSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.playerlifecycle/Systems/PlayerCreation/HandleCreatePlayerRequestSystem.cs
@@ -50,7 +50,7 @@ namespace Improbable.Gdk.PlayerLifecycle
         private async void SpawnPlayerEntity(PlayerCreator.CreatePlayer.ReceivedRequest receivedRequest)
         {
             var entityId = await entityReservationSystem.GetAsync();
-            
+
             var playerEntityTemplate = PlayerLifecycleConfig.CreatePlayerEntityTemplate(
                 entityId,
                 receivedRequest.CallerWorkerId,


### PR DESCRIPTION
#### Description
Player spawning now uses the EntityReservationSystem to provide a known entityId.
This is added to the `CreatePlayerEntityTemplate` for use in QBI.

This is a breaking change.

#### Tests
Playground tested.

#### Documentation
- [x] Changelog
- [x] Upgrade Guide
