### PR TITLE
Remove outline around component info button in Worker Inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Migrated launch configurations to latest game templates. [#1457](https://github.com/spatialos/gdk-for-unity/pull/1457)
 - Multithreaded component serialization through `SystemBase` jobs. [#1454](https://github.com/spatialos/gdk-for-unity/pull/1454)
 - Upgrade Unity Burst to 1.3.5. [#1467](https://github.com/spatialos/gdk-for-unity/pull/1467)
+- Removed outline and background around component info button in the Worker Inspector. [#1468](https://github.com/spatialos/gdk-for-unity/pull/1468)
 
 ### Fixed
 

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/EntityListData.cs
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/EntityListData.cs
@@ -42,7 +42,7 @@ namespace Improbable.Gdk.Debug.WorkerInspector
             fullData.Clear();
             FilteredData.Clear();
 
-            if (query != default)
+            if (query != default && world.IsCreated)
             {
                 query.Dispose();
             }

--- a/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
+++ b/workers/unity/Packages/io.improbable.gdk.debug/WorkerInspector/Templates/WorkerInspectorWindow.uss
@@ -91,6 +91,8 @@
     align-self: center;
     margin-right: 10px;
     margin-left: 10px;
+    border-width: 0;
+    background-color: rgba(0, 0, 0, 0);
 }
 
 .component-foldout .component-info-container {


### PR DESCRIPTION
#### Description

This PR removes the outline and background around the component info button in the Worker Inspector.

Before: 

![image](https://user-images.githubusercontent.com/13353733/91455901-90ba3d00-e87a-11ea-92e2-40b493c572bc.png)

After:

![image](https://user-images.githubusercontent.com/13353733/91455944-9fa0ef80-e87a-11ea-9449-325f417bd10b.png)

There is also a driveby that stops exceptions from being thrown if you stop playing in the Editor with the Worker Inspector open. (Probably introduced in #1463). 

#### Tests

N/A

#### Documentation

- [x] Changelog
