### PR TITLE
Fix search bar overflow in worker inspector

### DIFF
--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
@@ -27,6 +27,7 @@
 
 #entity-list-searchbar {
     flex-grow: 1;
+    width: 0;
 }
 
 #entity-detail {

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
@@ -27,7 +27,6 @@
 
 #entity-list-searchbar {
     flex-grow: 1;
-    width: auto;
 }
 
 #entity-detail {


### PR DESCRIPTION
Fixes a regression introduced in #1459 noticed by @paulbalaji.

Seems that the default styles changed which caused an overflow: 

![image](https://user-images.githubusercontent.com/13353733/91191143-4f942280-e6ec-11ea-929d-8a6892678487.png)

Removing `width: auto` fixes the issue. 