### PR TITLE
Add rendering support for user-defined types

### DIFF
--- a/workers/unity/Packages/io.improbable.gdk.debug/.codegen/Source/ComponentVisualElementJob.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/.codegen/Source/ComponentVisualElementJob.cs
@@ -20,8 +20,25 @@ namespace Improbable.Gdk.CodeGenerator
             AddJobTarget(Path.Combine(relativeOutputPath, DebugAsmdefFileName), () => DebugAssemblyGenerator.Generate());
 
             var componentsToGenerate = detailsStore.Components.Values.ToList();
-            AddGenerators(relativeOutputPath, componentsToGenerate, component => ($"{component.Name}Renderer.cs", ComponentVisualElementGenerator.Generate));
+            var componentGenerator = new ComponentVisualElementGenerator(detailsStore);
+            AddGenerators(relativeOutputPath, componentsToGenerate, component => ($"{component.Name}Renderer.cs", componentGenerator.Generate));
             Logger.Trace($"Added job targets for {componentsToGenerate.Count} components");
+
+            // Types
+            Logger.Trace("Gathering nested types.");
+            var allNestedTypes = detailsStore.Types
+                .SelectMany(kv => detailsStore.GetNestedTypes(kv.Key))
+                .ToHashSet();
+
+            Logger.Trace("Gathering types details.");
+            var typesToGenerate = detailsStore.Types
+                .Where(kv => !allNestedTypes.Contains(kv.Key))
+                .Select(kv => kv.Value)
+                .ToList();
+
+            var typeGenerator = new TypeVisualElementGenerator(detailsStore);
+            AddGenerators(relativeOutputPath, typesToGenerate, type => ($"{type.Name}Renderer.cs", typeGenerator.Generate));
+            Logger.Trace($"Added job targets for {typesToGenerate.Count} types");
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.debug/.codegen/Source/Generators/DebugExtensions/ComponentVisualElementGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/.codegen/Source/Generators/DebugExtensions/ComponentVisualElementGenerator.cs
@@ -1,18 +1,20 @@
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using Improbable.Gdk.CodeGeneration.CodeWriter;
 using Improbable.Gdk.CodeGeneration.CodeWriter.Scopes;
-using Improbable.Gdk.CodeGeneration.Model;
 using Improbable.Gdk.CodeGeneration.Model.Details;
-using Improbable.Gdk.CodeGeneration.Utils;
-using ValueType = Improbable.Gdk.CodeGeneration.Model.ValueType;
 
 namespace Improbable.Gdk.CodeGenerator
 {
-    public static class ComponentVisualElementGenerator
+    public class ComponentVisualElementGenerator
     {
-        public static CodeWriter Generate(UnityComponentDetails details)
+        private readonly FieldTypeHandler typeGenerator;
+
+        public ComponentVisualElementGenerator(DetailsStore detailsStore)
+        {
+            typeGenerator = new FieldTypeHandler(detailsStore);
+        }
+
+        public CodeWriter Generate(UnityComponentDetails details)
         {
             return CodeWriter.Populate(cgw =>
             {
@@ -29,7 +31,7 @@ namespace Improbable.Gdk.CodeGenerator
                     {
                         type.Line($"public override ComponentType ComponentType {{ get; }} = ComponentType.ReadOnly<{details.Name}.Component>();");
 
-                        type.TextList(details.FieldDetails.Select(ToFieldDeclaration));
+                        type.TextList(details.FieldDetails.Select(typeGenerator.ToFieldDeclaration));
 
                         GenerateConstructor(type, details);
                         GenerateUpdateMethod(type, details);
@@ -38,27 +40,7 @@ namespace Improbable.Gdk.CodeGenerator
             });
         }
 
-        private static string ToFieldDeclaration(UnityFieldDetails fieldDetails)
-        {
-            switch (fieldDetails.FieldType)
-            {
-                case SingularFieldType singularFieldType:
-                    var uiType = GetUiFieldType(singularFieldType.ContainedType);
-
-                    if (uiType == "")
-                    {
-                        // TODO: Eliminate this case.
-                        return "";
-                    }
-
-                    return $"private readonly {uiType} {fieldDetails.CamelCaseName}Field;";
-                default:
-                    // TODO: Lists, maps, and options
-                    return "";
-            }
-        }
-
-        private static void GenerateConstructor(TypeBlock typeBlock, UnityComponentDetails details)
+        private void GenerateConstructor(TypeBlock typeBlock, UnityComponentDetails details)
         {
             typeBlock.Method($"public {details.Name}Renderer() : base()", mb =>
             {
@@ -67,146 +49,20 @@ namespace Improbable.Gdk.CodeGenerator
 
                 foreach (var field in details.FieldDetails)
                 {
-                    mb.TextList(ToFieldInitialisation(field));
+                    mb.TextList(typeGenerator.ToFieldInitialisation(field, "ComponentFoldout"));
                 }
             });
         }
 
-        private static IEnumerable<string> ToFieldInitialisation(UnityFieldDetails fieldDetails)
-        {
-            switch (fieldDetails.FieldType)
-            {
-                case SingularFieldType singularFieldType:
-
-                    var uiType = GetUiFieldType(singularFieldType.ContainedType);
-
-                    if (uiType == "")
-                    {
-                        // TODO: Eliminate this case.
-                        yield break;
-                    }
-
-                    var humanReadableName = Formatting.SnakeCaseToHumanReadable(fieldDetails.Name);
-                    yield return $"{fieldDetails.CamelCaseName}Field = new {uiType}(\"{humanReadableName}\");";
-                    yield return $"{fieldDetails.CamelCaseName}Field.SetEnabled(false);";
-
-                    if (singularFieldType.ContainedType.Category == ValueType.Enum)
-                    {
-                        yield return $"{fieldDetails.CamelCaseName}Field.Init(default({fieldDetails.Type}));";
-                    }
-
-                    yield return $"ComponentFoldout.Add({fieldDetails.CamelCaseName}Field);";
-                    break;
-                default:
-                    // TODO: Lists, maps, and options
-                    yield break;
-            }
-        }
-
-        private static void GenerateUpdateMethod(TypeBlock typeBlock, UnityComponentDetails details)
+        private void GenerateUpdateMethod(TypeBlock typeBlock, UnityComponentDetails details)
         {
             typeBlock.Method("public override void Update(EntityManager manager, Entity entity)", mb =>
             {
                 mb.Line($"AuthoritativeToggle.value = manager.HasComponent<{details.Name}.HasAuthority>(entity);");
                 mb.Line($"var component = manager.GetComponentData<{details.Name}.Component>(entity);");
 
-                mb.TextList(TextList.New(details.FieldDetails.Select(ToUiFieldUpdate)));
+                mb.TextList(details.FieldDetails.Select(fd => typeGenerator.ToUiFieldUpdate(fd, "component")));
             });
-        }
-
-        private static string ToUiFieldUpdate(UnityFieldDetails fieldDetails)
-        {
-            switch (fieldDetails.FieldType)
-            {
-                case SingularFieldType singularFieldType:
-                    switch (singularFieldType.ContainedType.Category)
-                    {
-                        case ValueType.Enum:
-                            return $"{fieldDetails.CamelCaseName}Field.value = component.{fieldDetails.PascalCaseName};";
-                        case ValueType.Primitive:
-                            var primitiveType = singularFieldType.ContainedType.PrimitiveType.Value;
-
-                            switch (primitiveType)
-                            {
-                                case PrimitiveType.Int32:
-                                case PrimitiveType.Int64:
-                                case PrimitiveType.Uint32:
-                                case PrimitiveType.Uint64:
-                                case PrimitiveType.Sint32:
-                                case PrimitiveType.Sint64:
-                                case PrimitiveType.Fixed32:
-                                case PrimitiveType.Fixed64:
-                                case PrimitiveType.Sfixed32:
-                                case PrimitiveType.Sfixed64:
-                                case PrimitiveType.Float:
-                                case PrimitiveType.Double:
-                                case PrimitiveType.String:
-                                case PrimitiveType.EntityId:
-                                    return $"{fieldDetails.CamelCaseName}Field.value = component.{fieldDetails.PascalCaseName}.ToString();";
-                                case PrimitiveType.Bytes:
-                                    return $"{fieldDetails.CamelCaseName}Field.value = global::System.Text.Encoding.Default.GetString(component.{fieldDetails.PascalCaseName});";
-                                case PrimitiveType.Bool:
-                                    return $"{fieldDetails.CamelCaseName}Field.value = component.{fieldDetails.PascalCaseName};";
-                                    break;
-                                case PrimitiveType.Entity:
-                                    // TODO: Entity type.
-                                    return "";
-                                case PrimitiveType.Invalid:
-                                    throw new ArgumentException("Unknown primitive type encountered");
-                                default:
-                                    throw new ArgumentOutOfRangeException();
-                            }
-                        case ValueType.Type:
-                            // TODO: User defined types.
-                            return "";
-                        default:
-                            throw new ArgumentOutOfRangeException();
-                    }
-                default:
-                    // TODO: Lists, maps, and options
-                    return "";
-            }
-        }
-
-        private static string GetUiFieldType(ContainedType type)
-        {
-            switch (type.Category)
-            {
-                case ValueType.Enum:
-                    return "EnumField";
-                case ValueType.Primitive:
-                    switch (type.PrimitiveType.Value)
-                    {
-                        case PrimitiveType.Int32:
-                        case PrimitiveType.Int64:
-                        case PrimitiveType.Uint32:
-                        case PrimitiveType.Uint64:
-                        case PrimitiveType.Sint32:
-                        case PrimitiveType.Sint64:
-                        case PrimitiveType.Fixed32:
-                        case PrimitiveType.Fixed64:
-                        case PrimitiveType.Sfixed32:
-                        case PrimitiveType.Sfixed64:
-                        case PrimitiveType.Float:
-                        case PrimitiveType.Double:
-                        case PrimitiveType.String:
-                        case PrimitiveType.EntityId:
-                        case PrimitiveType.Bytes:
-                            return "TextField";
-                        case PrimitiveType.Bool:
-                            return "Toggle";
-                        case PrimitiveType.Entity:
-                            return "";
-                        case PrimitiveType.Invalid:
-                            throw new ArgumentException("Unknown primitive type encountered.");
-                        default:
-                            throw new ArgumentOutOfRangeException();
-                    }
-                case ValueType.Type:
-                    return "";
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.debug/.codegen/Source/Generators/DebugExtensions/FieldTypeHandler.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/.codegen/Source/Generators/DebugExtensions/FieldTypeHandler.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Improbable.Gdk.CodeGeneration.Model;
+using Improbable.Gdk.CodeGeneration.Model.Details;
+using Improbable.Gdk.CodeGeneration.Utils;
+using ValueType = Improbable.Gdk.CodeGeneration.Model.ValueType;
+
+namespace Improbable.Gdk.CodeGenerator
+{
+    public class FieldTypeHandler
+    {
+        private readonly DetailsStore detailsStore;
+
+        public FieldTypeHandler(DetailsStore detailsStore)
+        {
+            this.detailsStore = detailsStore;
+        }
+
+        public string ToFieldDeclaration(UnityFieldDetails fieldDetails)
+        {
+            switch (fieldDetails.FieldType)
+            {
+                case SingularFieldType singularFieldType:
+                    var uiType = GetUiFieldType(singularFieldType.ContainedType);
+
+                    if (uiType == "")
+                    {
+                        // TODO: Eliminate this case by supporting 'Entity'.
+                        return "";
+                    }
+
+                    return $"private readonly {uiType} {fieldDetails.CamelCaseName}Field;";
+                default:
+                    // TODO: Lists, maps, and options
+                    return "";
+            }
+        }
+
+        public IEnumerable<string> ToFieldInitialisation(UnityFieldDetails fieldDetails, string parentContainer)
+        {
+            switch (fieldDetails.FieldType)
+            {
+                case SingularFieldType singularFieldType:
+
+                    var uiType = GetUiFieldType(singularFieldType.ContainedType);
+
+                    if (uiType == "")
+                    {
+                        // TODO: Eliminate this case by supporting 'Entity'.
+                        yield break;
+                    }
+
+                    var humanReadableName = Formatting.SnakeCaseToHumanReadable(fieldDetails.Name);
+                    yield return $"{fieldDetails.CamelCaseName}Field = new {uiType}(\"{humanReadableName}\");";
+
+                    if (singularFieldType.ContainedType.Category != ValueType.Type)
+                    {
+                        yield return $"{fieldDetails.CamelCaseName}Field.SetEnabled(false);";
+                    }
+
+                    if (singularFieldType.ContainedType.Category == ValueType.Enum)
+                    {
+                        yield return $"{fieldDetails.CamelCaseName}Field.Init(default({fieldDetails.Type}));";
+                    }
+
+                    yield return $"{parentContainer}.Add({fieldDetails.CamelCaseName}Field);";
+                    break;
+                default:
+                    // TODO: Lists, maps, and options
+                    yield break;
+            }
+        }
+
+        public string ToUiFieldUpdate(UnityFieldDetails fieldDetails, string fieldParent)
+        {
+            var uiElementName = $"{fieldDetails.CamelCaseName}Field";
+            switch (fieldDetails.FieldType)
+            {
+                case SingularFieldType singularFieldType:
+                    switch (singularFieldType.ContainedType.Category)
+                    {
+                        case ValueType.Enum:
+                            return $"{uiElementName}.value = {fieldParent}.{fieldDetails.PascalCaseName};";
+                        case ValueType.Primitive:
+                            var primitiveType = singularFieldType.ContainedType.PrimitiveType.Value;
+
+                            switch (primitiveType)
+                            {
+                                case PrimitiveType.Int32:
+                                case PrimitiveType.Int64:
+                                case PrimitiveType.Uint32:
+                                case PrimitiveType.Uint64:
+                                case PrimitiveType.Sint32:
+                                case PrimitiveType.Sint64:
+                                case PrimitiveType.Fixed32:
+                                case PrimitiveType.Fixed64:
+                                case PrimitiveType.Sfixed32:
+                                case PrimitiveType.Sfixed64:
+                                case PrimitiveType.Float:
+                                case PrimitiveType.Double:
+                                case PrimitiveType.String:
+                                case PrimitiveType.EntityId:
+                                    return $"{uiElementName}.value = {fieldParent}.{fieldDetails.PascalCaseName}.ToString();";
+                                case PrimitiveType.Bytes:
+                                    return $"{uiElementName}.value = global::System.Text.Encoding.Default.GetString({fieldParent}.{fieldDetails.PascalCaseName});";
+                                case PrimitiveType.Bool:
+                                    return $"{uiElementName}.value = {fieldParent}.{fieldDetails.PascalCaseName};";
+                                    break;
+                                case PrimitiveType.Entity:
+                                    // TODO: Entity type.
+                                    return "";
+                                case PrimitiveType.Invalid:
+                                    throw new ArgumentException("Unknown primitive type encountered");
+                                default:
+                                    throw new ArgumentOutOfRangeException();
+                            }
+                        case ValueType.Type:
+                            return $"{uiElementName}.Update({fieldParent}.{fieldDetails.PascalCaseName});";
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                default:
+                    // TODO: Lists, maps, and options
+                    return "";
+            }
+        }
+
+        private string GetUiFieldType(ContainedType type)
+        {
+            switch (type.Category)
+            {
+                case ValueType.Enum:
+                    return "EnumField";
+                case ValueType.Primitive:
+                    switch (type.PrimitiveType.Value)
+                    {
+                        case PrimitiveType.Int32:
+                        case PrimitiveType.Int64:
+                        case PrimitiveType.Uint32:
+                        case PrimitiveType.Uint64:
+                        case PrimitiveType.Sint32:
+                        case PrimitiveType.Sint64:
+                        case PrimitiveType.Fixed32:
+                        case PrimitiveType.Fixed64:
+                        case PrimitiveType.Sfixed32:
+                        case PrimitiveType.Sfixed64:
+                        case PrimitiveType.Float:
+                        case PrimitiveType.Double:
+                        case PrimitiveType.String:
+                        case PrimitiveType.EntityId:
+                        case PrimitiveType.Bytes:
+                            return "TextField";
+                        case PrimitiveType.Bool:
+                            return "Toggle";
+                        case PrimitiveType.Entity:
+                            return "";
+                        case PrimitiveType.Invalid:
+                            throw new ArgumentException("Unknown primitive type encountered.");
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                case ValueType.Type:
+                    return CalculateRendererFullyQualifiedName(type);
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        // We generate child types inside the parent type (if we don't there will be clashes).
+        // However this means to get the renderer type we can't just grab the FQN, since each intermediate type will
+        // have 'Renderer' appended to it.
+        //
+        // We need to crawl back up the type tree until we find the most-parent type and construct the FQN from
+        // this information.
+        // i.e. - global::{namespace of parent type}.{parent type}Renderer.{child type}Renderer.{child type}Renderer
+        private string CalculateRendererFullyQualifiedName(ContainedType type)
+        {
+            var typeDetails = detailsStore.Types[type.RawType];
+
+            var rendererChain = new List<string>();
+
+            while (true)
+            {
+                rendererChain.Add($"{typeDetails.Name}Renderer");
+                if (typeDetails.Parent == null)
+                {
+                    break;
+                }
+
+                typeDetails = typeDetails.Parent;
+            }
+
+            rendererChain.Reverse();
+
+            return $"global::{typeDetails.Namespace}.{string.Join(".", rendererChain)}";
+        }
+    }
+}
+

--- a/workers/unity/Packages/io.improbable.gdk.debug/.codegen/Source/Generators/DebugExtensions/TypeVisualElementGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/.codegen/Source/Generators/DebugExtensions/TypeVisualElementGenerator.cs
@@ -1,0 +1,70 @@
+using System.Linq;
+using Improbable.Gdk.CodeGeneration.CodeWriter;
+using Improbable.Gdk.CodeGeneration.CodeWriter.Scopes;
+using Improbable.Gdk.CodeGeneration.Model.Details;
+
+namespace Improbable.Gdk.CodeGenerator
+{
+    public class TypeVisualElementGenerator
+    {
+        private readonly FieldTypeHandler fieldTypeHandler;
+
+        public TypeVisualElementGenerator(DetailsStore detailsStore)
+        {
+            fieldTypeHandler = new FieldTypeHandler(detailsStore);
+        }
+
+        public CodeWriter Generate(UnityTypeDetails details)
+        {
+            return CodeWriter.Populate(cgw =>
+            {
+                cgw.UsingDirectives(
+                    "UnityEngine.UIElements",
+                    "UnityEditor.UIElements",
+                    "Improbable.Gdk.Debug.WorkerInspector.Codegen"
+                );
+
+                cgw.Namespace(details.Namespace, ns =>
+                {
+                    ns.Type(GenerateType(details));
+                });
+            });
+        }
+
+        private TypeBlock GenerateType(UnityTypeDetails details)
+        {
+            return Scope.Type($"public class {details.Name}Renderer : SchemaTypeVisualElement<{details.FullyQualifiedName}>",
+                type =>
+                {
+                    type.TextList(details.FieldDetails.Select(fieldTypeHandler.ToFieldDeclaration));
+
+                    GenerateConstructor(type, details);
+                    GenerateUpdateMethod(type, details);
+
+                    foreach (var nestedType in details.ChildTypes)
+                    {
+                        type.Type(GenerateType(nestedType));
+                    }
+                });
+        }
+
+        private void GenerateConstructor(TypeBlock typeBlock, UnityTypeDetails details)
+        {
+            typeBlock.Method($"public {details.Name}Renderer(string label) : base(label)", mb =>
+            {
+                foreach (var field in details.FieldDetails)
+                {
+                    mb.TextList(fieldTypeHandler.ToFieldInitialisation(field, "Container"));
+                }
+            });
+        }
+
+        private void GenerateUpdateMethod(TypeBlock typeBlock, UnityTypeDetails details)
+        {
+            typeBlock.Method($"public override void Update({details.FullyQualifiedName} data)", mb =>
+            {
+                mb.TextList(details.FieldDetails.Select(fd => fieldTypeHandler.ToUiFieldUpdate(fd, "data")));
+            });
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/SchemaTypeVisualElement.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/SchemaTypeVisualElement.cs
@@ -1,0 +1,22 @@
+using UnityEngine.UIElements;
+
+namespace Improbable.Gdk.Debug.WorkerInspector.Codegen
+{
+    public abstract class SchemaTypeVisualElement<T> : VisualElement
+    {
+        protected readonly VisualElement Container;
+
+        protected SchemaTypeVisualElement(string label)
+        {
+            AddToClassList("user-defined-type-container");
+
+            Add(new Label(label));
+
+            Container = new VisualElement();
+            Container.AddToClassList("user-defined-type-container-data");
+            Add(Container);
+        }
+
+        public abstract void Update(T data);
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/SchemaTypeVisualElement.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/SchemaTypeVisualElement.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ae643d89cec94406bfb873080d4f44e4
+timeCreated: 1591785133

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
@@ -132,3 +132,19 @@
     flex-grow: 1;
     max-width: 50%;
 }
+
+.user-defined-type-container {
+    margin: 1px 0px 1px 3px;
+}
+
+.user-defined-type-container-data {
+    margin-left: 8px;
+}
+
+.component-foldout .unity-text-field:disabled, .unity-toggle:disabled {
+    opacity: 1;
+}
+
+#worker-details .unity-text-field:disabled, .unity-toggle:disabled {
+    opacity: 1;
+}

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow_Dark.uss
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow_Dark.uss
@@ -1,4 +1,8 @@
-.is-auth-toggle .unity-label:disabled {
+#worker-details .unity-label:disabled {
+    color: white;
+}
+
+.component-foldout .unity-label:disabled {
     color: white;
 }
 
@@ -7,5 +11,9 @@
 }
 
 #worker-flags .unity-label:disabled {
+    color: white;
+}
+
+.unity-label {
     color: white;
 }

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow_Light.uss
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow_Light.uss
@@ -1,4 +1,8 @@
-.is-auth-toggle .unity-label:disabled {
+#worker-details .unity-label:disabled {
+    color: black;
+}
+
+.component-foldout .unity-label:disabled {
     color: black;
 }
 
@@ -7,5 +11,9 @@
 }
 
 #worker-flags .unity-label:disabled {
+    color: black;
+}
+
+.unity-label {
     color: black;
 }

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/FieldTypes/ContainedType.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/FieldTypes/ContainedType.cs
@@ -6,6 +6,7 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
     public class ContainedType
     {
         public readonly string FqnType;
+        public readonly string RawType;
         public readonly ValueType Category;
         public readonly PrimitiveType? PrimitiveType;
 
@@ -16,16 +17,19 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
                 case ValueType.Enum:
                     Category = ValueType.Enum;
                     FqnType = DetailsUtils.GetCapitalisedFqnTypename(innerType.Enum);
+                    RawType = innerType.Enum;
                     PrimitiveType = null;
                     break;
                 case ValueType.Primitive:
                     Category = ValueType.Primitive;
                     FqnType = UnityTypeMappings.SchemaTypeToUnityType[innerType.Primitive];
+                    RawType = innerType.Primitive.ToString();
                     PrimitiveType = innerType.Primitive;
                     break;
                 case ValueType.Type:
                     Category = ValueType.Type;
                     FqnType = DetailsUtils.GetCapitalisedFqnTypename(innerType.Type);
+                    RawType = innerType.Type;
                     PrimitiveType = null;
                     break;
                 default:

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/UnityTypeDetails.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/UnityTypeDetails.cs
@@ -14,6 +14,8 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
         public IReadOnlyList<UnityTypeDetails> ChildTypes { get; private set; }
         public IReadOnlyList<UnityEnumDetails> ChildEnums { get; private set; }
 
+        public UnityTypeDetails Parent { get; private set; }
+
         public SerializationOverride SerializationOverride { get; internal set; }
 
         public bool HasSerializationOverride => SerializationOverride != null;
@@ -44,6 +46,11 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
                 .Select(kv => kv.Value)
                 .ToList()
                 .AsReadOnly();
+
+            foreach (var child in ChildTypes)
+            {
+                child.Parent = this;
+            }
 
             Logger.Trace($"Populating child enum details for type {rawTypeDefinition.QualifiedName}.");
             ChildEnums = store.Enums


### PR DESCRIPTION
#### Description

This PR adds support for rendering user-defined schema types in the Worker Inspector. 

- We generate a `VisualElement` implementation for each schema type.
- This is then used in components and other types to opaquely render the schema type.

Each type has indented labels (which does then indent the field, we can look at resolving this later, but its non-trivial). 

This PR also fixed some of the styling issues (where the fields were entirely grayed out due to an opacity setting). 

![image](https://user-images.githubusercontent.com/13353733/84262623-d1c17180-ab15-11ea-900d-585b588e6cd5.png)


#### Tests

Eyeball test with nested types.
