### PR TITLE
Limit perftest targets + package dependency fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Breaking Changes
 
 - All generated C# enums will now start from 0, being shifted to schema values on serialization and shifted back to C# values on deserialization. [#1412](https://github.com/spatialos/gdk-for-unity/pull/1412)
-    - A warning will be generated when enums defined in schema does not start from 0. 
+    - A warning will be generated when enums defined in schema do not start from 0.
 
 ### Added
 
@@ -24,6 +24,11 @@
 ### Fixed
 
 - Fixed a bug in the Worker Inspector where component foldouts were being rendered too often, causing poor performance when the entity had many components or very complex components. [#1403](https://github.com/spatialos/gdk-for-unity/pull/1403)
+
+### Internal
+
+- Added `com.unity.test-framework` and `com.unity.test-framework.performance` as dependencies to the `io.improbable.gdk.testutils` package. [#1416](https://github.com/spatialos/gdk-for-unity/pull/1416)
+    - In addition, both packages have been removed from the playground `manifest.json`.
 
 ## `0.3.7` - 2020-06-22
 

--- a/ci/perf-test.sh
+++ b/ci/perf-test.sh
@@ -10,6 +10,8 @@ cd "$(dirname "$0")/../"
 
 source .shared-ci/scripts/pinned-tools.sh
 
+BRANCH_NAME=${BUILDKITE_BRANCH:-"local"}
+
 ACCELERATOR_ARGS=$(getAcceleratorArgs)
 
 PROJECT_DIR="$(pwd)"
@@ -42,7 +44,7 @@ else
 fi
 
 function main {
-    if ! anyMatchingTargets ; then
+    if ! anyMatchingTargets; then
         echo "Skipping all targets for this job as current branch does not match any corresponding filters."
         return
     fi
@@ -88,7 +90,7 @@ function anyMatchingTargets {
     do
         local branchFilter=$(jq -r .[${configId}].branchFilter ${CONFIG_FILE})
 
-        if [[ ${BUILDKITE_BRANCH:-"local"} =~ ${branchFilter} ]]; then
+        if [[ ${BRANCH_NAME} =~ ${branchFilter} ]]; then
             return 0
         fi
     done
@@ -107,7 +109,7 @@ function runTests {
 
     local branchFilter=$(jq -r .[${configId}].branchFilter ${CONFIG_FILE})
 
-    if ! [[ ${BUILDKITE_BRANCH:-"local"} =~ ${branchFilter} ]]; then
+    if ! [[ ${BRANCH_NAME} =~ ${branchFilter} ]]; then
         echo "Skipping target as current branch does not match regex '${branchFilter}'."
         return
     fi

--- a/ci/perf-test.sh
+++ b/ci/perf-test.sh
@@ -84,7 +84,7 @@ function main {
 }
 
 function anyMatchingTargets {
-    for config in `seq ${JOB_ID} ${NUM_JOBS} $((${NUM_CONFIGS}-1))`
+    for configId in `seq ${JOB_ID} ${NUM_JOBS} $((${NUM_CONFIGS}-1))`
     do
         local branchFilter=$(jq -r .[${configId}].branchFilter ${CONFIG_FILE})
 

--- a/ci/perf-test.sh
+++ b/ci/perf-test.sh
@@ -87,6 +87,13 @@ function runTests {
     local apiProfile=$(jq -r .[${configId}].apiProfile ${CONFIG_FILE})
     local scriptingBackend=$(jq -r .[${configId}].scriptingBackend ${CONFIG_FILE})
 
+    local branchFilter=$(jq -r .[${configId}].branchFilter ${CONFIG_FILE})
+
+    if ! [[ ${BUILDKITE_BRANCH:-"local"} =~ ${branchFilter} ]]; then
+        echo "Skipping target as current branch does not match regex '${branchFilter}'."
+        return
+    fi
+
     local args=()
 
     if [[ "${platform}" == "Editmode" ]]; then

--- a/ci/perftest-configs.json
+++ b/ci/perftest-configs.json
@@ -4,111 +4,127 @@
     "category": "Performance",
     "burst": "default",
     "apiProfile": "NET_Standard_2_0",
-    "scriptingBackend": "Mono2x"
+    "scriptingBackend": "Mono2x",
+    "branchFilter": "^.*$"
   },
   {
     "platform": "Editmode",
     "category": "Performance",
     "burst": "default",
     "apiProfile": "NET_4_6",
-    "scriptingBackend": "Mono2x"
+    "scriptingBackend": "Mono2x",
+    "branchFilter": "^(master|develop)$"
   },
   {
     "platform": "Editmode",
     "category": "Performance",
     "burst": "disabled",
     "apiProfile": "NET_Standard_2_0",
-    "scriptingBackend": "Mono2x"
+    "scriptingBackend": "Mono2x",
+    "branchFilter": "^(master|develop)$"
   },
   {
     "platform": "Editmode",
     "category": "Performance",
     "burst": "disabled",
     "apiProfile": "NET_4_6",
-    "scriptingBackend": "Mono2x"
+    "scriptingBackend": "Mono2x",
+    "branchFilter": "^(master|develop)$"
   },
   {
     "platform": "Playmode",
     "category": "Performance",
     "burst": "default",
     "apiProfile": "NET_Standard_2_0",
-    "scriptingBackend": "Mono2x"
+    "scriptingBackend": "Mono2x",
+    "branchFilter": "^.*$"
   },
   {
     "platform": "Playmode",
     "category": "Performance",
     "burst": "default",
     "apiProfile": "NET_4_6",
-    "scriptingBackend": "Mono2x"
+    "scriptingBackend": "Mono2x",
+    "branchFilter": "^(master|develop)$"
   },
   {
     "platform": "Playmode",
     "category": "Performance",
     "burst": "disabled",
     "apiProfile": "NET_Standard_2_0",
-    "scriptingBackend": "Mono2x"
+    "scriptingBackend": "Mono2x",
+    "branchFilter": "^(master|develop)$"
   },
   {
     "platform": "Playmode",
     "category": "Performance",
     "burst": "disabled",
     "apiProfile": "NET_4_6",
-    "scriptingBackend": "Mono2x"
+    "scriptingBackend": "Mono2x",
+    "branchFilter": "^(master|develop)$"
   },
   {
     "platform": "Playmode",
     "category": "Performance",
     "burst": "default",
     "apiProfile": "NET_Standard_2_0",
-    "scriptingBackend": "IL2CPP"
+    "scriptingBackend": "IL2CPP",
+    "branchFilter": "^(master|develop)$"
   },
   {
     "platform": "Playmode",
     "category": "Performance",
     "burst": "default",
     "apiProfile": "NET_4_6",
-    "scriptingBackend": "IL2CPP"
+    "scriptingBackend": "IL2CPP",
+    "branchFilter": "^(master|develop)$"
   },
   {
     "platform": "Playmode",
     "category": "Performance",
     "burst": "disabled",
     "apiProfile": "NET_Standard_2_0",
-    "scriptingBackend": "IL2CPP"
+    "scriptingBackend": "IL2CPP",
+    "branchFilter": "^(master|develop)$"
   },
   {
     "platform": "Playmode",
     "category": "Performance",
     "burst": "disabled",
     "apiProfile": "NET_4_6",
-    "scriptingBackend": "IL2CPP"
+    "scriptingBackend": "IL2CPP",
+    "branchFilter": "^(master|develop)$"
   },
   {
     "platform": "Playmode",
     "category": "Performance",
     "burst": "default",
     "apiProfile": "NET_Standard_2_0",
-    "scriptingBackend": "WinRTDotNET"
+    "scriptingBackend": "WinRTDotNET",
+    "branchFilter": "^(master|develop)$"
   },
   {
     "platform": "Playmode",
     "category": "Performance",
     "burst": "default",
     "apiProfile": "NET_4_6",
-    "scriptingBackend": "WinRTDotNET"
+    "scriptingBackend": "WinRTDotNET",
+    "branchFilter": "^(master|develop)$"
   },
   {
     "platform": "Playmode",
     "category": "Performance",
     "burst": "disabled",
     "apiProfile": "NET_Standard_2_0",
-    "scriptingBackend": "WinRTDotNET"
+    "scriptingBackend": "WinRTDotNET",
+    "branchFilter": "^(master|develop)$"
   },
   {
     "platform": "Playmode",
     "category": "Performance",
     "burst": "disabled",
     "apiProfile": "NET_4_6",
-    "scriptingBackend": "WinRTDotNET"
+    "scriptingBackend": "WinRTDotNET",
+    "branchFilter": "^(master|develop)$"
   }
 ]

--- a/workers/unity/Packages/io.improbable.gdk.testutils/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/package.json
@@ -7,6 +7,8 @@
   "description": "SpatialOS GDK Test Utils.",
   "dependencies": {
     "io.improbable.gdk.core": "0.3.7",
-    "com.unity.ext.nunit": "1.0.0"
+    "com.unity.ext.nunit": "1.0.0",
+    "com.unity.test-framework": "1.1.14",
+    "com.unity.test-framework.performance": "2.2.0-preview"
   }
 }

--- a/workers/unity/Packages/manifest.json
+++ b/workers/unity/Packages/manifest.json
@@ -1,8 +1,6 @@
 {
   "dependencies": {
     "com.unity.ide.rider": "1.1.4",
-    "com.unity.test-framework": "1.1.14",
-    "com.unity.test-framework.performance": "2.2.0-preview",
     "com.unity.testtools.codecoverage": "0.2.3-preview",
     "com.unity.ugui": "1.0.0",
     "com.unity.ui.builder": "0.8.2-preview",


### PR DESCRIPTION
#### Description

This should also reduce our machine usage on premerge builds significantly

- Configure branch filters for the various perf testing targets:
	- only .net 2.0/burst enabled/Mono target is allowed for playmode/editmode on pre-merge
	- all targets run on master/develop
- Moved test framework/perftest package dependency to testutils instead of playground manifest
- only run the csproj/sln initialization if there are any matching targets

#### Tests

- Ran locally, only subset ran
- Run in buildkite, only subset should run
- Ran with branch variable set to master/develop, it iterates through all expected targets

#### Documentation

-  [x] internal changelog about adding dependencies to testutils package

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
