### PR TITLE
Add non-generic overloads to `EntityTemplate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added the ability to select a specific cluster for deployments in the [Deployment Launcher](https://documentation.improbable.io/gdk-for-unity/docs/deployment-launcher). [#1357](https://github.com/spatialos/gdk-for-unity/pull/1357)
     - You can select _either_ a region or a cluster, but not both!
+- Added non-generic overloads for the `EntityTemplate` class which allow you to use `ISpatialComponentSnapshot`s directly. [#1360](https://github.com/spatialos/gdk-for-unity/pull/1360)
 
 ### Changed
 
@@ -16,6 +17,11 @@
 
 - Invalid JSON is now logged if there is an error parsing the codegen output. [#1353](https://github.com/spatialos/gdk-for-unity/pull/1353)
 - The Mobile Launcher will no longer break if Android build support is not installed. [#1354](https://github.com/spatialos/gdk-for-unity/pull/1354)
+- Fixed a bug in the `EntityTemplate` class where calling `AddComponent` with an `EntityAcl.Snapshot` would incorrectly apply its write access [#1360](https://github.com/spatialos/gdk-for-unity/pull/1360)
+
+### Internal
+
+- Produce code coverage reports in tests [#1359](https://github.com/spatialos/gdk-for-unity/pull/1359)
 
 ## `0.3.5` - 2020-04-23
 

--- a/test-project/Assets/EditmodeTests/Utility/EntityTemplateTests.cs
+++ b/test-project/Assets/EditmodeTests/Utility/EntityTemplateTests.cs
@@ -20,10 +20,31 @@ namespace Improbable.Gdk.EditmodeTests.Utility
         }
 
         [Test]
+        public void AddComponent_type_erased_should_throw_if_duplicate_component_is_added()
+        {
+            var template = GetBasicTemplate();
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var component = (ISpatialComponentSnapshot) new Position.Snapshot();
+                template.AddComponent(component, "write-acesss");
+            });
+        }
+
+        [Test]
         public void AddComponent_should_ignore_EntityAcl()
         {
             var template = GetBasicTemplate();
             template.AddComponent(new EntityAcl.Snapshot(), "test");
+
+            Assert.IsFalse(template.HasComponent<EntityAcl.Snapshot>());
+        }
+
+        [Test]
+        public void AddComponent_type_erased_should_ignore_EntityAcl()
+        {
+            var template = GetBasicTemplate();
+            var component = (ISpatialComponentSnapshot) new EntityAcl.Snapshot();
+            template.AddComponent(component, "test");
 
             Assert.IsFalse(template.HasComponent<EntityAcl.Snapshot>());
         }
@@ -45,6 +66,23 @@ namespace Improbable.Gdk.EditmodeTests.Utility
         }
 
         [Test]
+        public void GetComponent_type_erased_should_return_the_component_if_present()
+        {
+            var template = GetBasicTemplate();
+
+            var component = (ISpatialComponentSnapshot) new ExhaustiveSingular.Snapshot
+            {
+                Field2 = 100 // Field to test equality for.
+            };
+
+            template.AddComponent(component);
+            var returned = template.GetComponent(ExhaustiveSingular.ComponentId);
+            Assert.IsNotNull(returned);
+            var exhaustiveSingular = (ExhaustiveSingular.Snapshot) returned;
+            Assert.AreEqual(100, exhaustiveSingular.Field2);
+        }
+
+        [Test]
         public void GetComponent_should_return_null_if_component_not_present()
         {
             var template = GetBasicTemplate();
@@ -53,10 +91,25 @@ namespace Improbable.Gdk.EditmodeTests.Utility
         }
 
         [Test]
+        public void GetComponent_type_erased_should_return_null_if_component_not_present()
+        {
+            var template = GetBasicTemplate();
+            var returned = template.GetComponent(ExhaustiveSingular.ComponentId);
+            Assert.IsNull(returned);
+        }
+
+        [Test]
         public void HasComponent_should_return_false_if_component_not_present()
         {
             var template = GetBasicTemplate();
             Assert.IsFalse(template.HasComponent<ExhaustiveSingular.Snapshot>());
+        }
+
+        [Test]
+        public void HasComponent_type_erased_should_return_false_if_component_not_present()
+        {
+            var template = GetBasicTemplate();
+            Assert.IsFalse(template.HasComponent(ExhaustiveSingular.ComponentId));
         }
 
         [Test]
@@ -75,7 +128,22 @@ namespace Improbable.Gdk.EditmodeTests.Utility
         }
 
         [Test]
-        public void ReplaceComponent_should_replace_the_underlying_component()
+        public void HasComponent_type_erased_should_return_true_if_component_present()
+        {
+            var exhaustiveSingular = new ExhaustiveSingular.Snapshot
+            {
+                Field7 = "",
+                Field3 = new byte[] { }
+            };
+
+            var template = GetBasicTemplate();
+            template.AddComponent(exhaustiveSingular, "write-access");
+
+            Assert.IsTrue(template.HasComponent(ExhaustiveSingular.ComponentId));
+        }
+
+        [Test]
+        public void SetComponent_should_replace_the_underlying_component()
         {
             var originalSnapshot = new ExhaustiveSingular.Snapshot
             {
@@ -98,6 +166,29 @@ namespace Improbable.Gdk.EditmodeTests.Utility
         }
 
         [Test]
+        public void SetComponent_type_erased_should_replace_the_underlying_component()
+        {
+            var originalSnapshot = new ExhaustiveSingular.Snapshot
+            {
+                Field7 = "",
+                Field3 = new byte[] { }
+            };
+
+            var template = GetBasicTemplate();
+            template.AddComponent(originalSnapshot, "");
+
+            var snapshotToReplace = (ISpatialComponentSnapshot) new ExhaustiveSingular.Snapshot
+            {
+                Field2 = 100 // Field to test equality for.
+            };
+
+            template.SetComponent(snapshotToReplace);
+
+            var component = template.GetComponent<ExhaustiveSingular.Snapshot>().Value;
+            Assert.AreEqual(100, component.Field2);
+        }
+
+        [Test]
         public void RemoveComponent_should_remove_component_if_present()
         {
             var exhaustiveSingular = new ExhaustiveSingular.Snapshot
@@ -109,6 +200,22 @@ namespace Improbable.Gdk.EditmodeTests.Utility
             var template = GetBasicTemplate();
             template.AddComponent(exhaustiveSingular, "");
             template.RemoveComponent<ExhaustiveSingular.Snapshot>();
+
+            Assert.IsFalse(template.GetComponent<ExhaustiveSingular.Snapshot>().HasValue);
+        }
+
+        [Test]
+        public void RemoveComponent_type_erased_should_remove_component_if_present()
+        {
+            var exhaustiveSingular = new ExhaustiveSingular.Snapshot
+            {
+                Field7 = "",
+                Field3 = new byte[] { }
+            };
+
+            var template = GetBasicTemplate();
+            template.AddComponent(exhaustiveSingular, "");
+            template.RemoveComponent(ExhaustiveSingular.ComponentId);
 
             Assert.IsFalse(template.GetComponent<ExhaustiveSingular.Snapshot>().HasValue);
         }

--- a/test-project/Assets/EditmodeTests/Utility/EntityTemplateTests.cs
+++ b/test-project/Assets/EditmodeTests/Utility/EntityTemplateTests.cs
@@ -20,31 +20,10 @@ namespace Improbable.Gdk.EditmodeTests.Utility
         }
 
         [Test]
-        public void AddComponent_type_erased_should_throw_if_duplicate_component_is_added()
-        {
-            var template = GetBasicTemplate();
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                var component = (ISpatialComponentSnapshot) new Position.Snapshot();
-                template.AddComponent(component, "write-acesss");
-            });
-        }
-
-        [Test]
         public void AddComponent_should_ignore_EntityAcl()
         {
             var template = GetBasicTemplate();
             template.AddComponent(new EntityAcl.Snapshot(), "test");
-
-            Assert.IsFalse(template.HasComponent<EntityAcl.Snapshot>());
-        }
-
-        [Test]
-        public void AddComponent_type_erased_should_ignore_EntityAcl()
-        {
-            var template = GetBasicTemplate();
-            var component = (ISpatialComponentSnapshot) new EntityAcl.Snapshot();
-            template.AddComponent(component, "test");
 
             Assert.IsFalse(template.HasComponent<EntityAcl.Snapshot>());
         }
@@ -96,6 +75,35 @@ namespace Improbable.Gdk.EditmodeTests.Utility
             var template = GetBasicTemplate();
             var returned = template.GetComponent(ExhaustiveSingular.ComponentId);
             Assert.IsNull(returned);
+        }
+
+        [Test]
+        public void TryGetComponent_should_return_true_if_component_exists()
+        {
+            var template = GetBasicTemplate();
+
+            var component = new Metadata.Snapshot { EntityType = "something" };
+            template.AddComponent(component);
+
+            Assert.IsTrue(template.TryGetComponent<Metadata.Snapshot>(out var metadata));
+            Assert.AreEqual("something", metadata.EntityType);
+
+            Assert.IsTrue(template.TryGetComponent(Metadata.ComponentId, out var boxedMetadata));
+            Assert.IsInstanceOf<Metadata.Snapshot>(boxedMetadata);
+
+            Assert.AreEqual("something", ((Metadata.Snapshot) boxedMetadata).EntityType);
+        }
+
+        [Test]
+        public void TryGetComponent_should_return_false_if_component_doesnt_exist()
+        {
+            var template = GetBasicTemplate();
+
+            Assert.IsFalse(template.TryGetComponent<Metadata.Snapshot>(out var metadata));
+            Assert.IsNull(metadata.EntityType);
+
+            Assert.IsFalse(template.TryGetComponent(Metadata.ComponentId, out var boxedMetadata));
+            Assert.IsNull(boxedMetadata);
         }
 
         [Test]

--- a/workers/unity/Packages/io.improbable.gdk.core/Utility/EntityTemplate.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Utility/EntityTemplate.cs
@@ -121,7 +121,7 @@ namespace Improbable.Gdk.Core
                 component = (TSnapshot) boxedComponent;
                 return true;
             }
-            
+
             component = default;
             return false;
         }

--- a/workers/unity/Packages/io.improbable.gdk.core/Utility/EntityTemplate.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Utility/EntityTemplate.cs
@@ -29,43 +29,6 @@ namespace Improbable.Gdk.Core
         }
 
         /// <summary>
-        ///     Adds a SpatialOS component to the EntityTemplate.
-        /// </summary>
-        /// <param name="snapshot">The component snapshot to add.</param>
-        /// <typeparam name="TSnapshot">The type of the component snapshot.</typeparam>
-        /// <exception cref="InvalidOperationException">
-        ///     Thrown if the EntityTemplate already contains a component snapshot of type <see cref="TSnapshot" />.
-        /// </exception>
-        /// <remarks>
-        ///     EntityACL is handled automatically by the EntityTemplate, so a EntityACL snapshot will be ignored.
-        /// </remarks>
-        public void AddComponent<TSnapshot>(TSnapshot snapshot)
-            where TSnapshot : struct, ISpatialComponentSnapshot
-        {
-            AddComponent((ISpatialComponentSnapshot) snapshot);
-        }
-
-        /// <summary>
-        ///     Adds a SpatialOS component to the EntityTemplate with write permissions specified.
-        /// </summary>
-        /// <param name="snapshot">The component snapshot to add.</param>
-        /// <param name="writeAccess">
-        ///     The worker attribute that should be granted write access over the <see cref="TSnapshot" /> component.
-        /// </param>
-        /// <typeparam name="TSnapshot">The type of the component snapshot.</typeparam>
-        /// <exception cref="InvalidOperationException">
-        ///     Thrown if the EntityTemplate already contains a component snapshot of type <see cref="TSnapshot" />.
-        /// </exception>
-        /// <remarks>
-        ///     EntityACL is handled automatically by the EntityTemplate, so a EntityACL snapshot will be ignored.
-        /// </remarks>
-        public void AddComponent<TSnapshot>(TSnapshot snapshot, string writeAccess)
-            where TSnapshot : struct, ISpatialComponentSnapshot
-        {
-            AddComponent((ISpatialComponentSnapshot) snapshot, writeAccess);
-        }
-
-        /// <summary>
         ///     Adds a SpatialOS component to the Entity Template.
         /// </summary>
         /// <param name="snapshot">The component snapshot to add.</param>
@@ -142,6 +105,40 @@ namespace Improbable.Gdk.Core
             return snapshot;
         }
 
+        /// <summary>Gets the component of the associated type.</summary>
+        /// <param name="component">
+        ///     When this method returns, contains the component, if the component is found; otherwise, the default value <see cref="TSnapshot"/>. This parameter is passed uninitialized.
+        /// </param>
+        /// <typeparam name="TSnapshot">The type of the component snapshot.</typeparam>
+        /// <returns>
+        ///     True if this contains a component of type <see cref="TSnapshot"/>; otherwise, false.
+        /// </returns>
+        public bool TryGetComponent<TSnapshot>(out TSnapshot component)
+            where TSnapshot : struct, ISpatialComponentSnapshot
+        {
+            if (entityData.TryGetValue(ComponentDatabase.GetSnapshotComponentId<TSnapshot>(), out var boxedComponent))
+            {
+                component = (TSnapshot) boxedComponent;
+                return true;
+            }
+            
+            component = default;
+            return false;
+        }
+
+        /// <summary>Gets the component with the associated component ID.</summary>
+        /// <param name="componentId">The ID of the component to get.</param>
+        /// <param name="component">
+        ///     When this method returns, contains the component, if the component is found; otherwise null. This parameter is passed uninitialized.
+        /// </param>
+        /// <returns>
+        ///     True if this contains a component with the associated component ID; otherwise, false.
+        /// </returns>
+        public bool TryGetComponent(uint componentId, out ISpatialComponentSnapshot component)
+        {
+            return entityData.TryGetValue(componentId, out component);
+        }
+
         /// <summary>
         ///     Checks if a component snapshot is stored in the EntityTemplate.
         /// </summary>
@@ -162,18 +159,6 @@ namespace Improbable.Gdk.Core
             return HasComponent(ComponentDatabase.GetSnapshotComponentId<TSnapshot>());
         }
 
-        /// <summary>
-        ///     Sets a component snapshot in the EntityTemplate.
-        /// </summary>
-        /// <param name="snapshot">The component snapshot that will be inserted into the EntityTemplate.</param>
-        /// <typeparam name="TSnapshot">The type of the component snapshot.</typeparam>
-        /// <remarks>
-        ///     This will override a snapshot of type <see cref="TSnapshot" /> in the EntityTemplate if one already exists.
-        /// </remarks>
-        public void SetComponent<TSnapshot>(TSnapshot snapshot) where TSnapshot : struct, ISpatialComponentSnapshot
-        {
-            entityData[snapshot.ComponentId] = snapshot;
-        }
 
         /// <summary>
         ///     Sets a component snapshot in the EntityTemplate.


### PR DESCRIPTION
#### Description

If you had an `ISpatialComponentSnapshot`, you couldn't interact with the `EntityTemplate` object w/o reflection or using the Dynamic API. This PR completes the set of APIs for type-erased usage of the `EntityTemplate` class.

Also driveby fixed a bug where if you added `EntityAcl.Snapshot` with write access, the snapshot wouldn't be added, but the write access would!

#### Tests

Yes there are tests.

#### Documentation

- [x] Class level docs
- [x] Changelog
 
