### PR TITLE
Set debug names for ecs entities in editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
     - `AddEntity(EntityId entityId, EntityTemplate entityTemplate)` adds an entity to the snapshot with a given entity ID.
 - Added an additional `AddComponent` method to the `EntityTemplate` class which does not require write-access to be given. [#1338](https://github.com/spatialos/gdk-for-unity/pull/1338)
     - This allows users to add undelegated components on entities.
+- Added debug names to entities shown in EntityDebugger. [#1342](https://github.com/spatialos/gdk-for-unity/pull/1342)
 
 ## Internal
 

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/GameObjectInitializationSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/GameObjectInitializationSystem.cs
@@ -1,7 +1,6 @@
 using System;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Subscriptions;
-using Unity.Collections;
 using Unity.Entities;
 using UnityEngine;
 

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/GameObjectInitializationSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/GameObjectInitializationSystem.cs
@@ -1,6 +1,7 @@
 using System;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Subscriptions;
+using Unity.Collections;
 using Unity.Entities;
 using UnityEngine;
 
@@ -130,6 +131,10 @@ namespace Improbable.Gdk.GameObjectCreation
                             return;
                         }
                     }
+
+#if UNITY_EDITOR
+                    EntityManager.SetName(entity, $"{entityType} (SpatialOS: {spatialEntityId.EntityId.Id.ToString()})");
+#endif
 
                     try
                     {


### PR DESCRIPTION
#### Description
Set ecs entity names in EntityDebugger when using the editor.