### PR TITLE
Remove `soft_fail` from sonarscanner

### DIFF
--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -81,7 +81,6 @@ steps:
     depends_on:
       - step: "test-windows"
     command: bash -c ci/sonar-scanner.sh
-    soft_fail: true # TODO: Remove once we've ran with this a bit more.
     <<: *windows
 
   - label: ":darwin: ~ test"


### PR DESCRIPTION
We've had this for a week with no problems, lets take the training wheels off 