### PR TITLE
Port Gdk Tools Configuration to Unity Project Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Added `Open inspector V2` menu item that opens the new inspector in the browser. [#1407](https://github.com/spatialos/gdk-for-unity/pull/1407)
 
 ### Changed
-- Moved Gdk Tools Configuration to the Unity "Project Settings" window. [#1408](https://github.com/spatialos/gdk-for-unity/pull/1408)
+- Moved Gdk Tools Configuration to the Unity "Project Settings" window under `Spatial OS`. [#1408](https://github.com/spatialos/gdk-for-unity/pull/1408)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Added `map<k,v>` support to the Worker Inspector window. [#1403](https://github.com/spatialos/gdk-for-unity/pull/1403)
 - Added `Open inspector V2` menu item that opens the new inspector in the browser. [#1407](https://github.com/spatialos/gdk-for-unity/pull/1407)
+
+### Changed
 - Moved Gdk Tools Configuration to the Unity "Project Settings" window. [#1408](https://github.com/spatialos/gdk-for-unity/pull/1408)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `Open inspector V2` menu item that opens the new inspector in the browser. [#1407](https://github.com/spatialos/gdk-for-unity/pull/1407)
 
 ### Changed
+
 - Moved Gdk Tools Configuration to the Unity "Project Settings" window under `Spatial OS`. [#1408](https://github.com/spatialos/gdk-for-unity/pull/1408)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added `map<k,v>` support to the Worker Inspector window. [#1403](https://github.com/spatialos/gdk-for-unity/pull/1403)
 - Added `Open inspector V2` menu item that opens the new inspector in the browser. [#1407](https://github.com/spatialos/gdk-for-unity/pull/1407)
+- Moved Gdk Tools Configuration to the Unity "Project Settings" window. [#1408](https://github.com/spatialos/gdk-for-unity/pull/1408)
 
 ### Fixed
 

--- a/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
+++ b/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
@@ -240,21 +240,6 @@ namespace Improbable.Gdk.DeploymentLauncher
                     EditorGUILayout.LabelField("Project Name", projectName);
                 }
 
-                using (new EditorGUILayout.HorizontalScope())
-                {
-                    using (new EditorGUI.DisabledScope(manager.IsActive))
-                    {
-                        if (GUILayout.Button(style.EditRuntimeVersionButtonContents, EditorStyles.miniButton, GUILayout.ExpandWidth(false)))
-                        {
-                            GdkToolsConfigurationWindow.ShowWindow();
-                        }
-                    }
-
-                    var config = GdkToolsConfiguration.GetOrCreateInstance();
-
-                    EditorGUILayout.LabelField("Runtime Version", config.RuntimeVersion);
-                }
-
                 CommonUIElements.DrawHorizontalLine(5, style.HorizontalLineColor);
 
                 launcherConfig.AssemblyConfig = DrawAssemblyConfig(launcherConfig.AssemblyConfig);

--- a/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
+++ b/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
@@ -240,6 +240,21 @@ namespace Improbable.Gdk.DeploymentLauncher
                     EditorGUILayout.LabelField("Project Name", projectName);
                 }
 
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    using (new EditorGUI.DisabledScope(manager.IsActive))
+                    {
+                        if (GUILayout.Button(style.EditRuntimeVersionButtonContents, EditorStyles.miniButton, GUILayout.ExpandWidth(false)))
+                        {
+                            SettingsService.OpenProjectSettings("Project/GDK Tools Configuration");
+                        }
+                    }
+
+                    var config = GdkToolsConfiguration.GetOrCreateInstance();
+
+                    EditorGUILayout.LabelField("Runtime Version", config.RuntimeVersion);
+                }
+
                 CommonUIElements.DrawHorizontalLine(5, style.HorizontalLineColor);
 
                 launcherConfig.AssemblyConfig = DrawAssemblyConfig(launcherConfig.AssemblyConfig);

--- a/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
+++ b/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/DeploymentLauncherWindow.cs
@@ -246,7 +246,7 @@ namespace Improbable.Gdk.DeploymentLauncher
                     {
                         if (GUILayout.Button(style.EditRuntimeVersionButtonContents, EditorStyles.miniButton, GUILayout.ExpandWidth(false)))
                         {
-                            SettingsService.OpenProjectSettings("Project/GDK Tools Configuration");
+                            SettingsService.OpenProjectSettings(GdkToolsConfigurationProvider.ProjectSettingsPath);
                         }
                     }
 

--- a/workers/unity/Packages/io.improbable.gdk.tools/GdkToolsConfiguration.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/GdkToolsConfiguration.cs
@@ -65,22 +65,22 @@ namespace Improbable.Gdk.Tools
 
             if (string.IsNullOrEmpty(CodegenLogOutputDir))
             {
-                errors.Add($"{GdkToolsConfigurationWindow.CodegenLogOutputDirLabel} cannot be empty.");
+                errors.Add($"{GdkToolsConfigurationProvider.CodegenLogOutputDirLabel} cannot be empty.");
             }
 
             if (string.IsNullOrEmpty(CodegenOutputDir))
             {
-                errors.Add($"{GdkToolsConfigurationWindow.CodegenOutputDirLabel} cannot be empty.");
+                errors.Add($"{GdkToolsConfigurationProvider.CodegenOutputDirLabel} cannot be empty.");
             }
 
             if (string.IsNullOrEmpty(CodegenEditorOutputDir))
             {
-                errors.Add($"{GdkToolsConfigurationWindow.CodegenEditorOutputDirLabel} cannot be empty");
+                errors.Add($"{GdkToolsConfigurationProvider.CodegenEditorOutputDirLabel} cannot be empty");
             }
 
             if (string.IsNullOrEmpty(DescriptorOutputDir))
             {
-                errors.Add($"{GdkToolsConfigurationWindow.DescriptorOutputDirLabel} cannot be empty.");
+                errors.Add($"{GdkToolsConfigurationProvider.DescriptorOutputDirLabel} cannot be empty.");
             }
 
             for (var i = 0; i < SchemaSourceDirs.Count; i++)
@@ -114,12 +114,12 @@ namespace Improbable.Gdk.Tools
 
             if (string.IsNullOrEmpty(DevAuthTokenDir))
             {
-                errors.Add($"{GdkToolsConfigurationWindow.DevAuthTokenDirLabel} cannot be empty.");
+                errors.Add($"{GdkToolsConfigurationProvider.DevAuthTokenDirLabel} cannot be empty.");
             }
             else if (!DevAuthTokenDir.Equals("Resources") && !DevAuthTokenDir.EndsWith("/Resources"))
             {
                 errors.Add(
-                    $"{GdkToolsConfigurationWindow.DevAuthTokenDirLabel} must be at root of a Resources folder.");
+                    $"{GdkToolsConfigurationProvider.DevAuthTokenDirLabel} must be at root of a Resources folder.");
             }
 
             return errors;

--- a/workers/unity/Packages/io.improbable.gdk.tools/GdkToolsConfigurationProvider.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/GdkToolsConfigurationProvider.cs
@@ -256,23 +256,5 @@ namespace Improbable.Gdk.Tools
                 }
             }
         }
-
-        //private void Update()
-        //{
-        //    TrySaveChanges();
-        //}
-
-        //private void TrySaveChanges()
-        //{
-        //    var timeSinceLastSave = DateTime.Now - lastSaveTime;
-        //    if (!hasUnsavedData || timeSinceLastSave < FileSavingInterval || configErrors.Any())
-        //    {
-        //        return;
-        //    }
-
-        //    toolsConfig.Save();
-        //    lastSaveTime = DateTime.Now;
-        //    hasUnsavedData = false;
-        //}
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.tools/GdkToolsConfigurationProvider.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/GdkToolsConfigurationProvider.cs
@@ -50,10 +50,10 @@ namespace Improbable.Gdk.Tools
             var provider = new GdkToolsConfigurationProvider(ProjectSettingsPath, SettingsScope.Project);
 
             // Extract all members (fields, methods etc) from the GdkToolsConfiguration class
-            // We later filter the results so we only have fields and properties remaining
-            // Use the names of the discovered members as the keyword search terms in Project Settings panel
             var gdkToolsConfigProperties = typeof(GdkToolsConfiguration).GetMembers();
 
+            // Filter the results so that fields and properties remain
+            // Use the names of the discovered members as the keyword search terms in the Project Settings panel
             provider.keywords = gdkToolsConfigProperties
                 .Where(member => member.MemberType == MemberTypes.Property || member.MemberType == MemberTypes.Field)
                 .Select(property => property.Name).ToList();

--- a/workers/unity/Packages/io.improbable.gdk.tools/GdkToolsConfigurationProvider.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/GdkToolsConfigurationProvider.cs
@@ -14,6 +14,8 @@ namespace Improbable.Gdk.Tools
     /// </summary>
     public class GdkToolsConfigurationProvider : SettingsProvider
     {
+        public const string ProjectSettingsPath = "Project/GDK Tools Configuration";
+
         internal const string SchemaStdLibDirLabel = "Standard library";
         internal const string VerboseLoggingLabel = "Verbose logging";
         internal const string CodegenLogOutputDirLabel = "Log output directory";
@@ -40,16 +42,15 @@ namespace Improbable.Gdk.Tools
         // Flag to indicate if we have unsaved changes in the settings window
         private bool hasUnsavedData;
 
-        public GdkToolsConfigurationProvider(string path, SettingsScope scope = SettingsScope.User)
-        : base(path, scope) { }
+        private GdkToolsConfigurationProvider(string path, SettingsScope scope = SettingsScope.User) : base(path, scope) { }
 
         [SettingsProvider]
         public static SettingsProvider CreateGdkToolsConfigurationProvider()
         {
-            var provider = new GdkToolsConfigurationProvider("Project/GDK Tools Configuration", SettingsScope.Project);
+            var provider = new GdkToolsConfigurationProvider(ProjectSettingsPath, SettingsScope.Project);
 
-            PropertyInfo[] GdkToolsConfigProperties = typeof(GdkToolsConfiguration).GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            provider.keywords = GdkToolsConfigProperties.Select(property => property.Name).ToList();
+            var gdkToolsConfigProperties = typeof(GdkToolsConfiguration).GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            provider.keywords = gdkToolsConfigProperties.Select(property => property.Name).ToList();
             return provider;
         }
 

--- a/workers/unity/Packages/io.improbable.gdk.tools/GdkToolsConfigurationProvider.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/GdkToolsConfigurationProvider.cs
@@ -49,11 +49,14 @@ namespace Improbable.Gdk.Tools
         {
             var provider = new GdkToolsConfigurationProvider(ProjectSettingsPath, SettingsScope.Project);
 
-            // Extract all public fields from the GdkToolsConfiguration class
-            // Use the names of the discovered fields as the keyword search terms in Project Settings panel
-            var gdkToolsConfigProperties = typeof(GdkToolsConfiguration).GetFields(BindingFlags.Public | BindingFlags.Instance);
+            // Extract all members (fields, methods etc) from the GdkToolsConfiguration class
+            // We later filter the results so we only have fields and properties remaining
+            // Use the names of the discovered members as the keyword search terms in Project Settings panel
+            var gdkToolsConfigProperties = typeof(GdkToolsConfiguration).GetMembers();
 
-            provider.keywords = gdkToolsConfigProperties.Select(property => property.Name).ToList();
+            provider.keywords = gdkToolsConfigProperties
+                .Where(member => member.MemberType == MemberTypes.Property || member.MemberType == MemberTypes.Field)
+                .Select(property => property.Name).ToList();
             return provider;
         }
 

--- a/workers/unity/Packages/io.improbable.gdk.tools/GdkToolsConfigurationProvider.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/GdkToolsConfigurationProvider.cs
@@ -118,14 +118,11 @@ namespace Improbable.Gdk.Tools
                 using (new EditorGUILayout.HorizontalScope())
                 {
                     GUILayout.FlexibleSpace();
-                    if (GUILayout.Button(ResetConfigurationButtonText, EditorStyles.miniButtonMid, GUILayout.Width(150)))
+                    if (GUILayout.Button(ResetConfigurationButtonText, EditorStyles.miniButtonMid, GUILayout.Width(150))
+                        && EditorUtility.DisplayDialog("Confirmation", "Are you sure you want to reset to defaults?", "Yes", "No"))
                     {
-                        if (EditorUtility.DisplayDialog("Confirmation", "Are you sure you want to reset to defaults?",
-                            "Yes", "No"))
-                        {
-                            GUI.FocusControl(null);
-                            toolsConfig.ResetToDefault();
-                        }
+                        GUI.FocusControl(null);
+                        toolsConfig.ResetToDefault();
                     }
 
                     GUILayout.FlexibleSpace();

--- a/workers/unity/Packages/io.improbable.gdk.tools/GdkToolsConfigurationProvider.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/GdkToolsConfigurationProvider.cs
@@ -49,6 +49,8 @@ namespace Improbable.Gdk.Tools
         {
             var provider = new GdkToolsConfigurationProvider(ProjectSettingsPath, SettingsScope.Project);
 
+            // Extract all public and private properties from the GdkToolsConfiguration class
+            // Use the names of the discovered properties as the keyword search terms in Project Settings panel
             var gdkToolsConfigProperties = typeof(GdkToolsConfiguration).GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
             provider.keywords = gdkToolsConfigProperties.Select(property => property.Name).ToList();
             return provider;

--- a/workers/unity/Packages/io.improbable.gdk.tools/GdkToolsConfigurationProvider.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/GdkToolsConfigurationProvider.cs
@@ -49,9 +49,10 @@ namespace Improbable.Gdk.Tools
         {
             var provider = new GdkToolsConfigurationProvider(ProjectSettingsPath, SettingsScope.Project);
 
-            // Extract all public and private properties from the GdkToolsConfiguration class
-            // Use the names of the discovered properties as the keyword search terms in Project Settings panel
-            var gdkToolsConfigProperties = typeof(GdkToolsConfiguration).GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            // Extract all public fields from the GdkToolsConfiguration class
+            // Use the names of the discovered fields as the keyword search terms in Project Settings panel
+            var gdkToolsConfigProperties = typeof(GdkToolsConfiguration).GetFields(BindingFlags.Public | BindingFlags.Instance);
+
             provider.keywords = gdkToolsConfigProperties.Select(property => property.Name).ToList();
             return provider;
         }

--- a/workers/unity/Packages/io.improbable.gdk.tools/GdkToolsConfigurationProvider.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/GdkToolsConfigurationProvider.cs
@@ -14,7 +14,7 @@ namespace Improbable.Gdk.Tools
     /// </summary>
     public class GdkToolsConfigurationProvider : SettingsProvider
     {
-        public const string ProjectSettingsPath = "Project/GDK Tools Configuration";
+        public const string ProjectSettingsPath = "Project/Spatial OS";
 
         internal const string SchemaStdLibDirLabel = "Standard library";
         internal const string VerboseLoggingLabel = "Verbose logging";

--- a/workers/unity/Packages/io.improbable.gdk.tools/GdkToolsConfigurationProvider.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.tools/GdkToolsConfigurationProvider.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2291c626cfa43b949ac83c6af98fd454
+guid: 6f9756bf329058747902aa0d242de8ec
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
For [UTY-2419](https://improbableio.atlassian.net/browse/UTY-2419)

#### Description

- Ported `GdkToolsConfiguration` setting window to the Unity SettingsProvider
- Enabled Project settings search functionality for GdkToolsConfiguration

![image](https://user-images.githubusercontent.com/12220760/85880871-a658ab00-b7d4-11ea-8d88-163a82bcb0bd.png)


The settings changes now save when `Project Settings` window is closed or  switched away from the Gdk Tools Configuration page (+ Only if changes are made to the settings)

#### Tests
How did you test these changes prior to submitting this pull request?
Manually tested that the `GdkToolsConfiguration.json` file represented the changes made in the Project Settings view
