### PR TITLE
Fix `WorldCommandSender` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed an issue where XCode would link the wrong library when building for iOS Simulator. [#1484](https://github.com/spatialos/gdk-for-unity/pull/1484)
 - The `AllowShortCircuiting` property is no longer ignored on command requests. [#1490](https://github.com/spatialos/gdk-for-unity/pull/1490)
+- The `WorldCommandSender` correctly has its callbacks removed when the containing Monobehaviour is disabled. [#1493](https://github.com/spatialos/gdk-for-unity/pull/1493)
 
 ## `0.4.0` - 2020-09-14
 

--- a/workers/unity/Packages/io.improbable.gdk.core/Commands/CommandSender.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Commands/CommandSender.cs
@@ -4,7 +4,7 @@ using Unity.Entities;
 
 namespace Improbable.Gdk.Core.Commands
 {
-    public abstract class CommandSender : IRequireable
+    public abstract class CommandSenderBase : IRequireable
     {
         private readonly Entity entity;
         private readonly CommandSystem commandSystem;
@@ -13,7 +13,7 @@ namespace Improbable.Gdk.Core.Commands
 
         public bool IsValid { get; set; }
 
-        protected CommandSender(Entity entity, World world)
+        protected CommandSenderBase(Entity entity, World world)
         {
             this.entity = entity;
             commandSystem = world.GetOrCreateSystem<CommandSystem>();

--- a/workers/unity/Packages/io.improbable.gdk.core/Commands/CommandSender.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Commands/CommandSender.cs
@@ -1,0 +1,52 @@
+using System;
+using Improbable.Gdk.Subscriptions;
+using Unity.Entities;
+
+namespace Improbable.Gdk.Core.Commands
+{
+    public abstract class CommandSender : IRequireable
+    {
+        private readonly Entity entity;
+        private readonly CommandSystem commandSystem;
+        private readonly CommandCallbackSystem callbackSystem;
+        private int callbackEpoch;
+
+        public bool IsValid { get; set; }
+
+        protected CommandSender(Entity entity, World world)
+        {
+            this.entity = entity;
+            commandSystem = world.GetOrCreateSystem<CommandSystem>();
+            callbackSystem = world.GetOrCreateSystem<CommandCallbackSystem>();
+            IsValid = true;
+        }
+
+        protected void SendCommand<TRequest, TResponse>(TRequest request, Action<TResponse> callback = null)
+            where TRequest : struct, ICommandRequest
+            where TResponse : struct, IReceivedCommandResponse
+        {
+            var validCallbackEpoch = callbackEpoch;
+            var requestId = commandSystem.SendCommand(request, entity);
+
+            if (callback != null)
+            {
+                Action<TResponse> wrappedCallback = response =>
+                {
+                    if (!IsValid || validCallbackEpoch != callbackEpoch)
+                    {
+                        return;
+                    }
+
+                    callback(response);
+                };
+
+                callbackSystem.RegisterCommandResponseCallback(requestId, wrappedCallback);
+            }
+        }
+
+        public void RemoveAllCallbacks()
+        {
+            ++callbackEpoch;
+        }
+    }
+}

--- a/workers/unity/Packages/io.improbable.gdk.core/Commands/CommandSender.cs.meta
+++ b/workers/unity/Packages/io.improbable.gdk.core/Commands/CommandSender.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: bdb419aca60440349bd8aae1b900dd75
+timeCreated: 1610545539

--- a/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/CommandSenderReceiverSubscriptionManagerBase.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/CommandSenderReceiverSubscriptionManagerBase.cs
@@ -1,22 +1,19 @@
 using System;
 using System.Collections.Generic;
 using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Commands;
 using Improbable.Worker.CInterop;
 using Unity.Entities;
 using Entity = Unity.Entities.Entity;
 
 namespace Improbable.Gdk.Subscriptions
 {
-    public interface ICommandSender : IRequireable
-    {
-    }
-
     public interface ICommandReceiver : IRequireable
     {
     }
 
     public abstract class CommandSenderSubscriptionManagerBase<T> : SubscriptionManager<T>
-        where T : ICommandSender
+        where T : CommandSender
     {
         private Dictionary<EntityId, HashSet<Subscription<T>>>
             entityIdToSenderSubscriptions =

--- a/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/CommandSenderReceiverSubscriptionManagerBase.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/CommandSenderReceiverSubscriptionManagerBase.cs
@@ -13,7 +13,7 @@ namespace Improbable.Gdk.Subscriptions
     }
 
     public abstract class CommandSenderSubscriptionManagerBase<T> : SubscriptionManager<T>
-        where T : CommandSender
+        where T : CommandSenderBase
     {
         private Dictionary<EntityId, HashSet<Subscription<T>>>
             entityIdToSenderSubscriptions =

--- a/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Subscriptions/StandardSubscriptionManagers/WorldCommands.cs
@@ -19,7 +19,7 @@ namespace Improbable.Gdk.Core
         }
     }
 
-    public class WorldCommandSender : CommandSender
+    public class WorldCommandSender : CommandSenderBase
     {
         public WorldCommandSender(Entity entity, World world) : base(entity, world)
         {

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/.codegen/Source/Generators/GameObjectCreation/UnityCommandSenderReceiverGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/.codegen/Source/Generators/GameObjectCreation/UnityCommandSenderReceiverGenerator.cs
@@ -87,7 +87,7 @@ protected override {commandReceiverType} CreateReceiver(World world, Entity enti
 
             var commandSenderType = $"{componentDetails.Name}CommandSender";
 
-            return Scope.Type($"public class {commandSenderType} : CommandSender", c =>
+            return Scope.Type($"public class {commandSenderType} : CommandSenderBase", c =>
             {
                 c.Line($@"
 internal {commandSenderType}(Entity entity, World world) : base(entity, world)

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/.codegen/Source/Generators/GameObjectCreation/UnityCommandSenderReceiverGenerator.cs
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/.codegen/Source/Generators/GameObjectCreation/UnityCommandSenderReceiverGenerator.cs
@@ -20,6 +20,7 @@ namespace Improbable.Gdk.CodeGenerator
                     "System.Collections.Generic",
                     "Unity.Entities",
                     "Improbable.Gdk.Core",
+                    "Improbable.Gdk.Core.Commands",
                     "Improbable.Gdk.Subscriptions",
                     "Entity = Unity.Entities.Entity"
                 );
@@ -86,25 +87,11 @@ protected override {commandReceiverType} CreateReceiver(World world, Entity enti
 
             var commandSenderType = $"{componentDetails.Name}CommandSender";
 
-            return Scope.Type($"public class {commandSenderType} : ICommandSender", c =>
+            return Scope.Type($"public class {commandSenderType} : CommandSender", c =>
             {
                 c.Line($@"
-private readonly Entity entity;
-private readonly CommandSystem commandSender;
-private readonly CommandCallbackSystem callbackSystem;
-private int callbackEpoch;
-
-public bool IsValid {{ get; set; }}
-");
-                c.Line($@"
-internal {commandSenderType}(Entity entity, World world)
+internal {commandSenderType}(Entity entity, World world) : base(entity, world)
 {{
-    this.entity = entity;
-    callbackSystem = world.GetOrCreateSystem<CommandCallbackSystem>();
-    // todo check that this exists
-    commandSender = world.GetExistingSystem<CommandSystem>();
-
-    IsValid = true;
 }}
 ");
                 foreach (var commandDetails in componentDetails.CommandDetails)
@@ -116,36 +103,15 @@ internal {commandSenderType}(Entity entity, World world)
 public void Send{commandDetails.PascalCaseName}Command(EntityId targetEntityId, {commandDetails.FqnRequestType} request, Action<{receivedCommandResponseType}> callback = null)
 {{
     var commandRequest = new {commandRequest}(targetEntityId, request);
-    Send{commandDetails.PascalCaseName}Command(commandRequest, callback);
+    SendCommand(commandRequest, callback);
 }}
 
 public void Send{commandDetails.PascalCaseName}Command({fullyQualifiedNamespace}.{commandDetails.PascalCaseName}.Request request, Action<{fullyQualifiedNamespace}.{commandDetails.PascalCaseName}.ReceivedResponse> callback = null)
 {{
-    int validCallbackEpoch = callbackEpoch;
-    var requestId = commandSender.SendCommand(request, entity);
-    if (callback != null)
-    {{
-        Action<{fullyQualifiedNamespace}.{commandDetails.PascalCaseName}.ReceivedResponse> wrappedCallback = response =>
-        {{
-            if (!this.IsValid || validCallbackEpoch != this.callbackEpoch)
-            {{
-                return;
-            }}
-
-            callback(response);
-        }};
-        callbackSystem.RegisterCommandResponseCallback(requestId, wrappedCallback);
-    }}
+    SendCommand(request, callback);
 }}
 ");
                 }
-
-                c.Line(@"
-public void RemoveAllCallbacks()
-{
-    ++callbackEpoch;
-}
-");
             });
         }
 


### PR DESCRIPTION
The code between the generated command senders and the `WorldCommandSender` drifted apart over time and so bugs that had been fixed weren't fixed in the `WorldCommandSender`.

Re-unified the generated & world command senders by using a common base and thus fixed the bug.

Split from #1491 