### PR TITLE
Add list support to Worker Inspector

### DIFF
--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/AssemblyInfo.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Improbable.Gdk.Debug.WorkerInspector.Codegen.EditmodeTests")]

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/AssemblyInfo.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/AssemblyInfo.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: af24913a485043009e9bf180b2f1aca8
+timeCreated: 1592324281

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/PaginatedListView.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/PaginatedListView.cs
@@ -19,6 +19,7 @@ namespace Improbable.Gdk.Debug.WorkerInspector.Codegen
         private readonly Pool elementPool;
         private readonly int elementsPerPage;
 
+        private readonly VisualElement controlsContainer;
         private readonly Button forwardButton;
         private readonly Button backButton;
         private readonly Label pageCounter;
@@ -36,6 +37,8 @@ namespace Improbable.Gdk.Debug.WorkerInspector.Codegen
 
             this.Q<Label>(name: "list-name").text = label;
             container = this.Q<VisualElement>(className: "user-defined-type-container-data");
+
+            controlsContainer = this.Q<VisualElement>(className: "paginated-list-controls");
             pageCounter = this.Q<Label>(name: "page-counter");
 
             backButton = this.Q<Button>(name: "back-button");
@@ -52,6 +55,16 @@ namespace Improbable.Gdk.Debug.WorkerInspector.Codegen
         public void Update(List<TData> newData)
         {
             data = newData;
+
+            if (data.Count == 0)
+            {
+                controlsContainer.AddToClassList("hidden");
+            }
+            else
+            {
+                controlsContainer.RemoveFromClassList("hidden");
+            }
+
             CalculatePages();
             RefreshView();
         }

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/PaginatedListView.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/PaginatedListView.cs
@@ -69,7 +69,7 @@ namespace Improbable.Gdk.Debug.WorkerInspector.Codegen
             RefreshView();
         }
 
-        private void ChangePageCount(int diff)
+        internal void ChangePageCount(int diff)
         {
             currentPage += diff;
             currentPage = Mathf.Clamp(currentPage, 0, numPages - 1);

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/PaginatedListView.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/PaginatedListView.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Improbable.Gdk.Debug.WorkerInspector.Codegen
+{
+    public class PaginatedListView<TElement, TData> : VisualElement
+        where TElement : VisualElement
+    {
+        private const string UxmlPath =
+            "Packages/io.improbable.gdk.debug/WorkerInspector/Templates/PaginatedListView.uxml";
+
+        private List<TData> data;
+
+        private readonly Action<int, TData, TElement> bindElement;
+        private readonly VisualElement container;
+        private readonly Pool elementPool;
+        private readonly int elementsPerPage;
+
+        private readonly Button forwardButton;
+        private readonly Button backButton;
+        private readonly Label pageCounter;
+
+        private int currentPage = 0;
+        private int numPages = 0;
+
+        public PaginatedListView(string label, Func<TElement> makeElement, Action<int, TData, TElement> bindElement, int elementsPerPage = 5)
+        {
+            this.bindElement = bindElement;
+            this.elementsPerPage = elementsPerPage;
+
+            var template = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(UxmlPath);
+            template.CloneTree(this);
+
+            this.Q<Label>(name: "list-name").text = label;
+            container = this.Q<VisualElement>(className: "user-defined-type-container-data");
+            pageCounter = this.Q<Label>(name: "page-counter");
+
+            backButton = this.Q<Button>(name: "back-button");
+            backButton.text = "<";
+            backButton.clickable.clicked += () => ChangePageCount(-1);
+
+            forwardButton = this.Q<Button>(name: "forward-button");
+            forwardButton.text = ">";
+            forwardButton.clickable.clicked += () => ChangePageCount(1);
+
+            elementPool = new Pool(makeElement);
+        }
+
+        public void Update(List<TData> newData)
+        {
+            data = newData;
+            CalculatePages();
+            RefreshView();
+        }
+
+        private void ChangePageCount(int diff)
+        {
+            currentPage += diff;
+            currentPage = Mathf.Clamp(currentPage, 0, numPages - 1);
+            CalculatePages();
+            RefreshView();
+        }
+
+        private void CalculatePages()
+        {
+            numPages = (int) Math.Ceiling((double) data.Count / elementsPerPage);
+            numPages = Mathf.Clamp(numPages, 1, numPages);
+            currentPage = Mathf.Clamp(currentPage, 0, numPages - 1);
+
+            pageCounter.text = $"{currentPage + 1}/{numPages}";
+        }
+
+        private void RefreshView()
+        {
+            // Calculate slice of list to be rendered.
+            var firstIndex = currentPage * elementsPerPage;
+            var length = Math.Min(elementsPerPage, data.Count - firstIndex);
+
+            // If the child count is the same, don't adjust it.
+            // If the child count is less, add the requisite number.
+            // If the child count is more, pop elements off the end.
+
+            var diff = container.childCount - length;
+
+            if (diff > 0)
+            {
+                for (var i = 0; i < diff; i++)
+                {
+                    var element = container.ElementAt(container.childCount - 1);
+                    container.RemoveAt(container.childCount - 1);
+                    elementPool.Return((TElement) element);
+                }
+            }
+            else if (diff < 0)
+            {
+                for (var i = diff; i < 0; i++)
+                {
+                    container.Add(elementPool.GetOrCreate());
+                }
+            }
+
+            // At this point, container.Children() has the same length as the slice.
+            var j = 0;
+            foreach (var child in container.Children())
+            {
+                bindElement(firstIndex + j, data[firstIndex + j], (TElement) child);
+                j++;
+            }
+
+            backButton.SetEnabled(currentPage != 0);
+            forwardButton.SetEnabled(currentPage != numPages - 1);
+        }
+
+        private class Pool
+        {
+            private readonly Stack<TElement> pool = new Stack<TElement>();
+            private readonly Func<TElement> makeElement;
+
+            public Pool(Func<TElement> makeElement)
+            {
+                this.makeElement = makeElement;
+            }
+
+            public TElement GetOrCreate()
+            {
+                return pool.Count == 0 ? makeElement() : pool.Pop();
+            }
+
+            public void Return(TElement element)
+            {
+                pool.Push(element);
+            }
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/PaginatedListView.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/PaginatedListView.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fe9f90008d144174b84cf9edccbd0152
+timeCreated: 1591889364

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/SchemaTypeVisualElement.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/SchemaTypeVisualElement.cs
@@ -4,13 +4,21 @@ namespace Improbable.Gdk.Debug.WorkerInspector.Codegen
 {
     public abstract class SchemaTypeVisualElement<T> : VisualElement
     {
+        public string Label
+        {
+            get => labelElement.text;
+            set => labelElement.text = value;
+        }
+
         protected readonly VisualElement Container;
+        private readonly Label labelElement;
 
         protected SchemaTypeVisualElement(string label)
         {
             AddToClassList("user-defined-type-container");
 
-            Add(new Label(label));
+            labelElement = new Label(label);
+            Add(labelElement);
 
             Container = new VisualElement();
             Container.AddToClassList("user-defined-type-container-data");

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/Tests.meta
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 15c0ca415a4844838eadcc42afef1dee
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/Tests/Improbable.Gdk.Debug.WorkerInspector.Codegen.EditmodeTests.asmdef
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/Tests/Improbable.Gdk.Debug.WorkerInspector.Codegen.EditmodeTests.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "Improbable.Gdk.Debug.WorkerInspector.Codegen.EditmodeTests",
+    "references": [
+        "Improbable.Gdk.Debug.WorkerInspector.Codegen"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/Tests/Improbable.Gdk.Debug.WorkerInspector.Codegen.EditmodeTests.asmdef.meta
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/Tests/Improbable.Gdk.Debug.WorkerInspector.Codegen.EditmodeTests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e484a5bd55ef8694abe8b9342cbf7baf
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/Tests/PaginatedListViewTests.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/Tests/PaginatedListViewTests.cs
@@ -1,0 +1,181 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+
+namespace Improbable.Gdk.Debug.WorkerInspector.Codegen.EditmodeTests
+{
+    [TestFixture]
+    public class PaginatedListViewTests
+    {
+        [Test]
+        public void Only_up_to_elementsPerPage_are_rendered_at_once()
+        {
+            var data = GetDummyData(10);
+            var observer = new PaginatedListViewObserver(5);
+
+            observer.UpdateData(data);
+
+            var elements = observer.VisibleElements.ToList();
+
+            Assert.AreEqual(5, elements.Count);
+        }
+
+        [Test]
+        public void Correct_list_slice_is_rendered_in_order()
+        {
+            var data = GetDummyData(10);
+            var observer = new PaginatedListViewObserver(5);
+
+            observer.UpdateData(data);
+
+            var elements = observer.VisibleElements.ToList();
+
+            for (var i = 0; i < elements.Count; i++)
+            {
+                Assert.AreEqual(i, ((PaginatedListViewObserver.DummyElement) elements[i]).Index);
+            }
+        }
+
+        [Test]
+        public void Forward_button_is_disabled_when_no_more_pages()
+        {
+            var data = GetDummyData(5);
+            var observer = new PaginatedListViewObserver(5);
+            observer.UpdateData(data);
+            Assert.IsFalse(observer.IsPageForwardButtonEnabled);
+        }
+
+        [Test]
+        public void Back_button_is_disabled_when_no_more_pages()
+        {
+            var data = GetDummyData(5);
+            var observer = new PaginatedListViewObserver(5);
+            observer.UpdateData(data);
+            Assert.IsFalse(observer.IsPageBackButtonEnabled);
+        }
+
+        [Test]
+        public void Forward_button_is_enabled_if_more_pages()
+        {
+            var data = GetDummyData(10);
+            var observer = new PaginatedListViewObserver(5);
+            observer.UpdateData(data);
+            Assert.IsTrue(observer.IsPageForwardButtonEnabled);
+        }
+
+        [Test]
+        public void Back_button_is_enabled_if_more_pages()
+        {
+            var data = GetDummyData(10);
+            var observer = new PaginatedListViewObserver(5);
+            observer.UpdateData(data);
+            observer.TryPageForward();
+            Assert.IsTrue(observer.IsPageBackButtonEnabled);
+        }
+
+        [Test]
+        public void Paging_forward_updates_rendered_data()
+        {
+            var data = GetDummyData(15);
+            var observer = new PaginatedListViewObserver(5);
+
+            observer.UpdateData(data);
+            observer.TryPageForward();
+
+            var elements = observer.VisibleElements.ToList();
+
+            for (var i = 0; i < elements.Count; i++)
+            {
+                var expectedIndex = i + 5; // We expect to be on the second page.
+                Assert.AreEqual(expectedIndex, ((PaginatedListViewObserver.DummyElement) elements[i]).Index);
+            }
+        }
+
+        [Test]
+        public void Paging_backwards_updates_rendered_data()
+        {
+            var data = GetDummyData(15);
+            var observer = new PaginatedListViewObserver(5);
+
+            observer.UpdateData(data);
+            observer.TryPageForward();
+            observer.TryPageBackwards();
+
+            var elements = observer.VisibleElements.ToList();
+
+            for (var i = 0; i < elements.Count; i++)
+            {
+                Assert.AreEqual(i, ((PaginatedListViewObserver.DummyElement) elements[i]).Index);
+            }
+        }
+
+        [Test]
+        public void Sub_slice_of_list_can_be_rendered()
+        {
+            var data = GetDummyData(8);
+            var observer = new PaginatedListViewObserver(5);
+
+            observer.UpdateData(data);
+            observer.TryPageForward();
+
+            var elements = observer.VisibleElements.ToList();
+
+            Assert.AreEqual(3, elements.Count);
+
+            for (var i = 0; i < elements.Count; i++)
+            {
+                var expectedIndex = i + 5; // We expect to be on the second page.
+                Assert.AreEqual(expectedIndex, ((PaginatedListViewObserver.DummyElement) elements[i]).Index);
+            }
+        }
+
+        private class PaginatedListViewObserver
+        {
+            public bool IsPageForwardButtonEnabled => listView.Q<Button>(name: "forward-button").enabledSelf;
+            public bool IsPageBackButtonEnabled => listView.Q<Button>(name: "back-button").enabledSelf;
+
+            public IEnumerable<VisualElement> VisibleElements =>
+                listView
+                    .Q<VisualElement>(className: "user-defined-type-container-data")
+                    .Children();
+
+            private readonly PaginatedListView<DummyElement, int> listView;
+
+            public PaginatedListViewObserver(int elementsPerPage)
+            {
+                listView = new PaginatedListView<DummyElement, int>("My List",
+                    () => new DummyElement(),
+                    (index, _, element) =>
+                    {
+                        element.Index = index;
+                    }, elementsPerPage);
+            }
+
+            public void TryPageForward()
+            {
+                listView.ChangePageCount(1);
+            }
+
+            public void TryPageBackwards()
+            {
+                listView.ChangePageCount(-1);
+            }
+
+            public void UpdateData(List<int> data)
+            {
+                listView.Update(data);
+            }
+
+            public class DummyElement : VisualElement
+            {
+                public int Index;
+            }
+        }
+
+        private static List<int> GetDummyData(int count)
+        {
+            return Enumerable.Repeat(0, count).ToList();
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/Tests/PaginatedListViewTests.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/Tests/PaginatedListViewTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 83deb3775bd94b3b8f6f1e2f8bdb08ba
+timeCreated: 1592318792

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/PaginatedListView.uxml
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/PaginatedListView.uxml
@@ -2,7 +2,7 @@
     <VisualElement class="user-defined-type-container">
         <Label name="list-name" />
         <VisualElement class="user-defined-type-container-data" />
-        <VisualElement class="paginated-list-controls">
+        <VisualElement class="paginated-list-controls hidden">
             <Button class="paginated-list-controls__child" name="back-button"/>
             <Label class="paginated-list-controls__child" name="page-counter" />
             <Button class="paginated-list-controls__child" name="forward-button"/>

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/PaginatedListView.uxml
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/PaginatedListView.uxml
@@ -1,0 +1,11 @@
+<UXML xmlns="UnityEngine.UIElements">
+    <VisualElement class="user-defined-type-container">
+        <Label name="list-name" />
+        <VisualElement class="user-defined-type-container-data" />
+        <VisualElement class="paginated-list-controls">
+            <Button class="paginated-list-controls__child" name="back-button"/>
+            <Label class="paginated-list-controls__child" name="page-counter" />
+            <Button class="paginated-list-controls__child" name="forward-button"/>
+        </VisualElement>
+    </VisualElement>
+</UXML>

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/PaginatedListView.uxml
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/PaginatedListView.uxml
@@ -3,9 +3,9 @@
         <Label name="list-name" />
         <VisualElement class="user-defined-type-container-data" />
         <VisualElement class="paginated-list-controls hidden">
-            <Button class="paginated-list-controls__child" name="back-button"/>
+            <Button class="paginated-list-controls__child" name="back-button" text="&lt;"/>
             <Label class="paginated-list-controls__child" name="page-counter" />
-            <Button class="paginated-list-controls__child" name="forward-button"/>
+            <Button class="paginated-list-controls__child" name="forward-button" text="&gt;"/>
         </VisualElement>
     </VisualElement>
 </UXML>

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/PaginatedListView.uxml.meta
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/PaginatedListView.uxml.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8d720bb5b4704a39ac3910f2397ce1fa
+timeCreated: 1592233589

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
@@ -161,3 +161,14 @@
     margin-top: 1px;
     margin-bottom: 1px;
 }
+
+.paginated-list-controls {
+    flex-direction: row;
+    justify-content: center;
+    margin: 5px 15px;
+    align-items: center;
+}
+
+.paginated-list-controls__child {
+    margin: 0 5px;
+}

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
@@ -172,3 +172,7 @@
 .paginated-list-controls__child {
     margin: 0 5px;
 }
+
+.hidden {
+    display: none;
+}

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/FieldTypes/ListFieldType.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/FieldTypes/ListFieldType.cs
@@ -4,20 +4,20 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
 {
     public class ListFieldType : IFieldType
     {
-        public string Type => $"global::System.Collections.Generic.List<{containedType.FqnType}>";
+        public string Type => $"global::System.Collections.Generic.List<{ContainedType.FqnType}>";
 
-        private readonly ContainedType containedType;
+        public readonly ContainedType ContainedType;
 
         public ListFieldType(TypeReference innerType)
         {
-            containedType = new ContainedType(innerType);
+            ContainedType = new ContainedType(innerType);
         }
 
         public string GetSerializationString(string fieldInstance, string schemaObject, uint fieldNumber)
         {
             return new LoopBlock($"foreach (var value in {fieldInstance})", body =>
             {
-                body.Line(containedType.GetSerializationStatement("value", schemaObject, fieldNumber));
+                body.Line(ContainedType.GetSerializationStatement("value", schemaObject, fieldNumber));
             }).Format();
         }
 
@@ -29,12 +29,12 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
                 {
                     $"{fieldInstance} = new {Type}();",
                     $"var list = {fieldInstance};",
-                    $"var listLength = {containedType.GetCountExpression(schemaObject, fieldNumber)};"
+                    $"var listLength = {ContainedType.GetCountExpression(schemaObject, fieldNumber)};"
                 });
 
                 scope.Loop("for (var i = 0; i < listLength; i++)", body =>
                 {
-                    body.Line($"list.Add({containedType.GetFieldIndexExpression(schemaObject, fieldNumber, "i")});");
+                    body.Line($"list.Add({ContainedType.GetFieldIndexExpression(schemaObject, fieldNumber, "i")});");
                 });
             }).Format();
         }
@@ -43,7 +43,7 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
         {
             return new CustomScopeBlock(scope =>
             {
-                scope.Line($"var listSize = {containedType.GetCountExpression(schemaObject, fieldNumber)};");
+                scope.Line($"var listSize = {ContainedType.GetCountExpression(schemaObject, fieldNumber)};");
 
                 scope.Line($"var isCleared = updateObj.IsFieldCleared({fieldNumber});");
 
@@ -56,7 +56,7 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
                 {
                     body.Line(new[]
                     {
-                        $"var value = {containedType.GetFieldIndexExpression(schemaObject, fieldNumber, "i")};",
+                        $"var value = {ContainedType.GetFieldIndexExpression(schemaObject, fieldNumber, "i")};",
                         $"{fieldInstance}.Add(value);"
                     });
                 });
@@ -67,7 +67,7 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
         {
             return new CustomScopeBlock(scope =>
             {
-                scope.Line($"var listSize = {containedType.GetCountExpression(schemaObject, fieldNumber)};");
+                scope.Line($"var listSize = {ContainedType.GetCountExpression(schemaObject, fieldNumber)};");
 
                 scope.Line($"var isCleared = updateObj.IsFieldCleared({fieldNumber});");
 
@@ -81,7 +81,7 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
                 {
                     body.Line(new[]
                     {
-                        $"var value = {containedType.GetFieldIndexExpression(schemaObject, fieldNumber, "i")};",
+                        $"var value = {ContainedType.GetFieldIndexExpression(schemaObject, fieldNumber, "i")};",
                         $"{updateFieldInstance}.Value.Add(value);"
                     });
                 });
@@ -94,7 +94,7 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
             {
                 scope.Line(new[]
                 {
-                    $"var listSize = {containedType.GetCountExpression(schemaObject, fieldNumber)};",
+                    $"var listSize = {ContainedType.GetCountExpression(schemaObject, fieldNumber)};",
                     $"{updateFieldInstance} = new global::Improbable.Gdk.Core.Option<{Type}>(new {Type}());"
                 });
 
@@ -102,7 +102,7 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
                 {
                     body.Line(new[]
                     {
-                        $"var value = {containedType.GetFieldIndexExpression(schemaObject, fieldNumber, "i")};",
+                        $"var value = {ContainedType.GetFieldIndexExpression(schemaObject, fieldNumber, "i")};",
                         $"{updateFieldInstance}.Value.Add(value);"
                     });
                 });


### PR DESCRIPTION
#### Description

This PR introduces list support for the worker inspector by adding a `PaginatedListView<TElement, TData>` visual element for use in the worker inspector. This maintains a pool of `TElement` objects that it will reuse. By default, the number of elements per page is `5`, we can tweak this pretty easily. The `PaginatedListView` accepts two closures in its constructor:

- `Func<TElement> makeElement`. This is what the pool calls when it needs to create a new element.
- `Action<int, TData, TElement> bindElement`. This is what is called when the list view is updating an element. The `int` parameter is the absolute position of the element in the list (i.e. - not the position in the page). 

The pagination handles elements being removed from the list underneath you as well as additions. 

![image](https://user-images.githubusercontent.com/13353733/84681766-88fe2400-af2c-11ea-923d-26d0ebc40666.png)

(See `CubeSpawner` component for the list)

#### Tests

- [x] Cube spawner in playground
- [x] Some unit tests for the list view around pagination and viewing a list slice.
- [x] Exhaustive list renderer.
