### PR TITLE
Fix the `PrefabPreprocessor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,15 @@
 - Added support for multiple annotations in Code Writer API. [#1427](https://github.com/spatialos/gdk-for-unity/pull/1427)
 - Prevent building workers with Unity Editor compile errors. [#1425](https://github.com/spatialos/gdk-for-unity/pull/1425)
 
-### Fixed
-
-- Fixed a bug where the entity list in the Worker Inspector does not refresh when switching to a worker with no entities checked out [#1432](https://github.com/spatialos/gdk-for-unity/pull/1432)
-
 ### Changed
 
 - Upgrade to Worker SDK v14.7.0. [#1434](https://github.com/spatialos/gdk-for-unity/pull/1434)
 
 ### Fixed
 
+- Fixed a bug where the entity list in the Worker Inspector does not refresh when switching to a worker with no entities checked out [#1432](https://github.com/spatialos/gdk-for-unity/pull/1432)
 - Build targets which are marked as 'Build', but not 'Required' are now properly skipped if build support is not installed. [#1435](https://github.com/spatialos/gdk-for-unity/pull/1435)
+- The `PrefabPreprocessor` will now correctly find and preprocess your prefabs. [#1438](https://github.com/spatialos/gdk-for-unity/pull/1438)
 
 ## `0.3.8` - 2020-07-20
 

--- a/workers/unity/Packages/io.improbable.gdk.core/Representation/Editor/PrefabPreprocessor.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Representation/Editor/PrefabPreprocessor.cs
@@ -44,7 +44,7 @@ namespace Improbable.Gdk.Core.Representation.Editor
 
         private static void PreprocessPrefabs()
         {
-            var resolvers = AssetDatabase.FindAssets("t:EntityLinkerDatabase")
+            var resolvers = AssetDatabase.FindAssets($"t:{typeof(EntityRepresentationMapping)}")
                 .Select(AssetDatabase.GUIDToAssetPath)
                 .Select(AssetDatabase.LoadAssetAtPath<EntityRepresentationMapping>)
                 .SelectMany(mapping => mapping.EntityRepresentationResolvers)


### PR DESCRIPTION
#### Description

We broke this in by #1393 as we forgot to change the string when we re-named it. I've changed it to a `typeof()` to avoid this in the future.

#### Tests

- Removed a behaviour and re-added it. Hit play and checked the prefab to make sure it was disabled.

#### Documentation

- [x] Changelog