### PR TITLE
Fix Readers not re-validating with AggregateSubscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Fixed a bug where Reader/Writer/CommandSender/CommandReceiver fields would not have their state set to invalid when the underlying constraints were not met. [#1297](https://github.com/spatialos/gdk-for-unity/pull/1297)
     - This bug would manifest itself in situations like a `Reader` reference attempting to read data that does not exist in your worker's view anymore.
 - Fixed the Mobile Launcher being unable to find the Android SDK when using the embedded installation. [#1319](https://github.com/spatialos/gdk-for-unity/pull/1319)
+- Fixed a bug where losing a `Reader` due to QBI would break the monobehaviour that required it. [#1326](https://github.com/spatialos/gdk-for-unity/pull/1326)
 
 ### Removed
 

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentComponentComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentComponentComponentReaderWriter.cs
@@ -57,6 +57,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (aUpdateCallbackToCallbackKey == null)
                 {
                     aUpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.TestSchema.ExhaustiveRepeatedData>, ulong>();
@@ -87,6 +92,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (bUpdateCallbackToCallbackKey == null)
                 {
                     bUpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.TestSchema.SomeEnum>, ulong>();
@@ -117,6 +127,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (cUpdateCallbackToCallbackKey == null)
                 {
                     cUpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.TestSchema.SomeEnum?>, ulong>();
@@ -147,6 +162,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (dUpdateCallbackToCallbackKey == null)
                 {
                     dUpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.List<global::Improbable.TestSchema.SomeType>>, ulong>();
@@ -177,6 +197,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (eUpdateCallbackToCallbackKey == null)
                 {
                     eUpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<global::Improbable.TestSchema.SomeEnum, global::Improbable.TestSchema.SomeType>>, ulong>();

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentComponentEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentComponentEcsViewManager.cs
@@ -88,7 +88,7 @@ namespace Improbable.DependentSchema
 
             private void AddComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 var component = new global::Improbable.DependentSchema.DependentComponent.Component();
 
                 component.aHandle = global::Improbable.DependentSchema.DependentComponent.ReferenceTypeProviders.AProvider.Allocate(world);
@@ -106,7 +106,7 @@ namespace Improbable.DependentSchema
 
             private void RemoveComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
                 var data = entityManager.GetComponentData<global::Improbable.DependentSchema.DependentComponent.Component>(entity);
@@ -124,7 +124,7 @@ namespace Improbable.DependentSchema
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)
             {
-                workerSystem.TryGetEntity(update.EntityId, out var entity);
+                var entity = workerSystem.GetEntity(update.EntityId);
                 if (!dataFromEntity.Exists(entity))
                 {
                     return;
@@ -167,13 +167,13 @@ namespace Improbable.DependentSchema
                 {
                     case Authority.NotAuthoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.NotAuthoritative);
                         break;
                     }
                     case Authority.Authoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.Authoritative);
                         break;
                     }

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponentComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponentComponentReaderWriter.cs
@@ -83,6 +83,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field1UpdateCallbackToCallbackKey == null)
                 {
                     field1UpdateCallbackToCallbackKey = new Dictionary<Action<bool?>, ulong>();
@@ -113,6 +118,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field2UpdateCallbackToCallbackKey == null)
                 {
                     field2UpdateCallbackToCallbackKey = new Dictionary<Action<float?>, ulong>();
@@ -143,6 +153,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field3UpdateCallbackToCallbackKey == null)
                 {
                     field3UpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.Gdk.Core.Option<byte[]>>, ulong>();
@@ -173,6 +188,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field4UpdateCallbackToCallbackKey == null)
                 {
                     field4UpdateCallbackToCallbackKey = new Dictionary<Action<int?>, ulong>();
@@ -203,6 +223,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field5UpdateCallbackToCallbackKey == null)
                 {
                     field5UpdateCallbackToCallbackKey = new Dictionary<Action<long?>, ulong>();
@@ -233,6 +258,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field6UpdateCallbackToCallbackKey == null)
                 {
                     field6UpdateCallbackToCallbackKey = new Dictionary<Action<double?>, ulong>();
@@ -263,6 +293,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field7UpdateCallbackToCallbackKey == null)
                 {
                     field7UpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.Gdk.Core.Option<string>>, ulong>();
@@ -293,6 +328,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field8UpdateCallbackToCallbackKey == null)
                 {
                     field8UpdateCallbackToCallbackKey = new Dictionary<Action<uint?>, ulong>();
@@ -323,6 +363,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field9UpdateCallbackToCallbackKey == null)
                 {
                     field9UpdateCallbackToCallbackKey = new Dictionary<Action<ulong?>, ulong>();
@@ -353,6 +398,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field10UpdateCallbackToCallbackKey == null)
                 {
                     field10UpdateCallbackToCallbackKey = new Dictionary<Action<int?>, ulong>();
@@ -383,6 +433,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field11UpdateCallbackToCallbackKey == null)
                 {
                     field11UpdateCallbackToCallbackKey = new Dictionary<Action<long?>, ulong>();
@@ -413,6 +468,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field12UpdateCallbackToCallbackKey == null)
                 {
                     field12UpdateCallbackToCallbackKey = new Dictionary<Action<uint?>, ulong>();
@@ -443,6 +503,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field13UpdateCallbackToCallbackKey == null)
                 {
                     field13UpdateCallbackToCallbackKey = new Dictionary<Action<ulong?>, ulong>();
@@ -473,6 +538,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field14UpdateCallbackToCallbackKey == null)
                 {
                     field14UpdateCallbackToCallbackKey = new Dictionary<Action<int?>, ulong>();
@@ -503,6 +573,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field15UpdateCallbackToCallbackKey == null)
                 {
                     field15UpdateCallbackToCallbackKey = new Dictionary<Action<long?>, ulong>();
@@ -533,6 +608,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field16UpdateCallbackToCallbackKey == null)
                 {
                     field16UpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.Gdk.Core.EntityId?>, ulong>();
@@ -563,6 +643,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field17UpdateCallbackToCallbackKey == null)
                 {
                     field17UpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.TestSchema.SomeType?>, ulong>();
@@ -593,6 +678,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field18UpdateCallbackToCallbackKey == null)
                 {
                     field18UpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.TestSchema.SomeEnum?>, ulong>();
@@ -624,6 +714,11 @@ namespace Improbable.DependentSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add event callback when Reader is not valid.");
+                }
+
                 if (fooEventEventCallbackToCallbackKey == null)
                 {
                     fooEventEventCallbackToCallbackKey = new Dictionary<Action<global::Improbable.TestSchema.SomeType>, ulong>();

--- a/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponentEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/dependentschema/DependentDataComponentEcsViewManager.cs
@@ -116,7 +116,7 @@ namespace Improbable.DependentSchema
 
             private void AddComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 var component = new global::Improbable.DependentSchema.DependentDataComponent.Component();
 
                 component.field1Handle = global::Improbable.DependentSchema.DependentDataComponent.ReferenceTypeProviders.Field1Provider.Allocate(world);
@@ -162,7 +162,7 @@ namespace Improbable.DependentSchema
 
             private void RemoveComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
                 var data = entityManager.GetComponentData<global::Improbable.DependentSchema.DependentDataComponent.Component>(entity);
@@ -208,7 +208,7 @@ namespace Improbable.DependentSchema
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)
             {
-                workerSystem.TryGetEntity(update.EntityId, out var entity);
+                var entity = workerSystem.GetEntity(update.EntityId);
                 if (!dataFromEntity.Exists(entity))
                 {
                     return;
@@ -316,13 +316,13 @@ namespace Improbable.DependentSchema
                 {
                     case Authority.NotAuthoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.NotAuthoritative);
                         break;
                     }
                     case Authority.Authoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.Authoritative);
                         break;
                     }

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestChildComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestChildComponentReaderWriter.cs
@@ -49,6 +49,11 @@ namespace Improbable.Tests
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (childUpdateCallbackToCallbackKey == null)
                 {
                     childUpdateCallbackToCallbackKey = new Dictionary<Action<uint>, ulong>();

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestChildEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestChildEcsViewManager.cs
@@ -81,7 +81,7 @@ namespace Improbable.Tests
 
             private void AddComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 var component = new global::Improbable.Tests.DependencyTestChild.Component();
 
                 component.MarkDataClean();
@@ -91,7 +91,7 @@ namespace Improbable.Tests
 
             private void RemoveComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
                 entityManager.RemoveComponent<global::Improbable.Tests.DependencyTestChild.Component>(entity);
@@ -99,7 +99,7 @@ namespace Improbable.Tests
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)
             {
-                workerSystem.TryGetEntity(update.EntityId, out var entity);
+                var entity = workerSystem.GetEntity(update.EntityId);
                 if (!dataFromEntity.Exists(entity))
                 {
                     return;
@@ -122,13 +122,13 @@ namespace Improbable.Tests
                 {
                     case Authority.NotAuthoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.NotAuthoritative);
                         break;
                     }
                     case Authority.Authoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.Authoritative);
                         break;
                     }

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestComponentReaderWriter.cs
@@ -49,6 +49,11 @@ namespace Improbable.Tests
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (rootUpdateCallbackToCallbackKey == null)
                 {
                     rootUpdateCallbackToCallbackKey = new Dictionary<Action<uint>, ulong>();

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestEcsViewManager.cs
@@ -81,7 +81,7 @@ namespace Improbable.Tests
 
             private void AddComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 var component = new global::Improbable.Tests.DependencyTest.Component();
 
                 component.MarkDataClean();
@@ -91,7 +91,7 @@ namespace Improbable.Tests
 
             private void RemoveComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
                 entityManager.RemoveComponent<global::Improbable.Tests.DependencyTest.Component>(entity);
@@ -99,7 +99,7 @@ namespace Improbable.Tests
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)
             {
-                workerSystem.TryGetEntity(update.EntityId, out var entity);
+                var entity = workerSystem.GetEntity(update.EntityId);
                 if (!dataFromEntity.Exists(entity))
                 {
                     return;
@@ -122,13 +122,13 @@ namespace Improbable.Tests
                 {
                     case Authority.NotAuthoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.NotAuthoritative);
                         break;
                     }
                     case Authority.Authoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.Authoritative);
                         break;
                     }

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestGrandchildComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestGrandchildComponentReaderWriter.cs
@@ -49,6 +49,11 @@ namespace Improbable.Tests
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (grandchildUpdateCallbackToCallbackKey == null)
                 {
                     grandchildUpdateCallbackToCallbackKey = new Dictionary<Action<uint>, ulong>();

--- a/test-project/Assets/Generated/Source/improbable/tests/DependencyTestGrandchildEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/tests/DependencyTestGrandchildEcsViewManager.cs
@@ -81,7 +81,7 @@ namespace Improbable.Tests
 
             private void AddComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 var component = new global::Improbable.Tests.DependencyTestGrandchild.Component();
 
                 component.MarkDataClean();
@@ -91,7 +91,7 @@ namespace Improbable.Tests
 
             private void RemoveComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
                 entityManager.RemoveComponent<global::Improbable.Tests.DependencyTestGrandchild.Component>(entity);
@@ -99,7 +99,7 @@ namespace Improbable.Tests
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)
             {
-                workerSystem.TryGetEntity(update.EntityId, out var entity);
+                var entity = workerSystem.GetEntity(update.EntityId);
                 if (!dataFromEntity.Exists(entity))
                 {
                     return;
@@ -122,13 +122,13 @@ namespace Improbable.Tests
                 {
                     case Authority.NotAuthoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.NotAuthoritative);
                         break;
                     }
                     case Authority.Authoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.Authoritative);
                         break;
                     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/ComponentUsingNestedTypeSameNameComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ComponentUsingNestedTypeSameNameComponentReaderWriter.cs
@@ -53,6 +53,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (nestedFieldUpdateCallbackToCallbackKey == null)
                 {
                     nestedFieldUpdateCallbackToCallbackKey = new Dictionary<Action<int>, ulong>();
@@ -83,6 +88,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (other0FieldUpdateCallbackToCallbackKey == null)
                 {
                     other0FieldUpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.TestSchema.NestedTypeSameName.Other.NestedTypeSameName.Other0.NestedTypeSameName>, ulong>();
@@ -113,6 +123,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (other1FieldUpdateCallbackToCallbackKey == null)
                 {
                     other1FieldUpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.TestSchema.NestedTypeSameName.Other.NestedTypeSameName.Other1.NestedTypeSameName>, ulong>();

--- a/test-project/Assets/Generated/Source/improbable/testschema/ComponentUsingNestedTypeSameNameEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ComponentUsingNestedTypeSameNameEcsViewManager.cs
@@ -81,7 +81,7 @@ namespace Improbable.TestSchema
 
             private void AddComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 var component = new global::Improbable.TestSchema.ComponentUsingNestedTypeSameName.Component();
 
                 component.MarkDataClean();
@@ -91,7 +91,7 @@ namespace Improbable.TestSchema
 
             private void RemoveComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
                 entityManager.RemoveComponent<global::Improbable.TestSchema.ComponentUsingNestedTypeSameName.Component>(entity);
@@ -99,7 +99,7 @@ namespace Improbable.TestSchema
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)
             {
-                workerSystem.TryGetEntity(update.EntityId, out var entity);
+                var entity = workerSystem.GetEntity(update.EntityId);
                 if (!dataFromEntity.Exists(entity))
                 {
                     return;
@@ -132,13 +132,13 @@ namespace Improbable.TestSchema
                 {
                     case Authority.NotAuthoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.NotAuthoritative);
                         break;
                     }
                     case Authority.Authoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.Authoritative);
                         break;
                     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveEntityComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveEntityComponentReaderWriter.cs
@@ -57,6 +57,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field1UpdateCallbackToCallbackKey == null)
                 {
                     field1UpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.Gdk.Core.EntitySnapshot>, ulong>();
@@ -87,6 +92,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field2UpdateCallbackToCallbackKey == null)
                 {
                     field2UpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.Gdk.Core.EntitySnapshot?>, ulong>();
@@ -117,6 +127,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field3UpdateCallbackToCallbackKey == null)
                 {
                     field3UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.List<global::Improbable.Gdk.Core.EntitySnapshot>>, ulong>();
@@ -147,6 +162,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field4UpdateCallbackToCallbackKey == null)
                 {
                     field4UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<global::Improbable.Gdk.Core.EntitySnapshot, string>>, ulong>();
@@ -177,6 +197,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field5UpdateCallbackToCallbackKey == null)
                 {
                     field5UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<string, global::Improbable.Gdk.Core.EntitySnapshot>>, ulong>();

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveEntityEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveEntityEcsViewManager.cs
@@ -90,7 +90,7 @@ namespace Improbable.TestSchema
 
             private void AddComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 var component = new global::Improbable.TestSchema.ExhaustiveEntity.Component();
 
                 component.field1Handle = global::Improbable.TestSchema.ExhaustiveEntity.ReferenceTypeProviders.Field1Provider.Allocate(world);
@@ -110,7 +110,7 @@ namespace Improbable.TestSchema
 
             private void RemoveComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
                 var data = entityManager.GetComponentData<global::Improbable.TestSchema.ExhaustiveEntity.Component>(entity);
@@ -130,7 +130,7 @@ namespace Improbable.TestSchema
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)
             {
-                workerSystem.TryGetEntity(update.EntityId, out var entity);
+                var entity = workerSystem.GetEntity(update.EntityId);
                 if (!dataFromEntity.Exists(entity))
                 {
                     return;
@@ -173,13 +173,13 @@ namespace Improbable.TestSchema
                 {
                     case Authority.NotAuthoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.NotAuthoritative);
                         break;
                     }
                     case Authority.Authoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.Authoritative);
                         break;
                     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapKeyComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapKeyComponentReaderWriter.cs
@@ -83,6 +83,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field1UpdateCallbackToCallbackKey == null)
                 {
                     field1UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<bool, string>>, ulong>();
@@ -113,6 +118,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field2UpdateCallbackToCallbackKey == null)
                 {
                     field2UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<float, string>>, ulong>();
@@ -143,6 +153,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field3UpdateCallbackToCallbackKey == null)
                 {
                     field3UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<byte[], string>>, ulong>();
@@ -173,6 +188,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field4UpdateCallbackToCallbackKey == null)
                 {
                     field4UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<int, string>>, ulong>();
@@ -203,6 +223,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field5UpdateCallbackToCallbackKey == null)
                 {
                     field5UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<long, string>>, ulong>();
@@ -233,6 +258,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field6UpdateCallbackToCallbackKey == null)
                 {
                     field6UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<double, string>>, ulong>();
@@ -263,6 +293,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field7UpdateCallbackToCallbackKey == null)
                 {
                     field7UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<string, string>>, ulong>();
@@ -293,6 +328,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field8UpdateCallbackToCallbackKey == null)
                 {
                     field8UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<uint, string>>, ulong>();
@@ -323,6 +363,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field9UpdateCallbackToCallbackKey == null)
                 {
                     field9UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<ulong, string>>, ulong>();
@@ -353,6 +398,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field10UpdateCallbackToCallbackKey == null)
                 {
                     field10UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<int, string>>, ulong>();
@@ -383,6 +433,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field11UpdateCallbackToCallbackKey == null)
                 {
                     field11UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<long, string>>, ulong>();
@@ -413,6 +468,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field12UpdateCallbackToCallbackKey == null)
                 {
                     field12UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<uint, string>>, ulong>();
@@ -443,6 +503,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field13UpdateCallbackToCallbackKey == null)
                 {
                     field13UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<ulong, string>>, ulong>();
@@ -473,6 +538,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field14UpdateCallbackToCallbackKey == null)
                 {
                     field14UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<int, string>>, ulong>();
@@ -503,6 +573,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field15UpdateCallbackToCallbackKey == null)
                 {
                     field15UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<long, string>>, ulong>();
@@ -533,6 +608,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field16UpdateCallbackToCallbackKey == null)
                 {
                     field16UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<global::Improbable.Gdk.Core.EntityId, string>>, ulong>();
@@ -563,6 +643,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field17UpdateCallbackToCallbackKey == null)
                 {
                     field17UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<global::Improbable.TestSchema.SomeType, string>>, ulong>();
@@ -593,6 +678,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field18UpdateCallbackToCallbackKey == null)
                 {
                     field18UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<global::Improbable.TestSchema.SomeEnum, string>>, ulong>();

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapKeyEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapKeyEcsViewManager.cs
@@ -116,7 +116,7 @@ namespace Improbable.TestSchema
 
             private void AddComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 var component = new global::Improbable.TestSchema.ExhaustiveMapKey.Component();
 
                 component.field1Handle = global::Improbable.TestSchema.ExhaustiveMapKey.ReferenceTypeProviders.Field1Provider.Allocate(world);
@@ -162,7 +162,7 @@ namespace Improbable.TestSchema
 
             private void RemoveComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
                 var data = entityManager.GetComponentData<global::Improbable.TestSchema.ExhaustiveMapKey.Component>(entity);
@@ -208,7 +208,7 @@ namespace Improbable.TestSchema
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)
             {
-                workerSystem.TryGetEntity(update.EntityId, out var entity);
+                var entity = workerSystem.GetEntity(update.EntityId);
                 if (!dataFromEntity.Exists(entity))
                 {
                     return;
@@ -316,13 +316,13 @@ namespace Improbable.TestSchema
                 {
                     case Authority.NotAuthoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.NotAuthoritative);
                         break;
                     }
                     case Authority.Authoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.Authoritative);
                         break;
                     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapValueComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapValueComponentReaderWriter.cs
@@ -83,6 +83,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field1UpdateCallbackToCallbackKey == null)
                 {
                     field1UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<string, bool>>, ulong>();
@@ -113,6 +118,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field2UpdateCallbackToCallbackKey == null)
                 {
                     field2UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<string, float>>, ulong>();
@@ -143,6 +153,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field3UpdateCallbackToCallbackKey == null)
                 {
                     field3UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<string, byte[]>>, ulong>();
@@ -173,6 +188,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field4UpdateCallbackToCallbackKey == null)
                 {
                     field4UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<string, int>>, ulong>();
@@ -203,6 +223,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field5UpdateCallbackToCallbackKey == null)
                 {
                     field5UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<string, long>>, ulong>();
@@ -233,6 +258,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field6UpdateCallbackToCallbackKey == null)
                 {
                     field6UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<string, double>>, ulong>();
@@ -263,6 +293,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field7UpdateCallbackToCallbackKey == null)
                 {
                     field7UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<string, string>>, ulong>();
@@ -293,6 +328,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field8UpdateCallbackToCallbackKey == null)
                 {
                     field8UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<string, uint>>, ulong>();
@@ -323,6 +363,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field9UpdateCallbackToCallbackKey == null)
                 {
                     field9UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<string, ulong>>, ulong>();
@@ -353,6 +398,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field10UpdateCallbackToCallbackKey == null)
                 {
                     field10UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<string, int>>, ulong>();
@@ -383,6 +433,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field11UpdateCallbackToCallbackKey == null)
                 {
                     field11UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<string, long>>, ulong>();
@@ -413,6 +468,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field12UpdateCallbackToCallbackKey == null)
                 {
                     field12UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<string, uint>>, ulong>();
@@ -443,6 +503,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field13UpdateCallbackToCallbackKey == null)
                 {
                     field13UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<string, ulong>>, ulong>();
@@ -473,6 +538,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field14UpdateCallbackToCallbackKey == null)
                 {
                     field14UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<string, int>>, ulong>();
@@ -503,6 +573,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field15UpdateCallbackToCallbackKey == null)
                 {
                     field15UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<string, long>>, ulong>();
@@ -533,6 +608,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field16UpdateCallbackToCallbackKey == null)
                 {
                     field16UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<string, global::Improbable.Gdk.Core.EntityId>>, ulong>();
@@ -563,6 +643,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field17UpdateCallbackToCallbackKey == null)
                 {
                     field17UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<string, global::Improbable.TestSchema.SomeType>>, ulong>();
@@ -593,6 +678,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field18UpdateCallbackToCallbackKey == null)
                 {
                     field18UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.Dictionary<string, global::Improbable.TestSchema.SomeEnum>>, ulong>();

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapValueEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveMapValueEcsViewManager.cs
@@ -116,7 +116,7 @@ namespace Improbable.TestSchema
 
             private void AddComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 var component = new global::Improbable.TestSchema.ExhaustiveMapValue.Component();
 
                 component.field1Handle = global::Improbable.TestSchema.ExhaustiveMapValue.ReferenceTypeProviders.Field1Provider.Allocate(world);
@@ -162,7 +162,7 @@ namespace Improbable.TestSchema
 
             private void RemoveComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
                 var data = entityManager.GetComponentData<global::Improbable.TestSchema.ExhaustiveMapValue.Component>(entity);
@@ -208,7 +208,7 @@ namespace Improbable.TestSchema
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)
             {
-                workerSystem.TryGetEntity(update.EntityId, out var entity);
+                var entity = workerSystem.GetEntity(update.EntityId);
                 if (!dataFromEntity.Exists(entity))
                 {
                     return;
@@ -316,13 +316,13 @@ namespace Improbable.TestSchema
                 {
                     case Authority.NotAuthoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.NotAuthoritative);
                         break;
                     }
                     case Authority.Authoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.Authoritative);
                         break;
                     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveOptionalComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveOptionalComponentReaderWriter.cs
@@ -83,6 +83,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field1UpdateCallbackToCallbackKey == null)
                 {
                     field1UpdateCallbackToCallbackKey = new Dictionary<Action<bool?>, ulong>();
@@ -113,6 +118,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field2UpdateCallbackToCallbackKey == null)
                 {
                     field2UpdateCallbackToCallbackKey = new Dictionary<Action<float?>, ulong>();
@@ -143,6 +153,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field3UpdateCallbackToCallbackKey == null)
                 {
                     field3UpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.Gdk.Core.Option<byte[]>>, ulong>();
@@ -173,6 +188,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field4UpdateCallbackToCallbackKey == null)
                 {
                     field4UpdateCallbackToCallbackKey = new Dictionary<Action<int?>, ulong>();
@@ -203,6 +223,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field5UpdateCallbackToCallbackKey == null)
                 {
                     field5UpdateCallbackToCallbackKey = new Dictionary<Action<long?>, ulong>();
@@ -233,6 +258,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field6UpdateCallbackToCallbackKey == null)
                 {
                     field6UpdateCallbackToCallbackKey = new Dictionary<Action<double?>, ulong>();
@@ -263,6 +293,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field7UpdateCallbackToCallbackKey == null)
                 {
                     field7UpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.Gdk.Core.Option<string>>, ulong>();
@@ -293,6 +328,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field8UpdateCallbackToCallbackKey == null)
                 {
                     field8UpdateCallbackToCallbackKey = new Dictionary<Action<uint?>, ulong>();
@@ -323,6 +363,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field9UpdateCallbackToCallbackKey == null)
                 {
                     field9UpdateCallbackToCallbackKey = new Dictionary<Action<ulong?>, ulong>();
@@ -353,6 +398,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field10UpdateCallbackToCallbackKey == null)
                 {
                     field10UpdateCallbackToCallbackKey = new Dictionary<Action<int?>, ulong>();
@@ -383,6 +433,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field11UpdateCallbackToCallbackKey == null)
                 {
                     field11UpdateCallbackToCallbackKey = new Dictionary<Action<long?>, ulong>();
@@ -413,6 +468,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field12UpdateCallbackToCallbackKey == null)
                 {
                     field12UpdateCallbackToCallbackKey = new Dictionary<Action<uint?>, ulong>();
@@ -443,6 +503,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field13UpdateCallbackToCallbackKey == null)
                 {
                     field13UpdateCallbackToCallbackKey = new Dictionary<Action<ulong?>, ulong>();
@@ -473,6 +538,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field14UpdateCallbackToCallbackKey == null)
                 {
                     field14UpdateCallbackToCallbackKey = new Dictionary<Action<int?>, ulong>();
@@ -503,6 +573,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field15UpdateCallbackToCallbackKey == null)
                 {
                     field15UpdateCallbackToCallbackKey = new Dictionary<Action<long?>, ulong>();
@@ -533,6 +608,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field16UpdateCallbackToCallbackKey == null)
                 {
                     field16UpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.Gdk.Core.EntityId?>, ulong>();
@@ -563,6 +643,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field17UpdateCallbackToCallbackKey == null)
                 {
                     field17UpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.TestSchema.SomeType?>, ulong>();
@@ -593,6 +678,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field18UpdateCallbackToCallbackKey == null)
                 {
                     field18UpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.TestSchema.SomeEnum?>, ulong>();

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveOptionalEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveOptionalEcsViewManager.cs
@@ -116,7 +116,7 @@ namespace Improbable.TestSchema
 
             private void AddComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 var component = new global::Improbable.TestSchema.ExhaustiveOptional.Component();
 
                 component.field1Handle = global::Improbable.TestSchema.ExhaustiveOptional.ReferenceTypeProviders.Field1Provider.Allocate(world);
@@ -162,7 +162,7 @@ namespace Improbable.TestSchema
 
             private void RemoveComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
                 var data = entityManager.GetComponentData<global::Improbable.TestSchema.ExhaustiveOptional.Component>(entity);
@@ -208,7 +208,7 @@ namespace Improbable.TestSchema
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)
             {
-                workerSystem.TryGetEntity(update.EntityId, out var entity);
+                var entity = workerSystem.GetEntity(update.EntityId);
                 if (!dataFromEntity.Exists(entity))
                 {
                     return;
@@ -316,13 +316,13 @@ namespace Improbable.TestSchema
                 {
                     case Authority.NotAuthoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.NotAuthoritative);
                         break;
                     }
                     case Authority.Authoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.Authoritative);
                         break;
                     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveRepeatedComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveRepeatedComponentReaderWriter.cs
@@ -83,6 +83,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field1UpdateCallbackToCallbackKey == null)
                 {
                     field1UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.List<bool>>, ulong>();
@@ -113,6 +118,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field2UpdateCallbackToCallbackKey == null)
                 {
                     field2UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.List<float>>, ulong>();
@@ -143,6 +153,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field3UpdateCallbackToCallbackKey == null)
                 {
                     field3UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.List<byte[]>>, ulong>();
@@ -173,6 +188,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field4UpdateCallbackToCallbackKey == null)
                 {
                     field4UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.List<int>>, ulong>();
@@ -203,6 +223,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field5UpdateCallbackToCallbackKey == null)
                 {
                     field5UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.List<long>>, ulong>();
@@ -233,6 +258,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field6UpdateCallbackToCallbackKey == null)
                 {
                     field6UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.List<double>>, ulong>();
@@ -263,6 +293,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field7UpdateCallbackToCallbackKey == null)
                 {
                     field7UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.List<string>>, ulong>();
@@ -293,6 +328,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field8UpdateCallbackToCallbackKey == null)
                 {
                     field8UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.List<uint>>, ulong>();
@@ -323,6 +363,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field9UpdateCallbackToCallbackKey == null)
                 {
                     field9UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.List<ulong>>, ulong>();
@@ -353,6 +398,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field10UpdateCallbackToCallbackKey == null)
                 {
                     field10UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.List<int>>, ulong>();
@@ -383,6 +433,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field11UpdateCallbackToCallbackKey == null)
                 {
                     field11UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.List<long>>, ulong>();
@@ -413,6 +468,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field12UpdateCallbackToCallbackKey == null)
                 {
                     field12UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.List<uint>>, ulong>();
@@ -443,6 +503,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field13UpdateCallbackToCallbackKey == null)
                 {
                     field13UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.List<ulong>>, ulong>();
@@ -473,6 +538,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field14UpdateCallbackToCallbackKey == null)
                 {
                     field14UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.List<int>>, ulong>();
@@ -503,6 +573,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field15UpdateCallbackToCallbackKey == null)
                 {
                     field15UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.List<long>>, ulong>();
@@ -533,6 +608,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field16UpdateCallbackToCallbackKey == null)
                 {
                     field16UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.List<global::Improbable.Gdk.Core.EntityId>>, ulong>();
@@ -563,6 +643,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field17UpdateCallbackToCallbackKey == null)
                 {
                     field17UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.List<global::Improbable.TestSchema.SomeType>>, ulong>();
@@ -593,6 +678,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field18UpdateCallbackToCallbackKey == null)
                 {
                     field18UpdateCallbackToCallbackKey = new Dictionary<Action<global::System.Collections.Generic.List<global::Improbable.TestSchema.SomeEnum>>, ulong>();

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveRepeatedEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveRepeatedEcsViewManager.cs
@@ -116,7 +116,7 @@ namespace Improbable.TestSchema
 
             private void AddComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 var component = new global::Improbable.TestSchema.ExhaustiveRepeated.Component();
 
                 component.field1Handle = global::Improbable.TestSchema.ExhaustiveRepeated.ReferenceTypeProviders.Field1Provider.Allocate(world);
@@ -162,7 +162,7 @@ namespace Improbable.TestSchema
 
             private void RemoveComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
                 var data = entityManager.GetComponentData<global::Improbable.TestSchema.ExhaustiveRepeated.Component>(entity);
@@ -208,7 +208,7 @@ namespace Improbable.TestSchema
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)
             {
-                workerSystem.TryGetEntity(update.EntityId, out var entity);
+                var entity = workerSystem.GetEntity(update.EntityId);
                 if (!dataFromEntity.Exists(entity))
                 {
                     return;
@@ -316,13 +316,13 @@ namespace Improbable.TestSchema
                 {
                     case Authority.NotAuthoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.NotAuthoritative);
                         break;
                     }
                     case Authority.Authoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.Authoritative);
                         break;
                     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveSingularComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveSingularComponentReaderWriter.cs
@@ -83,6 +83,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field1UpdateCallbackToCallbackKey == null)
                 {
                     field1UpdateCallbackToCallbackKey = new Dictionary<Action<bool>, ulong>();
@@ -113,6 +118,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field2UpdateCallbackToCallbackKey == null)
                 {
                     field2UpdateCallbackToCallbackKey = new Dictionary<Action<float>, ulong>();
@@ -143,6 +153,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field3UpdateCallbackToCallbackKey == null)
                 {
                     field3UpdateCallbackToCallbackKey = new Dictionary<Action<byte[]>, ulong>();
@@ -173,6 +188,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field4UpdateCallbackToCallbackKey == null)
                 {
                     field4UpdateCallbackToCallbackKey = new Dictionary<Action<int>, ulong>();
@@ -203,6 +223,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field5UpdateCallbackToCallbackKey == null)
                 {
                     field5UpdateCallbackToCallbackKey = new Dictionary<Action<long>, ulong>();
@@ -233,6 +258,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field6UpdateCallbackToCallbackKey == null)
                 {
                     field6UpdateCallbackToCallbackKey = new Dictionary<Action<double>, ulong>();
@@ -263,6 +293,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field7UpdateCallbackToCallbackKey == null)
                 {
                     field7UpdateCallbackToCallbackKey = new Dictionary<Action<string>, ulong>();
@@ -293,6 +328,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field8UpdateCallbackToCallbackKey == null)
                 {
                     field8UpdateCallbackToCallbackKey = new Dictionary<Action<uint>, ulong>();
@@ -323,6 +363,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field9UpdateCallbackToCallbackKey == null)
                 {
                     field9UpdateCallbackToCallbackKey = new Dictionary<Action<ulong>, ulong>();
@@ -353,6 +398,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field10UpdateCallbackToCallbackKey == null)
                 {
                     field10UpdateCallbackToCallbackKey = new Dictionary<Action<int>, ulong>();
@@ -383,6 +433,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field11UpdateCallbackToCallbackKey == null)
                 {
                     field11UpdateCallbackToCallbackKey = new Dictionary<Action<long>, ulong>();
@@ -413,6 +468,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field12UpdateCallbackToCallbackKey == null)
                 {
                     field12UpdateCallbackToCallbackKey = new Dictionary<Action<uint>, ulong>();
@@ -443,6 +503,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field13UpdateCallbackToCallbackKey == null)
                 {
                     field13UpdateCallbackToCallbackKey = new Dictionary<Action<ulong>, ulong>();
@@ -473,6 +538,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field14UpdateCallbackToCallbackKey == null)
                 {
                     field14UpdateCallbackToCallbackKey = new Dictionary<Action<int>, ulong>();
@@ -503,6 +573,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field15UpdateCallbackToCallbackKey == null)
                 {
                     field15UpdateCallbackToCallbackKey = new Dictionary<Action<long>, ulong>();
@@ -533,6 +608,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field16UpdateCallbackToCallbackKey == null)
                 {
                     field16UpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.Gdk.Core.EntityId>, ulong>();
@@ -563,6 +643,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field17UpdateCallbackToCallbackKey == null)
                 {
                     field17UpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.TestSchema.SomeType>, ulong>();
@@ -593,6 +678,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (field18UpdateCallbackToCallbackKey == null)
                 {
                     field18UpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.TestSchema.SomeEnum>, ulong>();

--- a/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveSingularEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/ExhaustiveSingularEcsViewManager.cs
@@ -84,7 +84,7 @@ namespace Improbable.TestSchema
 
             private void AddComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 var component = new global::Improbable.TestSchema.ExhaustiveSingular.Component();
 
                 component.field3Handle = global::Improbable.TestSchema.ExhaustiveSingular.ReferenceTypeProviders.Field3Provider.Allocate(world);
@@ -98,7 +98,7 @@ namespace Improbable.TestSchema
 
             private void RemoveComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
                 var data = entityManager.GetComponentData<global::Improbable.TestSchema.ExhaustiveSingular.Component>(entity);
@@ -112,7 +112,7 @@ namespace Improbable.TestSchema
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)
             {
-                workerSystem.TryGetEntity(update.EntityId, out var entity);
+                var entity = workerSystem.GetEntity(update.EntityId);
                 if (!dataFromEntity.Exists(entity))
                 {
                     return;
@@ -220,13 +220,13 @@ namespace Improbable.TestSchema
                 {
                     case Authority.NotAuthoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.NotAuthoritative);
                         break;
                     }
                     case Authority.Authoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.Authoritative);
                         break;
                     }

--- a/test-project/Assets/Generated/Source/improbable/testschema/RecursiveComponentComponentReaderWriter.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/RecursiveComponentComponentReaderWriter.cs
@@ -53,6 +53,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (aUpdateCallbackToCallbackKey == null)
                 {
                     aUpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.TestSchema.TypeA>, ulong>();
@@ -83,6 +88,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (bUpdateCallbackToCallbackKey == null)
                 {
                     bUpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.TestSchema.TypeB>, ulong>();
@@ -113,6 +123,11 @@ namespace Improbable.TestSchema
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add field update callback when Reader is not valid.");
+                }
+
                 if (cUpdateCallbackToCallbackKey == null)
                 {
                     cUpdateCallbackToCallbackKey = new Dictionary<Action<global::Improbable.TestSchema.TypeC>, ulong>();

--- a/test-project/Assets/Generated/Source/improbable/testschema/RecursiveComponentEcsViewManager.cs
+++ b/test-project/Assets/Generated/Source/improbable/testschema/RecursiveComponentEcsViewManager.cs
@@ -86,7 +86,7 @@ namespace Improbable.TestSchema
 
             private void AddComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 var component = new global::Improbable.TestSchema.RecursiveComponent.Component();
 
                 component.aHandle = global::Improbable.TestSchema.RecursiveComponent.ReferenceTypeProviders.AProvider.Allocate(world);
@@ -102,7 +102,7 @@ namespace Improbable.TestSchema
 
             private void RemoveComponent(EntityId entityId)
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 entityManager.RemoveComponent<ComponentAuthority>(entity);
 
                 var data = entityManager.GetComponentData<global::Improbable.TestSchema.RecursiveComponent.Component>(entity);
@@ -118,7 +118,7 @@ namespace Improbable.TestSchema
 
             private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)
             {
-                workerSystem.TryGetEntity(update.EntityId, out var entity);
+                var entity = workerSystem.GetEntity(update.EntityId);
                 if (!dataFromEntity.Exists(entity))
                 {
                     return;
@@ -151,13 +151,13 @@ namespace Improbable.TestSchema
                 {
                     case Authority.NotAuthoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.NotAuthoritative);
                         break;
                     }
                     case Authority.Authoritative:
                     {
-                        workerSystem.TryGetEntity(entityId, out var entity);
+                        var entity = workerSystem.GetEntity(entityId);
                         entityManager.SetSharedComponentData(entity, ComponentAuthority.Authoritative);
                         break;
                     }

--- a/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/UnityEcsViewManagerGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/.codegen/Source/Generators/Core/UnityEcsViewManagerGenerator.cs
@@ -105,7 +105,7 @@ public void Init(World world)
                             {
                                 m.Line(new[]
                                 {
-                                    "workerSystem.TryGetEntity(entityId, out var entity);",
+                                    "var entity = workerSystem.GetEntity(entityId);",
                                     $"var component = new {componentNamespace}.Component();"
                                 });
 
@@ -126,7 +126,7 @@ public void Init(World world)
                             {
                                 m.Line(new[]
                                 {
-                                    "workerSystem.TryGetEntity(entityId, out var entity);",
+                                    "var entity = workerSystem.GetEntity(entityId);",
                                     "entityManager.RemoveComponent<ComponentAuthority>(entity);"
                                 });
 
@@ -145,7 +145,7 @@ public void Init(World world)
                             evm.Method("private void ApplyUpdate(in ComponentUpdateReceived<Update> update, ComponentDataFromEntity<Component> dataFromEntity)", m =>
                             {
                                 m.Line(@"
-workerSystem.TryGetEntity(update.EntityId, out var entity);
+var entity = workerSystem.GetEntity(update.EntityId);
 if (!dataFromEntity.Exists(entity))
 {
     return;
@@ -177,13 +177,13 @@ private void SetAuthority(EntityId entityId, Authority authority)
     {
         case Authority.NotAuthoritative:
         {
-            workerSystem.TryGetEntity(entityId, out var entity);
+            var entity = workerSystem.GetEntity(entityId);
             entityManager.SetSharedComponentData(entity, ComponentAuthority.NotAuthoritative);
             break;
         }
         case Authority.Authoritative:
         {
-            workerSystem.TryGetEntity(entityId, out var entity);
+            var entity = workerSystem.GetEntity(entityId);
             entityManager.SetSharedComponentData(entity, ComponentAuthority.Authoritative);
             break;
         }

--- a/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/CommandSenderReceiverSubscriptionManagerBase.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/CommandSenderReceiverSubscriptionManagerBase.cs
@@ -37,7 +37,8 @@ namespace Improbable.Gdk.Subscriptions
                     return;
                 }
 
-                WorkerSystem.TryGetEntity(entityId, out var entity);
+                var entity = WorkerSystem.GetEntity(entityId);
+
                 foreach (var subscription in subscriptions)
                 {
                     if (!subscription.HasValue)
@@ -152,7 +153,7 @@ namespace Improbable.Gdk.Subscriptions
                         return;
                     }
 
-                    WorkerSystem.TryGetEntity(authorityChange.EntityId, out var entity);
+                    var entity = WorkerSystem.GetEntity(authorityChange.EntityId);
 
                     foreach (var subscription in entityIdToReceiveSubscriptions[authorityChange.EntityId])
                     {
@@ -168,8 +169,6 @@ namespace Improbable.Gdk.Subscriptions
                     {
                         return;
                     }
-
-                    WorkerSystem.TryGetEntity(authorityChange.EntityId, out var entity);
 
                     foreach (var subscription in entityIdToReceiveSubscriptions[authorityChange.EntityId])
                     {

--- a/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/EntityGameObjectLinker.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/EntityGameObjectLinker.cs
@@ -99,8 +99,8 @@ namespace Improbable.Gdk.Subscriptions
                 {
                     // todo this should possibly happen when the command buffer is flushed too
                     injectors.Add(new RequiredSubscriptionsInjector(component, entityId, subscriptionSystem,
-                        () => lifecycleSystem.EnableMonoBehaviour(component),
-                        () => lifecycleSystem.DisableMonoBehaviour(component)));
+                        target => lifecycleSystem.EnableMonoBehaviour((MonoBehaviour) target),
+                        target => lifecycleSystem.DisableMonoBehaviour((MonoBehaviour) target)));
                 }
             }
 
@@ -177,8 +177,6 @@ namespace Improbable.Gdk.Subscriptions
             {
                 return;
             }
-
-            workerSystem.TryGetEntity(entityId, out var entity);
 
             while (gameObjectSet.Count > 0)
             {

--- a/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/Reader.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/Reader.cs
@@ -76,6 +76,11 @@ namespace Improbable.Gdk.Subscriptions
         {
             add
             {
+                if (!IsValid)
+                {
+                    throw new InvalidOperationException("Cannot add OnUpdate callback when Reader is not valid.");
+                }
+
                 if (updateCallbackToCallbackKey == null)
                 {
                     updateCallbackToCallbackKey = new Dictionary<Action<TUpdate>, ulong>();

--- a/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/ReaderSubscriptionManager.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/ReaderSubscriptionManager.cs
@@ -37,7 +37,7 @@ namespace Improbable.Gdk.Subscriptions
                     return;
                 }
 
-                WorkerSystem.TryGetEntity(entityId, out var entity);
+                var entity = WorkerSystem.GetEntity(entityId);
 
                 foreach (var subscription in entityIdToReaderSubscriptions[entityId])
                 {

--- a/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/ReaderSubscriptionManager.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/ReaderSubscriptionManager.cs
@@ -55,8 +55,6 @@ namespace Improbable.Gdk.Subscriptions
                     return;
                 }
 
-                WorkerSystem.TryGetEntity(entityId, out _);
-
                 foreach (var subscription in entityIdToReaderSubscriptions[entityId])
                 {
                     ResetValue(subscription);

--- a/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/RequiredSubscriptionsInjector.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/RequiredSubscriptionsInjector.cs
@@ -65,7 +65,13 @@ namespace Improbable.Gdk.Subscriptions
         {
             foreach (var field in info.RequiredFields)
             {
-                field.SetValue(target, subscriptions.GetErasedValue(field.FieldType));
+                var obj = subscriptions.GetErasedValue(field.FieldType);
+                if (obj is IRequireable requireable)
+                {
+                    requireable.IsValid = true;
+                }
+
+                field.SetValue(target, obj);
             }
 
             onEnable?.Invoke(target);

--- a/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/RequiredSubscriptionsInjector.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/RequiredSubscriptionsInjector.cs
@@ -12,13 +12,13 @@ namespace Improbable.Gdk.Subscriptions
         private readonly RequiredSubscriptionsInfo info;
         private readonly object target;
 
-        private readonly Action onEnable;
-        private readonly Action onDisable;
+        private readonly Action<object> onEnable;
+        private readonly Action<object> onDisable;
 
         // todo should either special case monobehaviours or not use callbacks
         // for non monobehaviours we could use functors
         public RequiredSubscriptionsInjector(object target, EntityId entityId, SubscriptionSystem subscriptionSystem,
-            Action onEnable = null, Action onDisable = null)
+            Action<object> onEnable = null, Action<object> onDisable = null)
         {
             this.target = target;
             this.onEnable = onEnable;
@@ -28,7 +28,7 @@ namespace Improbable.Gdk.Subscriptions
 
             if (info == null || info.RequiredTypes.Length == 0)
             {
-                onEnable?.Invoke();
+                onEnable?.Invoke(target);
                 return;
             }
 
@@ -41,14 +41,14 @@ namespace Improbable.Gdk.Subscriptions
         {
             if (subscriptions == null)
             {
-                onDisable?.Invoke();
+                onDisable?.Invoke(target);
                 return;
             }
 
             Handler.Pool.Return((Handler) subscriptions.GetAvailabilityHandler());
             subscriptions.Cancel();
 
-            onDisable?.Invoke();
+            onDisable?.Invoke(target);
 
             if (target == null)
             {
@@ -68,12 +68,12 @@ namespace Improbable.Gdk.Subscriptions
                 field.SetValue(target, subscriptions.GetErasedValue(field.FieldType));
             }
 
-            onEnable?.Invoke();
+            onEnable?.Invoke(target);
         }
 
         private void HandleSubscriptionsNoLongerSatisfied()
         {
-            onDisable?.Invoke();
+            onDisable?.Invoke(target);
 
             foreach (var field in info.RequiredFields)
             {

--- a/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntitySubscriptionManager.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/EntitySubscriptionManager.cs
@@ -33,7 +33,7 @@ namespace Improbable.Gdk.Subscriptions
                     return;
                 }
 
-                WorkerSystem.TryGetEntity(entityId, out var entity);
+                var entity = WorkerSystem.GetEntity(entityId);
                 foreach (var subscription in subscriptions)
                 {
                     if (!subscription.HasValue)

--- a/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs
@@ -25,7 +25,8 @@ namespace Improbable.Gdk.Core
                     return;
                 }
 
-                WorkerSystem.TryGetEntity(entityId, out var entity);
+                var entity = WorkerSystem.GetEntity(entityId);
+
                 foreach (var subscription in subscriptions)
                 {
                     subscription.SetAvailable(new WorldCommandSender(entity, world));

--- a/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/WriterSubscriptionManager.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/WriterSubscriptionManager.cs
@@ -39,7 +39,7 @@ namespace Improbable.Gdk.Subscriptions
                         return;
                     }
 
-                    WorkerSystem.TryGetEntity(authorityChange.EntityId, out var entity);
+                    var entity = WorkerSystem.GetEntity(authorityChange.EntityId);
 
                     foreach (var subscription in entityIdToWriterSubscriptions[authorityChange.EntityId])
                     {
@@ -55,8 +55,6 @@ namespace Improbable.Gdk.Subscriptions
                     {
                         return;
                     }
-
-                    WorkerSystem.TryGetEntity(authorityChange.EntityId, out _);
 
                     foreach (var subscription in entityIdToWriterSubscriptions[authorityChange.EntityId])
                     {

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/WorkerSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/WorkerSystem.cs
@@ -67,7 +67,7 @@ namespace Improbable.Gdk.Core
         {
             return EntityIdToEntity.TryGetValue(entityId, out entity);
         }
-        
+
         public Entity GetEntity(EntityId entityId)
         {
             if (!EntityIdToEntity.TryGetValue(entityId, out var entity))

--- a/workers/unity/Packages/io.improbable.gdk.core/Systems/WorkerSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Systems/WorkerSystem.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Improbable.Gdk.Core.NetworkStats;
 using Improbable.Worker.CInterop;
@@ -65,6 +66,16 @@ namespace Improbable.Gdk.Core
         public bool TryGetEntity(EntityId entityId, out Entity entity)
         {
             return EntityIdToEntity.TryGetValue(entityId, out entity);
+        }
+        
+        public Entity GetEntity(EntityId entityId)
+        {
+            if (!EntityIdToEntity.TryGetValue(entityId, out var entity))
+            {
+                throw new ArgumentException($"Unknown EntityId {entityId}", nameof(entityId));
+            }
+
+            return entity;
         }
 
         /// <summary>

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs
@@ -67,7 +67,7 @@ namespace Improbable.Gdk.Core
         {
             currentDiff.RemoveComponent(entityId, componentId);
         }
-        
+
         public void AddComponent<T>(long entityId, uint componentId, T component)
             where T : ISpatialComponentUpdate
         {

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/ConnectionHandlers/MockConnectionHandler.cs
@@ -67,6 +67,12 @@ namespace Improbable.Gdk.Core
         {
             currentDiff.RemoveComponent(entityId, componentId);
         }
+        
+        public void AddComponent<T>(long entityId, uint componentId, T component)
+            where T : ISpatialComponentUpdate
+        {
+            currentDiff.AddComponent(component, entityId, componentId);
+        }
 
         public void UpdateComponentAndAddEvents<TUpdate, TEvent>(long entityId, uint componentId, TUpdate update,
             params TEvent[] events)

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/.codegen/Source/Generators/GameObjectCreation/UnityComponentReaderWriterGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/.codegen/Source/Generators/GameObjectCreation/UnityComponentReaderWriterGenerator.cs
@@ -103,6 +103,11 @@ public event Action<{fieldDetails.Type}> On{fieldDetails.PascalCaseName}Update
 {{
     add
     {{
+        if (!IsValid)
+        {{
+            throw new InvalidOperationException(""Cannot add field update callback when Reader is not valid."");
+        }}
+
         if ({fieldDetails.CamelCaseName}UpdateCallbackToCallbackKey == null)
         {{
             {fieldDetails.CamelCaseName}UpdateCallbackToCallbackKey = new Dictionary<Action<{fieldDetails.Type}>, ulong>();
@@ -141,6 +146,11 @@ public event Action<{eventDetails.FqnPayloadType}> On{eventDetails.PascalCaseNam
 {{
     add
     {{
+        if (!IsValid)
+        {{
+            throw new InvalidOperationException(""Cannot add event callback when Reader is not valid."");
+        }}
+
         if ({eventDetails.CamelCaseName}EventCallbackToCallbackKey == null)
         {{
             {eventDetails.CamelCaseName}EventCallbackToCallbackKey = new Dictionary<Action<{eventDetails.FqnPayloadType}>, ulong>();

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/GameObjectInitializationSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/GameObjectInitializationSystem.cs
@@ -60,7 +60,7 @@ namespace Improbable.Gdk.GameObjectCreation
         {
             foreach (var entityId in entitySystem.GetEntitiesAdded())
             {
-                workerSystem.TryGetEntity(entityId, out var entity);
+                var entity = workerSystem.GetEntity(entityId);
                 gameObjectCreator.OnEntityCreated(new SpatialOSEntity(entity, EntityManager), Linker);
             }
 


### PR DESCRIPTION
#### Description
This fixes the mysterious exceptions with injected, but invalid, readers when using QBI.
Some additional safety improvements.

#### Tests
Added 2 tests, 1 fails without the fix.

#### Documentation
 - [x] Changelog
