### PR TITLE
Add worker sdk override env variables

### DIFF
--- a/init.ps1
+++ b/init.ps1
@@ -15,7 +15,12 @@ $SdkPath = $PkgRoot + "/io.improbable.worker.sdk"
 $SdkMobilePath = $PkgRoot + "/io.improbable.worker.sdk.mobile"
 $TestSdkPath="test-project/Packages/io.improbable.worker.sdk.testschema"
 
-$SdkVersion = Get-Content ($SdkPath + "/.sdk.version")
+if (Test-Path env:WORKER_SDK_OVERRIDE) {
+    $SdkVersion = $env:WORKER_SDK_OVERRIDE;
+} else {
+    $SdkVersion = Get-Content ($SdkPath + "/.sdk.version")
+}
+
 $SpotVersion = Get-Content ($SdkPath + "/.spot.version")
 
 function UpdatePackage($type, $identifier, $path, $removes)

--- a/init.sh
+++ b/init.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -e -u -o pipefail
 
+if [[ -n "${DEBUG-}" ]]; then
+  set -x
+fi
+
 cd "$(dirname "$0")"
 
 if [[ -n "${1:-}" ]]; then
@@ -21,7 +25,12 @@ SDK_PATH="${PKG_ROOT}/io.improbable.worker.sdk"
 SDK_MOBILE_PATH="${PKG_ROOT}/io.improbable.worker.sdk.mobile"
 TEST_SDK_PATH="test-project/Packages/io.improbable.worker.sdk.testschema"
 
-SDK_VERSION="$(cat "${SDK_PATH}"/.sdk.version)"
+if [[ -n "${WORKER_SDK_OVERRIDE:-}" ]]; then
+    SDK_VERSION="${WORKER_SDK_OVERRIDE}"
+else 
+    SDK_VERSION="$(cat "${SDK_PATH}"/.sdk.version)"
+fi
+
 SPOT_VERSION="$(cat "${SDK_PATH}"/.spot.version)"
 
 update_package() {


### PR DESCRIPTION
#### Description

Added an override for the Worker SDK version in the `init.sh` and `init.ps1`. This allows for someone to run a Buildkite build against the GDK with a given Worker SDK version by setting the `WORKER_SDK_OVERRIDE` environment variable in the build options.

#### Tests

- Checked the value of `SDK_VERSION`/`$SdkVersion` with and without the environment variable set.

#### Documentation

Not sure where to put this info... wiki maybe? 
