### PR TITLE
Bugfix/asmdef guid

### DIFF
--- a/workers/unity/Packages/io.improbable.gdk.core/Editor/Improbable.Gdk.Core.Editor.asmdef
+++ b/workers/unity/Packages/io.improbable.gdk.core/Editor/Improbable.Gdk.Core.Editor.asmdef
@@ -1,8 +1,8 @@
 {
     "name": "Improbable.Gdk.Core.Editor",
     "references": [
-        "GUID:734d92eba21c94caba915361bd5ac177",
-        "GUID:edb3612c44ad0d24988d387581fd5fbe"
+        "Unity.Entities",
+        "Improbable.Gdk.Core"
     ],
     "includePlatforms": [
         "Editor"
@@ -13,5 +13,6 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": []
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/workers/unity/Packages/io.improbable.gdk.debug/Tests/Editmode/Improbable.Gdk.Debug.EditmodeTests.asmdef
+++ b/workers/unity/Packages/io.improbable.gdk.debug/Tests/Editmode/Improbable.Gdk.Debug.EditmodeTests.asmdef
@@ -1,13 +1,13 @@
 {
     "name": "Improbable.Gdk.Debug.EditmodeTests",
     "references": [
-        "GUID:40425aeb5a2b3f74797745fff21bc766",
-        "GUID:c5f2ea2f695256346af9ccd76c6f055d",
-        "GUID:edb3612c44ad0d24988d387581fd5fbe",
-        "GUID:0acc523941302664db1f4e527237feb3",
-        "GUID:27619889b8ba8c24980f49ee34dbb44a",
-        "GUID:734d92eba21c94caba915361bd5ac177",
-        "GUID:bd66e1825421d9041a8f2c4fa9ca562a"
+        "Improbable.Gdk.Debug",
+        "Improbable.Gdk.TestUtils",
+        "Improbable.Gdk.Core",
+        "UnityEditor.TestRunner",
+        "UnityEngine.TestRunner",
+        "Unity.Entities",
+        "Improbable.Gdk.Generated"
     ],
     "includePlatforms": [
         "Editor"

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/Improbable.Gdk.Debug.WorkerInspector.Codegen.asmdef
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/Improbable.Gdk.Debug.WorkerInspector.Codegen.asmdef
@@ -1,7 +1,7 @@
 {
     "name": "Improbable.Gdk.Debug.WorkerInspector.Codegen",
     "references": [
-        "GUID:734d92eba21c94caba915361bd5ac177"
+        "Unity.Entities"
     ],
     "includePlatforms": [
         "Editor"


### PR DESCRIPTION
#### Description
Remove usage of GUID references in assembly definition assets.

This caused an compile failure for the WorkerInspector tests in external projects
