### PR TITLE
UTY-2643: fix codegen indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 ### Fixed
 
 - Fixed a bug in the Worker Inspector where component foldouts were being rendered too often, causing poor performance when the entity had many components or very complex components. [#1403](https://github.com/spatialos/gdk-for-unity/pull/1403)
-- Fixed minor indentation issue in generated code caused by newline format [#1424](https://github.com/spatialos/gdk-for-unity/pull/1424)
+- Fixed minor indentation issue in generated code caused by newline formatting. [#1424](https://github.com/spatialos/gdk-for-unity/pull/1424)
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ### Fixed
 
 - Fixed a bug in the Worker Inspector where component foldouts were being rendered too often, causing poor performance when the entity had many components or very complex components. [#1403](https://github.com/spatialos/gdk-for-unity/pull/1403)
+- Fixed minor indentation issue in generated code caused by newline format [#1424](https://github.com/spatialos/gdk-for-unity/pull/1424)
 
 ### Internal
 

--- a/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Text.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/.CodeGenTemplate/CodeGenerationLib/CodeWriter/Text.cs
@@ -29,7 +29,8 @@ namespace Improbable.Gdk.CodeGeneration.CodeWriter
         {
             var spaces = CommonGeneratorUtils.GetIndentSpaces(indentLevel);
             var indentedCode = snippet
-                .Replace($"{Environment.NewLine}", $"{Environment.NewLine}{spaces}")
+                .Replace("\r\n", "\n")
+                .Replace("\n", $"{Environment.NewLine}{spaces}")
                 .Replace($"{Environment.NewLine}{spaces}{Environment.NewLine}", $"{Environment.NewLine}{Environment.NewLine}");
             return $"{spaces}{indentedCode}";
         }


### PR DESCRIPTION
#### Description
Standardizes newlines before replacing

#### Tests
Ran codegen with the changes in fps-starter-project where bug was observed

#### Documentation
None
- [x] **Did you remember a changelog entry?**

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
