### PR TITLE
Fix Event Tracing ItemType Conversion

### DIFF
--- a/workers/unity/Packages/io.improbable.worker.sdk/CEventTrace.cs
+++ b/workers/unity/Packages/io.improbable.worker.sdk/CEventTrace.cs
@@ -60,7 +60,7 @@ namespace Improbable.Worker.CInterop.Internal
             public fixed Char Data[16];
         }
 
-        public enum ItemType
+        public enum ItemType : byte
         {
             Span = 1,
             Event = 2


### PR DESCRIPTION
#### Description
There was a bug introduced in #1440 and slipped by unnoticed in #1452 where the `TraceCallback` callback not provide the expected value for the `ItemType` property in the callbacks `responseItem`. It only happened for an `Event` but not for a `Span`.

This PR resolves the issue by adding the type of `byte` to the internal `ItemType` enum.

#### Tests
How did you test these changes prior to submitting this pull request?
Manually verified that both callbacks for `Event` and `Span` provides the correct data.

#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?
None

- [ ] Changelog

