### PR TITLE
Fix `Set Kinematic When Not Authoritative` not being applied correctly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - The 'Build Configuration' Inspector window will no longer report your Android SDK installation as missing if you have a completely fresh Unity installation with the bundled Android SDK. [#1441](https://github.com/spatialos/gdk-for-unity/pull/1441)
 - Fixed a bug where having spaces in the path to your project would cause the 'Local launch' and 'Launch standalone client' menu options to fail on MacOS. [#1442](https://github.com/spatialos/gdk-for-unity/pull/1442)
 - Fixed a faulty sync point caused by using `ComponentDataFromEntity` of the `WorkerSystem`. [#1430](https://github.com/spatialos/gdk-for-unity/pull/1430)
+- Fixed a bug where the Transform Sync Feature Module would not correctly apply the `Is Kinematic` option. [#1456](https://github.com/spatialos/gdk-for-unity/pull/1456)
 
 ### Internal
 

--- a/workers/unity/Packages/io.improbable.gdk.transformsynchronization/Systems/DefaultApplyLatestTransformSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.transformsynchronization/Systems/DefaultApplyLatestTransformSystem.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Improbable.Gdk.Core;
 using Unity.Entities;
 using UnityEngine;
+using static Improbable.Gdk.TransformSynchronization.TransformUtils;
 
 namespace Improbable.Gdk.TransformSynchronization
 {
@@ -32,7 +33,7 @@ namespace Improbable.Gdk.TransformSynchronization
         internal void RegisterTransformSyncType<T>(ITransformSync<T> impl)
             where T : class
         {
-            var entityQuery = GetEntityQuery(TransformUtils.ConstructEntityQueryDesc<T>(requireAuthority: false, baseComponentTypes));
+            var entityQuery = GetEntityQuery(ConstructEntityQueryDesc<T>(AuthorityRequirements.Exclude, baseComponentTypes));
 
             applyLatestTransformActions.Add(typeof(T),
                 () => Entities.With(entityQuery)
@@ -42,7 +43,7 @@ namespace Improbable.Gdk.TransformSynchronization
 
         private void UpdateTransformQuery()
         {
-            var transformQueryDesc = TransformUtils.ConstructEntityQueryDesc<UnityEngine.Transform>(requireAuthority: false, baseComponentTypes);
+            var transformQueryDesc = ConstructEntityQueryDesc<UnityEngine.Transform>(AuthorityRequirements.Exclude, baseComponentTypes);
             transformQueryDesc.None = transformQueryDesc.None
                 .Union(
                     applyLatestTransformActions.Keys

--- a/workers/unity/Packages/io.improbable.gdk.transformsynchronization/Systems/DefaultUpdateLatestTransformSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.transformsynchronization/Systems/DefaultUpdateLatestTransformSystem.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Improbable.Gdk.Core;
 using Unity.Entities;
 using UnityEngine;
+using static Improbable.Gdk.TransformSynchronization.TransformUtils;
 
 namespace Improbable.Gdk.TransformSynchronization
 {
@@ -32,7 +33,7 @@ namespace Improbable.Gdk.TransformSynchronization
         internal void RegisterTransformSyncType<T>(ITransformSync<T> impl)
             where T : class
         {
-            var entityQuery = GetEntityQuery(TransformUtils.ConstructEntityQueryDesc<T>(requireAuthority: true, baseComponentTypes));
+            var entityQuery = GetEntityQuery(ConstructEntityQueryDesc<T>(AuthorityRequirements.Require, baseComponentTypes));
 
             updateLatestTransformActions.Add(typeof(T),
                 () => Entities.With(entityQuery)
@@ -43,7 +44,7 @@ namespace Improbable.Gdk.TransformSynchronization
 
         private void UpdateTransformQuery()
         {
-            var transformQueryDesc = TransformUtils.ConstructEntityQueryDesc<UnityEngine.Transform>(requireAuthority: true, baseComponentTypes);
+            var transformQueryDesc = ConstructEntityQueryDesc<UnityEngine.Transform>(AuthorityRequirements.Require, baseComponentTypes);
             transformQueryDesc.None = updateLatestTransformActions.Keys
                 .Select(ComponentType.ReadOnly)
                 .ToArray();

--- a/workers/unity/Packages/io.improbable.gdk.transformsynchronization/Systems/ResetForAuthorityGainedSystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.transformsynchronization/Systems/ResetForAuthorityGainedSystem.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Improbable.Gdk.Core;
 using Unity.Entities;
-using UnityEngine;
+using static Improbable.Gdk.TransformSynchronization.TransformUtils;
 
 namespace Improbable.Gdk.TransformSynchronization
 {
@@ -49,7 +49,7 @@ namespace Improbable.Gdk.TransformSynchronization
         internal void RegisterTransformSyncType<T>(ITransformSync<T> impl)
             where T : class
         {
-            var componentQueryDesc = TransformUtils.ConstructEntityQueryDesc<T>(requireAuthority: true, baseComponentTypes);
+            var componentQueryDesc = ConstructEntityQueryDesc<T>(AuthorityRequirements.Require, baseComponentTypes);
             componentQueryDesc.None = baseExcludeComponentTypes;
 
             var entityQuery = GetEntityQuery(componentQueryDesc);
@@ -81,7 +81,7 @@ namespace Improbable.Gdk.TransformSynchronization
 
         private void UpdateTransformQuery()
         {
-            var transformQueryDesc = TransformUtils.ConstructEntityQueryDesc<UnityEngine.Transform>(requireAuthority: true, baseComponentTypes);
+            var transformQueryDesc = ConstructEntityQueryDesc<UnityEngine.Transform>(AuthorityRequirements.Require, baseComponentTypes);
             transformQueryDesc.None = resetAuthorityActions.Keys
                 .Select(ComponentType.ReadOnly)
                 .Concat(baseExcludeComponentTypes)

--- a/workers/unity/Packages/io.improbable.gdk.transformsynchronization/Systems/SetKinematicFromAuthoritySystem.cs
+++ b/workers/unity/Packages/io.improbable.gdk.transformsynchronization/Systems/SetKinematicFromAuthoritySystem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Improbable.Gdk.Core;
 using Unity.Entities;
+using static Improbable.Gdk.TransformSynchronization.TransformUtils;
 
 namespace Improbable.Gdk.TransformSynchronization
 {
@@ -55,7 +56,7 @@ namespace Improbable.Gdk.TransformSynchronization
         private void CreateInitAction<T>(EntityQueryBuilder.F_DC<KinematicStateWhenAuth, T> initFunc)
             where T : class
         {
-            var entityQuery = GetEntityQuery(TransformUtils.ConstructEntityQueryDesc<T>(requireAuthority: false, initBaseComponentTypes));
+            var entityQuery = GetEntityQuery(ConstructEntityQueryDesc<T>(AuthorityRequirements.Exclude, initBaseComponentTypes));
 
             initKinematicActions.Add(typeof(T), () => Entities.With(entityQuery).ForEach(initFunc));
         }
@@ -63,7 +64,7 @@ namespace Improbable.Gdk.TransformSynchronization
         private void CreateAuthChangeAction<T>(AuthChangeFunc<T> authFunc)
             where T : class
         {
-            var componentQueryDesc = TransformUtils.ConstructEntityQueryDesc<T>(requireAuthority: false, authBaseComponentTypes);
+            var componentQueryDesc = ConstructEntityQueryDesc<T>(AuthorityRequirements.Ignore, authBaseComponentTypes);
             componentQueryDesc.None = componentQueryDesc.None
                 .Append(ComponentType.ReadOnly<NewlyAddedSpatialOSEntity>())
                 .ToArray();
@@ -83,7 +84,8 @@ namespace Improbable.Gdk.TransformSynchronization
                         return;
                     }
 
-                    var auth = changes[changes.Count - 1];
+                    // The first element is actually the latest value!
+                    var auth = changes[0];
 
                     authFunc(ref kinematicStateWhenAuth, auth, component);
                 }));

--- a/workers/unity/Packages/io.improbable.gdk.transformsynchronization/TransformUtils.cs
+++ b/workers/unity/Packages/io.improbable.gdk.transformsynchronization/TransformUtils.cs
@@ -70,13 +70,13 @@ namespace Improbable.Gdk.TransformSynchronization
         /// <param name="baseTypes">The base set of types.</param>
         /// <typeparam name="T">The type to add.</typeparam>
         /// <returns>An <see cref="EntityQueryDesc"/> that is the union of <see cref="baseTypes"/> and typeof(<see cref="T"/>)</returns>
-        internal static EntityQueryDesc ConstructEntityQueryDesc<T>(bool requireAuthority, params ComponentType[] baseTypes)
+        internal static EntityQueryDesc ConstructEntityQueryDesc<T>(AuthorityRequirements authorityRequirements, params ComponentType[] baseTypes)
         {
             var componentType = ComponentType.ReadOnly<T>();
             var includedComponentTypes = baseTypes
                 .Append(componentType);
 
-            if (requireAuthority)
+            if (authorityRequirements == AuthorityRequirements.Require)
             {
                 includedComponentTypes = includedComponentTypes
                     .Append(ComponentType.ReadOnly<TransformInternal.HasAuthority>());
@@ -87,7 +87,7 @@ namespace Improbable.Gdk.TransformSynchronization
                 All = includedComponentTypes.ToArray(),
             };
 
-            if (!requireAuthority)
+            if (authorityRequirements == AuthorityRequirements.Exclude)
             {
                 componentQueryDesc.None = new[]
                 {
@@ -96,6 +96,13 @@ namespace Improbable.Gdk.TransformSynchronization
             }
 
             return componentQueryDesc;
+        }
+
+        internal enum AuthorityRequirements
+        {
+            Exclude,
+            Ignore,
+            Require
         }
     }
 }


### PR DESCRIPTION
#### Description

We had two different bugs that revealed themselves when we removed the `AuthorityLossImminent` state in #1451 

- The `SetKinematicFromAuthoritySystem` was grabbing the _first_ authority change received in that frame to use as the authority change. In the case where you got `AuthorityLossImminent` and then `NotAuthoritative` in the same frame, it would grab `AuthorityLossImminent` (incorrectly).
- The query returned by `ConstructEntityQueryDesc<T>` would have an `Exclude<TransformInternal.HasAuthority>` filter on it. This meant that we would never even attempt to reset the kinematic authority set when you become 'not authoritative'. 

These two bugs combined meant that the kinematic state would never be by the system ever. In the playground, this seemed not to matter so we never noticed it (and the fact that we typically would only ever run with 1 worker locally). 

When we removed the `AuthorityLossImminent` state, the first bug ceased to apply meaning that we just ended up with weird behaviour with multiple GameLogic workers.

This PR fixes both these bugs, the first by grabbing the correct element from the authority changes span and the second by making `ConstructEntityQueryDesc` take a tri-state enum of either (Exclude, Ignore, or Required).

**Remaining work**
- [ ] Cubes are now being shot across the world and I'm not entirely sure why.. 
- [x] Changelog

#### Tests

- [x] Ran locally with two workers and ensured that the `Is Kinematic` state was being set. 
