### PR TITLE
Add Option<T> rendering to the Worker Inspector

### DIFF
--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/Improbable.Gdk.Debug.WorkerInspector.Codegen.asmdef
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/Improbable.Gdk.Debug.WorkerInspector.Codegen.asmdef
@@ -1,7 +1,8 @@
 {
     "name": "Improbable.Gdk.Debug.WorkerInspector.Codegen",
     "references": [
-        "Unity.Entities"
+        "Unity.Entities",
+        "Improbable.Gdk.Core"
     ],
     "includePlatforms": [
         "Editor"

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/OptionVisualElement.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/OptionVisualElement.cs
@@ -1,0 +1,93 @@
+using System;
+using Improbable.Gdk.Core;
+using UnityEngine.UIElements;
+
+namespace Improbable.Gdk.Debug.WorkerInspector.Codegen
+{
+    public sealed class OptionVisualElement<TElement, TData> : OptionalVisualElementBase<TElement, TData>
+        where TElement : VisualElement
+    {
+        public OptionVisualElement(string label, TElement innerElement, Action<TElement, TData> applyData) : base(label, innerElement, applyData)
+        {
+        }
+
+        public void Update(Option<TData> data)
+        {
+            if (data.HasValue)
+            {
+                UpdateWithData(data.Value);
+            }
+            else
+            {
+                UpdateWithoutData();
+            }
+        }
+    }
+
+    public sealed class NullableVisualElement<TElement, TData> : OptionalVisualElementBase<TElement, TData>
+        where TData : struct
+        where TElement : VisualElement
+    {
+        public NullableVisualElement(string label, TElement innerElement, Action<TElement, TData> applyData) : base(label, innerElement, applyData)
+        {
+        }
+
+        public void Update(TData? data)
+        {
+            if (data.HasValue)
+            {
+                UpdateWithData(data.Value);
+            }
+            else
+            {
+                UpdateWithoutData();
+            }
+        }
+    }
+
+    public class OptionalVisualElementBase<TElement, TData> : VisualElement where TElement : VisualElement
+    {
+        private readonly VisualElement container;
+        private readonly TElement innerElement;
+        private readonly Label isEmptyLabel;
+        private readonly Action<TElement, TData> applyData;
+
+        protected OptionalVisualElementBase(string label, TElement innerElement, Action<TElement, TData> applyData)
+        {
+            AddToClassList("user-defined-type-container");
+            Add(new Label(label));
+
+            container = new VisualElement();
+            container.AddToClassList("user-defined-type-container-data");
+            Add(container);
+
+            isEmptyLabel = new Label("Option is empty.");
+            isEmptyLabel.AddToClassList("label-empty-option");
+
+            this.innerElement = innerElement;
+            this.applyData = applyData;
+        }
+
+        protected void UpdateWithData(TData data)
+        {
+            RemoveIfPresent(isEmptyLabel);
+            container.Add(innerElement);
+
+            applyData(innerElement, data);
+        }
+
+        protected void UpdateWithoutData()
+        {
+            RemoveIfPresent(innerElement);
+            container.Add(isEmptyLabel);
+        }
+
+        private void RemoveIfPresent(VisualElement element)
+        {
+            if (container.Contains(element))
+            {
+                container.Remove(element);
+            }
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/OptionVisualElement.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/OptionVisualElement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 24ddbdd6b93c4554387fa191108c1669
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
@@ -148,3 +148,9 @@
 #worker-details .unity-text-field:disabled, .unity-toggle:disabled {
     opacity: 1;
 }
+
+.label-empty-option {
+    margin-left: 3px;
+    margin-top: 1px;
+    margin-bottom: 1px;
+}


### PR DESCRIPTION
#### Description

This PR adds rendering support for `Option<T>` to the Worker Inspector. 

- Add `OptionVisualElement` and `NullableVisualElement` to render `Option<T>` and `T?` respectively. (We use `T?` except for when `T` is a reference type, i.e. - string and bytes).
- Refactor `FieldTypeHandler` a bit to support the above VisualElements. 

#### Tests

Eyeball test of the `ExhaustiveOptional` component. 

![image](https://user-images.githubusercontent.com/13353733/84374841-8a4eea00-abd6-11ea-89c6-1d0fac025a77.png)

