### PR TITLE
Enable Accelerator

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -4,4 +4,12 @@ set -euo pipefail
 
 if [[ "${BUILDKITE_AGENT_META_DATA_CAPABLE_OF_BUILDING}" == "gdk-for-unity" ]] && [[ "${BUILDKITE_AGENT_META_DATA_OS}" != "linux" ]]; then
   spatial auth login --log_level debug
+
+  if [[ "${BUILDKITE_AGENT_META_DATA_OS}" == "macos" ]]; then
+    export ACCELERATOR_ENDPOINT="172.16.100.150"
+  fi
+
+  if [[ "${BUILDKITE_AGENT_META_DATA_OS}" == "windows" ]]; then
+    export ACCELERATOR_ENDPOINT="unity-accelerator.production-intinf-eu1.i8e.io"
+  fi
 fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -4,12 +4,4 @@ set -euo pipefail
 
 if [[ "${BUILDKITE_AGENT_META_DATA_CAPABLE_OF_BUILDING}" == "gdk-for-unity" ]] && [[ "${BUILDKITE_AGENT_META_DATA_OS}" != "linux" ]]; then
   spatial auth login --log_level debug
-
-  if [[ "${BUILDKITE_AGENT_META_DATA_OS}" == "macos" ]]; then
-    export ACCELERATOR_ENDPOINT="172.16.100.150"
-  fi
-
-  if [[ "${BUILDKITE_AGENT_META_DATA_OS}" == "windows" ]]; then
-    export ACCELERATOR_ENDPOINT="unity-accelerator.production-intinf-eu1.i8e.io"
-  fi
 fi

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -30,7 +30,7 @@ windows: &windows
         # Workaround for flaky Git clones, likely due to - https://github.com/PowerShell/Win32-OpenSSH/issues/1322
       - exit_status: 128
         limit: 3
-  env: *windows-env
+  env: &windows-env
     ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
 linux: &linux
@@ -61,7 +61,7 @@ macos: &macos
         # This is designed to trap and retry failures because agent lost connection. Agent exits with -1 in this case.
       - exit_status: -1
         limit: 3
-  env: *mac-env
+  env: &mac-env
     ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -76,12 +76,16 @@ steps:
     <<: *windows
     artifact_paths:
       - logs/**/*
+    env:
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":windows: ~ sonar scanner :sonarqube:"
     depends_on:
       - step: "test-windows"
     command: bash -c ci/sonar-scanner.sh
     <<: *windows
+    env:
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":darwin: ~ test"
     id: "test-darwin"
@@ -89,6 +93,8 @@ steps:
     <<: *macos
     artifact_paths:
       - logs/**/*
+    env:
+      ACCELERATOR_ENDPOINT: "172.16.100.150"
 
   - label: ":debian: ~ annotate :windows: test results :pencil2:"
     depends_on:
@@ -137,6 +143,7 @@ steps:
       BUILD_ENVIRONMENT: "local"
       BUILD_TARGET_FILTER: "android"
       SCRIPTING_BACKEND: "mono"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":windows: ~ build UnityClient mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -147,6 +154,7 @@ steps:
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":windows: ~ build UnityClient il2cpp"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -157,6 +165,7 @@ steps:
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "local"
       SCRIPTING_BACKEND: "il2cpp"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":windows: ~ build UnityGameLogic mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -167,6 +176,7 @@ steps:
       WORKER_TYPE: "UnityGameLogic"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":darwin: ~ build :ios:"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -179,3 +189,4 @@ steps:
       BUILD_TARGET_FILTER: "ios"
       SCRIPTING_BACKEND: "il2cpp"
       TARGET_IOS_SDK: "simulator"
+      ACCELERATOR_ENDPOINT: "172.16.100.150"

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -30,6 +30,8 @@ windows: &windows
         # Workaround for flaky Git clones, likely due to - https://github.com/PowerShell/Win32-OpenSSH/issues/1322
       - exit_status: 128
         limit: 3
+  env:
+    ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
 linux: &linux
   agents:
@@ -59,6 +61,8 @@ macos: &macos
         # This is designed to trap and retry failures because agent lost connection. Agent exits with -1 in this case.
       - exit_status: -1
         limit: 3
+  env:
+    ACCELERATOR_ENDPOINT: "172.16.100.150"
 
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.
 # These are then relied on to have stable names by other things, so once named, please beware renaming has consequences.
@@ -76,16 +80,12 @@ steps:
     <<: *windows
     artifact_paths:
       - logs/**/*
-    env:
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":windows: ~ sonar scanner :sonarqube:"
     depends_on:
       - step: "test-windows"
     command: bash -c ci/sonar-scanner.sh
     <<: *windows
-    env:
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":darwin: ~ test"
     id: "test-darwin"
@@ -93,8 +93,6 @@ steps:
     <<: *macos
     artifact_paths:
       - logs/**/*
-    env:
-      ACCELERATOR_ENDPOINT: "172.16.100.150"
 
   - label: ":debian: ~ annotate :windows: test results :pencil2:"
     depends_on:
@@ -143,7 +141,6 @@ steps:
       BUILD_ENVIRONMENT: "local"
       BUILD_TARGET_FILTER: "android"
       SCRIPTING_BACKEND: "mono"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":windows: ~ build UnityClient mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -154,7 +151,6 @@ steps:
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":windows: ~ build UnityClient il2cpp"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -165,7 +161,6 @@ steps:
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "local"
       SCRIPTING_BACKEND: "il2cpp"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":windows: ~ build UnityGameLogic mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -176,7 +171,6 @@ steps:
       WORKER_TYPE: "UnityGameLogic"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: ":darwin: ~ build :ios:"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -189,4 +183,3 @@ steps:
       BUILD_TARGET_FILTER: "ios"
       SCRIPTING_BACKEND: "il2cpp"
       TARGET_IOS_SDK: "simulator"
-      ACCELERATOR_ENDPOINT: "172.16.100.150"

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -30,6 +30,8 @@ windows: &windows
         # Workaround for flaky Git clones, likely due to - https://github.com/PowerShell/Win32-OpenSSH/issues/1322
       - exit_status: 128
         limit: 3
+  env: *windows-env
+    ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
 linux: &linux
   agents:
@@ -59,6 +61,8 @@ macos: &macos
         # This is designed to trap and retry failures because agent lost connection. Agent exits with -1 in this case.
       - exit_status: -1
         limit: 3
+  env: *mac-env
+    ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.
 # These are then relied on to have stable names by other things, so once named, please beware renaming has consequences.
@@ -133,6 +137,7 @@ steps:
       - logs/**/*
       - workers/unity/build/worker/**/*
     env:
+      <<: *windows-env
       WORKER_TYPE: "MobileClient"
       BUILD_ENVIRONMENT: "local"
       BUILD_TARGET_FILTER: "android"
@@ -144,6 +149,7 @@ steps:
     artifact_paths:
       - logs/**/*
     env:
+      <<: *windows-env
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
@@ -154,6 +160,7 @@ steps:
     artifact_paths:
       - logs/**/*
     env:
+      <<: *windows-env
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "local"
       SCRIPTING_BACKEND: "il2cpp"
@@ -164,6 +171,7 @@ steps:
     artifact_paths:
       - logs/**/*
     env:
+      <<: *windows-env
       WORKER_TYPE: "UnityGameLogic"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
@@ -174,6 +182,7 @@ steps:
     artifact_paths:
       - logs/**/*
     env:
+      <<: *mac-env
       WORKER_TYPE: "MobileClient"
       BUILD_ENVIRONMENT: "local"
       BUILD_TARGET_FILTER: "ios"

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -30,8 +30,6 @@ windows: &windows
         # Workaround for flaky Git clones, likely due to - https://github.com/PowerShell/Win32-OpenSSH/issues/1322
       - exit_status: 128
         limit: 3
-  env:
-    ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
 linux: &linux
   agents:
@@ -61,8 +59,6 @@ macos: &macos
         # This is designed to trap and retry failures because agent lost connection. Agent exits with -1 in this case.
       - exit_status: -1
         limit: 3
-  env:
-    ACCELERATOR_ENDPOINT: "172.16.100.150"
 
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.
 # These are then relied on to have stable names by other things, so once named, please beware renaming has consequences.

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -61,7 +61,7 @@ macos: &macos
         # This is designed to trap and retry failures because agent lost connection. Agent exits with -1 in this case.
       - exit_status: -1
         limit: 3
-  env: &mac-env
+  env: &macos-env
     ACCELERATOR_ENDPOINT: "172.16.100.150"
 
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.
@@ -182,7 +182,7 @@ steps:
     artifact_paths:
       - logs/**/*
     env:
-      <<: *mac-env
+      <<: *macos-env
       WORKER_TYPE: "MobileClient"
       BUILD_ENVIRONMENT: "local"
       BUILD_TARGET_FILTER: "ios"

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -62,7 +62,7 @@ macos: &macos
       - exit_status: -1
         limit: 3
   env: &mac-env
-    ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
+    ACCELERATOR_ENDPOINT: "172.16.100.150"
 
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.
 # These are then relied on to have stable names by other things, so once named, please beware renaming has consequences.

--- a/.buildkite/release-qa.steps.yaml
+++ b/.buildkite/release-qa.steps.yaml
@@ -30,8 +30,6 @@ common: &common
         # Workaround for flaky Git clones, likely due to - https://github.com/PowerShell/Win32-OpenSSH/issues/1322
       - exit_status: 128
         limit: 3
-  env:
-    ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.
 # These are then relied on to have stable names by other things, so once named, please beware renaming has consequences.

--- a/.buildkite/release-qa.steps.yaml
+++ b/.buildkite/release-qa.steps.yaml
@@ -46,6 +46,7 @@ steps:
       BUILD_ENVIRONMENT: "cloud"
       BUILD_TARGET_FILTER: "android"
       SCRIPTING_BACKEND: "mono"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: "build :ios:"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -58,6 +59,7 @@ steps:
       BUILD_ENVIRONMENT: "cloud"
       BUILD_TARGET_FILTER: "ios"
       SCRIPTING_BACKEND: "il2cpp"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: "build UnityClient mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -69,6 +71,7 @@ steps:
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: "build UnityGameLogic mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -80,6 +83,7 @@ steps:
       WORKER_TYPE: "UnityGameLogic"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
+      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
   - wait
   - label: Launch deployments
     command: bash -c ci/launch.sh

--- a/.buildkite/release-qa.steps.yaml
+++ b/.buildkite/release-qa.steps.yaml
@@ -30,6 +30,8 @@ common: &common
         # Workaround for flaky Git clones, likely due to - https://github.com/PowerShell/Win32-OpenSSH/issues/1322
       - exit_status: 128
         limit: 3
+  env: *base-env
+    ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.
 # These are then relied on to have stable names by other things, so once named, please beware renaming has consequences.
@@ -42,6 +44,7 @@ steps:
       - logs/**/*
       - build/assembly/**/*
     env:
+      <<: *base-env
       WORKER_TYPE: "MobileClient"
       BUILD_ENVIRONMENT: "cloud"
       BUILD_TARGET_FILTER: "android"
@@ -54,6 +57,7 @@ steps:
       - logs/**/*
       - build/assembly/**/*
     env:
+      <<: *base-env
       WORKER_TYPE: "MobileClient"
       BUILD_ENVIRONMENT: "cloud"
       BUILD_TARGET_FILTER: "ios"
@@ -66,6 +70,7 @@ steps:
       - logs/**/*
       - build/assembly/**/*
     env:
+      <<: *base-env
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
@@ -77,6 +82,7 @@ steps:
       - logs/**/*
       - build/assembly/**/*
     env:
+      <<: *base-env
       WORKER_TYPE: "UnityGameLogic"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"

--- a/.buildkite/release-qa.steps.yaml
+++ b/.buildkite/release-qa.steps.yaml
@@ -30,6 +30,8 @@ common: &common
         # Workaround for flaky Git clones, likely due to - https://github.com/PowerShell/Win32-OpenSSH/issues/1322
       - exit_status: 128
         limit: 3
+  env:
+    ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.
 # These are then relied on to have stable names by other things, so once named, please beware renaming has consequences.
@@ -46,7 +48,6 @@ steps:
       BUILD_ENVIRONMENT: "cloud"
       BUILD_TARGET_FILTER: "android"
       SCRIPTING_BACKEND: "mono"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: "build :ios:"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -59,7 +60,6 @@ steps:
       BUILD_ENVIRONMENT: "cloud"
       BUILD_TARGET_FILTER: "ios"
       SCRIPTING_BACKEND: "il2cpp"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: "build UnityClient mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -71,7 +71,6 @@ steps:
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
   - label: "build UnityGameLogic mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
@@ -83,7 +82,6 @@ steps:
       WORKER_TYPE: "UnityGameLogic"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
-      ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
   - wait
   - label: Launch deployments
     command: bash -c ci/launch.sh

--- a/.buildkite/release-qa.steps.yaml
+++ b/.buildkite/release-qa.steps.yaml
@@ -7,7 +7,7 @@
 # You may find the example pipeline steps listed here helpful: https://buildkite.com/docs/pipelines/defining-steps#example-pipeline but please
 #  note that the setup is already done, so you should not manually adjust anything through the BuildKite interface.
 #
-common: &common
+windows: &windows
   agents:
     - "capable_of_building=gdk-for-unity"
     - "environment=production"
@@ -30,7 +30,7 @@ common: &common
         # Workaround for flaky Git clones, likely due to - https://github.com/PowerShell/Win32-OpenSSH/issues/1322
       - exit_status: 128
         limit: 3
-  env: &base-env
+  env: &windows-env
     ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.
@@ -39,12 +39,12 @@ common: &common
 steps:
   - label: "build :android:"
     command: bash -c .shared-ci/scripts/build-worker.sh
-    <<: *common
+    <<: *windows
     artifact_paths:
       - logs/**/*
       - build/assembly/**/*
     env:
-      <<: *base-env
+      <<: *windows-env
       WORKER_TYPE: "MobileClient"
       BUILD_ENVIRONMENT: "cloud"
       BUILD_TARGET_FILTER: "android"
@@ -52,12 +52,12 @@ steps:
 
   - label: "build :ios:"
     command: bash -c .shared-ci/scripts/build-worker.sh
-    <<: *common
+    <<: *windows
     artifact_paths:
       - logs/**/*
       - build/assembly/**/*
     env:
-      <<: *base-env
+      <<: *windows-env
       WORKER_TYPE: "MobileClient"
       BUILD_ENVIRONMENT: "cloud"
       BUILD_TARGET_FILTER: "ios"
@@ -65,31 +65,31 @@ steps:
 
   - label: "build UnityClient mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
-    <<: *common
+    <<: *windows
     artifact_paths:
       - logs/**/*
       - build/assembly/**/*
     env:
-      <<: *base-env
+      <<: *windows-env
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
 
   - label: "build UnityGameLogic mono"
     command: bash -c .shared-ci/scripts/build-worker.sh
-    <<: *common
+    <<: *windows
     artifact_paths:
       - logs/**/*
       - build/assembly/**/*
     env:
-      <<: *base-env
+      <<: *windows-env
       WORKER_TYPE: "UnityGameLogic"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
   - wait
   - label: Launch deployments
     command: bash -c ci/launch.sh
-    <<: *common
+    <<: *windows
     env:
       ASSEMBLY_PREFIX: "playground"
       PROJECT_NAME: "unity_gdk"

--- a/.buildkite/release-qa.steps.yaml
+++ b/.buildkite/release-qa.steps.yaml
@@ -30,7 +30,7 @@ common: &common
         # Workaround for flaky Git clones, likely due to - https://github.com/PowerShell/Win32-OpenSSH/issues/1322
       - exit_status: 128
         limit: 3
-  env: *base-env
+  env: &base-env
     ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.

--- a/ci/shared-ci.pinned
+++ b/ci/shared-ci.pinned
@@ -1,1 +1,1 @@
-accelerator 8ca3c40
+master f802ed7

--- a/ci/shared-ci.pinned
+++ b/ci/shared-ci.pinned
@@ -1,1 +1,1 @@
-master 7980ef5db74d8db47c0f683378a38d64accd2c0a
+accelerator 8ca3c40

--- a/ci/sonar-scanner.sh
+++ b/ci/sonar-scanner.sh
@@ -12,6 +12,8 @@ PROJECT_DIR="$(pwd)"
 
 source .shared-ci/scripts/pinned-tools.sh
 
+ACCELERATOR_ARGS=$(getAcceleratorArgs)
+
 # TODO: Add a more specific secret-type to vault and swap these around
 TOKEN=$(imp-ci secrets read --environment="production" --buildkite-org="improbable" --secret-type="generic-token" --secret-name="gdk-for-unity-bot-sonarcloud-token" --field="token")
 
@@ -59,7 +61,7 @@ fi
 #   3. Run `dotnet-sonarscanner end` which runs post-processing. (This looks like it runs an embedded version of the generic sonar-scanner CLI which requires the JRE).
 #
 # To enable this to work with Unity, we first need to generate the `.sln` and `.csproj` files in order to build them with `msbuild`
-# For ease of use, we execute msbuild through `dotnet`! 
+# For ease of use, we execute msbuild through `dotnet`!
 pushd "workers/unity"
 
   echo "--- Downloading Buildkite artifacts :buildkite:"
@@ -80,8 +82,9 @@ pushd "workers/unity"
       -batchmode \
       -projectPath "${PROJECT_DIR}/workers/unity" \
       -quit \
-      -executeMethod UnityEditor.SyncVS.SyncSolution
-  
+      -executeMethod UnityEditor.SyncVS.SyncSolution \
+      "${ACCELERATOR_ARGS}"
+
   echo "--- Execute sonar-scanner :sonarqube:"
   dotnet-sonarscanner begin "${args[@]}"
   dotnet msbuild ./unity.sln -t:Rebuild -nr:false

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -10,6 +10,8 @@ cd "$(dirname "$0")/../"
 
 source .shared-ci/scripts/pinned-tools.sh
 
+ACCELERATOR_ARGS=$(getAcceleratorArgs)
+
 PROJECT_DIR="$(pwd)"
 TEST_RESULTS_DIR="${PROJECT_DIR}/logs/nunit"
 mkdir -p "${TEST_RESULTS_DIR}"
@@ -36,7 +38,8 @@ pushd "workers/unity"
         -projectPath "${PROJECT_DIR}/workers/unity" \
         -runEditorTests \
         -logfile "${PROJECT_DIR}/logs/unity-editmode-test-run.log" \
-        -editorTestsResultFile "${TEST_RESULTS_DIR}/editmode-test-results.xml"
+        -editorTestsResultFile "${TEST_RESULTS_DIR}/editmode-test-results.xml" \
+        "${ACCELERATOR_ARGS}"
 popd
 
 cleanUnity "$(pwd)/workers/unity"
@@ -52,7 +55,8 @@ pushd "test-project"
         -projectPath "${PROJECT_DIR}/test-project" \
         -runEditorTests \
         -logfile "${PROJECT_DIR}/logs/test-project-editmode-test-run.log" \
-        -editorTestsResultFile "${TEST_RESULTS_DIR}/test-project-editmode-test-results.xml"
+        -editorTestsResultFile "${TEST_RESULTS_DIR}/test-project-editmode-test-results.xml" \
+        "${ACCELERATOR_ARGS}"
 popd
 
 echo "--- Testing Unity: Test Project Playmode :joystick:"
@@ -67,5 +71,6 @@ pushd "test-project"
         -runTests \
         -testPlatform playmode \
         -logfile "${PROJECT_DIR}/logs/test-project-playmode-test-run.log" \
-        -testResults "${TEST_RESULTS_DIR}/test-project-playmode-test-results.xml"
+        -testResults "${TEST_RESULTS_DIR}/test-project-playmode-test-results.xml" \
+        "${ACCELERATOR_ARGS}"
 popd


### PR DESCRIPTION
#### Description

Provides `ACCELERATOR_ENDPOINT` argument to agents and provides the relevant arguments to use either the local/cloud Accelerators for mac/windows agents.

Depends on https://github.com/spatialos/gdk-for-unity-shared-ci/pull/72

#### Tests

Ran the pipeline. Multiple times.

#### Documentation

n/a
