### PR TITLE
Correctly skip builds which are not marked as required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 
 - Upgrade to Worker SDK v14.7.0. [#1434](https://github.com/spatialos/gdk-for-unity/pull/1434)
 
+### Fixed
+
+- Build targets which are marked as 'Build', but not 'Required' are now properly skipped if build support is not installed. [#1435](https://github.com/spatialos/gdk-for-unity/pull/1435)
+
 ## `0.3.8` - 2020-07-20
 
 ### Breaking Changes

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildContext.cs
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildContext.cs
@@ -58,7 +58,7 @@ namespace Improbable.Gdk.BuildSystem.Configuration
                     Debug.LogWarning(
                         $"Skipping ({targetNames}) because build support is not installed in the Unity Editor and the build target is not marked as 'Required'.");
 
-                    targetConfigs.RemoveAll(t => missingTargets.Contains(t));
+                    supportedTargets.RemoveAll(t => missingTargets.Contains(t));
                 }
 
                 result.AddRange(supportedTargets.Select(targetConfig => new BuildContext


### PR DESCRIPTION
We added the concept of a deprecated target in https://github.com/spatialos/gdk-for-unity/pull/1421 but missing changing this reference from `targetConfigs` to `supportedTargets`