### PR TITLE
Scripting Implementation option in Build config UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added `map<k,v>` support to the Worker Inspector window. [#1403](https://github.com/spatialos/gdk-for-unity/pull/1403)
 - Added `Open inspector V2` menu item that opens the new inspector in the browser. [#1407](https://github.com/spatialos/gdk-for-unity/pull/1407)
+- Added `Scripting Backend` option dropdown to the Build Configuration UI. [#1411](https://github.com/spatialos/gdk-for-unity/pull/1411)
 
 ### Changed
 

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -1,5 +1,11 @@
 # Upgrade Guide
 
+## From `0.3.7` to `0.3.8`
+
+### Scripting Backend in Project Settings is now overwritten by the Build Configuration
+
+The Scripting Backend defined in the Unity Project Settings is now overwritten by the Build Configuration Asset. More information can be found on the [Build Configuration UI](https://documentation.improbable.io/gdk-for-unity/v0.3.8/docs/build-configuration#section-build-configuration-ui) wiki page.
+
 ## From `0.3.6` to `0.3.7`
 
 ### Update your `.gitignore`

--- a/init.ps1
+++ b/init.ps1
@@ -47,7 +47,7 @@ UpdatePackage worker_sdk c-dynamic-x86_64-vc141_mt-win32 "$SdkPath/Plugins/Impro
 UpdatePackage worker_sdk csharp_cinterop "$SdkPath/Plugins/Improbable/Sdk/Common"
 
 UpdatePackage schema standard_library "$SdkPath/.schema"
-UpdatePackage schema test_schema_library "$TestSdkPath/.schema"
+UpdatePackage schema test_schema_library "schema"
 
 UpdatePackage tools schema_compiler-x86_64-win32 "$SdkPath/.schema_compiler"
 UpdatePackage tools schema_compiler-x86_64-macos "$SdkPath/.schema_compiler"

--- a/workers/unity/Assets/Playground/Config/BuildConfiguration.asset
+++ b/workers/unity/Assets/Playground/Config/BuildConfiguration.asset
@@ -21,32 +21,41 @@ MonoBehaviour:
       - Options: 1
         Enabled: 1
         Required: 0
+        ScriptingImplementation: 0
       - Options: 0
         Enabled: 0
         Required: 0
+        ScriptingImplementation: 0
       - Options: 0
         Enabled: 0
         Required: 0
+        ScriptingImplementation: 1
     CloudBuildConfig:
       BuildTargets:
       - Options: 0
         Enabled: 1
         Required: 0
+        ScriptingImplementation: 0
       - Options: 0
         Enabled: 1
         Required: 0
+        ScriptingImplementation: 0
       - Options: 16384
         Enabled: 0
         Required: 0
+        ScriptingImplementation: 0
       - Options: 0
         Enabled: 1
         Required: 0
+        ScriptingImplementation: 0
       - Options: 0
         Enabled: 0
         Required: 0
+        ScriptingImplementation: 0
       - Options: 0
         Enabled: 0
         Required: 0
+        ScriptingImplementation: 1
   - WorkerType: UnityGameLogic
     ScenesForWorker:
     - {fileID: 102900000, guid: 8c0c8d31c7a7905409ce6be1f36f162e, type: 3}
@@ -55,32 +64,41 @@ MonoBehaviour:
       - Options: 1
         Enabled: 1
         Required: 0
+        ScriptingImplementation: 0
       - Options: 0
         Enabled: 0
         Required: 0
+        ScriptingImplementation: 0
       - Options: 0
         Enabled: 0
         Required: 0
+        ScriptingImplementation: 1
     CloudBuildConfig:
       BuildTargets:
       - Options: 0
         Enabled: 0
         Required: 0
+        ScriptingImplementation: 0
       - Options: 0
         Enabled: 0
         Required: 0
+        ScriptingImplementation: 0
       - Options: 16384
         Enabled: 1
         Required: 1
+        ScriptingImplementation: 0
       - Options: 0
         Enabled: 0
         Required: 0
+        ScriptingImplementation: 0
       - Options: 0
         Enabled: 0
         Required: 0
+        ScriptingImplementation: 0
       - Options: 0
         Enabled: 0
         Required: 0
+        ScriptingImplementation: 1
   - WorkerType: MobileClient
     ScenesForWorker:
     - {fileID: 102900000, guid: 82ccd0fd96a2ba24f88d0c7d01592f2e, type: 3}
@@ -89,30 +107,39 @@ MonoBehaviour:
       - Options: 0
         Enabled: 0
         Required: 0
+        ScriptingImplementation: 0
       - Options: 1
         Enabled: 1
         Required: 0
+        ScriptingImplementation: 0
       - Options: 1
         Enabled: 1
         Required: 0
+        ScriptingImplementation: 1
     CloudBuildConfig:
       BuildTargets:
       - Options: 0
         Enabled: 0
         Required: 0
+        ScriptingImplementation: 0
       - Options: 0
         Enabled: 0
         Required: 0
+        ScriptingImplementation: 0
       - Options: 16384
         Enabled: 0
         Required: 0
+        ScriptingImplementation: 0
       - Options: 0
         Enabled: 0
         Required: 0
+        ScriptingImplementation: 0
       - Options: 0
         Enabled: 1
         Required: 0
+        ScriptingImplementation: 0
       - Options: 0
         Enabled: 1
         Required: 0
+        ScriptingImplementation: 1
   isInitialised: 1

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildConfigEditor.cs
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildConfigEditor.cs
@@ -655,6 +655,9 @@ namespace Improbable.Gdk.BuildSystem.Configuration
             var enabled = buildTarget.Enabled;
             var required = buildTarget.Required;
 
+            // Pick the current backend based on the current build target
+            var scriptingImplementation = buildTarget.ScriptingImplementation;
+
             using (var check = new EditorGUI.ChangeCheckScope())
             using (new EditorGUILayout.VerticalScope(GUILayout.ExpandWidth(true)))
             {
@@ -695,6 +698,8 @@ namespace Improbable.Gdk.BuildSystem.Configuration
                     }
 
                     options = ConfigureCompression(options);
+
+                    scriptingImplementation = ConfigureScriptingImplementation(scriptingImplementation, buildTarget.Target);
                 }
 
                 if (!canBuildTarget)
@@ -710,11 +715,25 @@ namespace Improbable.Gdk.BuildSystem.Configuration
                     RecordUndo("Worker build options");
 
                     env.BuildTargets[selectedBuildTarget.Index] =
-                        new BuildTargetConfig(buildTarget.Target, options, enabled, required);
+                        new BuildTargetConfig(buildTarget.Target, options, enabled, required, scriptingImplementation);
 
                     selectedBuildTarget.Choices = null;
                 }
             }
+        }
+
+        private ScriptingImplementation ConfigureScriptingImplementation(ScriptingImplementation backend, BuildTarget buildTarget)
+        {
+            var choice = backend;
+            var disallowBackendChoice = buildTarget == BuildTarget.iOS;
+
+            using (new EditorGUI.DisabledScope(disallowBackendChoice))
+            {
+                choice = (ScriptingImplementation) EditorGUILayout.Popup("Scripting Backend",
+                    (int) choice, style.ScriptingImplementationOptions);
+            }
+
+            return choice;
         }
 
         private BuildOptions ConfigureCompression(BuildOptions options)

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildConfigEditor.cs
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildConfigEditor.cs
@@ -724,16 +724,15 @@ namespace Improbable.Gdk.BuildSystem.Configuration
 
         private ScriptingImplementation ConfigureScriptingImplementation(ScriptingImplementation backend, BuildTarget buildTarget)
         {
-            var choice = backend;
             var disallowBackendChoice = buildTarget == BuildTarget.iOS;
 
             using (new EditorGUI.DisabledScope(disallowBackendChoice))
             {
-                choice = (ScriptingImplementation) EditorGUILayout.Popup("Scripting Backend",
-                    (int) choice, style.ScriptingImplementationOptions);
+                backend = (ScriptingImplementation) EditorGUILayout.Popup("Scripting Backend",
+                    (int) backend, style.ScriptingImplementationOptions);
             }
 
-            return choice;
+            return backend;
         }
 
         private BuildOptions ConfigureCompression(BuildOptions options)

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildConfigEditorStyle.cs
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildConfigEditorStyle.cs
@@ -20,6 +20,8 @@ namespace Improbable.Gdk.BuildSystem.Configuration
 
         internal readonly string[] CompressionOptions = { "Default", "LZ4", "LZ4HC" };
 
+        internal readonly string[] ScriptingImplementationOptions = { "Mono", "IL2CPP" };
+
         internal readonly Dictionary<BuildTarget, GUIContent> BuildTargetIcons =
             new Dictionary<BuildTarget, GUIContent>();
 

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildContext.cs
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildContext.cs
@@ -60,8 +60,7 @@ namespace Improbable.Gdk.BuildSystem.Configuration
                 {
                     WorkerType = workerType,
                     BuildEnvironment = buildEnvironment,
-                    ScriptingImplementation = scriptImplementation ??
-                        PlayerSettings.GetScriptingBackend(BuildPipeline.GetBuildTargetGroup(targetConfig.Target)),
+                    ScriptingImplementation = scriptImplementation ?? targetConfig.ScriptingImplementation,
                     BuildTargetConfig = targetConfig,
                     IOSSdkVersion = (targetConfig.Target == BuildTarget.iOS) ? iosSdkVersion : null
                 }));

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildTargetConfig.cs
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildTargetConfig.cs
@@ -30,6 +30,11 @@ namespace Improbable.Gdk.BuildSystem.Configuration
         /// </summary>
         public bool Required;
 
+        /// <summary>
+        /// The backend scripting implementation.
+        /// </summary>
+        public ScriptingImplementation ScriptingImplementation;
+
         internal string Label
         {
             get
@@ -57,12 +62,16 @@ namespace Improbable.Gdk.BuildSystem.Configuration
         /// <summary>
         ///     Creates a new instance of a build target and its options.
         /// </summary>
-        public BuildTargetConfig(BuildTarget target, BuildOptions options, bool enabled, bool required)
+        public BuildTargetConfig(BuildTarget target, BuildOptions options,
+            bool enabled, bool required, ScriptingImplementation scriptingImplementation = ScriptingImplementation.Mono2x)
         {
             Enabled = enabled;
             Required = required;
             Target = target;
             Options = options;
+
+            // If build target is iOS then force the Scripting Implementation to be IL2CPP (as Mono is not supported)
+            ScriptingImplementation = target == BuildTarget.iOS ? ScriptingImplementation.IL2CPP : scriptingImplementation;
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/WorkerBuilder.cs
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/WorkerBuilder.cs
@@ -169,7 +169,11 @@ namespace Improbable.Gdk.BuildSystem
             };
 
             var buildTargetGroup = BuildPipeline.GetBuildTargetGroup(buildContext.BuildTargetConfig.Target);
-            PlayerSettings.SetScriptingBackend(buildTargetGroup, buildContext.ScriptingImplementation);
+            var activeScriptingBackend = PlayerSettings.GetScriptingBackend(buildTargetGroup);
+            if (activeScriptingBackend != buildContext.ScriptingImplementation)
+            {
+                PlayerSettings.SetScriptingBackend(buildTargetGroup, buildContext.ScriptingImplementation);
+            }
 
             var activeIOSSdkVersion = PlayerSettings.iOS.sdkVersion;
             if (buildContext.IOSSdkVersion.HasValue && activeIOSSdkVersion != buildContext.IOSSdkVersion)
@@ -206,7 +210,7 @@ namespace Improbable.Gdk.BuildSystem
             {
                 currentContext = null;
                 PlayerSettings.iOS.sdkVersion = activeIOSSdkVersion;
-                PlayerSettings.SetScriptingBackend(buildTargetGroup, buildContext.ScriptingImplementation);
+                PlayerSettings.SetScriptingBackend(buildTargetGroup, activeScriptingBackend);
             }
 
             if (buildContext.BuildTargetConfig.Target == BuildTarget.StandaloneOSX)

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/WorkerBuilder.cs
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/WorkerBuilder.cs
@@ -169,11 +169,7 @@ namespace Improbable.Gdk.BuildSystem
             };
 
             var buildTargetGroup = BuildPipeline.GetBuildTargetGroup(buildContext.BuildTargetConfig.Target);
-            var activeScriptingBackend = PlayerSettings.GetScriptingBackend(buildTargetGroup);
-            if (activeScriptingBackend != buildContext.ScriptingImplementation)
-            {
-                PlayerSettings.SetScriptingBackend(buildTargetGroup, buildContext.ScriptingImplementation);
-            }
+            PlayerSettings.SetScriptingBackend(buildTargetGroup, buildContext.ScriptingImplementation);
 
             var activeIOSSdkVersion = PlayerSettings.iOS.sdkVersion;
             if (buildContext.IOSSdkVersion.HasValue && activeIOSSdkVersion != buildContext.IOSSdkVersion)
@@ -210,7 +206,7 @@ namespace Improbable.Gdk.BuildSystem
             {
                 currentContext = null;
                 PlayerSettings.iOS.sdkVersion = activeIOSSdkVersion;
-                PlayerSettings.SetScriptingBackend(buildTargetGroup, activeScriptingBackend);
+                PlayerSettings.SetScriptingBackend(buildTargetGroup, buildContext.ScriptingImplementation);
             }
 
             if (buildContext.BuildTargetConfig.Target == BuildTarget.StandaloneOSX)


### PR DESCRIPTION
For [UTY-1818](https://improbableio.atlassian.net/browse/UTY-1818)

#### Description
Added the option to choose the scripting implementation (backend) in the build configuration UI

#### Tests
How did you test these changes prior to submitting this pull request?
Manually tested that scripting backend was changed using the UI

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?

- Updated v0.3.8 docs to have `Scripting Backend` option in Build Configuration UI
- Some in-code documentation, see (workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildTargetConfig.cs)
