### PR TITLE
Allow headless development builds for Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
     - This allows users to add undelegated components on entities.
 - Added debug names to entities shown in EntityDebugger. [#1342](https://github.com/spatialos/gdk-for-unity/pull/1342)
 
+## Changed
+
+- Allow headless development builds for Linux. [#1347](https://github.com/spatialos/gdk-for-unity/pull/1347)
+
 ## Internal
 
 - Added component result type filters to playground QBI queries. [#1338](https://github.com/spatialos/gdk-for-unity/pull/1338)

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildConfigEditor.cs
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildConfigEditor.cs
@@ -749,26 +749,23 @@ namespace Improbable.Gdk.BuildSystem.Configuration
 
         private BuildOptions ConfigureLinux(BuildTargetConfig buildTarget)
         {
-            // NB: On Linux, headless and Development mode are mutually exclusive.
             var options = buildTarget.Options;
-            if (EditorGUILayout.Toggle("Server build", options.HasFlag(BuildOptions.EnableHeadlessMode)))
-            {
-                options |= BuildOptions.EnableHeadlessMode;
-                options &= ~BuildOptions.Development;
-            }
-            else
-            {
-                options &= ~BuildOptions.EnableHeadlessMode;
-            }
-
             if (EditorGUILayout.Toggle("Development", options.HasFlag(BuildOptions.Development)))
             {
                 options |= BuildOptions.Development;
-                options &= ~BuildOptions.EnableHeadlessMode;
             }
             else
             {
                 options &= ~BuildOptions.Development;
+            }
+
+            if (EditorGUILayout.Toggle("Server build", options.HasFlag(BuildOptions.EnableHeadlessMode)))
+            {
+                options |= BuildOptions.EnableHeadlessMode;
+            }
+            else
+            {
+                options &= ~BuildOptions.EnableHeadlessMode;
             }
 
             return options;


### PR DESCRIPTION
#### Description
With our upgrade to 2019.3f, we can do headless development builds again for Linux without having it crash!

Also re-ordered the options on the GUI so that they are the same order for all platforms.

#### Documentation

- [ ] Changelog
