### PR TITLE
Hide Android in mobile launcher if build support not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Invalid JSON is now logged if there is an error parsing the codegen output. [#1353](https://github.com/spatialos/gdk-for-unity/pull/1353)
+- The Mobile Launcher will no longer break if Android build support is not installed. [#1354](https://github.com/spatialos/gdk-for-unity/pull/1354)
 
 ## `0.3.5` - 2020-04-23
 

--- a/workers/unity/Packages/io.improbable.gdk.mobile/Editor/AndroidUtils.cs
+++ b/workers/unity/Packages/io.improbable.gdk.mobile/Editor/AndroidUtils.cs
@@ -212,5 +212,11 @@ namespace Improbable.Gdk.Mobile
                 return EditorPrefs.GetString("AndroidSdkRoot");
             }
         }
+
+        public static bool IsAndroidPlaybackEngineInstalled()
+        {
+            var targetGroup = BuildPipeline.GetBuildTargetGroup(BuildTarget.Android);
+            return BuildPipeline.IsBuildTargetSupported(targetGroup, BuildTarget.Android);
+        }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.mobile/Editor/MobileLauncherWindow.cs
+++ b/workers/unity/Packages/io.improbable.gdk.mobile/Editor/MobileLauncherWindow.cs
@@ -29,6 +29,8 @@ namespace Improbable.Gdk.Mobile
 
         private readonly string[] emptyDeviceNameList = { "No devices found" };
 
+        private bool androidPlaybackEngineInstalled;
+
         [MenuItem("SpatialOS/Mobile Launcher", false, 52)]
         public static void ShowWindow()
         {
@@ -41,7 +43,12 @@ namespace Improbable.Gdk.Mobile
 
         private void OnEnable()
         {
-            RefreshAndroidEmulatorsAndDevices();
+            androidPlaybackEngineInstalled = AndroidUtils.IsAndroidPlaybackEngineInstalled();
+
+            if (androidPlaybackEngineInstalled)
+            {
+                RefreshAndroidEmulatorsAndDevices();
+            }
 
 #if UNITY_EDITOR_OSX
             RefreshiOSEmulatorsAndDevices();
@@ -57,7 +64,10 @@ namespace Improbable.Gdk.Mobile
                 mobileLaunchConfig.ShouldConnectLocally = EditorGUILayout.Toggle(ConnectLocallyLabel, mobileLaunchConfig.ShouldConnectLocally);
             }
 
-            DisplayAndroidMenu();
+            if (androidPlaybackEngineInstalled)
+            {
+                DisplayAndroidMenu();
+            }
 
 #if UNITY_EDITOR_OSX
             DisplayiOSMenu();


### PR DESCRIPTION
#### Description

Only show android section of mobile launcher if android build support is installed.

#### Tests

- [x] windows with android
- [x] windows without android
- [x] mac with android
- [x] mac without android

#### Documentation

- [x] changelog

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
