### PR TITLE
Push packages to the China registry.

### DIFF
--- a/ci/publish_packages.sh
+++ b/ci/publish_packages.sh
@@ -22,8 +22,12 @@ pushd "${PKG_ROOT}" > /dev/null
             PACKAGE_NAME=$(npm pack | tail -n 1)
             if [[ -n "${DRY_RUN-}" ]]; then
                 cloudsmith push npm spatialos/gdk-for-unity "${PACKAGE_NAME}" --republish --dry-run
+                # NOTE: The trailing slash on the repository URL is required.
+                npm publish "${PACKAGE_NAME}" --registry="https://npm.spatialoschina.com/repository/unity/" --dry-run
             else
                 cloudsmith push npm spatialos/gdk-for-unity "${PACKAGE_NAME}" --republish
+                # NOTE: The trailing slash on the repository URL is required.
+                npm publish "${PACKAGE_NAME}" --registry="https://npm.spatialoschina.com/repository/unity/"
             fi
             rm "${PACKAGE_NAME}"
         popd > /dev/null


### PR DESCRIPTION
#### Description
The sibling of https://github.com/spatialos/gdk-for-unity-shared-ci/pull/76, here we actually do the npm push.

#### Tests

Ran it on my local machine & a GCE buildkite agent canary.

#### Documentation

- Wiki paging incoming