### PR TITLE
Metadata Authoring Component

### DIFF
--- a/workers/unity/Assets/Tests/EditmodeTests/Correctness/SceneAuthoring/MetadataFromGameObjectTests.cs
+++ b/workers/unity/Assets/Tests/EditmodeTests/Correctness/SceneAuthoring/MetadataFromGameObjectTests.cs
@@ -1,0 +1,28 @@
+using System.Security.Cryptography;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.SceneAuthoring.AuthoringComponents;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Improbable.Gdk.EditmodeTests.SceneAuthoring
+{
+    [TestFixture]
+    public class MetadataFromGameObjectTests
+    {
+        [Test]
+        public void WriteTo_uses_the_GameObject_name()
+        {
+            var gameObject = new GameObject();
+            gameObject.name = "My Entity";
+            var metadataFromGameObject = gameObject.AddComponent<MetadataFromGameObjectAuthoringComponent>();
+
+            var entityTemplate = new EntityTemplate();
+            metadataFromGameObject.WriteTo(entityTemplate);
+
+            Assert.IsTrue(entityTemplate.HasComponent<Metadata.Snapshot>());
+
+            var metadata = entityTemplate.GetComponent<Metadata.Snapshot>().Value;
+            Assert.AreEqual(gameObject.name, metadata.EntityType);
+        }
+    }
+}

--- a/workers/unity/Assets/Tests/EditmodeTests/Correctness/SceneAuthoring/MetadataFromGameObjectTests.cs.meta
+++ b/workers/unity/Assets/Tests/EditmodeTests/Correctness/SceneAuthoring/MetadataFromGameObjectTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7bbb847721aa479c885081ce18ad02fb
+timeCreated: 1599136914

--- a/workers/unity/Packages/io.improbable.gdk.core/SceneAuthoring/AuthoringComponents/MetadataFromGameObjectAuthoringComponent.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/SceneAuthoring/AuthoringComponents/MetadataFromGameObjectAuthoringComponent.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+namespace Improbable.Gdk.Core.SceneAuthoring.AuthoringComponents
+{
+    [AddComponentMenu("SpatialOS/Authoring Components/Metadata From GameObject Authoring Component")]
+    public class MetadataFromGameObjectAuthoringComponent : MonoBehaviour, ISpatialOsAuthoringComponent
+    {
+#pragma warning disable 649
+        [SerializeField] private string writeAccess;
+#pragma warning restore 649
+
+        public void WriteTo(EntityTemplate template)
+        {
+            var metadata = new Metadata.Snapshot(gameObject.name);
+            template.AddComponent(metadata, writeAccess);
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/SceneAuthoring/AuthoringComponents/MetadataFromGameObjectAuthoringComponent.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/SceneAuthoring/AuthoringComponents/MetadataFromGameObjectAuthoringComponent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d815b3878c2942479b3c68841188d326
+timeCreated: 1599136840


### PR DESCRIPTION
#### Description

Think I forgot to create a ticket for this one..

...but this is an authoring component that uses the GameObject name as the metadata. 

#### Tests

- [x] Unit tests
