### PR TITLE
Unity 2020.1 Upgrade

### DIFF
--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -13,7 +13,7 @@ windows: &windows
     - "environment=production"
     - "permission_set=builder"
     - "platform=windows"
-    - "queue=${WINDOWS_BUILDER_QUEUE:-v4-20-07-30-165418-bk13785-82b83865-d}"
+    - "queue=${WINDOWS_BUILDER_QUEUE:-v4-20-08-13-090826-bk14267-5f831930-d}"
     - "scaler_version=2"
     - "minimum_instances=1"
     - "agent_count=1"

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -33,8 +33,8 @@ windows: &windows
         # Workaround for flaky Git clones, likely due to - https://github.com/PowerShell/Win32-OpenSSH/issues/1322
       - exit_status: 128
         limit: 3
-  env: &windows-env
-    # ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
+  # env: &windows-env
+  #   ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
 linux: &linux
   agents:
@@ -147,7 +147,7 @@ steps:
       - logs/**/*
       - workers/unity/build/worker/**/*
     env:
-      <<: *windows-env
+      # <<: *windows-env
       WORKER_TYPE: "MobileClient"
       BUILD_ENVIRONMENT: "local"
       BUILD_TARGET_FILTER: "android"
@@ -159,7 +159,7 @@ steps:
     artifact_paths:
       - logs/**/*
     env:
-      <<: *windows-env
+      # <<: *windows-env
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
@@ -170,7 +170,7 @@ steps:
     artifact_paths:
       - logs/**/*
     env:
-      <<: *windows-env
+      # <<: *windows-env
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "local"
       SCRIPTING_BACKEND: "il2cpp"
@@ -181,7 +181,7 @@ steps:
     artifact_paths:
       - logs/**/*
     env:
-      <<: *windows-env
+      # <<: *windows-env
       WORKER_TYPE: "UnityGameLogic"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"

--- a/.buildkite/premerge.steps.yaml
+++ b/.buildkite/premerge.steps.yaml
@@ -34,7 +34,7 @@ windows: &windows
       - exit_status: 128
         limit: 3
   env: &windows-env
-    ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
+    # ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
 linux: &linux
   agents:

--- a/.buildkite/release-qa.steps.yaml
+++ b/.buildkite/release-qa.steps.yaml
@@ -13,7 +13,7 @@ windows: &windows
     - "environment=production"
     - "permission_set=builder"
     - "platform=windows"
-    - "queue=${WINDOWS_BUILDER_QUEUE:-v4-20-07-30-165418-bk13785-82b83865-d}"
+    - "queue=${WINDOWS_BUILDER_QUEUE:-v4-20-08-13-090826-bk14267-5f831930-d}"
     - "scaler_version=2"
     - "minimum_instances=1"
     - "agent_count=1"

--- a/.buildkite/release-qa.steps.yaml
+++ b/.buildkite/release-qa.steps.yaml
@@ -33,8 +33,8 @@ windows: &windows
         # Workaround for flaky Git clones, likely due to - https://github.com/PowerShell/Win32-OpenSSH/issues/1322
       - exit_status: 128
         limit: 3
-  env: &windows-env
-    # ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
+  # env: &windows-env
+  #   ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.
 # These are then relied on to have stable names by other things, so once named, please beware renaming has consequences.
@@ -47,7 +47,7 @@ steps:
       - logs/**/*
       - build/assembly/**/*
     env:
-      <<: *windows-env
+      # <<: *windows-env
       WORKER_TYPE: "MobileClient"
       BUILD_ENVIRONMENT: "cloud"
       BUILD_TARGET_FILTER: "android"
@@ -60,7 +60,7 @@ steps:
       - logs/**/*
       - build/assembly/**/*
     env:
-      <<: *windows-env
+      # <<: *windows-env
       WORKER_TYPE: "MobileClient"
       BUILD_ENVIRONMENT: "cloud"
       BUILD_TARGET_FILTER: "ios"
@@ -73,7 +73,7 @@ steps:
       - logs/**/*
       - build/assembly/**/*
     env:
-      <<: *windows-env
+      # <<: *windows-env
       WORKER_TYPE: "UnityClient"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"
@@ -85,7 +85,7 @@ steps:
       - logs/**/*
       - build/assembly/**/*
     env:
-      <<: *windows-env
+      # <<: *windows-env
       WORKER_TYPE: "UnityGameLogic"
       BUILD_ENVIRONMENT: "cloud"
       SCRIPTING_BACKEND: "mono"

--- a/.buildkite/release-qa.steps.yaml
+++ b/.buildkite/release-qa.steps.yaml
@@ -34,7 +34,7 @@ windows: &windows
       - exit_status: 128
         limit: 3
   env: &windows-env
-    ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
+    # ACCELERATOR_ENDPOINT: "unity-accelerator.production-intinf-eu1.i8e.io"
 
 # NOTE: step labels turn into commit-status names like {org}/{repo}/{pipeline}/{step-label}, lower-case and hyphenated.
 # These are then relied on to have stable names by other things, so once named, please beware renaming has consequences.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- The minimum supported version of Unity is now 2020.1. [#1459](https://github.com/spatialos/gdk-for-unity/pull/1459)
+
 ### Added
 
 - Added `MeansImplicitUse` attribute to `RequireAttribute` to reduce warnings in Rider IDE. [#1462](https://github.com/spatialos/gdk-for-unity/pull/1462)

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -4,7 +4,7 @@
 
 ### Unity 2020.1
 
-In order to use the GDK for Unity `0.4.0`, you will need to upgrade your project to Unity 2020.1. We test against 2020.1.2f1, but any version _should_ work.
+In order to use the GDK for Unity `0.4.0`, you will need to upgrade your project to Unity 2020.1. We test against 2020.1.2f1, but any `2020.1.x` version _should_ work.
 
 ## From `0.3.9` to `0.3.10`
 

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -1,5 +1,11 @@
 # Upgrade Guide
 
+## From `0.3.10` to `0.4.0`
+
+### Unity 2020.1
+
+In order to use the GDK for Unity `0.4.0`, you will need to upgrade your project to Unity 2020.1. We test against 2020.1.2f1, but any version _should_ work.
+
 ## From `0.3.9` to `0.3.10`
 
 ### AuthorityLossImminent support removed

--- a/workers/unity/.gitignore
+++ b/workers/unity/.gitignore
@@ -7,6 +7,7 @@
 /ProjectSettings/UnityConnectSettings.asset
 /*.csproj
 /*.sln
+/Packages/packages-lock.json
 
 # Build artifacts
 /build/

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/EntityList.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/EntityList.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Improbable.Gdk.Core;
 using Unity.Entities;
 using UnityEditor;
@@ -30,7 +31,7 @@ namespace Improbable.Gdk.Debug.WorkerInspector
             listView = this.Q<ListView>();
             listView.makeItem = () => new Label();
             listView.bindItem = BindItem;
-            listView.onSelectionChanged += OnSelectionChanged;
+            listView.onSelectionChange += OnSelectionChanged;
             listView.itemsSource = entities.FilteredData;
 
             var searchField = this.Q<ToolbarSearchField>();
@@ -83,16 +84,16 @@ namespace Improbable.Gdk.Debug.WorkerInspector
             label.text = entity.ToString();
         }
 
-        private void OnSelectionChanged(List<object> selections)
+        private void OnSelectionChanged(IEnumerable<object> selections)
         {
-            if (selections.Count != 1)
+            if (selections.Count() != 1)
             {
                 throw new InvalidOperationException("Unexpectedly selected more than one entity.");
             }
 
-            if (!(selections[0] is EntityData entityData))
+            if (!(selections.First() is EntityData entityData))
             {
-                throw new InvalidOperationException($"Unexpected type for selection: {selections[0].GetType()}");
+                throw new InvalidOperationException($"Unexpected type for selection: {selections.First().GetType()}");
             }
 
             if (!selectedEntity.HasValue || selectedEntity.Value != entityData)

--- a/workers/unity/Packages/manifest.json
+++ b/workers/unity/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.unity.ide.rider": "1.2.1",
+    "com.unity.ide.rider": "2.0.7",
     "com.unity.ide.visualstudio": "2.0.2",
     "com.unity.quicksearch": "2.0.0",
     "com.unity.testtools.codecoverage": "0.2.3-preview",

--- a/workers/unity/Packages/manifest.json
+++ b/workers/unity/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.ide.rider": "1.2.1",
-    "com.unity.ide.visualstudio": "2.0.1",
+    "com.unity.ide.visualstudio": "2.0.2",
     "com.unity.quicksearch": "2.0.0",
     "com.unity.testtools.codecoverage": "0.2.3-preview",
     "com.unity.ugui": "1.0.0",

--- a/workers/unity/ProjectSettings/PackageManagerSettings.asset
+++ b/workers/unity/ProjectSettings/PackageManagerSettings.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 61
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13964, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EnablePreviewPackages: 1
+  m_EnablePackageDependencies: 1
+  m_AdvancedSettingsExpanded: 1
+  oneTimeWarningShown: 1

--- a/workers/unity/ProjectSettings/ProjectSettings.asset
+++ b/workers/unity/ProjectSettings/ProjectSettings.asset
@@ -49,6 +49,8 @@ PlayerSettings:
   m_StereoRenderingPath: 0
   m_ActiveColorSpace: 0
   m_MTRendering: 1
+  mipStripping: 0
+  numberOfMipsStripped: 0
   m_StackTraceTypes: 010000000100000001000000010000000100000001000000
   iosShowActivityIndicatorOnLoading: -1
   androidShowActivityIndicatorOnLoading: -1
@@ -111,6 +113,10 @@ PlayerSettings:
   switchNVNShaderPoolsGranularity: 33554432
   switchNVNDefaultPoolsGranularity: 16777216
   switchNVNOtherPoolsGranularity: 16777216
+  switchNVNMaxPublicTextureIDCount: 0
+  switchNVNMaxPublicSamplerIDCount: 0
+  stadiaPresentMode: 0
+  stadiaTargetFramerate: 0
   vulkanNumSwapchainBuffers: 3
   vulkanEnableSetSRGBWrite: 0
   m_SupportedAspectRatios:
@@ -184,32 +190,16 @@ PlayerSettings:
   StripUnusedMeshComponents: 1
   VertexChannelCompressionMask: 4054
   iPhoneSdkVersion: 988
-  iOSTargetOSVersionString: 10.0
+  iOSTargetOSVersionString: 11.0
   tvOSSdkVersion: 0
   tvOSRequireExtendedGameController: 0
-  tvOSTargetOSVersionString: 10.0
+  tvOSTargetOSVersionString: 11.0
   uIPrerenderedIcon: 0
   uIRequiresPersistentWiFi: 0
   uIRequiresFullScreen: 1
   uIStatusBarHidden: 1
   uIExitOnSuspend: 0
   uIStatusBarStyle: 0
-  iPhoneSplashScreen: {fileID: 0}
-  iPhoneHighResSplashScreen: {fileID: 0}
-  iPhoneTallHighResSplashScreen: {fileID: 0}
-  iPhone47inSplashScreen: {fileID: 0}
-  iPhone55inPortraitSplashScreen: {fileID: 0}
-  iPhone55inLandscapeSplashScreen: {fileID: 0}
-  iPhone58inPortraitSplashScreen: {fileID: 0}
-  iPhone58inLandscapeSplashScreen: {fileID: 0}
-  iPadPortraitSplashScreen: {fileID: 0}
-  iPadHighResPortraitSplashScreen: {fileID: 0}
-  iPadLandscapeSplashScreen: {fileID: 0}
-  iPadHighResLandscapeSplashScreen: {fileID: 0}
-  iPhone65inPortraitSplashScreen: {fileID: 0}
-  iPhone65inLandscapeSplashScreen: {fileID: 0}
-  iPhone61inPortraitSplashScreen: {fileID: 0}
-  iPhone61inLandscapeSplashScreen: {fileID: 0}
   appleTVSplashScreen: {fileID: 0}
   appleTVSplashScreen2x: {fileID: 0}
   tvOSSmallIconLayers: []
@@ -275,6 +265,9 @@ PlayerSettings:
     height: 180
     banner: {fileID: 0}
   androidGamepadSupportLevel: 0
+  AndroidMinifyWithR8: 0
+  AndroidMinifyRelease: 0
+  AndroidMinifyDebug: 0
   AndroidValidateAppBundleSize: 1
   AndroidAppBundleSizeToValidate: 150
   m_BuildTargetIcons: []
@@ -433,12 +426,14 @@ PlayerSettings:
   cameraUsageDescription: 
   locationUsageDescription: 
   microphoneUsageDescription: 
+  switchNMETAOverride: 
   switchNetLibKey: 
   switchSocketMemoryPoolSize: 6144
   switchSocketAllocatorPoolSize: 128
   switchSocketConcurrencyLimit: 14
   switchScreenResolutionBehavior: 2
   switchUseCPUProfiler: 0
+  switchUseGOLDLinker: 0
   switchApplicationID: 0x01004b9000490000
   switchNSODependencies: 
   switchTitleNames_0: 
@@ -614,6 +609,7 @@ PlayerSettings:
   ps4UseResolutionFallback: 0
   ps4ReprojectionSupport: 0
   ps4UseAudio3dBackend: 0
+  ps4UseLowGarlicFragmentationMode: 1
   ps4SocialScreenEnabled: 0
   ps4ScriptOptimizationLevel: 0
   ps4Audio3dVirtualSpeakerCount: 14
@@ -649,9 +645,10 @@ PlayerSettings:
   webGLAnalyzeBuildSize: 0
   webGLUseEmbeddedResources: 0
   webGLCompressionFormat: 1
+  webGLWasmArithmeticExceptions: 0
   webGLLinkerTarget: 0
   webGLThreadsSupport: 0
-  webGLWasmStreaming: 0
+  webGLDecompressionFallback: 0
   scriptingDefineSymbols:
     1: UNITY_POST_PROCESSING_STACK_V2;UNITY_DISABLE_AUTOMATIC_SYSTEM_BOOTSTRAP
     4: UNITY_POST_PROCESSING_STACK_V2;UNITY_DISABLE_AUTOMATIC_SYSTEM_BOOTSTRAP
@@ -676,6 +673,7 @@ PlayerSettings:
   managedStrippingLevel: {}
   incrementalIl2cppBuild: {}
   allowUnsafeCode: 0
+  useDeterministicCompilation: 1
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1
   gcIncremental: 0
@@ -737,6 +735,7 @@ PlayerSettings:
   XboxOnePersistentLocalStorageSize: 0
   XboxOneXTitleMemory: 8
   XboxOneOverrideIdentityName: 
+  XboxOneOverrideIdentityPublisher: 
   vrEditorSettings:
     daydream:
       daydreamIconForeground: {fileID: 0}
@@ -763,3 +762,4 @@ PlayerSettings:
   enableNativePlatformBackendsForNewInputSystem: 0
   disableOldInputManagerSupport: 0
   legacyClampBlendShapeWeights: 1
+  virtualTexturingSupportEnabled: 0

--- a/workers/unity/ProjectSettings/ProjectVersion.txt
+++ b/workers/unity/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.3.7f1
-m_EditorVersionWithRevision: 2019.3.7f1 (6437fd74d35d)
+m_EditorVersion: 2020.1.2f1
+m_EditorVersionWithRevision: 2020.1.2f1 (7b32bc54ba47)

--- a/workers/unity/ProjectSettings/VersionControlSettings.asset
+++ b/workers/unity/ProjectSettings/VersionControlSettings.asset
@@ -1,0 +1,8 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!890905787 &1
+VersionControlSettings:
+  m_ObjectHideFlags: 0
+  m_Mode: Visible Meta Files
+  m_CollabEditorSettings:
+    inProgressEnabled: 1


### PR DESCRIPTION
#### Description

This PR upgrades the GDK for Unity to 2020.1 as the minimum Unity version. There will be follow up PRs for:

- https://github.com/spatialos/gdk-for-unity-fps-starter-project/pull/291
- Blank

Most of this was auto-generated or performed by Unity on upgrade, except for the changes in `EntityList` where there was a deprecation. 

#### Tests

- [x] Local
- [x] Cloud

#### Documentation

- [x] Changelog
- [x] Upgrade Guide
