### PR TITLE
Fix finding of Android SDK path when using the embedded Android SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 - Fixed a bug where component events were not dropped properly when the entity-component pair was removed from the View. [#1298])(https://github.com/spatialos/gdk-for-unity/pull/1298)
 - Fixed a bug where Reader/Writer/CommandSender/CommandReceiver fields would not have their state set to invalid when the underlying constraints were not met. [#1297](https://github.com/spatialos/gdk-for-unity/pull/1297)
     - This bug would manifest itself in situations like a `Reader` reference attempting to read data that does not exist in your worker's view anymore.
-- Fixed the Mobile Launcher being unable to find the Android SDK when using the Embedded installation. [#1319](https://github.com/spatialos/gdk-for-unity/pull/1319)
+- Fixed the Mobile Launcher being unable to find the Android SDK when using the embedded installation. [#1319](https://github.com/spatialos/gdk-for-unity/pull/1319)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Fixed a bug where component events were not dropped properly when the entity-component pair was removed from the View. [#1298])(https://github.com/spatialos/gdk-for-unity/pull/1298)
 - Fixed a bug where Reader/Writer/CommandSender/CommandReceiver fields would not have their state set to invalid when the underlying constraints were not met. [#1297](https://github.com/spatialos/gdk-for-unity/pull/1297)
     - This bug would manifest itself in situations like a `Reader` reference attempting to read data that does not exist in your worker's view anymore.
+- Fixed the Mobile Launcher being unable to find the Android SDK when using the Embedded installation. [#1319](https://github.com/spatialos/gdk-for-unity/pull/1319)
 
 ### Removed
 

--- a/workers/unity/Packages/io.improbable.gdk.mobile/Editor/AndroidUtils.cs
+++ b/workers/unity/Packages/io.improbable.gdk.mobile/Editor/AndroidUtils.cs
@@ -169,7 +169,7 @@ namespace Improbable.Gdk.Mobile
 
         private static bool TryGetAdbPath(out string adbPath)
         {
-            var sdkRootPath = EditorPrefs.GetString("AndroidSdkRoot");
+            var sdkRootPath = GetSDKDirectory();
             if (string.IsNullOrEmpty(sdkRootPath))
             {
                 adbPath = null;
@@ -193,6 +193,24 @@ namespace Improbable.Gdk.Mobile
 
             apkPath = string.Empty;
             return false;
+        }
+        
+        private static bool UseEmbeddedSDK()
+        {
+            const string SDKPrefKey = "SdkUseEmbedded";
+            return !EditorPrefs.HasKey(SDKPrefKey) || EditorPrefs.GetBool(SDKPrefKey);
+        }
+        
+        private static string GetSDKDirectory()
+        {
+            if (UseEmbeddedSDK())
+            {
+                return Path.Combine(BuildPipeline.GetPlaybackEngineDirectory(BuildTarget.Android, BuildOptions.None), "SDK");
+            }
+            else
+            {
+                return EditorPrefs.GetString("AndroidSdkRoot");
+            }
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.mobile/Editor/AndroidUtils.cs
+++ b/workers/unity/Packages/io.improbable.gdk.mobile/Editor/AndroidUtils.cs
@@ -194,13 +194,13 @@ namespace Improbable.Gdk.Mobile
             apkPath = string.Empty;
             return false;
         }
-        
+
         private static bool UseEmbeddedSDK()
         {
             const string SDKPrefKey = "SdkUseEmbedded";
             return !EditorPrefs.HasKey(SDKPrefKey) || EditorPrefs.GetBool(SDKPrefKey);
         }
-        
+
         private static string GetSDKDirectory()
         {
             if (UseEmbeddedSDK())


### PR DESCRIPTION
#### Description
Fix up path detection for the Android SDK when using the embedded install.

#### Documentation
 - [x] Changelog
