### PR TITLE
One-to-one GameObject converter

### DIFF
--- a/workers/unity/Packages/io.improbable.gdk.core/AssemblyInfo.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Improbable.Gdk.Core.EditmodeTests")]
+[assembly: InternalsVisibleTo("Improbable.Gdk.Core.Editor")]
 [assembly: InternalsVisibleTo("Improbable.Gdk.GameObjectCreation.EditmodeTests")]
 [assembly: InternalsVisibleTo("Improbable.Gdk.EditmodeTests")]
 [assembly: InternalsVisibleTo("Improbable.Gdk.PlaymodeTests")]

--- a/workers/unity/Packages/io.improbable.gdk.core/Editor/SceneAuthoring.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/Editor/SceneAuthoring.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 316c6a68afff44428ba03d6c7a266b79
+timeCreated: 1598531927

--- a/workers/unity/Packages/io.improbable.gdk.core/Editor/SceneAuthoring/ConvertToSingleEntityEditor.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Editor/SceneAuthoring/ConvertToSingleEntityEditor.cs
@@ -1,0 +1,36 @@
+using Improbable.Gdk.Core.SceneAuthoring;
+using UnityEditor;
+
+namespace Improbable.Gdk.Core.Editor.SceneAuthoring
+{
+    [CustomEditor(typeof(ConvertToSingleEntity))]
+    public class ConvertToSingleEntityEditor : UnityEditor.Editor
+    {
+        private SerializedProperty useSpecificEntityIdProperty;
+        private SerializedProperty desiredEntityIdProperty;
+        private SerializedProperty readAclProperty;
+
+        private void OnEnable()
+        {
+            useSpecificEntityIdProperty = serializedObject.FindProperty(nameof(ConvertToSingleEntity.UseSpecificEntityId));
+            desiredEntityIdProperty = serializedObject.FindProperty(nameof(ConvertToSingleEntity.DesiredEntityId));
+            readAclProperty = serializedObject.FindProperty(nameof(ConvertToSingleEntity.ReadAcl));
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            EditorGUILayout.PropertyField(useSpecificEntityIdProperty);
+
+            if (useSpecificEntityIdProperty.boolValue)
+            {
+                EditorGUILayout.PropertyField(desiredEntityIdProperty);
+            }
+
+            EditorGUILayout.PropertyField(readAclProperty);
+
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/Editor/SceneAuthoring/ConvertToSingleEntityEditor.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/Editor/SceneAuthoring/ConvertToSingleEntityEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: eee1b103019f40859ad28ff35dde8f47
+timeCreated: 1598531934

--- a/workers/unity/Packages/io.improbable.gdk.core/SceneAuthoring/ConvertToSingleEntity.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/SceneAuthoring/ConvertToSingleEntity.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Improbable.Gdk.Core.SceneAuthoring
+{
+    [AddComponentMenu("SpatialOS/Authoring Components/Convert to Single Entity")]
+    public class ConvertToSingleEntity : MonoBehaviour, IConvertGameObjectToSpatialOsEntity
+    {
+        [SerializeField] internal bool UseSpecificEntityId;
+        [SerializeField] internal long DesiredEntityId;
+        [SerializeField] internal string[] ReadAcl = { };
+
+        public List<ConvertedEntity> Convert()
+        {
+            var components = GetComponents<ISpatialOsAuthoringComponent>();
+            var template = new EntityTemplate();
+
+            foreach (var component in components)
+            {
+                component.WriteTo(template);
+            }
+
+            template.SetReadAccess(ReadAcl);
+
+            var entity = UseSpecificEntityId
+                ? new ConvertedEntity(new EntityId(DesiredEntityId), template)
+                : new ConvertedEntity(template);
+
+            return new List<ConvertedEntity> { entity };
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/SceneAuthoring/ConvertToSingleEntity.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/SceneAuthoring/ConvertToSingleEntity.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 71b18e76249b449bb116778890de4f6b
+timeCreated: 1598531592


### PR DESCRIPTION
#### Description

Following on from #1466, this implements the `IConvertGameObjectToSpatialOsEntity` interface for a 1:1 mapping between a GameObject and SpatialOS entity.

This PR also includes a custom editor for a more intuitive user experience when filling out optional parameters (desired entity ID).

#### Tests

- [x] Manual tests of the editor drawer.
- More complete integration tests to be written once more components are in place.
