### PR TITLE
Change up worker connector semantics slightly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 - `WorkerConnector.HandleWorkerConnectionFailure` has been removed and `WorkerConnector.Connect` now throws exceptions for connection errors instead. [#1365](https://github.com/spatialos/gdk-for-unity/pull/1365)
+- `WorkerConnector` no longer destroys itself in `Dispose`. [#1365](https://github.com/spatialos/gdk-for-unity/pull/1365)
 
 ### Added
 
@@ -15,7 +16,6 @@
 ### Changed
 
 - GDK Tools Configuration window now autosaves. [#1356](https://github.com/spatialos/gdk-for-unity/pull/1356)
-- `WorkerConnector` no longer destroys itself in `Dispose`. [#1365](https://github.com/spatialos/gdk-for-unity/pull/1365)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- `WorkerConnector.HandleWorkerConnectionFailure` has been removed and `WorkerConnector.Connect` now throws exceptions for connection errors instead. [#1365](https://github.com/spatialos/gdk-for-unity/pull/1365)
+
 ### Added
 
 - Added the ability to select a specific cluster for deployments in the [Deployment Launcher](https://documentation.improbable.io/gdk-for-unity/docs/deployment-launcher). [#1357](https://github.com/spatialos/gdk-for-unity/pull/1357)
@@ -11,6 +15,7 @@
 ### Changed
 
 - GDK Tools Configuration window now autosaves. [#1356](https://github.com/spatialos/gdk-for-unity/pull/1356)
+- `WorkerConnector` no longer destroys itself in `Dispose`. [#1365](https://github.com/spatialos/gdk-for-unity/pull/1365)
 
 ### Fixed
 

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -1,5 +1,53 @@
 # Upgrade Guide
 
+## From `0.3.5` to `0.3.6`
+
+### WorkerConnector changes
+
+There are two related changes that you will need to adjust for. Previously, the `WorkerConnector.Connect` class would trigger the `HandleWorkerConnectionFailure` callback if the connection failed. 
+
+We've removed this callback, and `WorkerConnector.Connect` will now throw an exception for a failed connection. For example:
+
+```csharp
+public class MyWorkerConnector : WorkerConnector
+{
+    public async void Start()
+    {
+        // Setup connection flow.
+        var builder = ...;
+
+        await Connect(builder, new ForwardingDispatcher());
+    }
+
+    protected override void HandleWorkerConnectionFailure(string errorMessage)
+    {
+        Debug.LogError(errorMessage);
+    }
+}
+```
+
+Would change to:
+
+```csharp
+public class MyWorkerConnector : WorkerConnector
+{
+    public async void Start()
+    {
+        // Setup connection flow.
+        var builder = ...;
+
+        try
+        {
+            await Connect(builder, new ForwardingDispatcher());
+        }
+        catch (Exception e)
+        {
+            Debug.LogException(e);
+        }
+    }
+}
+```
+
 ## From `0.3.4` to `0.3.5`
 
 ### Unity 2019.3 upgrade

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -4,9 +4,11 @@
 
 ### WorkerConnector changes
 
-There are two related changes that you will need to adjust for. Previously, the `WorkerConnector.Connect` class would trigger the `HandleWorkerConnectionFailure` callback if the connection failed. 
+There are two related changes that you will need to adjust for.
 
-We've removed this callback, and `WorkerConnector.Connect` will now throw an exception for a failed connection. For example:
+The `WorkerConnector.Connect` class would previously trigger the `HandleWorkerConnectionFailure` callback if the connection failed. We've now removed this callback, and `WorkerConnector.Connect` will now throw an exception for a failed connection.
+
+For example:
 
 ```csharp
 public class MyWorkerConnector : WorkerConnector

--- a/workers/unity/Assets/Playground/Scripts/Worker/ClientWorkerConnector.cs
+++ b/workers/unity/Assets/Playground/Scripts/Worker/ClientWorkerConnector.cs
@@ -43,18 +43,19 @@ namespace Playground
                 builder.SetConnectionFlow(new ReceptionistFlow(CreateNewWorkerId(WorkerUtils.UnityClient)));
             }
 
-            await Connect(builder, new ForwardingDispatcher()).ConfigureAwait(false);
-        }
+            await Connect(builder, new ForwardingDispatcher());
 
-        protected override void HandleWorkerConnectionEstablished()
-        {
-            WorkerUtils.AddClientSystems(Worker.World);
             if (level == null)
             {
                 return;
             }
 
             levelInstance = Instantiate(level, transform.position, transform.rotation);
+        }
+
+        protected override void HandleWorkerConnectionEstablished()
+        {
+            WorkerUtils.AddClientSystems(Worker.World);
         }
 
         public override void Dispose()

--- a/workers/unity/Assets/Playground/Scripts/Worker/GameLogicWorkerConnector.cs
+++ b/workers/unity/Assets/Playground/Scripts/Worker/GameLogicWorkerConnector.cs
@@ -37,12 +37,7 @@ namespace Playground
                 .SetConnectionFlow(flow)
                 .SetConnectionParameters(connectionParameters);
 
-            await Connect(builder, new ForwardingDispatcher()).ConfigureAwait(false);
-        }
-
-        protected override void HandleWorkerConnectionEstablished()
-        {
-            WorkerUtils.AddGameLogicSystems(Worker.World);
+            await Connect(builder, new ForwardingDispatcher());
 
             if (level == null)
             {
@@ -50,6 +45,11 @@ namespace Playground
             }
 
             levelInstance = Instantiate(level, transform.position, transform.rotation);
+        }
+
+        protected override void HandleWorkerConnectionEstablished()
+        {
+            WorkerUtils.AddGameLogicSystems(Worker.World);
         }
 
         public override void Dispose()

--- a/workers/unity/Assets/Playground/Scripts/Worker/MobileClientWorkerConnector.cs
+++ b/workers/unity/Assets/Playground/Scripts/Worker/MobileClientWorkerConnector.cs
@@ -39,12 +39,7 @@ namespace Playground
                     throw new ArgumentException("Received unsupported connection service.");
             }
 
-            await Connect(builder, new ForwardingDispatcher()).ConfigureAwait(false);
-        }
-
-        protected override void HandleWorkerConnectionEstablished()
-        {
-            WorkerUtils.AddClientSystems(Worker.World);
+            await Connect(builder, new ForwardingDispatcher());
 
             if (level == null)
             {
@@ -52,6 +47,11 @@ namespace Playground
             }
 
             levelInstance = Instantiate(level, transform.position, transform.rotation);
+        }
+
+        protected override void HandleWorkerConnectionEstablished()
+        {
+            WorkerUtils.AddClientSystems(Worker.World);
         }
 
         public override void Dispose()

--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/WorkerConnector.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/WorkerConnector.cs
@@ -107,13 +107,8 @@ namespace Improbable.Gdk.Core
                 PlayerLoopUtils.ResolveSystemGroups(Worker.World);
                 ScriptBehaviourUpdateOrder.UpdatePlayerLoop(Worker.World, PlayerLoop.GetCurrentPlayerLoop());
             }
-            catch (Exception e)
+            catch (Exception)
             {
-                logger.HandleLog(LogType.Error, new LogEvent("Failed to create worker")
-                    .WithException(e)
-                    .WithField("WorkerType", builder.WorkerType)
-                    .WithField("Message", e.Message)
-                    .WithField("Stacktrace", e.StackTrace));
 #if UNITY_EDITOR
                 // Temporary warning to be replaced when we can reliably detect if a local runtime is running, or not.
                 logger.HandleLog(LogType.Warning,
@@ -124,9 +119,10 @@ namespace Improbable.Gdk.Core
                 // A check is needed for the case that play mode is exited before the connection can complete.
                 if (Application.isPlaying)
                 {
-                    HandleWorkerConnectionFailure(e.Message);
                     Dispose();
                 }
+
+                throw;
             }
             finally
             {
@@ -152,10 +148,6 @@ namespace Improbable.Gdk.Core
         }
 
         protected virtual void HandleWorkerConnectionEstablished()
-        {
-        }
-
-        protected virtual void HandleWorkerConnectionFailure(string errorMessage)
         {
         }
 
@@ -251,7 +243,6 @@ namespace Improbable.Gdk.Core
             RemoveFromPlayerLoop();
             Worker?.Dispose();
             Worker = null;
-            UnityObjectDestroyer.Destroy(this);
         }
 
         private void RemoveFromPlayerLoop()


### PR DESCRIPTION
#### Description

`WorkerConnecter.Connect` now throws when it fails to connect. This makes the `HandleWorkerConnectionFailed` redundant and has been removed. I've also made a couple of behavioural tweaks:

- The `WorkerConnector` no longer destroys itself when it fails to connect. Only concern I have here is embedded in the WorkerConnector is this odd disposable MonoBehaviour, I _think_ the reason it destroyed itself was that it was considered "consumed" after a disconnect, but there's no reason why you can't use the same object to connect again! This feels like its tied up in a confused abstraction (where the `WorkerConnector` is both a way to connect a worker and something to represent the worker after connection).
- The WorkerConnector won't log the failure (since an unhandled exception would log, and a handled exception.. is well.. handled).

I expect we will want further work to refine this abstraction (probably related to some of the thoughts that @zeroZshadow had). 

#### Tests

Tested successful & failed worker connections to observe the behaviour.

#### Documentation

- [x] Changelog
- [x] Upgrade guide
- [x] Public docs changes (https://documentation.improbable.io/gdk-for-unity/docs/worker-connectors & https://documentation.improbable.io/gdk-for-unity/docs/blank-project-tutorial-3a-instantiate-a-level) 
