### PR TITLE
Produce test coverage reports

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -14,6 +14,9 @@ PROJECT_DIR="$(pwd)"
 TEST_RESULTS_DIR="${PROJECT_DIR}/logs/nunit"
 mkdir -p "${TEST_RESULTS_DIR}"
 
+COVERAGE_OPTIONS="generateHtmlReport\;assemblyFilters:+Improbable.Gdk.*,-Improbable.Gdk.Generated,-Improbable.Gdk.Generated.BuildSystem"
+COVERAGE_RESULTS_PATH="${PROJECT_DIR}/logs/coverage-results"
+
 echo "--- Testing Code Generator :gear:"
 
 dotnet test \
@@ -27,6 +30,9 @@ echo "--- Testing Unity: Editmode :writing_hand:"
 pushd "workers/unity"
     dotnet run -p "${PROJECT_DIR}/.shared-ci/tools/RunUnity/RunUnity.csproj" -- \
         -batchmode \
+        -enableCodeCoverage \
+        -coverageResultsPath "${COVERAGE_RESULTS_PATH}/playground" \
+        -coverageOptions "${COVERAGE_OPTIONS}" \
         -projectPath "${PROJECT_DIR}/workers/unity" \
         -runEditorTests \
         -logfile "${PROJECT_DIR}/logs/unity-editmode-test-run.log" \
@@ -35,23 +41,14 @@ popd
 
 cleanUnity "$(pwd)/workers/unity"
 
-echo "--- Testing Unity: Playmode :joystick:"
-
-pushd "workers/unity"
-    dotnet run -p "${PROJECT_DIR}/.shared-ci/tools/RunUnity/RunUnity.csproj" -- \
-        -batchmode \
-        -projectPath "${PROJECT_DIR}/workers/unity" \
-        -runTests \
-        -testPlatform playmode \
-        -logfile "${PROJECT_DIR}/logs/unity-playmode-test-run.log" \
-        -testResults "${TEST_RESULTS_DIR}/playmode-test-results.xml"
-popd
-
 echo "--- Testing Unity: Test Project Editmode :microscope:"
 
 pushd "test-project"
     dotnet run -p "${PROJECT_DIR}/.shared-ci/tools/RunUnity/RunUnity.csproj" -- \
         -batchmode \
+        -enableCodeCoverage \
+        -coverageResultsPath "${COVERAGE_RESULTS_PATH}/test-project" \
+        -coverageOptions "${COVERAGE_OPTIONS}" \
         -projectPath "${PROJECT_DIR}/test-project" \
         -runEditorTests \
         -logfile "${PROJECT_DIR}/logs/test-project-editmode-test-run.log" \
@@ -63,6 +60,9 @@ echo "--- Testing Unity: Test Project Playmode :joystick:"
 pushd "test-project"
     dotnet run -p "${PROJECT_DIR}/.shared-ci/tools/RunUnity/RunUnity.csproj" -- \
         -batchmode \
+        -enableCodeCoverage \
+        -coverageResultsPath "${COVERAGE_RESULTS_PATH}/test-project" \
+        -coverageOptions "${COVERAGE_OPTIONS}" \
         -projectPath "${PROJECT_DIR}/test-project" \
         -runTests \
         -testPlatform playmode \

--- a/test-project/Packages/manifest.json
+++ b/test-project/Packages/manifest.json
@@ -1,8 +1,7 @@
 {
   "dependencies": {
-    "com.unity.ext.nunit": "1.0.0",
     "com.unity.ide.rider": "1.1.4",
-    "com.unity.test-framework": "1.1.11",
+    "com.unity.testtools.codecoverage": "0.2.3-preview",
     "com.unity.ugui": "1.0.0",
     "io.improbable.gdk.buildsystem": "file:../../workers/unity/Packages/io.improbable.gdk.buildsystem",
     "io.improbable.gdk.core": "file:../../workers/unity/Packages/io.improbable.gdk.core",
@@ -13,11 +12,7 @@
     "io.improbable.gdk.testutils": "file:../../workers/unity/Packages/io.improbable.gdk.testutils",
     "io.improbable.gdk.tools": "file:../../workers/unity/Packages/io.improbable.gdk.tools",
     "io.improbable.gdk.transformsynchronization": "file:../../workers/unity/Packages/io.improbable.gdk.transformsynchronization",
-    "io.improbable.worker.sdk": "file:../../workers/unity/Packages/io.improbable.worker.sdk",
-    "com.unity.modules.animation": "1.0.0",
-    "com.unity.modules.physics": "1.0.0",
-    "com.unity.modules.physics2d": "1.0.0",
-    "com.unity.modules.ui": "1.0.0"
+    "io.improbable.worker.sdk": "file:../../workers/unity/Packages/io.improbable.worker.sdk"
   },
   "registry": "https://packages.unity.com"
 }

--- a/workers/unity/Packages/manifest.json
+++ b/workers/unity/Packages/manifest.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "com.unity.ide.rider": "1.1.4",
+    "com.unity.testtools.codecoverage": "0.2.3-preview",
     "com.unity.ugui": "1.0.0",
     "com.unity.ui.builder": "0.8.2-preview",
     "io.improbable.gdk.buildsystem": "file:io.improbable.gdk.buildsystem",


### PR DESCRIPTION
#### Description

When running our tests, we will now output an `.xml` file with test coverage information. This will later be consumed by a service. I've also removed the Playmode tests for the `playground` project as we have none of those. I'm pretty sure that the existing Playmode tests can be ported to Editmode in the `test-project` too. This should cut down on runtime :) 

#### Tests

Observed artifacts in CI. 

#### Documentation

- [ ] Changelog
