### PR TITLE
Fix MacOS local launch errors when there are spaces in paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,15 @@
 
 ## Unreleased
 
+### Added
+
+- Added capability to test commands through the `MockConnectionHandler`. [#1437](https://github.com/spatialos/gdk-for-unity/pull/1437)
+
 ### Fixed
 
 - Fixed an `IndexOutOfRangeException` that could be thrown when editing your 'Build Configuration' asset. [#1441](https://github.com/spatialos/gdk-for-unity/pull/1441)
 - The 'Build Configuration' Inspector window will no longer report your Android SDK installation as missing if you have a completely fresh Unity installation with the bundled Android SDK. [#1441](https://github.com/spatialos/gdk-for-unity/pull/1441)
-
-### Added
-
-- Added capability to test commands through the `MockConnectionHandler`. [#1437](https://github.com/spatialos/gdk-for-unity/pull/1437)
+- Fixed a bug where having spaces in the path to your project would cause the 'Local launch' and 'Launch standalone client' menu options to fail on MacOS. [#1442](https://github.com/spatialos/gdk-for-unity/pull/1442)
 
 ### Internal
 

--- a/workers/unity/Packages/io.improbable.gdk.tools/LocalLaunch.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/LocalLaunch.cs
@@ -221,7 +221,7 @@ namespace Improbable.Gdk.Tools
             var command = Common.SpatialBinary;
 
 #if UNITY_EDITOR_OSX
-            var commandArgs = $"local launch --enable_pre_run_check=false --snapshot '{toolsConfig.CustomSnapshotPath}' --experimental_runtime={toolsConfig.RuntimeVersion}";
+            var commandArgs = $"local launch --enable_pre_run_check=false --experimental_runtime={toolsConfig.RuntimeVersion}";
 #else
             var commandArgs = $"local launch --enable_pre_run_check=false --snapshot \"{toolsConfig.CustomSnapshotPath}\" --experimental_runtime={toolsConfig.RuntimeVersion}";
 #endif
@@ -237,7 +237,9 @@ namespace Improbable.Gdk.Tools
                 command = "osascript";
                 commandArgs = $@"-e 'tell application ""Terminal""
                                      activate
-                                     do script ""cd {Common.SpatialProjectRootDir} && {Common.SpatialBinary} {commandArgs}""
+                                     set projectDir to ""{Common.SpatialProjectRootDir}""
+                                     set snapshotPath to ""{toolsConfig.CustomSnapshotPath}""
+                                     do script ""cd "" & quoted form of projectDir & "" && {Common.SpatialBinary} {commandArgs} --snapshot "" & quoted form of snapshotPath
                                      end tell'";
             }
 
@@ -245,7 +247,7 @@ namespace Improbable.Gdk.Tools
             {
                 CreateNoWindow = false,
                 UseShellExecute = true,
-                WorkingDirectory = Common.SpatialProjectRootDir
+                WorkingDirectory = Common.SpatialProjectRootDir,
             };
 
             var process = Process.Start(processInfo);

--- a/workers/unity/Packages/io.improbable.gdk.tools/LocalLaunch.cs
+++ b/workers/unity/Packages/io.improbable.gdk.tools/LocalLaunch.cs
@@ -91,8 +91,9 @@ namespace Improbable.Gdk.Tools
             {
                 command = "osascript";
                 commandArgs = $@"-e 'tell application ""Terminal""
+                                     set projectDir to ""{Common.SpatialProjectRootDir}""
                                      activate
-                                     do script ""cd {Common.SpatialProjectRootDir} && {Common.SpatialBinary} {commandArgs}""
+                                     do script ""cd "" & quoted form of projectDir & "" && {Common.SpatialBinary} {commandArgs}""
                                      end tell'";
                 unityClientZipName = "UnityClient@Mac.zip";
             }


### PR DESCRIPTION
#### Description
We use `osascript` for launching a local deployment with `spatial`. This has some particular rules around quotation, especially as we are running the script inline from a shell. 

This resulted in errors when paths had spaces in them. To handle these, I've used the built-in quoting abilities in `osascript` rather than trying to escape them manually twice (once for shell and once for osascript!). 

#### Tests

- Renamed `gdk-for-unity` to `gdk for unity` on my local machine to test launching a deployment & standalone client.

#### Documentation

- [x] Changelog
- [ ] Known issue - #1225 

