### PR TITLE
Add `PositionFromGameObject` authoring component

### DIFF
--- a/workers/unity/Assets/Tests/EditmodeTests/Correctness/SceneAuthoring.meta
+++ b/workers/unity/Assets/Tests/EditmodeTests/Correctness/SceneAuthoring.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3ef736ae3ee7472abe1eeee871f664fa
+timeCreated: 1598616958

--- a/workers/unity/Assets/Tests/EditmodeTests/Correctness/SceneAuthoring/PositionFromGameObjectTests.cs
+++ b/workers/unity/Assets/Tests/EditmodeTests/Correctness/SceneAuthoring/PositionFromGameObjectTests.cs
@@ -1,0 +1,27 @@
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.SceneAuthoring.AuthoringComponents;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Improbable.Gdk.EditmodeTests.SceneAuthoring
+{
+    [TestFixture]
+    public class PositionFromGameObjectTests
+    {
+        [Test]
+        public void WriteTo_uses_the_GameObject_position()
+        {
+            var gameObject = new GameObject();
+            gameObject.transform.position = new Vector3(100, 100, 100);
+            var positionFromGameObject = gameObject.AddComponent<PositionFromGameObjectAuthoringComponent>();
+
+            var entityTemplate = new EntityTemplate();
+            positionFromGameObject.WriteTo(entityTemplate);
+
+            Assert.IsTrue(entityTemplate.HasComponent<Position.Snapshot>());
+
+            var position = entityTemplate.GetComponent<Position.Snapshot>().Value;
+            Assert.AreEqual(gameObject.transform.position, position.Coords.ToUnityVector());
+        }
+    }
+}

--- a/workers/unity/Assets/Tests/EditmodeTests/Correctness/SceneAuthoring/PositionFromGameObjectTests.cs.meta
+++ b/workers/unity/Assets/Tests/EditmodeTests/Correctness/SceneAuthoring/PositionFromGameObjectTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f20f444437d44e8fba61701e9b88f80f
+timeCreated: 1598616972

--- a/workers/unity/Assets/Tests/EditmodeTests/Improbable.Gdk.EditmodeTests.asmdef
+++ b/workers/unity/Assets/Tests/EditmodeTests/Improbable.Gdk.EditmodeTests.asmdef
@@ -2,6 +2,7 @@
     "name": "Improbable.Gdk.EditmodeTests",
     "references": [
         "Improbable.Gdk.Core",
+        "Improbable.Gdk.Core.SceneAuthoring.AuthoringComponents",
         "Improbable.Gdk.Debug",
         "Improbable.Gdk.GameObjectCreation",
         "Improbable.Gdk.Generated",

--- a/workers/unity/Packages/io.improbable.gdk.core/SceneAuthoring/AuthoringComponents.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/SceneAuthoring/AuthoringComponents.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ed0f8c41a7f886f4cbacfa1c98a4c310
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.core/SceneAuthoring/AuthoringComponents/Improbable.Gdk.Core.SceneAuthoring.AuthoringComponents.asmdef
+++ b/workers/unity/Packages/io.improbable.gdk.core/SceneAuthoring/AuthoringComponents/Improbable.Gdk.Core.SceneAuthoring.AuthoringComponents.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "Improbable.Gdk.Core.SceneAuthoring.AuthoringComponents",
+    "references": [
+        "Improbable.Gdk.Core",
+        "Improbable.Gdk.Generated"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/SceneAuthoring/AuthoringComponents/Improbable.Gdk.Core.SceneAuthoring.AuthoringComponents.asmdef.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/SceneAuthoring/AuthoringComponents/Improbable.Gdk.Core.SceneAuthoring.AuthoringComponents.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 86c54450cd516d445a6481158fd2fca9
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/io.improbable.gdk.core/SceneAuthoring/AuthoringComponents/PositionFromGameObjectAuthoringComponent.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/SceneAuthoring/AuthoringComponents/PositionFromGameObjectAuthoringComponent.cs
@@ -5,7 +5,9 @@ namespace Improbable.Gdk.Core.SceneAuthoring.AuthoringComponents
     [AddComponentMenu("SpatialOS/Authoring Components/Position From GameObject Authoring Component")]
     public class PositionFromGameObjectAuthoringComponent : MonoBehaviour, ISpatialOsAuthoringComponent
     {
+#pragma warning disable 649
         [SerializeField] private string writeAccess;
+#pragma warning restore 649
 
         public void WriteTo(EntityTemplate template)
         {

--- a/workers/unity/Packages/io.improbable.gdk.core/SceneAuthoring/AuthoringComponents/PositionFromGameObjectAuthoringComponent.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/SceneAuthoring/AuthoringComponents/PositionFromGameObjectAuthoringComponent.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace Improbable.Gdk.Core.SceneAuthoring.AuthoringComponents
+{
+    [AddComponentMenu("SpatialOS/Authoring Components/Position From GameObject Authoring Component")]
+    public class PositionFromGameObjectAuthoringComponent : MonoBehaviour, ISpatialOsAuthoringComponent
+    {
+        [SerializeField] private string writeAccess;
+
+        public void WriteTo(EntityTemplate template)
+        {
+            var coords = Coordinates.FromUnityVector(transform.position);
+            template.AddComponent(new Position.Snapshot(coords), writeAccess);
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/SceneAuthoring/AuthoringComponents/PositionFromGameObjectAuthoringComponent.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/SceneAuthoring/AuthoringComponents/PositionFromGameObjectAuthoringComponent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a5ce904b69284f0bbdd010431759880a
+timeCreated: 1598531170


### PR DESCRIPTION
#### Description

Add a simple authoring component that uses the GameObject position as the `Position` component. These need to go in their own `asmdef` as they need to reference generated code.

#### Tests

- [x] Unit test included
