### PR TITLE
UTY-2640: Add component info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Added `Allow Debug` toggle to the Build Configuration UI. [#1413](https://github.com/spatialos/gdk-for-unity/pull/1413)
     - Enabling the option allows .NET debuggers (Rider/Visual Studio) to use breakpoints while in the Unity Player.
 - Added `Authority` type field to `IComponentMetaclass`. [#1393](https://github.com/spatialos/gdk-for-unity/pull/1393)
+- Added info button on the component details in the Worker Inspector Window that prints ComponentID and schema filepath to log [#1423](https://github.com/spatialos/gdk-for-unity/pull/1423)
 
 ### Changed
 

--- a/workers/unity/Packages/io.improbable.gdk.debug/.codegen/Source/Generators/DebugExtensions/ComponentVisualElementGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/.codegen/Source/Generators/DebugExtensions/ComponentVisualElementGenerator.cs
@@ -54,6 +54,7 @@ namespace Improbable.Gdk.CodeGenerator
                 }
 
                 mb.Line($"InjectComponentIcon(\"{GetComponentIcon(details)}\");");
+                mb.Line($"AddInfoIcon(() => UnityEngine.Debug.Log(\"{details.Name} generated from '{details.SchemaFilePath}' with Component ID {details.ComponentId}\"));");
             });
         }
 

--- a/workers/unity/Packages/io.improbable.gdk.debug/.codegen/Source/Generators/DebugExtensions/ComponentVisualElementGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/.codegen/Source/Generators/DebugExtensions/ComponentVisualElementGenerator.cs
@@ -73,7 +73,7 @@ namespace Improbable.Gdk.CodeGenerator
         {
             typeBlock.Method("protected override void WriteDebugInfo()", mb =>
             {
-                mb.Line($"UnityEngine.Debug.Log(\"{details.Name} generated from '{details.SchemaFilePath}' with Component ID {details.ComponentId}\");");
+                mb.Line($"UnityEngine.Debug.Log(\"{details.Name} generated from '{details.SchemaFilePath}' with Component ID '{details.ComponentId}'\");");
             });
         }
 

--- a/workers/unity/Packages/io.improbable.gdk.debug/.codegen/Source/Generators/DebugExtensions/ComponentVisualElementGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/.codegen/Source/Generators/DebugExtensions/ComponentVisualElementGenerator.cs
@@ -36,6 +36,7 @@ namespace Improbable.Gdk.CodeGenerator
 
                         GenerateConstructor(type, details);
                         GenerateUpdateMethod(type, details);
+                        GenerateDebugMethod(type, details);
                     });
                 });
             });
@@ -54,7 +55,6 @@ namespace Improbable.Gdk.CodeGenerator
                 }
 
                 mb.Line($"InjectComponentIcon(\"{GetComponentIcon(details)}\");");
-                mb.Line($"AddInfoIcon(() => UnityEngine.Debug.Log(\"{details.Name} generated from '{details.SchemaFilePath}' with Component ID {details.ComponentId}\"));");
             });
         }
 
@@ -66,6 +66,14 @@ namespace Improbable.Gdk.CodeGenerator
                 mb.Line($"var component = manager.GetComponentData<{details.Name}.Component>(entity);");
 
                 mb.TextList(details.FieldDetails.Select(fd => typeGenerator.ToUiFieldUpdate(fd, "component")));
+            });
+        }
+
+        private void GenerateDebugMethod(TypeBlock typeBlock, UnityComponentDetails details)
+        {
+            typeBlock.Method("protected override void WriteDebugInfo()", mb =>
+            {
+                mb.Line($"UnityEngine.Debug.Log(\"{details.Name} generated from '{details.SchemaFilePath}' with Component ID {details.ComponentId}\");");
             });
         }
 

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/ComponentVisualElement.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/ComponentVisualElement.cs
@@ -21,7 +21,6 @@ namespace Improbable.Gdk.Debug.WorkerInspector.Codegen
 
             ComponentFoldout = this.Q<Foldout>(className: "component-foldout");
             AuthoritativeToggle = this.Q<Toggle>(className: "is-auth-toggle");
-            AddInfoIcon();
         }
 
         protected void InjectComponentIcon(string iconName)
@@ -36,21 +35,16 @@ namespace Improbable.Gdk.Debug.WorkerInspector.Codegen
             foldoutToggle.Insert(1, iconVisualElement);
         }
 
-        private void AddInfoIcon()
+        protected void AddInfoIcon(Action action)
         {
             var iconContent = EditorGUIUtility.IconContent("console.infoicon.sml");
             var iconVisualElement = new Button();
             iconVisualElement.style.backgroundImage = new StyleBackground((Texture2D) iconContent.image);
             iconVisualElement.AddToClassList("component-info-icon");
+            iconVisualElement.clicked += action;
 
-            // We want to inject the icon after the toggle icon and before the text.
             var foldoutToggle = ComponentFoldout.Q<VisualElement>(className: "unity-toggle__input");
             foldoutToggle.Add(iconVisualElement);
-        }
-
-        protected void RegisterInfoCallback(Action action)
-        {
-            ComponentFoldout.Q<Button>(className: "component-info-icon").clicked += action;
         }
 
         public abstract ComponentType ComponentType { get; }

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/ComponentVisualElement.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/ComponentVisualElement.cs
@@ -21,6 +21,9 @@ namespace Improbable.Gdk.Debug.WorkerInspector.Codegen
 
             ComponentFoldout = this.Q<Foldout>(className: "component-foldout");
             AuthoritativeToggle = this.Q<Toggle>(className: "is-auth-toggle");
+
+            ComponentFoldout.text = "Component";
+            SetInfoButton();
         }
 
         protected void InjectComponentIcon(string iconName)
@@ -35,18 +38,23 @@ namespace Improbable.Gdk.Debug.WorkerInspector.Codegen
             foldoutToggle.Insert(1, iconVisualElement);
         }
 
-        protected void AddInfoIcon(Action action)
+        private void SetInfoButton()
         {
             var iconContent = EditorGUIUtility.IconContent("console.infoicon.sml");
-            var iconVisualElement = new Button();
-            iconVisualElement.style.backgroundImage = new StyleBackground((Texture2D) iconContent.image);
-            iconVisualElement.AddToClassList("component-info-icon");
-            iconVisualElement.clicked += action;
+            var infoButton = new Button();
+            infoButton.style.backgroundImage = new StyleBackground((Texture2D) iconContent.image);
+            infoButton.AddToClassList("component-info-icon");
+            infoButton.clicked += WriteDebugInfo;
+
+            var buttonContainer = new VisualElement();
+            buttonContainer.AddToClassList("component-info-container");
+            buttonContainer.Add(infoButton);
 
             var foldoutToggle = ComponentFoldout.Q<VisualElement>(className: "unity-toggle__input");
-            foldoutToggle.Add(iconVisualElement);
+            foldoutToggle.Add(buttonContainer);
         }
 
+        protected abstract void WriteDebugInfo();
         public abstract ComponentType ComponentType { get; }
         public abstract void Update(EntityManager manager, Entity entity);
     }

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/ComponentVisualElement.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/ComponentVisualElement.cs
@@ -22,6 +22,8 @@ namespace Improbable.Gdk.Debug.WorkerInspector.Codegen
             ComponentFoldout = this.Q<Foldout>(className: "component-foldout");
             AuthoritativeToggle = this.Q<Toggle>(className: "is-auth-toggle");
 
+            // This assignment forces the generation of the text element
+            // This prevents the text element from generating after the button which aligns the text element to the right.
             ComponentFoldout.text = "Component";
             SetInfoButton();
         }

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/ComponentVisualElement.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/ComponentVisualElement.cs
@@ -1,4 +1,3 @@
-using System;
 using Unity.Entities;
 using UnityEditor;
 using UnityEngine;

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/ComponentVisualElement.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/ComponentVisualElement.cs
@@ -1,3 +1,4 @@
+using System;
 using Unity.Entities;
 using UnityEditor;
 using UnityEngine;
@@ -20,6 +21,7 @@ namespace Improbable.Gdk.Debug.WorkerInspector.Codegen
 
             ComponentFoldout = this.Q<Foldout>(className: "component-foldout");
             AuthoritativeToggle = this.Q<Toggle>(className: "is-auth-toggle");
+            AddInfoIcon();
         }
 
         protected void InjectComponentIcon(string iconName)
@@ -32,6 +34,23 @@ namespace Improbable.Gdk.Debug.WorkerInspector.Codegen
             // We want to inject the icon after the toggle icon and before the text.
             var foldoutToggle = ComponentFoldout.Q<VisualElement>(className: "unity-toggle__input");
             foldoutToggle.Insert(1, iconVisualElement);
+        }
+
+        private void AddInfoIcon()
+        {
+            var iconContent = EditorGUIUtility.IconContent("console.infoicon.sml");
+            var iconVisualElement = new Button();
+            iconVisualElement.style.backgroundImage = new StyleBackground((Texture2D) iconContent.image);
+            iconVisualElement.AddToClassList("component-info-icon");
+
+            // We want to inject the icon after the toggle icon and before the text.
+            var foldoutToggle = ComponentFoldout.Q<VisualElement>(className: "unity-toggle__input");
+            foldoutToggle.Add(iconVisualElement);
+        }
+
+        protected void RegisterInfoCallback(Action action)
+        {
+            ComponentFoldout.Q<Button>(className: "component-info-icon").clicked += action;
         }
 
         public abstract ComponentType ComponentType { get; }

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/PaginatedListView.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Codegen/PaginatedListView.cs
@@ -1,13 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
 
 namespace Improbable.Gdk.Debug.WorkerInspector.Codegen
 {
-    public class PaginatedListView<TElement, TData> : VisualElement, IConcealable<List<TData>>
+    public class PaginatedListView<TElement, TData> : VisualElement
         where TElement : VisualElement
     {
         private const string UxmlPath =
@@ -27,8 +26,6 @@ namespace Improbable.Gdk.Debug.WorkerInspector.Codegen
 
         private int currentPage = 0;
         private int numPages = 0;
-
-        private bool hideEmptyCollections;
 
         public PaginatedListView(string label, Func<TElement> makeElement, Action<int, TData, TElement> bindElement, int elementsPerPage = 5)
         {
@@ -51,28 +48,6 @@ namespace Improbable.Gdk.Debug.WorkerInspector.Codegen
             forwardButton.clickable.clicked += () => ChangePageCount(1);
 
             elementPool = new ElementPool<TElement>(makeElement);
-        }
-
-        public void SetVisibility(List<TData> dataSource, bool hideIfEmpty)
-        {
-            hideEmptyCollections = hideIfEmpty;
-            Update(dataSource);
-            if (dataSource.Count == 0 && hideIfEmpty)
-            {
-                AddToClassList("hidden");
-            }
-            else
-            {
-                RemoveFromClassList("hidden");
-            }
-
-            foreach (var i in Enumerable.Range(0, container.childCount))
-            {
-                if (container.ElementAt(i) is IConcealable<TData> element)
-                {
-                    element.SetVisibility(this.data[i], hideIfEmpty);
-                }
-            }
         }
 
         public void Update(List<TData> newData)

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
@@ -93,7 +93,7 @@
     margin-left: 10px;
 }
 
-.component-info-container {
+.component-foldout .component-info-container {
     display: flex;
     flex-grow: 1;
     flex-direction: row;

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
@@ -93,6 +93,13 @@
     margin-left: 10px;
 }
 
+.component-info-container {
+    display: flex;
+    flex-grow: 1;
+    flex-direction: row;
+    justify-content: flex-end;
+}
+
 #worker-details {
     padding: 8px 4px;
     border-top-color: rgba(0, 0, 0, 0.20);

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
@@ -85,6 +85,14 @@
     margin-right: 10px;
 }
 
+.component-foldout .component-info-icon {
+    height: 15px;
+    width: 15px;
+    align-self: center;
+    margin-right: 10px;
+    margin-left: 10px;
+}
+
 #worker-details {
     padding: 8px 4px;
     border-top-color: rgba(0, 0, 0, 0.20);

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/DetailsStore.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/DetailsStore.cs
@@ -61,12 +61,12 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
 
                 foreach (var rawEnum in file.Enums)
                 {
-                    enums.Add(rawEnum.QualifiedName, new UnityEnumDetails(file.Package.Name, rawEnum));
+                    enums.Add(rawEnum.QualifiedName, new UnityEnumDetails(file.Package.Name, file.CanonicalPath, rawEnum));
                 }
 
                 foreach (var type in file.Types)
                 {
-                    var typeDetails = new UnityTypeDetails(file.Package.Name, type);
+                    var typeDetails = new UnityTypeDetails(file.Package.Name, file.CanonicalPath, type);
 
                     if (overrideMap.TryGetValue(typeDetails.FullyQualifiedName, out var staticClassFqn))
                     {
@@ -79,7 +79,7 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
 
                 foreach (var component in file.Components)
                 {
-                    components.Add(component.QualifiedName, new UnityComponentDetails(file.Package.Name, component, this));
+                    components.Add(component.QualifiedName, new UnityComponentDetails(file.Package.Name, file.CanonicalPath, component, this));
                 }
 
                 Logger.Trace($"Enums added: {file.Enums.Count}.");

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/GeneratorInputDetails.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/GeneratorInputDetails.cs
@@ -36,9 +36,9 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
         /// </summary>
         public readonly string SchemaFilePath;
 
-        protected GeneratorInputDetails(string package, string path, QualifiedDefinition qualifiedDefinition) : base(qualifiedDefinition)
+        protected GeneratorInputDetails(string package, string schemaPath, QualifiedDefinition qualifiedDefinition) : base(qualifiedDefinition)
         {
-            SchemaFilePath = path;
+            SchemaFilePath = schemaPath;
             Namespace = Formatting.CapitaliseQualifiedNameParts(package);
             NamespacePath = Formatting.GetNamespacePath(package);
 

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/GeneratorInputDetails.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/GeneratorInputDetails.cs
@@ -31,8 +31,14 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
         /// </remarks>
         public readonly string FullyQualifiedName;
 
-        protected GeneratorInputDetails(string package, QualifiedDefinition qualifiedDefinition) : base(qualifiedDefinition)
+        /// <summary>
+        /// The path of the file relative to the schema directory
+        /// </summary>
+        public readonly string SchemaFilePath;
+
+        protected GeneratorInputDetails(string package, string path, QualifiedDefinition qualifiedDefinition) : base(qualifiedDefinition)
         {
+            SchemaFilePath = path;
             Namespace = Formatting.CapitaliseQualifiedNameParts(package);
             NamespacePath = Formatting.GetNamespacePath(package);
 

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/UnityComponentDetails.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/UnityComponentDetails.cs
@@ -18,8 +18,8 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
 
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public UnityComponentDetails(string package, ComponentDefinition rawComponentDefinition, DetailsStore store)
-            : base(package, rawComponentDefinition)
+        public UnityComponentDetails(string package, string path, ComponentDefinition rawComponentDefinition, DetailsStore store)
+            : base(package, path, rawComponentDefinition)
         {
             ComponentId = rawComponentDefinition.ComponentId;
 

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/UnityComponentDetails.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/UnityComponentDetails.cs
@@ -18,8 +18,8 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
 
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public UnityComponentDetails(string package, string path, ComponentDefinition rawComponentDefinition, DetailsStore store)
-            : base(package, path, rawComponentDefinition)
+        public UnityComponentDetails(string package, string schemaPath, ComponentDefinition rawComponentDefinition, DetailsStore store)
+            : base(package, schemaPath, rawComponentDefinition)
         {
             ComponentId = rawComponentDefinition.ComponentId;
 

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/UnityEnumDetails.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/UnityEnumDetails.cs
@@ -13,8 +13,8 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
 
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public UnityEnumDetails(string package, string path, EnumDefinition rawEnumDefinition)
-            : base(package, path, rawEnumDefinition)
+        public UnityEnumDetails(string package, string schemaPath, EnumDefinition rawEnumDefinition)
+            : base(package, schemaPath, rawEnumDefinition)
         {
             var min = rawEnumDefinition.Values.Select(list => list.Value).Min();
             EnumMinimums[FullyQualifiedName] = min;

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/UnityEnumDetails.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/UnityEnumDetails.cs
@@ -13,8 +13,8 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
 
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public UnityEnumDetails(string package, EnumDefinition rawEnumDefinition)
-            : base(package, rawEnumDefinition)
+        public UnityEnumDetails(string package, string path, EnumDefinition rawEnumDefinition)
+            : base(package, path, rawEnumDefinition)
         {
             var min = rawEnumDefinition.Values.Select(list => list.Value).Min();
             EnumMinimums[FullyQualifiedName] = min;

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/UnityTypeDetails.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/UnityTypeDetails.cs
@@ -24,8 +24,8 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
 
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public UnityTypeDetails(string package, TypeDefinition rawTypeDefinition)
-            : base(package, rawTypeDefinition)
+        public UnityTypeDetails(string package, string path, TypeDefinition rawTypeDefinition)
+            : base(package, path, rawTypeDefinition)
         {
             this.rawTypeDefinition = rawTypeDefinition;
         }

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/UnityTypeDetails.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/Model/Details/TypeDetails/UnityTypeDetails.cs
@@ -24,8 +24,8 @@ namespace Improbable.Gdk.CodeGeneration.Model.Details
 
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public UnityTypeDetails(string package, string path, TypeDefinition rawTypeDefinition)
-            : base(package, path, rawTypeDefinition)
+        public UnityTypeDetails(string package, string schemaPath, TypeDefinition rawTypeDefinition)
+            : base(package, schemaPath, rawTypeDefinition)
         {
             this.rawTypeDefinition = rawTypeDefinition;
         }


### PR DESCRIPTION
#### Description
Component details in the worker inspector window now has a new button. Clicking on it will print component ID and filepath to log.
- [x] screenshots

#### Tests
Play sample scene and click on new button next to component name in the worker inspector

#### Documentation
- [ ] Todo
- [x] **Did you remember a changelog entry?**

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
