### PR TITLE
Fix bug where CommandSender would not reenable after being disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 - Fixed a bug in the Worker Inspector where component foldouts were being rendered too often, causing poor performance when the entity had many components or very complex components. [#1403](https://github.com/spatialos/gdk-for-unity/pull/1403)
 - Fixed minor indentation issue in generated code caused by newline formatting. [#1424](https://github.com/spatialos/gdk-for-unity/pull/1424)
+- Fixed a bug where `CommandSender` objects would not be made valid again after being _re-injected_. [#1429](https://github.com/spatialos/gdk-for-unity/pull/1429)
 
 ### Internal
 

--- a/workers/unity/Assets/Tests/EditmodeTests/Correctness/Subscriptions/RequireablesReenableTests.cs
+++ b/workers/unity/Assets/Tests/EditmodeTests/Correctness/Subscriptions/RequireablesReenableTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Commands;
+using Improbable.Gdk.PlayerLifecycle;
+using Improbable.Gdk.Subscriptions;
+using Improbable.Gdk.Test;
+using Improbable.Gdk.TestUtils;
+using Improbable.Worker.CInterop;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Empty = Improbable.Gdk.Core.Empty;
+using Entity = Unity.Entities.Entity;
+
+namespace Improbable.Gdk.EditmodeTests
+{
+    [TestFixture]
+    public class RequireablesReenableTests : MockBase
+    {
+        private const long EntityId = 100;
+
+        [Test]
+        public void CommandSenders_and_Receivers_are_valid_after_reinjection()
+        {
+            World
+                .Step(world => world.Connection.CreateEntity(EntityId, GetTemplate()))
+                .Step(world =>
+                    world.Connection.ChangeAuthority(EntityId, TestCommands.ComponentId, Authority.Authoritative))
+                .Step(world =>
+                {
+                    var (_, behaviour) = world.CreateGameObject<CommandSenderTestBehaviour>(EntityId);
+                    return behaviour;
+                })
+                .Step((world, behaviour) =>
+                {
+                    Assert.IsNotNull(behaviour.CommandReceiver);
+                    Assert.IsNotNull(behaviour.CommandSender);
+                    Assert.IsTrue(behaviour.CommandReceiver.IsValid);
+                    Assert.IsTrue(behaviour.CommandSender.IsValid);
+                })
+                .Step(world =>
+                    world.Connection.ChangeAuthority(EntityId, TestCommands.ComponentId, Authority.NotAuthoritative))
+                .Step((world, behaviour) =>
+                {
+                    Assert.IsNull(behaviour.CommandReceiver);
+                    Assert.IsNull(behaviour.CommandSender);
+                })
+                .Step(world =>
+                    world.Connection.ChangeAuthority(EntityId, TestCommands.ComponentId, Authority.Authoritative))
+                .Step((world, behaviour) =>
+                {
+                    Assert.IsNotNull(behaviour.CommandReceiver);
+                    Assert.IsNotNull(behaviour.CommandSender);
+                    Assert.IsTrue(behaviour.CommandReceiver.IsValid);
+                    Assert.IsTrue(behaviour.CommandSender.IsValid);
+                });
+        }
+
+        [Test]
+        public void Readers_and_Writers_are_valid_after_reinjection()
+        {
+            World
+                .Step(world => world.Connection.CreateEntity(EntityId, GetTemplate()))
+                .Step(world =>
+                    world.Connection.ChangeAuthority(EntityId, TestCommands.ComponentId, Authority.Authoritative))
+                .Step(world =>
+                {
+                    var (_, behaviour) = world.CreateGameObject<ReaderTestBehaviour>(EntityId);
+                    return behaviour;
+                })
+                .Step((world, behaviour) =>
+                {
+                    Assert.IsNotNull(behaviour.Writer);
+                    Assert.IsNotNull(behaviour.Reader);
+                    Assert.IsTrue(behaviour.Writer.IsValid);
+                    Assert.IsTrue(behaviour.Reader.IsValid);
+                })
+                .Step(world =>
+                    world.Connection.ChangeAuthority(EntityId, TestCommands.ComponentId, Authority.NotAuthoritative))
+                .Step((world, behaviour) =>
+                {
+                    Assert.IsNull(behaviour.Writer);
+                    Assert.IsNull(behaviour.Reader);
+                })
+                .Step(world =>
+                    world.Connection.ChangeAuthority(EntityId, TestCommands.ComponentId, Authority.Authoritative))
+                .Step((world, behaviour) =>
+                {
+                    Assert.IsNotNull(behaviour.Writer);
+                    Assert.IsNotNull(behaviour.Reader);
+                    Assert.IsTrue(behaviour.Writer.IsValid);
+                    Assert.IsTrue(behaviour.Reader.IsValid);
+                });
+        }
+
+        private static EntityTemplate GetTemplate()
+        {
+            var template = new EntityTemplate();
+            template.AddComponent(new Position.Snapshot(), "worker");
+            template.AddComponent(new TestCommands.Snapshot(), "worker");
+            return template;
+        }
+
+        private class CommandSenderTestBehaviour : MonoBehaviour
+        {
+            [Require] public TestCommandsCommandReceiver CommandReceiver;
+            [Require] public PlayerHeartbeatClientCommandSender CommandSender;
+        }
+
+        private class ReaderTestBehaviour : MonoBehaviour
+        {
+            [Require] public TestCommandsWriter Writer;
+            [Require] public TestCommandsReader Reader;
+        }
+    }
+}

--- a/workers/unity/Assets/Tests/EditmodeTests/Correctness/Subscriptions/RequireablesReenableTests.cs
+++ b/workers/unity/Assets/Tests/EditmodeTests/Correctness/Subscriptions/RequireablesReenableTests.cs
@@ -29,7 +29,7 @@ namespace Improbable.Gdk.EditmodeTests
                     world.Connection.ChangeAuthority(EntityId, TestCommands.ComponentId, Authority.Authoritative))
                 .Step(world =>
                 {
-                    var (_, behaviour) = world.CreateGameObject<CommandSenderTestBehaviour>(EntityId);
+                    var (_, behaviour) = world.CreateGameObject<CommandSenderReceiverTestBehaviour>(EntityId);
                     return behaviour;
                 })
                 .Step((world, behaviour) =>
@@ -66,7 +66,7 @@ namespace Improbable.Gdk.EditmodeTests
                     world.Connection.ChangeAuthority(EntityId, TestCommands.ComponentId, Authority.Authoritative))
                 .Step(world =>
                 {
-                    var (_, behaviour) = world.CreateGameObject<ReaderTestBehaviour>(EntityId);
+                    var (_, behaviour) = world.CreateGameObject<ReaderWriterTestBehaviour>(EntityId);
                     return behaviour;
                 })
                 .Step((world, behaviour) =>
@@ -102,13 +102,13 @@ namespace Improbable.Gdk.EditmodeTests
             return template;
         }
 
-        private class CommandSenderTestBehaviour : MonoBehaviour
+        private class CommandSenderReceiverTestBehaviour : MonoBehaviour
         {
             [Require] public TestCommandsCommandReceiver CommandReceiver;
             [Require] public PlayerHeartbeatClientCommandSender CommandSender;
         }
 
-        private class ReaderTestBehaviour : MonoBehaviour
+        private class ReaderWriterTestBehaviour : MonoBehaviour
         {
             [Require] public TestCommandsWriter Writer;
             [Require] public TestCommandsReader Reader;

--- a/workers/unity/Assets/Tests/EditmodeTests/Correctness/Subscriptions/RequireablesReenableTests.cs
+++ b/workers/unity/Assets/Tests/EditmodeTests/Correctness/Subscriptions/RequireablesReenableTests.cs
@@ -104,14 +104,18 @@ namespace Improbable.Gdk.EditmodeTests
 
         private class CommandSenderReceiverTestBehaviour : MonoBehaviour
         {
+#pragma warning disable 649
             [Require] public TestCommandsCommandReceiver CommandReceiver;
             [Require] public PlayerHeartbeatClientCommandSender CommandSender;
+#pragma warning restore 649
         }
 
         private class ReaderWriterTestBehaviour : MonoBehaviour
         {
+#pragma warning disable 649
             [Require] public TestCommandsWriter Writer;
             [Require] public TestCommandsReader Reader;
+#pragma warning restore 649
         }
     }
 }

--- a/workers/unity/Assets/Tests/EditmodeTests/Correctness/Subscriptions/RequireablesReenableTests.cs
+++ b/workers/unity/Assets/Tests/EditmodeTests/Correctness/Subscriptions/RequireablesReenableTests.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections.Generic;
 using Improbable.Gdk.Core;
-using Improbable.Gdk.Core.Commands;
 using Improbable.Gdk.PlayerLifecycle;
 using Improbable.Gdk.Subscriptions;
 using Improbable.Gdk.Test;
@@ -9,9 +6,7 @@ using Improbable.Gdk.TestUtils;
 using Improbable.Worker.CInterop;
 using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.TestTools;
-using Empty = Improbable.Gdk.Core.Empty;
-using Entity = Unity.Entities.Entity;
+
 
 namespace Improbable.Gdk.EditmodeTests
 {

--- a/workers/unity/Assets/Tests/EditmodeTests/Correctness/Subscriptions/RequireablesReenableTests.cs.meta
+++ b/workers/unity/Assets/Tests/EditmodeTests/Correctness/Subscriptions/RequireablesReenableTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2d91ccecd89a43eb80a388ecf12817f9
+timeCreated: 1594992696

--- a/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/CommandSenderReceiverSubscriptionManagerBase.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/CommandSenderReceiverSubscriptionManagerBase.cs
@@ -7,16 +7,12 @@ using Entity = Unity.Entities.Entity;
 
 namespace Improbable.Gdk.Subscriptions
 {
-    public interface ICommandSender
+    public interface ICommandSender : IRequireable
     {
-        bool IsValid { get; set; }
-        void RemoveAllCallbacks();
     }
 
-    public interface ICommandReceiver
+    public interface ICommandReceiver : IRequireable
     {
-        bool IsValid { get; set; }
-        void RemoveAllCallbacks();
     }
 
     public abstract class CommandSenderSubscriptionManagerBase<T> : SubscriptionManager<T>


### PR DESCRIPTION
#### Description

If you have a behaviour that looks like:

```csharp
public class MyBehaviour : MonoBehaviour 
{
	[Require] private ComponentCommandSender sender;
	[Require] private OtherComponentCommandReceiver receiver;
}
```

If this behaviour is disabled due to `OtherComponent` losing authority, `receiver` will be set to `null` and the underlying object has `IsValid` set to `false`. 

If then the behaviour is re-enabled due to `OtherComponent` gaining authority, `receiver` will be re-injected, but `IsValid` will not be set to true. 

This is the same bug as https://github.com/spatialos/gdk-for-unity/pull/1326, but for the sender rather than the readers. The fix is to have everything implement `IRequireable`. This is a consequence of https://github.com/spatialos/gdk-for-unity/pull/1297 where we changed the behaviour of behaviours with multiple requireables. 

#### Tests

Test cases for reader/writer/commandsender/commandreceiver

#### Documentation

- [x] Changelog
