### PR TITLE
Better gameobject initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@
 - `CustomSpatialOSSendSystem` is no longer available. [#1308](https://github.com/spatialos/gdk-for-unity/pull/1308)
 - The Player Lifecycle feature module now provides an `EntityId` in its `CreatePlayerEntityTemplate` callback. [#1315](https://github.com/spatialos/gdk-for-unity/pull/1315)
     - You will have to change your callback from `(string clientWorkerId, byte[] serializedArguments)` to `(EntityId entityId, string clientWorkerId, byte[] serializedArguments)`.
-- Added the `ComponentType[] MiniumComponentTypes { get; }` property to `IEntityGameObjectCreator`. [#1330](https://github.com/spatialos/gdk-for-unity/pull/1330)
-    - You will have to define the minimum set of components required on an entity to trigger the `OnEntityCreated` method on your custom GameObject creator.
+- Added the `PopulateEntityTypeExpectations` method to `IEntityGameObjectCreator`. [#1333](https://github.com/spatialos/gdk-for-unity/pull/1333)
+    - Use this method to define the set of components expected on an entity to be able create GameObjects for a given entity type.
+- Added `string entityType` as an argument to  `IEntityGameObjectCreator.OnEntityCreated`. [#1333](https://github.com/spatialos/gdk-for-unity/pull/1333)
+    - This means that your entities must have the `Metadata` component to use the GameObject Creation Feature Module.
 
 ### Added
 

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -37,8 +37,8 @@ If you have written custom GameObject creators implementing `IEntityGameObjectCr
 
 The `EntityTypeExpectations` class provides two public methods for defining a set of components expected on an entity to be able create GameObjects for a given entity type:
 
-- `void RegisterDefault(Type[] defaultComponentTypes = null)`
-- `void RegisterEntityType(string entityType, Type[] expectedComponentTypes = null)`
+- `void RegisterDefault(IEnumerable<Type> defaultComponentTypes = null)`
+- `void RegisterEntityType(string entityType, IEnumerable<Type> expectedComponentTypes = null)`
 
 For example, the `GameObjectCreatorFromMetadata` class implements the method like so:
 

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -33,11 +33,14 @@ public static EntityTemplate Player(EntityId entityId, string workerId, byte[] a
 
 #### Implement `PopulateEntityTypeExpectations` method
 
-If you have written custom GameObject creators implementing `IEntityGameObjectCreator`, you will now have to implement a `PopulateEntityTypeExpectations` method.
+If you have written custom GameObject creators implementing `IEntityGameObjectCreator`, you will now have to implement a `void PopulateEntityTypeExpectations(EntityTypeExpectations entityTypeExpectations)` method.
 
-This method is used to define a set of components expected on an entity to be able create GameObjects for a given entity type.
+The `EntityTypeExpectations` class provides two public methods for defining a set of components expected on an entity to be able create GameObjects for a given entity type:
 
-For example, the `GameObjectCreatorFromMetadata` class implements it like so:
+- `void RegisterDefault(Type[] defaultComponentTypes = null)`
+- `void RegisterEntityType(string entityType, Type[] expectedComponentTypes = null)`
+
+For example, the `GameObjectCreatorFromMetadata` class implements the method like so:
 
 ```csharp
 public void PopulateEntityTypeExpectations(EntityTypeExpectations entityTypeExpectations)
@@ -48,6 +51,20 @@ public void PopulateEntityTypeExpectations(EntityTypeExpectations entityTypeExpe
     });
 }
 ```
+
+The `AdvancedEntityPipeline` in the FPS Starter Project makes use of both public methods on the `EntityTypeExpectations` class. This is done in order to use a specifc method for creating "Player" GameObjects, and a fallback for any other entity type:
+
+```csharp
+public void PopulateEntityTypeExpectations(EntityTypeExpectations entityTypeExpectations)
+{
+    entityTypeExpectations.RegisterEntityType(PlayerEntityType, new[]
+    {
+        typeof(OwningWorker.Component), typeof(ServerMovement.Component)
+    });
+
+    fallback.PopulateEntityTypeExpectations(entityTypeExpectations);
+}
+``
 
 #### Add `string entityType` as argument to `OnEntityCreated`
 

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -29,21 +29,48 @@ public static EntityTemplate Player(EntityId entityId, string workerId, byte[] a
 }
 ```
 
-### The `IEntityGameObjectCreator` now requires the `ComponentType[] MiniumComponentTypes { get; }` property
+### `IEntityGameObjectCreator` changes
 
-If you have written custom GameObject creators implementing `IEntityGameObjectCreator`, you will have to define the minimum set of components required on an entity to trigger the `OnEntityCreated` method.
+#### Implement `PopulateEntityTypeExpectations` method
 
-For example, the following has been added to the `GameObjectCreatorFromMetadata` class:
+If you have written custom GameObject creators implementing `IEntityGameObjectCreator`, you will now have to implement a `PopulateEntityTypeExpectations` method.
+
+This method is used to define a set of components expected on an entity to be able create GameObjects for a given entity type.
+
+For example, the `GameObjectCreatorFromMetadata` class implements it like so:
 
 ```csharp
-public ComponentType[] MinimumComponentTypes { get; } =
+public void PopulateEntityTypeExpectations(EntityTypeExpectations entityTypeExpectations)
 {
-    ComponentType.ReadOnly<Metadata.Component>(),
-    ComponentType.ReadOnly<Position.Component>()
-};
+    entityTypeExpectations.RegisterDefault(new[]
+    {
+        typeof(Position.Component)
+    });
+}
 ```
 
-> You will need to add `using Unity.Entities;` to the top of the file and reference it in the assembly that your custom GameObject creator is in.
+#### Add `string entityType` as argument to `OnEntityCreated`
+
+The `EntityType` available the `Metadata` component is now provided as an argument when calling `OnEntityCreated` on your GameObject creator.
+
+> This means that your entities must have the `Metadata` component to use the GameObject Creation Feature Module.
+
+The `AdvancedEntityPipeline` in the FPS Starter Project makes use of it like so:
+
+```csharp
+public void OnEntityCreated(string entityType, SpatialOSEntity entity, EntityGameObjectLinker linker)
+{
+    switch (entityType)
+    {
+        case PlayerEntityType:
+            CreatePlayerGameObject(entity, linker);
+            break;
+        default:
+            fallback.OnEntityCreated(entityType, entity, linker);
+            break;
+    }
+}
+```
 
 ## From `0.3.2` to `0.3.3`
 

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -52,7 +52,7 @@ public void PopulateEntityTypeExpectations(EntityTypeExpectations entityTypeExpe
 }
 ```
 
-The `AdvancedEntityPipeline` in the FPS Starter Project makes use of both public methods on the `EntityTypeExpectations` class. This is done in order to use a specifc method for creating "Player" GameObjects, and a fallback for any other entity type:
+The `AdvancedEntityPipeline` in the FPS Starter Project makes use of both public methods on the `EntityTypeExpectations` class. This is done in order to wait for specific components when creating "Player" GameObjects, and a different set of components for any other entity type:
 
 ```csharp
 public void PopulateEntityTypeExpectations(EntityTypeExpectations entityTypeExpectations)

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/EntityTypeExpectations.cs
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/EntityTypeExpectations.cs
@@ -13,14 +13,14 @@ namespace Improbable.Gdk.GameObjectCreation
         private readonly Dictionary<string, Type[]> entityExpectations
             = new Dictionary<string, Type[]>();
 
-        public void RegisterDefault(Type[] defaultComponentTypes)
+        public void RegisterDefault(Type[] defaultComponentTypes = null)
         {
             defaultExpectation = defaultComponentTypes;
         }
 
-        public void RegisterEntityType(string entityType, Type[] expectedComponentTypes)
+        public void RegisterEntityType(string entityType, Type[] expectedComponentTypes = null)
         {
-            entityExpectations.Add(entityType, expectedComponentTypes ?? new Type[] { });
+            entityExpectations.Add(entityType, expectedComponentTypes);
         }
 
         internal Type[] GetExpectedTypes(string entityType)
@@ -30,7 +30,7 @@ namespace Improbable.Gdk.GameObjectCreation
                 return defaultExpectation;
             }
 
-            return types;
+            return types ?? new Type[] { };
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/EntityTypeExpectations.cs
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/EntityTypeExpectations.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Unity.Entities;
 
 namespace Improbable.Gdk.GameObjectCreation
 {
@@ -8,29 +10,34 @@ namespace Improbable.Gdk.GameObjectCreation
     /// </summary>
     public class EntityTypeExpectations
     {
-        private Type[] defaultExpectation;
+        private ComponentType[] defaultExpectation;
 
-        private readonly Dictionary<string, Type[]> entityExpectations
-            = new Dictionary<string, Type[]>();
+        private readonly Dictionary<string, ComponentType[]> entityExpectations
+            = new Dictionary<string, ComponentType[]>();
 
         public void RegisterDefault(Type[] defaultComponentTypes = null)
         {
-            defaultExpectation = defaultComponentTypes;
+            defaultExpectation = defaultComponentTypes?
+                .Select(type => new ComponentType(type, ComponentType.AccessMode.ReadOnly))
+                .ToArray();
         }
 
         public void RegisterEntityType(string entityType, Type[] expectedComponentTypes = null)
         {
-            entityExpectations.Add(entityType, expectedComponentTypes);
+            var expectedTypes = expectedComponentTypes?
+                .Select(type => new ComponentType(type, ComponentType.AccessMode.ReadOnly))
+                .ToArray();
+            entityExpectations.Add(entityType, expectedTypes);
         }
 
-        internal Type[] GetExpectedTypes(string entityType)
+        internal ComponentType[] GetExpectedTypes(string entityType)
         {
             if (!entityExpectations.TryGetValue(entityType, out var types))
             {
                 return defaultExpectation;
             }
 
-            return types ?? new Type[] { };
+            return types ?? new ComponentType[] { };
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/EntityTypeExpectations.cs
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/EntityTypeExpectations.cs
@@ -10,23 +10,40 @@ namespace Improbable.Gdk.GameObjectCreation
     /// </summary>
     public class EntityTypeExpectations
     {
-        private ComponentType[] defaultExpectation;
+        private ComponentType[] defaultExpectation = new ComponentType[] { };
 
         private readonly Dictionary<string, ComponentType[]> entityExpectations
             = new Dictionary<string, ComponentType[]>();
 
-        public void RegisterDefault(Type[] defaultComponentTypes = null)
+        public void RegisterDefault(IEnumerable<Type> defaultComponentTypes = null)
         {
-            defaultExpectation = defaultComponentTypes?
-                .Select(type => new ComponentType(type, ComponentType.AccessMode.ReadOnly))
-                .ToArray();
+            if (defaultComponentTypes == null)
+            {
+                defaultExpectation = new ComponentType[] { };
+            }
+            else
+            {
+                defaultExpectation = defaultComponentTypes
+                    .Select(type => new ComponentType(type, ComponentType.AccessMode.ReadOnly))
+                    .ToArray();
+            }
         }
 
-        public void RegisterEntityType(string entityType, Type[] expectedComponentTypes = null)
+        public void RegisterEntityType(string entityType, IEnumerable<Type> expectedComponentTypes = null)
         {
-            var expectedTypes = expectedComponentTypes?
-                .Select(type => new ComponentType(type, ComponentType.AccessMode.ReadOnly))
-                .ToArray();
+            ComponentType[] expectedTypes;
+
+            if (expectedComponentTypes == null)
+            {
+                expectedTypes = new ComponentType[] { };
+            }
+            else
+            {
+                expectedTypes = expectedComponentTypes
+                    .Select(type => new ComponentType(type, ComponentType.AccessMode.ReadOnly))
+                    .ToArray();
+            }
+
             entityExpectations.Add(entityType, expectedTypes);
         }
 
@@ -37,7 +54,7 @@ namespace Improbable.Gdk.GameObjectCreation
                 return defaultExpectation;
             }
 
-            return types ?? new ComponentType[] { };
+            return types;
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/EntityTypeExpectations.cs
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/EntityTypeExpectations.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+namespace Improbable.Gdk.GameObjectCreation
+{
+    /// <summary>
+    ///     Holds mappings from entity types to the set of components expected before creating their GameObjects.
+    /// </summary>
+    public class EntityTypeExpectations
+    {
+        private Type[] defaultExpectation;
+
+        private readonly Dictionary<string, Type[]> entityExpectations
+            = new Dictionary<string, Type[]>();
+
+        public void RegisterDefault(Type[] defaultComponentTypes)
+        {
+            defaultExpectation = defaultComponentTypes;
+        }
+
+        public void RegisterEntityType(string entityType, Type[] expectedComponentTypes)
+        {
+            entityExpectations.Add(entityType, expectedComponentTypes ?? new Type[] { });
+        }
+
+        internal Type[] GetExpectedTypes(string entityType)
+        {
+            if (!entityExpectations.TryGetValue(entityType, out var types))
+            {
+                return defaultExpectation;
+            }
+
+            return types;
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/EntityTypeExpectations.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/EntityTypeExpectations.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: de42ed6972a975b40b36508dec6b9560
+guid: 4be9cff6b85886645a770d139d53eadd
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/EntityTypeRegistrations.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/EntityTypeRegistrations.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: de42ed6972a975b40b36508dec6b9560
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/GameObjectCreatorFromMetadata.cs
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/GameObjectCreatorFromMetadata.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Subscriptions;
-using Unity.Entities;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
@@ -23,15 +22,7 @@ namespace Improbable.Gdk.GameObjectCreation
 
         private readonly Type[] componentsToAdd =
         {
-            typeof(Transform),
-            typeof(Rigidbody),
-            typeof(MeshRenderer)
-        };
-
-        public ComponentType[] MinimumComponentTypes { get; } =
-        {
-            ComponentType.ReadOnly<Metadata.Component>(),
-            ComponentType.ReadOnly<Position.Component>()
+            typeof(Transform), typeof(Rigidbody), typeof(MeshRenderer)
         };
 
         public GameObjectCreatorFromMetadata(string workerType, Vector3 workerOrigin, ILogDispatcher logger)
@@ -41,7 +32,15 @@ namespace Improbable.Gdk.GameObjectCreation
             this.logger = logger;
         }
 
-        public void OnEntityCreated(SpatialOSEntity entity, EntityGameObjectLinker linker)
+        public void PopulateEntityTypeExpectations(EntityTypeExpectations entityTypeExpectations)
+        {
+            entityTypeExpectations.RegisterDefault(new[]
+            {
+                typeof(Metadata.Component), typeof(Position.Component)
+            });
+        }
+
+        public void OnEntityCreated(string entityType, SpatialOSEntity entity, EntityGameObjectLinker linker)
         {
             if (!entity.TryGetComponent<Metadata.Component>(out var metadata) ||
                 !entity.TryGetComponent<Position.Component>(out var spatialOSPosition))

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/GameObjectCreatorFromMetadata.cs
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/GameObjectCreatorFromMetadata.cs
@@ -16,8 +16,6 @@ namespace Improbable.Gdk.GameObjectCreation
         private readonly string workerType;
         private readonly Vector3 workerOrigin;
 
-        private readonly ILogDispatcher logger;
-
         private readonly Dictionary<EntityId, GameObject> entityIdToGameObject = new Dictionary<EntityId, GameObject>();
 
         private readonly Type[] componentsToAdd =
@@ -29,26 +27,21 @@ namespace Improbable.Gdk.GameObjectCreation
         {
             this.workerType = workerType;
             this.workerOrigin = workerOrigin;
-            this.logger = logger;
         }
 
         public void PopulateEntityTypeExpectations(EntityTypeExpectations entityTypeExpectations)
         {
             entityTypeExpectations.RegisterDefault(new[]
             {
-                typeof(Metadata.Component), typeof(Position.Component)
+                typeof(Position.Component)
             });
         }
 
         public void OnEntityCreated(string entityType, SpatialOSEntity entity, EntityGameObjectLinker linker)
         {
-            if (!entity.TryGetComponent<Metadata.Component>(out var metadata) ||
-                !entity.TryGetComponent<Position.Component>(out var spatialOSPosition))
-            {
-                return;
-            }
+            var spatialOSPosition = entity.GetComponent<Position.Component>();
 
-            var prefabName = metadata.EntityType;
+            var prefabName = entityType;
             var position = spatialOSPosition.Coords.ToUnityVector() + workerOrigin;
 
             if (!cachedPrefabs.TryGetValue(prefabName, out var prefab))

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/GameObjectInitializationSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/GameObjectInitializationSystem.cs
@@ -32,8 +32,6 @@ namespace Improbable.Gdk.GameObjectCreation
         {
             this.gameObjectCreator = gameObjectCreator;
             this.workerGameObject = workerGameObject;
-
-            gameObjectCreator.PopulateEntityTypeExpectations(entityTypeExpectations);
         }
 
         protected override void OnCreate()
@@ -65,6 +63,8 @@ namespace Improbable.Gdk.GameObjectCreation
                 All = new[] { ComponentType.ReadOnly<GameObjectInitSystemStateComponent>() },
                 None = minimumComponentSet
             });
+
+            gameObjectCreator.PopulateEntityTypeExpectations(entityTypeExpectations);
         }
 
         protected override void OnDestroy()

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/IEntityGameObjectCreator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/IEntityGameObjectCreator.cs
@@ -11,9 +11,9 @@ namespace Improbable.Gdk.GameObjectCreation
     public interface IEntityGameObjectCreator
     {
         /// <summary>
-        ///     The minimum set of components required on an entity to create a GameObject.
+        ///     Called to register the components expected on an entity to create a GameObject for a given entity type.
         /// </summary>
-        ComponentType[] MinimumComponentTypes { get; }
+        void PopulateEntityTypeExpectations(EntityTypeExpectations entityTypeExpectations);
 
         /// <summary>
         ///     Called when a new SpatialOS Entity is checked out by the worker.
@@ -21,7 +21,7 @@ namespace Improbable.Gdk.GameObjectCreation
         /// <returns>
         ///     A GameObject to be linked to the entity, or null if no GameObject should be linked.
         /// </returns>
-        void OnEntityCreated(SpatialOSEntity entity, EntityGameObjectLinker linker);
+        void OnEntityCreated(string entityType, SpatialOSEntity entity, EntityGameObjectLinker linker);
 
         /// <summary>
         ///     Called when a SpatialOS Entity is removed from the worker's view.

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/Tests/Editmode/GameObjectCreationTests.cs
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/Tests/Editmode/GameObjectCreationTests.cs
@@ -115,18 +115,20 @@ namespace Improbable.Gdk.GameObjectCreation.EditmodeTests
 
             private readonly Dictionary<EntityId, GameObject> entityIdToGameObject = new Dictionary<EntityId, GameObject>();
 
-            public ComponentType[] MinimumComponentTypes { get; } =
-            {
-                ComponentType.ReadOnly<Position.Component>(),
-                ComponentType.ReadOnly<Metadata.Component>()
-            };
-
             public TestGameObjectCreator(string workerType)
             {
                 this.workerType = workerType;
             }
 
-            public void OnEntityCreated(SpatialOSEntity entity, EntityGameObjectLinker linker)
+            public void PopulateEntityTypeExpectations(EntityTypeExpectations entityTypeExpectations)
+            {
+                entityTypeExpectations.RegisterDefault(new[]
+                {
+                    typeof(Metadata.Component), typeof(Position.Component)
+                });
+            }
+
+            public void OnEntityCreated(string entityType, SpatialOSEntity entity, EntityGameObjectLinker linker)
             {
                 var gameObject = new GameObject();
                 gameObject.transform.position = Vector3.one;

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/Tests/Editmode/MockGameObjectCreator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/Tests/Editmode/MockGameObjectCreator.cs
@@ -7,16 +7,18 @@ namespace Improbable.Gdk.GameObjectCreation.EditmodeTests
 {
     public class MockGameObjectCreator : IEntityGameObjectCreator
     {
-        public ComponentType[] MinimumComponentTypes { get; } = { };
-
-        public void OnEntityCreated(SpatialOSEntity entity, EntityGameObjectLinker linker)
+        public void PopulateEntityTypeExpectations(EntityTypeExpectations entityTypeExpectations)
         {
-            throw new System.NotImplementedException();
+        }
+
+        public void OnEntityCreated(string entityType, SpatialOSEntity entity, EntityGameObjectLinker linker)
+        {
+            throw new NotImplementedException();
         }
 
         public void OnEntityRemoved(EntityId entityId)
         {
-            throw new System.NotImplementedException();
+            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
#### Description

- `EntityTypeExpectations` keeps track of entitytype -> expectedtype[] map
	- ability to define a default type[] as a fallback
- gameobject initialization system will check if entity has the expected types
	- if it does -> call `OnEntityCreated`
    - if not, return 

#### Tests

- [x] playground
- [x] existing unit tests
- [x] fps

#### Documentation

- [x] changelog
- [x] upgrade guide
- [ ] readme

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
