### PR TITLE
Fix Xcode project modification for iOS Simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed an issue where XCode would link the wrong library when building for iOS Simulator. [#1484](https://github.com/spatialos/gdk-for-unity/pull/1484)
+
 ## `0.4.0` - 2020-09-14
 
 ### Breaking Changes

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/BuildPostProcessXCode.cs
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/BuildPostProcessXCode.cs
@@ -46,17 +46,12 @@ namespace Improbable.Gdk.Mobile
             InvokeMethod(xcodeObject, "ReadFromString", xcodeText);
 
             // Get Target GUIDs
-            var unityTargetName = InvokeStaticMethod<string>("GetUnityTargetName");
-            var unityTestTargetName = InvokeStaticMethod<string>("GetUnityTestTargetName");
-            var targetGUID = InvokeMethod<string>(xcodeObject, "GetUnityMainTargetGuid");
-            var targetTestingGUID = InvokeMethod<string>(xcodeObject, "TargetGuidByName", unityTestTargetName);
+            var targetGUID = InvokeMethod<string>(xcodeObject, "GetUnityFrameworkTargetGuid");
 
             // Enumerate configGUIDs that need library path patching
             var configNames = InvokeMethod<IEnumerable<string>>(xcodeObject, "BuildConfigNames");
             var configGUIDs = configNames
-                .Select(configName => InvokeMethod<string>(xcodeObject, "BuildConfigByName", targetGUID, configName))
-                .Concat(configNames.Select(configName =>
-                    InvokeMethod<string>(xcodeObject, "BuildConfigByName", targetTestingGUID, configName)));
+                .Select(configName => InvokeMethod<string>(xcodeObject, "BuildConfigByName", targetGUID, configName));
 
             // Update library paths for each config
             foreach (var configGUID in configGUIDs)


### PR DESCRIPTION
#### Description

This PR changes the xcode post-process step to grab the GUID using the `GetUnityFrameworkTargetGuid` method.

#### Tests

Building and launching Simulator in 2020.1 works. Simulator client could connect to a local deployment.

#### Documentation

- [x] changelog

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
