### PR TITLE
Fix regression introduced in #1454

### DIFF
--- a/workers/unity/Packages/io.improbable.gdk.core/Worker/SerializedMessagesToSend.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Worker/SerializedMessagesToSend.cs
@@ -131,8 +131,8 @@ namespace Improbable.Gdk.Core
             for (var i = 0; i < updates.Count; ++i)
             {
                 ref readonly var update = ref updates[i];
-                connection.SendComponentUpdate(update.EntityId, update.Update, UpdateParams);
                 netFrameStats.AddUpdate(update.Update);
+                connection.SendComponentUpdate(update.EntityId, update.Update, UpdateParams);
             }
 
             for (var i = 0; i < requests.Count; ++i)


### PR DESCRIPTION
#### Description

There was a race whereby if the Worker SDK consumed and cleared the serialized data before we tried to read the data, we would hard crash.

#### Tests

- Ran it a bunch and couldn't repro.

#### Documentation

- None required as this regression was unreleased.

