### PR TITLE
Expose cluster in deployment launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## Unreleased
 
+### Added
+
+- Added the ability to select a specific cluster for deployments in the [Deployment Launcher](https://documentation.improbable.io/gdk-for-unity/docs/deployment-launcher). [#1357](https://github.com/spatialos/gdk-for-unity/pull/1357)
+    - You can select _either_ a region or a cluster, but not both!
+
 ### Changed
 
 - GDK Tools Configuration window now autosaves. [#1356](https://github.com/spatialos/gdk-for-unity/pull/1356)
+
 
 ### Fixed
 

--- a/workers/unity/Assets/Playground/Config/DeploymentLauncherConfig.asset
+++ b/workers/unity/Assets/Playground/Config/DeploymentLauncherConfig.asset
@@ -24,5 +24,7 @@ MonoBehaviour:
       SnapshotPath: snapshots/default.snapshot
       LaunchJson: cloud_launch.json
       Region: 1
+      Cluster: 
+      DeploymentLocationType: 0
       Tags: []
     SimulatedPlayerDeploymentConfigs: []

--- a/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Commands/Create.cs
+++ b/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Commands/Create.cs
@@ -40,9 +40,21 @@ namespace Improbable.Gdk.DeploymentLauncher.Commands
                     },
                     Name = options.DeploymentName,
                     ProjectName = options.ProjectName,
-                    RegionCode = options.Region.ToString(),
                     RuntimeVersion = options.RuntimeVersion
                 };
+
+                if (options.Cluster != null)
+                {
+                    deployment.ClusterCode = options.Cluster;
+                }
+                else if (options.Region != Options.DeploymentRegionCode.None)
+                {
+                    deployment.RegionCode = options.Region.ToString();
+                }
+                else
+                {
+                    throw new ArgumentException("Expected either --region or --cluster to be provided, but found neither.");
+                }
 
                 if (options.SnapshotPath != null)
                 {

--- a/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Options.cs
+++ b/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/.DeploymentLauncher/Options.cs
@@ -29,8 +29,11 @@ namespace Improbable.Gdk.DeploymentLauncher
             [Option("snapshot_path", Required = false, HelpText = "The path to the snapshot.")]
             public string SnapshotPath { get; set; }
 
-            [Option("region", Required = true, HelpText = "The region to launch the deployment in.")]
+            [Option("region", Required = false, HelpText = "The region to launch the deployment in.")]
             public DeploymentRegionCode Region { get; set; }
+
+            [Option("cluster", Required = false, HelpText = "The specific cluster to launch a deployment in.")]
+            public string Cluster { get; set; }
 
             [Option("tags", Required = false, HelpText = "Tags to add to this deployment. Comma separated",
                 Separator = ',')]
@@ -73,6 +76,7 @@ namespace Improbable.Gdk.DeploymentLauncher
 
         public enum DeploymentRegionCode
         {
+            None,
             US,
             EU,
             CN

--- a/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentConfigurations.cs
+++ b/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentConfigurations.cs
@@ -162,6 +162,8 @@ namespace Improbable.Gdk.DeploymentLauncher
                 SnapshotPath = SnapshotPath,
                 LaunchJson = LaunchJson,
                 Region = Region,
+                Cluster = Cluster,
+                DeploymentLocationType = DeploymentLocationType,
                 Tags = Tags.ToList(),
 
                 TargetDeploymentName = TargetDeploymentName,
@@ -268,6 +270,17 @@ namespace Improbable.Gdk.DeploymentLauncher
         public DeploymentRegionCode Region;
 
         /// <summary>
+        ///     The cluster to launch the deployment in.
+        /// </summary>
+        public string Cluster;
+
+        /// <summary>
+        ///     Whether to use <see cref="Region"/> or <see cref="Cluster"/> as the deployment location.
+        /// </summary>
+        /// <returns></returns>
+        public DeploymentLocationType DeploymentLocationType;
+
+        /// <summary>
         ///     Tags to add to the deployment.
         /// </summary>
         public List<string> Tags;
@@ -278,6 +291,8 @@ namespace Improbable.Gdk.DeploymentLauncher
             SnapshotPath = string.Empty;
             LaunchJson = string.Empty;
             Region = DeploymentRegionCode.EU;
+            Cluster = string.Empty;
+            DeploymentLocationType = DeploymentLocationType.Region;
             Tags = new List<string>();
         }
 
@@ -289,14 +304,25 @@ namespace Improbable.Gdk.DeploymentLauncher
             {
                 "create",
                 $"--deployment_name={Name}",
-                $"--launch_json_path=\"{Path.Combine(Tools.Common.SpatialProjectRootDir, LaunchJson)}\"",
-                $"--region={Region.ToString()}",
+                $"--launch_json_path=\"{Path.Combine(Common.SpatialProjectRootDir, LaunchJson)}\"",
                 $"--runtime_version={toolsConfig.RuntimeVersion}"
             };
 
+            switch (DeploymentLocationType)
+            {
+                case DeploymentLocationType.Region:
+                    args.Add($"--region={Region.ToString()}");
+                    break;
+                case DeploymentLocationType.Cluster:
+                    args.Add($"--cluster={Cluster}");
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
             if (!string.IsNullOrEmpty(SnapshotPath))
             {
-                args.Add($"--snapshot_path=\"{Path.Combine(Tools.Common.SpatialProjectRootDir, SnapshotPath)}\"");
+                args.Add($"--snapshot_path=\"{Path.Combine(Common.SpatialProjectRootDir, SnapshotPath)}\"");
             }
 
             if (Tags.Count > 0)
@@ -315,6 +341,8 @@ namespace Improbable.Gdk.DeploymentLauncher
                 SnapshotPath = SnapshotPath,
                 LaunchJson = LaunchJson,
                 Region = Region,
+                Cluster = Cluster,
+                DeploymentLocationType = DeploymentLocationType,
                 Tags = Tags.ToList()
             };
         }
@@ -350,6 +378,11 @@ namespace Improbable.Gdk.DeploymentLauncher
                         yield return message;
                     }
                 }
+            }
+
+            if (DeploymentLocationType == DeploymentLocationType.Cluster && string.IsNullOrEmpty(Cluster))
+            {
+                yield return "Cluster cannot be empty.";
             }
         }
 
@@ -429,6 +462,12 @@ namespace Improbable.Gdk.DeploymentLauncher
         US,
         EU,
         CN
+    }
+
+    internal enum DeploymentLocationType
+    {
+        Region,
+        Cluster
     }
 
     internal class DeploymentInfo

--- a/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
+++ b/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
@@ -579,7 +579,37 @@ namespace Improbable.Gdk.DeploymentLauncher
 
             dest.SnapshotPath = EditorGUILayout.TextField("Snapshot Path", source.SnapshotPath);
             dest.LaunchJson = EditorGUILayout.TextField("Launch Config", source.LaunchJson);
-            dest.Region = (DeploymentRegionCode) EditorGUILayout.EnumPopup("Region", source.Region);
+
+            var foldoutState = stateManager.GetStateObjectOrDefault<bool>((source.Name + "region").GetHashCode());
+
+            foldoutState = EditorGUILayout.Foldout(foldoutState, new GUIContent("Deployment location"));
+            stateManager.SetStateObject((source.Name + "region").GetHashCode(), foldoutState);
+
+            if (foldoutState)
+            {
+                using (new EditorGUI.IndentLevelScope())
+                {
+                    using (new GUILayout.HorizontalScope())
+                    {
+                        GUILayout.Space(EditorGUI.indentLevel * 15.0f);
+                        dest.DeploymentLocationType =
+                            (DeploymentLocationType) GUILayout.SelectionGrid((int) source.DeploymentLocationType,
+                                new[] { "Region", "Cluster" }, 1, EditorStyles.radioButton);
+                    }
+
+                    switch (dest.DeploymentLocationType)
+                    {
+                        case DeploymentLocationType.Region:
+                            dest.Region = (DeploymentRegionCode) EditorGUILayout.EnumPopup("Region", source.Region);
+                            break;
+                        case DeploymentLocationType.Cluster:
+                            dest.Cluster = EditorGUILayout.TextField("Cluster", source.Cluster);
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                }
+            }
 
             EditorGUILayout.LabelField("Tags");
 

--- a/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
+++ b/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
@@ -580,10 +580,10 @@ namespace Improbable.Gdk.DeploymentLauncher
             dest.SnapshotPath = EditorGUILayout.TextField("Snapshot Path", source.SnapshotPath);
             dest.LaunchJson = EditorGUILayout.TextField("Launch Config", source.LaunchJson);
 
-            var foldoutState = stateManager.GetStateObjectOrDefault<bool>((source.Name + "region").GetHashCode());
+            var foldoutState = stateManager.GetStateObjectOrDefault<bool>($"{source.Name}region".GetHashCode());
 
             foldoutState = EditorGUILayout.Foldout(foldoutState, new GUIContent("Deployment location"));
-            stateManager.SetStateObject((source.Name + "region").GetHashCode(), foldoutState);
+            stateManager.SetStateObject($"{source.Name}region".GetHashCode(), foldoutState);
 
             if (foldoutState)
             {
@@ -591,22 +591,30 @@ namespace Improbable.Gdk.DeploymentLauncher
                 {
                     using (new GUILayout.HorizontalScope())
                     {
-                        GUILayout.Space(EditorGUI.indentLevel * 15.0f);
-                        dest.DeploymentLocationType =
-                            (DeploymentLocationType) GUILayout.SelectionGrid((int) source.DeploymentLocationType,
-                                new[] { "Region", "Cluster" }, 1, EditorStyles.radioButton);
+                        if (EditorGUILayout.Toggle("Region",
+                            source.DeploymentLocationType == DeploymentLocationType.Region, EditorStyles.radioButton))
+                        {
+                            dest.DeploymentLocationType = DeploymentLocationType.Region;
+                        }
+
+                        using (new EditorGUI.DisabledScope(dest.DeploymentLocationType == DeploymentLocationType.Cluster))
+                        {
+                            dest.Region = (DeploymentRegionCode) EditorGUILayout.EnumPopup(source.Region);
+                        }
                     }
 
-                    switch (dest.DeploymentLocationType)
+                    using (new GUILayout.HorizontalScope())
                     {
-                        case DeploymentLocationType.Region:
-                            dest.Region = (DeploymentRegionCode) EditorGUILayout.EnumPopup("Region", source.Region);
-                            break;
-                        case DeploymentLocationType.Cluster:
-                            dest.Cluster = EditorGUILayout.TextField("Cluster", source.Cluster);
-                            break;
-                        default:
-                            throw new ArgumentOutOfRangeException();
+                        if (EditorGUILayout.Toggle("Cluster",
+                            dest.DeploymentLocationType == DeploymentLocationType.Cluster, EditorStyles.radioButton))
+                        {
+                            dest.DeploymentLocationType = DeploymentLocationType.Cluster;
+                        }
+
+                        using (new EditorGUI.DisabledScope(dest.DeploymentLocationType == DeploymentLocationType.Region))
+                        {
+                            dest.Cluster = EditorGUILayout.TextField(source.Cluster);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
#### Description

As usual, commits are ordered and self contained.

This PR adds support for choosing a specific cluster for a deployment. This is exposed to the user as a exclusive choice between a region _or_ cluster. 

![image](https://user-images.githubusercontent.com/13353733/81287235-56722900-905a-11ea-980d-0e2c536f8b9a.png)

![image](https://user-images.githubusercontent.com/13353733/81287272-64c04500-905a-11ea-8c0e-436223433d43.png)

The same change is applied to the `DeploymentLauncher` csproj. I chose to make the `--cluster` and `--region` flags both optional, but it will throw if neither are provided. In the case where both are provided, `--cluster` takes precedence since it is the more specific option.

This change was made in a way such that it should be backward compatible, there should be no action required upon upgrade.

Also if anyone knows a better way of aligning `GUILayout` controls with `EditorGUILayout` scopes, please let me know 😅 

#### Tests
- [x] Ran a deployment against a region
- [x] Ran a deployment in a specific cluster

#### Documentation

- [x] Changelog
- [x] Readme.io

