### PR TITLE
Add entity type rendering to Worker Inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
     - This window also displays the entities that a worker has checked out.
     - For each entity checked out, you can view the components on that entity and whether the worker is authoritative over that component.
     - Each component can have an icon associated with it, set through a schema annotation. [#1385](https://github.com/spatialos/gdk-for-unity/pull/1385)
+    - Each component's data will also be rendered in the Worker Inspector, with the exception of `map<k, v>` fields. (This will come in a future release!) [#1387](https://github.com/spatialos/gdk-for-unity/pull/1387) [#1391](https://github.com/spatialos/gdk-for-unity/pull/1391) [#1392](https://github.com/spatialos/gdk-for-unity/pull/1392) [#1396](https://github.com/spatialos/gdk-for-unity/pull/1396) [#1401](https://github.com/spatialos/gdk-for-unity/pull/1401)
+- Added two ways to instantiate valid `EntitySnapshot` objects. [#1401](https://github.com/spatialos/gdk-for-unity/pull/1401)
+    - `EntitySnapshot.Empty()` to create an empty `EntitySnapshot`
+    - `new EntitySnapshot(params ISpatialComponentSnapshot[] components)` to create and seed the `EntitySnapshot` with some data.
 
 ### Fixed
 

--- a/workers/unity/Packages/io.improbable.gdk.core/Utility/EntitySnapshot.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Utility/EntitySnapshot.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using Improbable.Worker.CInterop;
 
 namespace Improbable.Gdk.Core
@@ -8,7 +10,22 @@ namespace Improbable.Gdk.Core
     /// </summary>
     public struct EntitySnapshot
     {
-        private readonly Dictionary<uint, ISpatialComponentSnapshot> components;
+        private Dictionary<uint, ISpatialComponentSnapshot> components;
+
+        public static EntitySnapshot Empty()
+        {
+            return new EntitySnapshot { components = new Dictionary<uint, ISpatialComponentSnapshot>() };
+        }
+
+        public EntitySnapshot(params ISpatialComponentSnapshot[] snapshots)
+        {
+            components = new Dictionary<uint, ISpatialComponentSnapshot>();
+
+            foreach (var snapshot in snapshots)
+            {
+                components[snapshot.ComponentId] = snapshot;
+            }
+        }
 
         /// <summary>
         ///     Gets the SpatialOS component snapshot if present.
@@ -89,6 +106,25 @@ namespace Improbable.Gdk.Core
             {
                 Dynamic.ForComponent(pair.Key, handler);
             }
+        }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder("Entity Snapshot: ");
+
+            var componentNames = components.Keys.Select(id =>
+            {
+                if (!ComponentDatabase.Metaclasses.TryGetValue(id, out var metaclass))
+                {
+                    return $"Unknown Component ({id})";
+                }
+
+                return metaclass.Name;
+            });
+
+            sb.Append(string.Join(", ", componentNames));
+
+            return sb.ToString();
         }
     }
 

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
@@ -41,8 +41,6 @@
 #entity-detail .unity-text-field__input {
     white-space: normal;
 }
-
-
 #entity-info {
     min-height: 50px;
     padding: 8px;

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
@@ -38,6 +38,11 @@
     border-top-width: 1px;
 }
 
+#entity-detail .unity-text-field__input {
+    white-space: normal;
+}
+
+
 #entity-info {
     min-height: 50px;
     padding: 8px;
@@ -51,6 +56,7 @@
     -unity-font-style: bold;
     font-size: 14px;
     padding-bottom: 4px;
+    white-space: normal;
 }
 
 .component-foldout {


### PR DESCRIPTION
#### Description

- Add Entity rendering to the Worker Inspector. This rendered through a `TextField` and presents itself as the list of components in the `EntitySnapshot`. I.e. - `EntitySnapshot: Metadata, Position, Health`
- Drive by fix on `EntitySnapshot`. There was no way to actually make one of these yourselves 😬 
- Fix text overflowing on text input fields and entity names in the Worker Inspector. (It can still happen in the listview, but its clipped and given the fixed height there's not a _ton_ I can do about this). 
- Refactored some common logic in the `FieldTypeHandler`

#### Tests

- `ExhaustiveEntityRenderer`
- Overflowing text in the `Metadata` (not in this PR)

#### Documentation

- [x] Changelog
