### PR TITLE
Log invalid JSON if error parsing the codegen output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Invalid JSON is now logged if there is an error parsing the codegen output. [#1353](https://github.com/spatialos/gdk-for-unity/pull/1353)
+
 ## `0.3.5` - 2020-04-23
 
 ### Breaking Changes

--- a/workers/unity/Packages/io.improbable.gdk.tools/GenerateCode.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/GenerateCode.cs
@@ -318,7 +318,7 @@ namespace Improbable.Gdk.Tools
             }
             catch (Exception e)
             {
-                Debug.LogWarning(e);
+                Debug.LogWarning($"Failed to parse output: \"{output}\"{Environment.NewLine}{e}");
             }
         }
 


### PR DESCRIPTION
#### Description
Invalid JSON is now logged if there is an error parsing the codegen output

#### Tests
passed in json that wasn't valid

#### Documentation

- [x] changelog

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
