### PR TITLE
UTY-1970: invalid enum definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Breaking Changes
 
-- C# enums will be generated to start from 0 and shifted to schema values on serialization and shifted back to C# values on deserialization. [#1412](https://github.com/spatialos/gdk-for-unity/pull/1412)
+- All generated C# enums will now start from 0, being shifted to schema values on serialization and shifted back to C# values on deserialization. [#1412](https://github.com/spatialos/gdk-for-unity/pull/1412)
     - A warning will be generated when enums defined in schema does not start from 0. 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Added support for flag arguments in `CommandLineParser`. [#1409](https://github.com/spatialos/gdk-for-unity/pull/1409)
 - Added `Scripting Backend` option dropdown to the Build Configuration UI. [#1411](https://github.com/spatialos/gdk-for-unity/pull/1411)
 
+### Breaking Changes
+- C# enums will be generated to start from 0 and shifted to schema values on serialization and shifted back to C# values on deserialization. [#1412](https://github.com/spatialos/gdk-for-unity/pull/1412)
+    - A warning will be generated when enums defined in schema does not start from 0. 
+
 ### Changed
 
 - Moved Gdk Tools Configuration to the Unity "Project Settings" window under `Spatial OS`. [#1408](https://github.com/spatialos/gdk-for-unity/pull/1408)
@@ -54,7 +58,6 @@
 - `WorkerConnector` no longer destroys itself in `Dispose`. [#1365](https://github.com/spatialos/gdk-for-unity/pull/1365)
 - `MultiThreadedSpatialOSConnectionHandler` and `SpatialOSConnectionHandlerBuilder.SetThreadingMode` have been removed. [#1367](https://github.com/spatialos/gdk-for-unity/pull/1367)
 - Command request IDs are now typed as `CommandRequestID` instead of `long`. [#1372](https://github.com/spatialos/gdk-for-unity/pull/1372)
-- C# enums will be generated to start from 0 and shifted to schema values on serialization and shifted back to C# values on deserialization.  A warning will be generated when enums defined in schema does not start from 0. [#1412](https://github.com/spatialos/gdk-for-unity/pull/1412)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added support for flag arguments in `CommandLineParser`. [#1409](https://github.com/spatialos/gdk-for-unity/pull/1409)
 - Added `Scripting Backend` option dropdown to the Build Configuration UI. [#1411](https://github.com/spatialos/gdk-for-unity/pull/1411)
 
+
 ### Changed
 
 - Moved Gdk Tools Configuration to the Unity "Project Settings" window under `Spatial OS`. [#1408](https://github.com/spatialos/gdk-for-unity/pull/1408)
@@ -54,6 +55,7 @@
 - `WorkerConnector` no longer destroys itself in `Dispose`. [#1365](https://github.com/spatialos/gdk-for-unity/pull/1365)
 - `MultiThreadedSpatialOSConnectionHandler` and `SpatialOSConnectionHandlerBuilder.SetThreadingMode` have been removed. [#1367](https://github.com/spatialos/gdk-for-unity/pull/1367)
 - Command request IDs are now typed as `CommandRequestID` instead of `long`. [#1372](https://github.com/spatialos/gdk-for-unity/pull/1372)
+- C# enums will be generated to start from 0 and shifted to schema values on serialization and shifted back to C# values on deserialization. A warning will be generated when enums defined in schema does not start from 0. [#1412](https://github.com/spatialos/gdk-for-unity/pull/1412)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- All generated C# enums will now start from 0, being shifted to schema values on serialization and shifted back to C# values on deserialization. [#1412](https://github.com/spatialos/gdk-for-unity/pull/1412)
+    - A warning will be generated when enums defined in schema does not start from 0. 
+
 ### Added
 
 - Added `map<k,v>` support to the Worker Inspector window. [#1403](https://github.com/spatialos/gdk-for-unity/pull/1403)
@@ -9,11 +14,6 @@
 - Added the option to set `UseExternalIp` using the command line argument `+useExternalIp` with the `CommandLineConnectionParameterInitializer`. [#1409](https://github.com/spatialos/gdk-for-unity/pull/1409)
 - Added support for flag arguments in `CommandLineParser`. [#1409](https://github.com/spatialos/gdk-for-unity/pull/1409)
 - Added `Scripting Backend` option dropdown to the Build Configuration UI. [#1411](https://github.com/spatialos/gdk-for-unity/pull/1411)
-
-### Breaking Changes
-
-- All generated C# enums will now start from 0, being shifted to schema values on serialization and shifted back to C# values on deserialization. [#1412](https://github.com/spatialos/gdk-for-unity/pull/1412)
-    - A warning will be generated when enums defined in schema does not start from 0. 
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@
 - `WorkerConnector` no longer destroys itself in `Dispose`. [#1365](https://github.com/spatialos/gdk-for-unity/pull/1365)
 - `MultiThreadedSpatialOSConnectionHandler` and `SpatialOSConnectionHandlerBuilder.SetThreadingMode` have been removed. [#1367](https://github.com/spatialos/gdk-for-unity/pull/1367)
 - Command request IDs are now typed as `CommandRequestID` instead of `long`. [#1372](https://github.com/spatialos/gdk-for-unity/pull/1372)
-- C# enums will be generated to start from 0 and shifted to schema values on serialization and shifted back to C# values on deserialization. A warning will be generated when enums defined in schema does not start from 0. [#1412](https://github.com/spatialos/gdk-for-unity/pull/1412)
+- C# enums will be generated to start from 0 and shifted to schema values on serialization and shifted back to C# values on deserialization.  A warning will be generated when enums defined in schema does not start from 0. [#1412](https://github.com/spatialos/gdk-for-unity/pull/1412)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 - Added support for flag arguments in `CommandLineParser`. [#1409](https://github.com/spatialos/gdk-for-unity/pull/1409)
 - Added `Scripting Backend` option dropdown to the Build Configuration UI. [#1411](https://github.com/spatialos/gdk-for-unity/pull/1411)
 
-
 ### Changed
 
 - Moved Gdk Tools Configuration to the Unity "Project Settings" window under `Spatial OS`. [#1408](https://github.com/spatialos/gdk-for-unity/pull/1408)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added `Scripting Backend` option dropdown to the Build Configuration UI. [#1411](https://github.com/spatialos/gdk-for-unity/pull/1411)
 
 ### Breaking Changes
+
 - C# enums will be generated to start from 0 and shifted to schema values on serialization and shifted back to C# values on deserialization. [#1412](https://github.com/spatialos/gdk-for-unity/pull/1412)
     - A warning will be generated when enums defined in schema does not start from 0. 
 

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/FieldTypes/ContainedType.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/FieldTypes/ContainedType.cs
@@ -44,7 +44,8 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
                 case ValueType.Primitive:
                     return $"{schemaObject}.{SchemaFunctionMappings.AddSchemaFunctionFromType(PrimitiveType.Value)}({fieldNumber}, {instance});";
                 case ValueType.Enum:
-                    return $"{schemaObject}.AddEnum({fieldNumber}, (uint) {instance});";
+                    var shifter = UnityEnumDetails.GetEnumMinimum(FqnType);
+                    return $"{schemaObject}.AddEnum({fieldNumber}, (uint) ({instance}) + {shifter});";
                 case ValueType.Type:
                     return $"{FqnType}.Serialization.Serialize({instance}, {schemaObject}.AddObject({fieldNumber}));";
                 default:
@@ -60,7 +61,8 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
                     return
                         $"{schemaObject}.{SchemaFunctionMappings.GetSchemaFunctionFromType(PrimitiveType.Value)}({fieldNumber})";
                 case ValueType.Enum:
-                    return $"({FqnType}) {schemaObject}.GetEnum({fieldNumber})";
+                    var shifter = UnityEnumDetails.GetEnumMinimum(FqnType);
+                    return $"({FqnType}) ({schemaObject}.GetEnum({fieldNumber}) - {shifter})";
                 case ValueType.Type:
                     return $"{FqnType}.Serialization.Deserialize({schemaObject}.GetObject({fieldNumber}))";
                 default:

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/UnityEnumDetails.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/UnityEnumDetails.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using NLog;
 
 namespace Improbable.Gdk.CodeGeneration.Model.Details
 {
@@ -7,10 +8,28 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
     {
         public readonly IReadOnlyList<(uint, string)> Values;
 
+        private static readonly Dictionary<string, uint> EnumMinimums = new Dictionary<string, uint>();
+
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
         public UnityEnumDetails(string package, EnumDefinition rawEnumDefinition)
             : base(package, rawEnumDefinition)
         {
-            Values = rawEnumDefinition.Values.Select(value => (value.Value, value.Name)).ToList();
+            var min = rawEnumDefinition.Values.Select(list => list.Value).Min();
+            EnumMinimums[FullyQualifiedName] = min;
+            Values = rawEnumDefinition.Values.Select(value => (value.Value - min, value.Name)).ToList();
+            if (min != 0)
+            {
+                Logger.Warn($"The enum, {Name}, is defined with a minimum value of {min}, which is greater than 0. Shifting the enum values to start from 0. " +
+                    "This will lead to inconsistencies in the values used in Unity and the values captured in snapshots. " +
+                    $"This inconsistency is handled in the serialization/deserialization process but please consider redefining the values in {Name} to start from 0");
+            }
+        }
+
+        public static uint GetEnumMinimum(string fullQualifiedName)
+        {
+            EnumMinimums.TryGetValue(fullQualifiedName, out var output);
+            return output;
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/UnityEnumDetails.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/UnityEnumDetails.cs
@@ -17,13 +17,14 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
         {
             var min = rawEnumDefinition.Values.Select(list => list.Value).Min();
             EnumMinimums[FullyQualifiedName] = min;
-            Values = rawEnumDefinition.Values.Select(value => (value.Value - min, value.Name)).ToList();
             if (min != 0)
             {
                 Logger.Warn($"The enum, {Name}, is defined with a minimum value of {min}, which is greater than 0. Shifting the enum values to start from 0. " +
                     "This will lead to inconsistencies in the values used in Unity and the values captured in snapshots. " +
                     $"This inconsistency is handled in the serialization/deserialization process but please consider redefining the values in {Name} to start from 0");
             }
+
+            Values = rawEnumDefinition.Values.Select(value => (value.Value - min, value.Name)).ToList();
         }
 
         public static uint GetEnumMinimum(string fullQualifiedName)

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/UnityEnumDetails.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/UnityEnumDetails.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NLog;
@@ -29,7 +30,11 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
 
         public static uint GetEnumMinimum(string fullQualifiedName)
         {
-            EnumMinimums.TryGetValue(fullQualifiedName, out var output);
+            if (!EnumMinimums.TryGetValue(fullQualifiedName, out var output))
+            {
+                throw new ArgumentException($"Could not find the following enum: {fullQualifiedName}");
+            }
+
             return output;
         }
     }


### PR DESCRIPTION
#### Description
Shifted all C# enum definition to start from 0 to ensure no invalid enums are generated by default constructors. Serialization is done by `value + min_val` and Deserialization `value - min_val`. A warning is also generated to advice users to redefine the schema enums to start from 0.

#### Tests
Change the playground schema for `Color` (sorted and unsorted, sequential and non-sequential) and ran the code generator to ensure the enum definition, serialization and deserialization function in `ColorData` is what's expected.

#### Documentation

- [x] Todo

**Did you remember a changelog entry?**
Yes

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
