### PR TITLE
Fix Android support check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed an `IndexOutOfRangeException` that could be thrown when editing your 'Build Configuration' asset. [#1441](https://github.com/spatialos/gdk-for-unity/pull/1441)
+- The 'Build Configuration' Inspector window will no longer report your Android SDK installation as missing if you have a completely fresh Unity installation with the bundled Android SDK. [#1441](https://github.com/spatialos/gdk-for-unity/pull/1441)
+
 ## `0.3.9` - 2020-07-24
 
 ### Breaking Changes

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildConfigEditor.cs
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildConfigEditor.cs
@@ -41,6 +41,7 @@ namespace Improbable.Gdk.BuildSystem.Configuration
         private WorkerChoicePopup workerChooser;
         private UIStateManager stateManager = new UIStateManager();
         private readonly Dictionary<int, int> toolbarMapping = new Dictionary<int, int>();
+        private BuildEnvironmentConfig lastEnvironmentConfig;
 
         private static string[] allWorkers;
 
@@ -635,9 +636,12 @@ namespace Improbable.Gdk.BuildSystem.Configuration
         {
             // Build a mapping from the 'build target' position in the toolbar to it's position in the 'BuildTargets' array.
             // We do this since sometimes there are different number of targets in the BuildTargets array and those
-            // in the toolbar as some targets are deprecated
-            if (toolbarMapping.Count == 0)
+            // in the toolbar as some targets are deprecated.
+            // We need to build this when the BuildEnvironmentConfig has changed.
+            if (toolbarMapping.Count == 0 || lastEnvironmentConfig != env)
             {
+                toolbarMapping.Clear();
+                lastEnvironmentConfig = env;
                 var toolbarIndex = 0;
                 for (var buildTargetIndex = 0; buildTargetIndex < env.BuildTargets.Count; buildTargetIndex++)
                 {

--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildConfigEditor.cs
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/Configuration/BuildConfigEditor.cs
@@ -168,8 +168,8 @@ namespace Improbable.Gdk.BuildSystem.Configuration
                                 tooltip = "Missing build support for one or more build targets."
                             };
                     }
-                    else if (configurationForWorker.CloudBuildConfig.BuildTargets.Any(NeedsAndroidSdk) ||
-                        configurationForWorker.LocalBuildConfig.BuildTargets.Any(NeedsAndroidSdk))
+                    else if (configurationForWorker.CloudBuildConfig.BuildTargets.Any(IsMissingAndroidSdk) ||
+                        configurationForWorker.LocalBuildConfig.BuildTargets.Any(IsMissingAndroidSdk))
                     {
                         foldoutState.Icon =
                             new GUIContent(EditorGUIUtility.IconContent(BuildConfigEditorStyle.BuiltInErrorIcon))
@@ -862,9 +862,14 @@ namespace Improbable.Gdk.BuildSystem.Configuration
         }
 
 
-        private static bool NeedsAndroidSdk(BuildTargetConfig t)
+        private static bool IsMissingAndroidSdk(BuildTargetConfig t)
         {
-            return t.Enabled && t.Target == BuildTarget.Android && string.IsNullOrEmpty(EditorPrefs.GetString("AndroidSdkRoot"));
+            if (!t.Enabled || t.Target != BuildTarget.Android)
+            {
+                return false;
+            }
+
+            return string.IsNullOrEmpty(EditorPrefs.GetString("AndroidSdkRoot")) && !Directory.Exists(Path.Combine(BuildPipeline.GetPlaybackEngineDirectory(BuildTarget.Android, BuildOptions.None), "SDK"));
         }
     }
 }


### PR DESCRIPTION
#### Description

This PR is two bug fixes combined in one! 

The first commit is a driveby where selecting the 'Cloud Build Options' and then the 'Local Build Options' and then selecting the `iOS` target would throw errors. TL;DR - We built a cache and forget to clear it when its invalidated.

The second is the fix for the associated ticket, if the editor pref isn't set, we look to ensure that the default location for the Android SDK installed by Unity is present. 

#### Tests

Put my build configuration in a configuration that would give me the missing Android SDK error (even though it was installed), then applied the code changes and checked that it correctly identifies it as installed. 

#### Documentation

- [x] Changelog
