### PR TITLE
[UTY-2631] Add new menu item to open inspector v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added `map<k,v>` support to the Worker Inspector window. [#1403](https://github.com/spatialos/gdk-for-unity/pull/1403)
+- Added `Open inspector V2` menu item that opens the new inspector in the browser. [#1407](https://github.com/spatialos/gdk-for-unity/pull/1407)
 
 ### Fixed
 

--- a/init.ps1
+++ b/init.ps1
@@ -37,7 +37,7 @@ function UpdatePackage($type, $identifier, $path, $removes)
 
 function UpdateSpot($identifier, $path)
 {
-    spatial package get spot $identifier $SpotVersion "$path" --force --json_output $EnvironmentArgs
+    spatial package get spot $identifier $SpotVersion "$path" --force $EnvironmentArgs
 }
 
 UpdatePackage worker_sdk c-dynamic-x86_64-gcc510-linux "$SdkPath/Plugins/Improbable/Core/Linux/x86_64"
@@ -59,7 +59,7 @@ UpdateSpot spot-macos "$SdkPath/.spot/spot"
 UpdatePackage worker_sdk c-static-arm-clang-ios "$SdkMobilePath/Plugins/Improbable/Core/iOS/arm"
 UpdatePackage worker_sdk c-static-x86_64-clang-ios "$SdkMobilePath/Plugins/Improbable/Core/iOS/x86_64"
 
-UpdatePackage worker_sdk c-dynamic-arm64v8a-clang_ndk16b-android "$SdkMobilePath/Plugins/Improbable/Core/Android/arm64"
-UpdatePackage worker_sdk c-dynamic-armv7a-clang_ndk16b-android "$SdkMobilePath/Plugins/Improbable/Core/Android/armv7"
+UpdatePackage worker_sdk c-dynamic-arm64v8a-clang_ndk21-android "$SdkMobilePath/Plugins/Improbable/Core/Android/arm64"
+UpdatePackage worker_sdk c-dynamic-armv7a-clang_ndk21-android "$SdkMobilePath/Plugins/Improbable/Core/Android/armv7"
 
 UpdatePackage worker_sdk csharp_cinterop_static "$SdkMobilePath/Plugins/Improbable/Sdk/iOS"

--- a/init.ps1
+++ b/init.ps1
@@ -37,7 +37,7 @@ function UpdatePackage($type, $identifier, $path, $removes)
 
 function UpdateSpot($identifier, $path)
 {
-    spatial package get spot $identifier $SpotVersion "$path" --force $EnvironmentArgs
+    spatial package get spot $identifier $SpotVersion "$path" --force --json_output $EnvironmentArgs
 }
 
 UpdatePackage worker_sdk c-dynamic-x86_64-gcc510-linux "$SdkPath/Plugins/Improbable/Core/Linux/x86_64"

--- a/workers/unity/Packages/io.improbable.gdk.tools/LocalLaunch.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/LocalLaunch.cs
@@ -12,6 +12,7 @@ namespace Improbable.Gdk.Tools
     public static class LocalLaunch
     {
         private const string InspectorUrl = "http://localhost:21000/inspector";
+        private const string InspectorV2Url = "http://localhost:21000/inspector-v2";
 
         private static readonly string DefaultLogFileName
             = Path.GetFullPath(Path.Combine(Common.SpatialProjectRootDir, "logs", "*unityclient.log"));
@@ -59,6 +60,12 @@ namespace Improbable.Gdk.Tools
         private static void OpenInspector()
         {
             Application.OpenURL(InspectorUrl);
+        }
+
+        [MenuItem("SpatialOS/Open inspector V2 (Beta)", false, MenuPriorities.OpenInspectorV2)]
+        private static void OpenInspectorV2()
+        {
+            Application.OpenURL(InspectorV2Url);
         }
 
         public static void BuildConfig()

--- a/workers/unity/Packages/io.improbable.gdk.tools/MenuPriorities.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/MenuPriorities.cs
@@ -9,7 +9,8 @@ namespace Improbable.Gdk.Tools
         internal const int LocalLaunch = 71;
         internal const int LaunchStandaloneClient = 72;
         internal const int OpenInspector = 74;
-        internal const int PortForwarding = 75;
+        internal const int OpenInspectorV2 = 75;
+        internal const int PortForwarding = 76;
 
         internal const int GdkToolsConfiguration = 201;
         internal const int GenerateDevAuthToken = 202;


### PR DESCRIPTION
#### Description
- Added a new menu item to the SpatialOS menu that opens inspector v2
- Update android SDK versions in `init.ps1` script to match those in `init.sh`

#### Tests
How did you test these changes prior to submitting this pull request?
Manually tested that inspector v2 opens in browser

What automated tests are included in this PR?
None

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?
Added to changelog
