### PR TITLE
Fix EntityRangeCollection.Dequeue

### DIFF
--- a/workers/unity/Packages/io.improbable.gdk.core/Collections/EntityRangeCollection.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Collections/EntityRangeCollection.cs
@@ -18,7 +18,10 @@ namespace Improbable.Gdk.Core
             }
 
             var (splitRange, remainder) = firstElement.Split(1);
-            firstElement = remainder;
+            firstElement = remainder.Count == 0 && queue.Count > 0
+                ? queue.Dequeue()
+                : remainder;
+
             Count -= 1;
             return splitRange.FirstEntityId;
         }

--- a/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Collections/EntityRangeCollectionTests.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Collections/EntityRangeCollectionTests.cs
@@ -69,7 +69,7 @@ namespace Improbable.Gdk.Core.EditmodeTests.Collections
             Assert.Throws<InvalidOperationException>(() => collection.Dequeue());
             Assert.AreEqual(0, collection.Count);
         }
-        
+
         [Test]
         public void Dequeue_pops_ranges()
         {

--- a/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Collections/EntityRangeCollectionTests.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Collections/EntityRangeCollectionTests.cs
@@ -69,6 +69,18 @@ namespace Improbable.Gdk.Core.EditmodeTests.Collections
             Assert.Throws<InvalidOperationException>(() => collection.Dequeue());
             Assert.AreEqual(0, collection.Count);
         }
+        
+        [Test]
+        public void Dequeue_pops_ranges()
+        {
+            var collection = new EntityRangeCollection();
+            collection.Add(new EntityRangeCollection.EntityIdRange(new EntityId(1), 1));
+            collection.Add(new EntityRangeCollection.EntityIdRange(new EntityId(2), 1));
+
+            collection.Dequeue();
+            collection.Dequeue();
+            Assert.AreEqual(0, collection.Count);
+        }
 
         [Test]
         public void Take_single_range()


### PR DESCRIPTION
#### Description
EntityRangeCollection.Dequeue wasn't popping ranges off the queue once the first element was empty.

#### Tests
Added additional test for this behaviour