### PR TITLE
Add map support to the Worker Inspector and fix performance bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Added
+
+- Added `map<k,v>` support to the Worker Inspector window. [#1403](https://github.com/spatialos/gdk-for-unity/pull/1403)
+
+### Fixed
+
+- Fixed a bug in the Worker Inspector where component foldouts were being rendered too often, causing poor performance when the entity had many components or very complex components. [#1403](https://github.com/spatialos/gdk-for-unity/pull/1403)
+
 ## `0.3.7` - 2020-06-22
 
 ### Added

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/PaginatedMapView.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/PaginatedMapView.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine.UIElements;
+
+namespace Improbable.Gdk.Debug.WorkerInspector.Codegen
+{
+    public class PaginatedMapView<TKeyElement, TKeyData, TValueElement, TValueData> : VisualElement
+        where TKeyElement : VisualElement
+        where TValueElement : VisualElement
+    {
+        private readonly PaginatedListView<KeyValuePairElement, KeyValuePair<TKeyData, TValueData>> list;
+        private readonly List<KeyValuePair<TKeyData, TValueData>> listData = new List<KeyValuePair<TKeyData, TValueData>>();
+        private Comparer<TKeyData> comparer = Comparer<TKeyData>.Default;
+
+        public PaginatedMapView(string label, Func<TKeyElement> makeKey, Action<TKeyData, TKeyElement> bindKey,
+            Func<TValueElement> makeValue, Action<TValueData, TValueElement> bindValue)
+        {
+            list = new PaginatedListView<KeyValuePairElement, KeyValuePair<TKeyData, TValueData>>(label,
+                () => new KeyValuePairElement(makeKey(), makeValue(), bindKey, bindValue),
+                (index, kvp, element) => element.Update(kvp));
+
+            Add(list);
+        }
+
+        public void Update(Dictionary<TKeyData, TValueData> data)
+        {
+            listData.Clear();
+            listData.AddRange(data);
+            listData.Sort((first, second) => comparer.Compare(first.Key, second.Key));
+
+            list.Update(listData);
+        }
+
+        private class KeyValuePairElement : VisualElement
+        {
+            private readonly TKeyElement keyElement;
+            private readonly TValueElement valueElement;
+
+            private Action<TKeyData, TKeyElement> bindKey;
+            private Action<TValueData, TValueElement> bindValue;
+
+            public KeyValuePairElement(TKeyElement keyElement, TValueElement valueElement,
+                Action<TKeyData, TKeyElement> bindKey, Action<TValueData, TValueElement> bindValue)
+            {
+                this.keyElement = keyElement;
+                this.valueElement = valueElement;
+                this.bindKey = bindKey;
+                this.bindValue = bindValue;
+
+                Add(keyElement);
+                Add(valueElement);
+
+                AddToClassList("map-view__item");
+            }
+
+            public void Update(KeyValuePair<TKeyData, TValueData> keyValuePair)
+            {
+                bindKey(keyValuePair.Key, keyElement);
+                bindValue(keyValuePair.Value, valueElement);
+            }
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/PaginatedMapView.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/PaginatedMapView.cs
@@ -10,7 +10,7 @@ namespace Improbable.Gdk.Debug.WorkerInspector.Codegen
     {
         private readonly PaginatedListView<KeyValuePairElement, KeyValuePair<TKeyData, TValueData>> list;
         private readonly List<KeyValuePair<TKeyData, TValueData>> listData = new List<KeyValuePair<TKeyData, TValueData>>();
-        private Comparer<TKeyData> comparer = Comparer<TKeyData>.Default;
+        private readonly Comparer<TKeyData> comparer = Comparer<TKeyData>.Default;
 
         public PaginatedMapView(string label, Func<TKeyElement> makeKey, Action<TKeyData, TKeyElement> bindKey,
             Func<TValueElement> makeValue, Action<TValueData, TValueElement> bindValue)
@@ -36,8 +36,8 @@ namespace Improbable.Gdk.Debug.WorkerInspector.Codegen
             private readonly TKeyElement keyElement;
             private readonly TValueElement valueElement;
 
-            private Action<TKeyData, TKeyElement> bindKey;
-            private Action<TValueData, TValueElement> bindValue;
+            private readonly Action<TKeyData, TKeyElement> bindKey;
+            private readonly Action<TValueData, TValueElement> bindValue;
 
             public KeyValuePairElement(TKeyElement keyElement, TValueElement valueElement,
                 Action<TKeyData, TKeyElement> bindKey, Action<TValueData, TValueElement> bindValue)

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/PaginatedMapView.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/PaginatedMapView.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d90c7443bf314da29eacea8cd7c123dd
+timeCreated: 1592841620

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/EntityDetail.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/EntityDetail.cs
@@ -105,7 +105,7 @@ namespace Improbable.Gdk.Debug.WorkerInspector
 
             foreach (var componentType in componentTypes)
             {
-                if (componentType != componentVisualElements[i].ComponentType)
+                if (componentType.TypeIndex != componentVisualElements[i].ComponentType.TypeIndex)
                 {
                     return false;
                 }

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
@@ -180,3 +180,7 @@
 .hidden {
     display: none;
 }
+
+.map-view__item {
+    padding: 5px 0px;
+}

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/FieldTypes/MapFieldType.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/FieldTypes/MapFieldType.cs
@@ -5,15 +5,15 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
 {
     public class MapFieldType : IFieldType
     {
-        public string Type => $"global::System.Collections.Generic.Dictionary<{keyType.FqnType}, {valueType.FqnType}>";
+        public string Type => $"global::System.Collections.Generic.Dictionary<{KeyType.FqnType}, {ValueType.FqnType}>";
 
-        private readonly ContainedType keyType;
-        private readonly ContainedType valueType;
+        public readonly ContainedType KeyType;
+        public readonly ContainedType ValueType;
 
         public MapFieldType(TypeReference keyType, TypeReference valueType)
         {
-            this.keyType = new ContainedType(keyType);
-            this.valueType = new ContainedType(valueType);
+            KeyType = new ContainedType(keyType);
+            ValueType = new ContainedType(valueType);
         }
 
         public string GetSerializationString(string fieldInstance, string schemaObject, uint fieldNumber)
@@ -23,8 +23,8 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
                 body.Line(new[]
                 {
                     $"var mapObj = {schemaObject}.AddObject({fieldNumber});",
-                    keyType.GetSerializationStatement("keyValuePair.Key", "mapObj", 1),
-                    valueType.GetSerializationStatement("keyValuePair.Value", "mapObj", 2)
+                    KeyType.GetSerializationStatement("keyValuePair.Key", "mapObj", 1),
+                    ValueType.GetSerializationStatement("keyValuePair.Value", "mapObj", 2)
                 });
             }).Format();
         }
@@ -45,8 +45,8 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
                     body.Line(new[]
                     {
                         $"var mapObj = {schemaObject}.IndexObject({fieldNumber}, (uint) i);",
-                        $"var key = {keyType.GetDeserializationExpression("mapObj", 1)};",
-                        $"var value = {valueType.GetDeserializationExpression("mapObj", 2)};",
+                        $"var key = {KeyType.GetDeserializationExpression("mapObj", 1)};",
+                        $"var value = {ValueType.GetDeserializationExpression("mapObj", 2)};",
                         "map.Add(key, value);"
                     });
                 });
@@ -71,8 +71,8 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
                     body.Line(new[]
                     {
                         $"var mapObj = {schemaObject}.IndexObject({fieldNumber}, (uint) i);",
-                        $"var key = {keyType.GetDeserializationExpression("mapObj", 1)};",
-                        $"var value = {valueType.GetDeserializationExpression("mapObj", 2)};",
+                        $"var key = {KeyType.GetDeserializationExpression("mapObj", 1)};",
+                        $"var value = {ValueType.GetDeserializationExpression("mapObj", 2)};",
                         $"{fieldInstance}.Add(key, value);"
                     });
                 });
@@ -99,8 +99,8 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
                     body.Line(new[]
                     {
                         $"var mapObj = {schemaObject}.IndexObject({fieldNumber}, (uint) i);",
-                        $"var key = {keyType.GetDeserializationExpression("mapObj", 1)};",
-                        $"var value = {valueType.GetDeserializationExpression("mapObj", 2)};",
+                        $"var key = {KeyType.GetDeserializationExpression("mapObj", 1)};",
+                        $"var value = {ValueType.GetDeserializationExpression("mapObj", 2)};",
                         $"{updateFieldInstance}.Value.Add(key, value);"
                     });
                 });
@@ -123,8 +123,8 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
                     body.Line(new[]
                     {
                         $"var mapObj = {schemaObject}.IndexObject({fieldNumber}, (uint) i);",
-                        $"var key = {keyType.GetDeserializationExpression("mapObj", 1)};",
-                        $"var value = {valueType.GetDeserializationExpression("mapObj", 2)};",
+                        $"var key = {KeyType.GetDeserializationExpression("mapObj", 1)};",
+                        $"var value = {ValueType.GetDeserializationExpression("mapObj", 2)};",
                         "map.Add(key, value);"
                     });
                 });


### PR DESCRIPTION
#### Description
This PR adds support for `map<k, v>` types to the Worker Inspector. These are rendered as a list of `key-value` pairs, using the same underlying visualization as the `list<>` fields.

This PR also contains a performance optimization where components were being needlessly re-rendered every frame. This becomes apparent when you have:

- many components
- very complex components (for example - interest)

#### Tests

- Interest component rendering
- Some other random test components in the `schema/` directory.

#### Documentation

- [x] Changelog
