### PR TITLE
Render primitive schema data & enums in the worker inspector

### DIFF
--- a/workers/unity/Packages/io.improbable.gdk.debug/.codegen/Source/Generators/DebugExtensions/ComponentVisualElementGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/.codegen/Source/Generators/DebugExtensions/ComponentVisualElementGenerator.cs
@@ -29,7 +29,7 @@ namespace Improbable.Gdk.CodeGenerator
                     {
                         type.Line($"public override ComponentType ComponentType {{ get; }} = ComponentType.ReadOnly<{details.Name}.Component>();");
 
-                        type.TextList(TextList.New(details.FieldDetails.Select(ToFieldDeclaration)));
+                        type.TextList(details.FieldDetails.Select(ToFieldDeclaration));
 
                         GenerateConstructor(type, details);
                         GenerateUpdateMethod(type, details);
@@ -67,7 +67,7 @@ namespace Improbable.Gdk.CodeGenerator
 
                 foreach (var field in details.FieldDetails)
                 {
-                    mb.TextList(TextList.New(ToFieldInitialisation(field)));
+                    mb.TextList(ToFieldInitialisation(field));
                 }
             });
         }

--- a/workers/unity/Packages/io.improbable.gdk.debug/.codegen/Source/Generators/DebugExtensions/ComponentVisualElementGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/.codegen/Source/Generators/DebugExtensions/ComponentVisualElementGenerator.cs
@@ -1,6 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Improbable.Gdk.CodeGeneration.CodeWriter;
 using Improbable.Gdk.CodeGeneration.CodeWriter.Scopes;
+using Improbable.Gdk.CodeGeneration.Model;
 using Improbable.Gdk.CodeGeneration.Model.Details;
+using Improbable.Gdk.CodeGeneration.Utils;
+using ValueType = Improbable.Gdk.CodeGeneration.Model.ValueType;
 
 namespace Improbable.Gdk.CodeGenerator
 {
@@ -13,6 +19,7 @@ namespace Improbable.Gdk.CodeGenerator
                 cgw.UsingDirectives(
                     "Unity.Entities",
                     "UnityEngine.UIElements",
+                    "UnityEditor.UIElements",
                     "Improbable.Gdk.Debug.WorkerInspector.Codegen"
                 );
 
@@ -22,11 +29,33 @@ namespace Improbable.Gdk.CodeGenerator
                     {
                         type.Line($"public override ComponentType ComponentType {{ get; }} = ComponentType.ReadOnly<{details.Name}.Component>();");
 
+                        type.TextList(TextList.New(details.FieldDetails.Select(ToFieldDeclaration)));
+
                         GenerateConstructor(type, details);
                         GenerateUpdateMethod(type, details);
                     });
                 });
             });
+        }
+
+        private static string ToFieldDeclaration(UnityFieldDetails fieldDetails)
+        {
+            switch (fieldDetails.FieldType)
+            {
+                case SingularFieldType singularFieldType:
+                    var uiType = GetUiFieldType(singularFieldType.ContainedType);
+
+                    if (uiType == "")
+                    {
+                        // TODO: Eliminate this case.
+                        return "";
+                    }
+
+                    return $"private readonly {uiType} {fieldDetails.CamelCaseName}Field;";
+                default:
+                    // TODO: Lists, maps, and options
+                    return "";
+            }
         }
 
         private static void GenerateConstructor(TypeBlock typeBlock, UnityComponentDetails details)
@@ -35,7 +64,43 @@ namespace Improbable.Gdk.CodeGenerator
             {
                 mb.Line($"ComponentFoldout.text = \"{details.Name}\";");
                 mb.Line($"AuthoritativeToggle.SetEnabled(false);");
+
+                foreach (var field in details.FieldDetails)
+                {
+                    mb.TextList(TextList.New(ToFieldInitialisation(field)));
+                }
             });
+        }
+
+        private static IEnumerable<string> ToFieldInitialisation(UnityFieldDetails fieldDetails)
+        {
+            switch (fieldDetails.FieldType)
+            {
+                case SingularFieldType singularFieldType:
+
+                    var uiType = GetUiFieldType(singularFieldType.ContainedType);
+
+                    if (uiType == "")
+                    {
+                        // TODO: Eliminate this case.
+                        yield break;
+                    }
+
+                    var humanReadableName = Formatting.SnakeCaseToHumanReadable(fieldDetails.Name);
+                    yield return $"{fieldDetails.CamelCaseName}Field = new {uiType}(\"{humanReadableName}\");";
+                    yield return $"{fieldDetails.CamelCaseName}Field.SetEnabled(false);";
+
+                    if (singularFieldType.ContainedType.Category == ValueType.Enum)
+                    {
+                        yield return $"{fieldDetails.CamelCaseName}Field.Init(default({fieldDetails.Type}));";
+                    }
+
+                    yield return $"ComponentFoldout.Add({fieldDetails.CamelCaseName}Field);";
+                    break;
+                default:
+                    // TODO: Lists, maps, and options
+                    yield break;
+            }
         }
 
         private static void GenerateUpdateMethod(TypeBlock typeBlock, UnityComponentDetails details)
@@ -43,7 +108,105 @@ namespace Improbable.Gdk.CodeGenerator
             typeBlock.Method("public override void Update(EntityManager manager, Entity entity)", mb =>
             {
                 mb.Line($"AuthoritativeToggle.value = manager.HasComponent<{details.Name}.HasAuthority>(entity);");
+                mb.Line($"var component = manager.GetComponentData<{details.Name}.Component>(entity);");
+
+                mb.TextList(TextList.New(details.FieldDetails.Select(ToUiFieldUpdate)));
             });
+        }
+
+        private static string ToUiFieldUpdate(UnityFieldDetails fieldDetails)
+        {
+            switch (fieldDetails.FieldType)
+            {
+                case SingularFieldType singularFieldType:
+                    switch (singularFieldType.ContainedType.Category)
+                    {
+                        case ValueType.Enum:
+                            return $"{fieldDetails.CamelCaseName}Field.value = component.{fieldDetails.PascalCaseName};";
+                        case ValueType.Primitive:
+                            var primitiveType = singularFieldType.ContainedType.PrimitiveType.Value;
+
+                            switch (primitiveType)
+                            {
+                                case PrimitiveType.Int32:
+                                case PrimitiveType.Int64:
+                                case PrimitiveType.Uint32:
+                                case PrimitiveType.Uint64:
+                                case PrimitiveType.Sint32:
+                                case PrimitiveType.Sint64:
+                                case PrimitiveType.Fixed32:
+                                case PrimitiveType.Fixed64:
+                                case PrimitiveType.Sfixed32:
+                                case PrimitiveType.Sfixed64:
+                                case PrimitiveType.Float:
+                                case PrimitiveType.Double:
+                                case PrimitiveType.String:
+                                case PrimitiveType.EntityId:
+                                    return $"{fieldDetails.CamelCaseName}Field.value = component.{fieldDetails.PascalCaseName}.ToString();";
+                                case PrimitiveType.Bytes:
+                                    return $"{fieldDetails.CamelCaseName}Field.value = global::System.Text.Encoding.Default.GetString(component.{fieldDetails.PascalCaseName});";
+                                case PrimitiveType.Bool:
+                                    return $"{fieldDetails.CamelCaseName}Field.value = component.{fieldDetails.PascalCaseName};";
+                                    break;
+                                case PrimitiveType.Entity:
+                                    // TODO: Entity type.
+                                    return "";
+                                case PrimitiveType.Invalid:
+                                    throw new ArgumentException("Unknown primitive type encountered");
+                                default:
+                                    throw new ArgumentOutOfRangeException();
+                            }
+                        case ValueType.Type:
+                            // TODO: User defined types.
+                            return "";
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                default:
+                    // TODO: Lists, maps, and options
+                    return "";
+            }
+        }
+
+        private static string GetUiFieldType(ContainedType type)
+        {
+            switch (type.Category)
+            {
+                case ValueType.Enum:
+                    return "EnumField";
+                case ValueType.Primitive:
+                    switch (type.PrimitiveType.Value)
+                    {
+                        case PrimitiveType.Int32:
+                        case PrimitiveType.Int64:
+                        case PrimitiveType.Uint32:
+                        case PrimitiveType.Uint64:
+                        case PrimitiveType.Sint32:
+                        case PrimitiveType.Sint64:
+                        case PrimitiveType.Fixed32:
+                        case PrimitiveType.Fixed64:
+                        case PrimitiveType.Sfixed32:
+                        case PrimitiveType.Sfixed64:
+                        case PrimitiveType.Float:
+                        case PrimitiveType.Double:
+                        case PrimitiveType.String:
+                        case PrimitiveType.EntityId:
+                        case PrimitiveType.Bytes:
+                            return "TextField";
+                        case PrimitiveType.Bool:
+                            return "Toggle";
+                        case PrimitiveType.Entity:
+                            return "";
+                        case PrimitiveType.Invalid:
+                            throw new ArgumentException("Unknown primitive type encountered.");
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                case ValueType.Type:
+                    return "";
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.debug/.codegen/Source/Generators/DebugExtensions/DebugAssemblyGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/.codegen/Source/Generators/DebugExtensions/DebugAssemblyGenerator.cs
@@ -7,6 +7,7 @@ namespace Improbable.Gdk.CodeGenerator
             return @"{
     ""name"": ""Improbable.Gdk.Generated.Debug"",
     ""references"": [
+        ""Improbable.Gdk.Core"",
         ""Improbable.Gdk.Generated"",
         ""Improbable.Gdk.Debug.WorkerInspector.Codegen"",
         ""Unity.Entities""

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/Abstract/ScopeBody.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/Abstract/ScopeBody.cs
@@ -29,6 +29,11 @@ namespace Improbable.Gdk.CodeGeneration.CodeWriter.Scopes
             Add(textList);
         }
 
+        public void TextList(IEnumerable<string> text)
+        {
+            Add(CodeGeneration.CodeWriter.TextList.New(text));
+        }
+
         public void Line(string snippet)
         {
             Add(new Text(snippet));

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/TypeBlock.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Scopes/TypeBlock.cs
@@ -29,6 +29,11 @@ namespace Improbable.Gdk.CodeGeneration.CodeWriter.Scopes
             Add(textList);
         }
 
+        public void TextList(IEnumerable<string> text)
+        {
+            Add(CodeGeneration.CodeWriter.TextList.New(text));
+        }
+
         public void Line(string snippet)
         {
             Add(new Text(snippet));

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/FieldTypes/ContainedType.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/FieldTypes/ContainedType.cs
@@ -6,27 +6,27 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
     public class ContainedType
     {
         public readonly string FqnType;
-        private readonly ValueType category;
-        private PrimitiveType? primitiveType;
+        public readonly ValueType Category;
+        public PrimitiveType? PrimitiveType;
 
         public ContainedType(TypeReference innerType)
         {
             switch (innerType.ValueTypeSelector)
             {
                 case ValueType.Enum:
-                    category = ValueType.Enum;
+                    Category = ValueType.Enum;
                     FqnType = DetailsUtils.GetCapitalisedFqnTypename(innerType.Enum);
-                    primitiveType = null;
+                    PrimitiveType = null;
                     break;
                 case ValueType.Primitive:
-                    category = ValueType.Primitive;
+                    Category = ValueType.Primitive;
                     FqnType = UnityTypeMappings.SchemaTypeToUnityType[innerType.Primitive];
-                    primitiveType = innerType.Primitive;
+                    PrimitiveType = innerType.Primitive;
                     break;
                 case ValueType.Type:
-                    category = ValueType.Type;
+                    Category = ValueType.Type;
                     FqnType = DetailsUtils.GetCapitalisedFqnTypename(innerType.Type);
-                    primitiveType = null;
+                    PrimitiveType = null;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException("Malformed inner type.");
@@ -35,64 +35,64 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
 
         public string GetSerializationStatement(string instance, string schemaObject, uint fieldNumber)
         {
-            switch (category)
+            switch (Category)
             {
                 case ValueType.Primitive:
-                    return $"{schemaObject}.{SchemaFunctionMappings.AddSchemaFunctionFromType(primitiveType.Value)}({fieldNumber}, {instance});";
+                    return $"{schemaObject}.{SchemaFunctionMappings.AddSchemaFunctionFromType(PrimitiveType.Value)}({fieldNumber}, {instance});";
                 case ValueType.Enum:
                     return $"{schemaObject}.AddEnum({fieldNumber}, (uint) {instance});";
                 case ValueType.Type:
                     return $"{FqnType}.Serialization.Serialize({instance}, {schemaObject}.AddObject({fieldNumber}));";
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(category), "Unknown type category encountered.");
+                    throw new ArgumentOutOfRangeException(nameof(Category), "Unknown type category encountered.");
             }
         }
 
         public string GetDeserializationExpression(string schemaObject, uint fieldNumber)
         {
-            switch (category)
+            switch (Category)
             {
                 case ValueType.Primitive:
                     return
-                        $"{schemaObject}.{SchemaFunctionMappings.GetSchemaFunctionFromType(primitiveType.Value)}({fieldNumber})";
+                        $"{schemaObject}.{SchemaFunctionMappings.GetSchemaFunctionFromType(PrimitiveType.Value)}({fieldNumber})";
                 case ValueType.Enum:
                     return $"({FqnType}) {schemaObject}.GetEnum({fieldNumber})";
                 case ValueType.Type:
                     return $"{FqnType}.Serialization.Deserialize({schemaObject}.GetObject({fieldNumber}))";
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(category), "Unknown type category encountered.");
+                    throw new ArgumentOutOfRangeException(nameof(Category), "Unknown type category encountered.");
             }
         }
 
         public string GetCountExpression(string schemaObject, uint fieldNumber)
         {
-            switch (category)
+            switch (Category)
             {
                 case ValueType.Primitive:
                     return
-                        $"{schemaObject}.{SchemaFunctionMappings.GetCountSchemaFunctionFromType(primitiveType.Value)}({fieldNumber})";
+                        $"{schemaObject}.{SchemaFunctionMappings.GetCountSchemaFunctionFromType(PrimitiveType.Value)}({fieldNumber})";
                 case ValueType.Enum:
                     return $"{schemaObject}.GetEnumCount({fieldNumber})";
                 case ValueType.Type:
                     return $"{schemaObject}.GetObjectCount({fieldNumber})";
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(category), "Unknown type category encountered.");
+                    throw new ArgumentOutOfRangeException(nameof(Category), "Unknown type category encountered.");
             }
         }
 
         public string GetFieldIndexExpression(string schemaObject, uint fieldNumber, string index)
         {
-            switch (category)
+            switch (Category)
             {
                 case ValueType.Primitive:
                     return
-                        $"{schemaObject}.{SchemaFunctionMappings.IndexSchemaFunctionFromType(primitiveType.Value)}({fieldNumber}, (uint) {index})";
+                        $"{schemaObject}.{SchemaFunctionMappings.IndexSchemaFunctionFromType(PrimitiveType.Value)}({fieldNumber}, (uint) {index})";
                 case ValueType.Enum:
                     return $"({FqnType}) {schemaObject}.IndexEnum({fieldNumber}, (uint) {index})";
                 case ValueType.Type:
                     return $"{FqnType}.Serialization.Deserialize({schemaObject}.IndexObject({fieldNumber}, (uint) {index}))";
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(category), "Unknown type category encountered.");
+                    throw new ArgumentOutOfRangeException(nameof(Category), "Unknown type category encountered.");
             }
         }
     }

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/FieldTypes/ContainedType.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/FieldTypes/ContainedType.cs
@@ -7,7 +7,7 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
     {
         public readonly string FqnType;
         public readonly ValueType Category;
-        public PrimitiveType? PrimitiveType;
+        public readonly PrimitiveType? PrimitiveType;
 
         public ContainedType(TypeReference innerType)
         {

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/FieldTypes/SingularFieldType.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/FieldTypes/SingularFieldType.cs
@@ -4,44 +4,44 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
 {
     public class SingularFieldType : IFieldType
     {
-        public string Type => containedType.FqnType;
+        public string Type => ContainedType.FqnType;
 
-        private readonly ContainedType containedType;
+        public readonly ContainedType ContainedType;
 
         public SingularFieldType(TypeReference innerType)
         {
-            containedType = new ContainedType(innerType);
+            ContainedType = new ContainedType(innerType);
         }
 
         public string GetSerializationString(string fieldInstance, string schemaObject, uint fieldNumber)
         {
-            return containedType.GetSerializationStatement(fieldInstance, schemaObject, fieldNumber);
+            return ContainedType.GetSerializationStatement(fieldInstance, schemaObject, fieldNumber);
         }
 
         public string GetDeserializationString(string fieldInstance, string schemaObject, uint fieldNumber)
         {
-            return $"{fieldInstance} = {containedType.GetDeserializationExpression(schemaObject, fieldNumber)};";
+            return $"{fieldInstance} = {ContainedType.GetDeserializationExpression(schemaObject, fieldNumber)};";
         }
 
         public string GetDeserializeUpdateString(string fieldInstance, string schemaObject, uint fieldNumber)
         {
-            return new IfElseBlock($"{containedType.GetCountExpression(schemaObject, fieldNumber)} == 1", then =>
+            return new IfElseBlock($"{ContainedType.GetCountExpression(schemaObject, fieldNumber)} == 1", then =>
             {
-                then.Line($"{fieldInstance} = {containedType.GetDeserializationExpression(schemaObject, fieldNumber)};");
+                then.Line($"{fieldInstance} = {ContainedType.GetDeserializationExpression(schemaObject, fieldNumber)};");
             }).Format();
         }
 
         public string GetDeserializeUpdateIntoUpdateString(string updateFieldInstance, string schemaObject, uint fieldNumber)
         {
-            return new IfElseBlock($"{containedType.GetCountExpression(schemaObject, fieldNumber)} == 1", then =>
+            return new IfElseBlock($"{ContainedType.GetCountExpression(schemaObject, fieldNumber)} == 1", then =>
             {
-                then.Line($"{updateFieldInstance} = {containedType.GetDeserializationExpression(schemaObject, fieldNumber)};");
+                then.Line($"{updateFieldInstance} = {ContainedType.GetDeserializationExpression(schemaObject, fieldNumber)};");
             }).Format();
         }
 
         public string GetDeserializeDataIntoUpdateString(string updateFieldInstance, string schemaObject, uint fieldNumber)
         {
-            return $"{updateFieldInstance} = {containedType.GetDeserializationExpression(schemaObject, fieldNumber)};";
+            return $"{updateFieldInstance} = {ContainedType.GetDeserializationExpression(schemaObject, fieldNumber)};";
         }
 
         public string GetTrySetClearedFieldString(string fieldInstance, string componentUpdateSchemaObject, uint fieldNumber)

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/PropertyDetails/UnityFieldDetails.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/PropertyDetails/UnityFieldDetails.cs
@@ -4,14 +4,14 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
 {
     public class UnityFieldDetails : Details
     {
-        public string Type => fieldType.Type;
+        public string Type => FieldType.Type;
 
         private readonly uint fieldNumber;
 
         public readonly bool IsBlittable;
         public readonly bool CanBeEmpty;
 
-        private readonly IFieldType fieldType;
+        public readonly IFieldType FieldType;
 
         internal readonly FieldDefinition RawFieldDefinition;
 
@@ -24,21 +24,21 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
             if (rawFieldDefinition.OptionType != null)
             {
                 CanBeEmpty = true;
-                fieldType = new OptionFieldType(rawFieldDefinition.OptionType.InnerType);
+                FieldType = new OptionFieldType(rawFieldDefinition.OptionType.InnerType);
             }
             else if (rawFieldDefinition.ListType != null)
             {
                 CanBeEmpty = true;
-                fieldType = new ListFieldType(rawFieldDefinition.ListType.InnerType);
+                FieldType = new ListFieldType(rawFieldDefinition.ListType.InnerType);
             }
             else if (rawFieldDefinition.MapType != null)
             {
                 CanBeEmpty = true;
-                fieldType = new MapFieldType(rawFieldDefinition.MapType.KeyType, rawFieldDefinition.MapType.ValueType);
+                FieldType = new MapFieldType(rawFieldDefinition.MapType.KeyType, rawFieldDefinition.MapType.ValueType);
             }
             else
             {
-                fieldType = new SingularFieldType(rawFieldDefinition.SingularType.Type);
+                FieldType = new SingularFieldType(rawFieldDefinition.SingularType.Type);
             }
 
             RawFieldDefinition = rawFieldDefinition;
@@ -53,7 +53,7 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
         /// <param name="indents">The indent level that the block of code should be at.</param>
         public string GetSerializationString(string fieldInstance, string schemaObject, int indents)
         {
-            var serializationString = fieldType.GetSerializationString(fieldInstance, schemaObject, fieldNumber);
+            var serializationString = FieldType.GetSerializationString(fieldInstance, schemaObject, fieldNumber);
             return CommonGeneratorUtils.IndentEveryNewline(serializationString, indents);
         }
 
@@ -66,7 +66,7 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
         /// <param name="indents">The indent level that the block of code should be at.</param>
         public string GetDeserializeString(string fieldInstance, string schemaObject, int indents)
         {
-            var deserializationString = fieldType.GetDeserializationString(fieldInstance, schemaObject, fieldNumber);
+            var deserializationString = FieldType.GetDeserializationString(fieldInstance, schemaObject, fieldNumber);
             return CommonGeneratorUtils.IndentEveryNewline(deserializationString, indents);
         }
 
@@ -80,7 +80,7 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
         /// <returns></returns>
         public string GetDeserializeUpdateString(string fieldInstance, string schemaObject, int indents)
         {
-            var deserializationString = fieldType.GetDeserializeUpdateString(fieldInstance, schemaObject, fieldNumber);
+            var deserializationString = FieldType.GetDeserializeUpdateString(fieldInstance, schemaObject, fieldNumber);
             return CommonGeneratorUtils.IndentEveryNewline(deserializationString, indents);
         }
 
@@ -98,7 +98,7 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
         public string GetDeserializeUpdateIntoUpdateString(string updateFieldInstance, string schemaObject, int indents)
         {
             var deserializationString =
-                fieldType.GetDeserializeUpdateIntoUpdateString(updateFieldInstance, schemaObject, fieldNumber);
+                FieldType.GetDeserializeUpdateIntoUpdateString(updateFieldInstance, schemaObject, fieldNumber);
             return CommonGeneratorUtils.IndentEveryNewline(deserializationString, indents);
         }
 
@@ -116,13 +116,13 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
         public string GetDeserializeDataIntoUpdateString(string updateFieldInstance, string schemaObject, int indents)
         {
             var deserializationString =
-                fieldType.GetDeserializeDataIntoUpdateString(updateFieldInstance, schemaObject, fieldNumber);
+                FieldType.GetDeserializeDataIntoUpdateString(updateFieldInstance, schemaObject, fieldNumber);
             return CommonGeneratorUtils.IndentEveryNewline(deserializationString, indents);
         }
 
         public string GetTrySetClearedFieldString(string fieldInstance, string componentUpdateSchemaObj, int indents)
         {
-            var trySetClearedFieldString = fieldType.GetTrySetClearedFieldString(fieldInstance, componentUpdateSchemaObj, fieldNumber);
+            var trySetClearedFieldString = FieldType.GetTrySetClearedFieldString(fieldInstance, componentUpdateSchemaObj, fieldNumber);
             return CommonGeneratorUtils.IndentEveryNewline(trySetClearedFieldString, indents);
         }
     }

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Utils/Formatting.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Utils/Formatting.cs
@@ -22,6 +22,12 @@ namespace Improbable.Gdk.CodeGeneration.Utils
                 .Aggregate(string.Empty, (s1, s2) => s1 + s2);
         }
 
+        public static string SnakeCaseToHumanReadable(string text)
+        {
+            return string.Join(" ", text.Split(new[] { "_" }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(s => char.ToUpperInvariant(s[0]) + s.Substring(1, s.Length - 1)));
+        }
+
         public static string GetNamespacePath(string packageName)
         {
             var capitalisedPackageName = CapitaliseQualifiedNameParts(packageName);


### PR DESCRIPTION
#### Description

This PR adds a subset of the component data rendering to the Worker Inspector. It adds support for all schema primitives (except for `Entity`) and schema enums. Later PRs will add

- user defined types
- schema collections (lists, maps, and options)
- the `Entity` schema type

Note in https://github.com/spatialos/gdk-for-unity/pull/1387/commits/f0816334405202b840b365a4ecf92eec682f7a5d I turned quite a few things public. Discussed a strategy with Paul and will raise a ticket to go back and refactor these to make using them easier in the modular codegen world. 

![image](https://user-images.githubusercontent.com/13353733/84047738-753e4500-a9a3-11ea-9d54-5baaec47dfe9.png)

#### Tests

Eyeball test. Will conduct more exhaustive tests once all the data types are in 
