### PR TITLE
SpatialDeploymentManager requires runtime version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- `SpatialDeploymentManager` requires the runtime version to be specified. [#1494](https://github.com/spatialos/gdk-for-unity/pull/1494)
+
 ### Added
 
 - Added a set of extension methods for the `ILogDispatcher` for the common cases of `Info`/`Warn`/`Error`. [#1492](https://github.com/spatialos/gdk-for-unity/pull/1492)

--- a/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Connection/ReceptionistFlowTests.cs
+++ b/workers/unity/Packages/io.improbable.gdk.core/Tests/Editmode/Connection/ReceptionistFlowTests.cs
@@ -13,15 +13,17 @@ namespace Improbable.Gdk.Core.EditmodeTests.Connection
         private SpatialDeploymentManager deploymentManager;
         private Improbable.Worker.CInterop.Connection connection;
 
-        private static string LaunchConfigPath = Path.Combine(Common.SpatialProjectRootDir, "default_launch.json");
+        private static readonly string LaunchConfigPath = Path.Combine(Common.SpatialProjectRootDir, "default_launch.json");
 
-        private static string SnapshotPath =
+        private static readonly string SnapshotPath =
             Path.Combine(Common.SpatialProjectRootDir, "snapshots", "default.snapshot");
+
+        private static readonly string RuntimeVersion = GdkToolsConfiguration.GetOrCreateInstance().RuntimeVersion;
 
         [SetUp]
         public void Setup()
         {
-            deploymentManager = SpatialDeploymentManager.Start(LaunchConfigPath, SnapshotPath).Result;
+            deploymentManager = SpatialDeploymentManager.Start(LaunchConfigPath, SnapshotPath, RuntimeVersion).Result;
         }
 
         [TearDown]

--- a/workers/unity/Packages/io.improbable.gdk.testutils/Editor/SpatialDeploymentManager.cs
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/Editor/SpatialDeploymentManager.cs
@@ -17,7 +17,7 @@ namespace Improbable.Gdk.TestUtils.Editor
     {
         private Process spatialProcess;
 
-        public static async Task<SpatialDeploymentManager> Start(string deploymentJsonPath, string snapshotPath)
+        public static async Task<SpatialDeploymentManager> Start(string deploymentJsonPath, string snapshotPath, string runtimeVersion)
         {
             if (!File.Exists(Path.Combine(Common.SpatialProjectRootDir, deploymentJsonPath)))
             {
@@ -30,7 +30,7 @@ namespace Improbable.Gdk.TestUtils.Editor
             }
 
             await BuildWorkerConfigs().ConfigureAwait(false);
-            var process = await StartSpatial(deploymentJsonPath, snapshotPath).ConfigureAwait(false);
+            var process = await StartSpatial(deploymentJsonPath, snapshotPath, runtimeVersion).ConfigureAwait(false);
 
             return new SpatialDeploymentManager
             {
@@ -84,12 +84,12 @@ Raw stderr:
             return tcs.Task;
         }
 
-        private static Task<Process> StartSpatial(string deploymentJsonPath, string snapshotPath)
+        private static Task<Process> StartSpatial(string deploymentJsonPath, string snapshotPath, string runtimeVersion)
         {
             var tcs = new TaskCompletionSource<Process>();
 
             var processInfo =
-                new ProcessStartInfo(Common.SpatialBinary, $"local launch \"{deploymentJsonPath}\" --snapshot \"{snapshotPath}\" --enable_pre_run_check=false")
+                new ProcessStartInfo(Common.SpatialBinary, $"local launch \"{deploymentJsonPath}\" --snapshot \"{snapshotPath}\" --enable_pre_run_check=false --experimental_runtime={runtimeVersion}")
                 {
                     CreateNoWindow = true,
                     RedirectStandardOutput = true,

--- a/workers/unity/Packages/io.improbable.gdk.testutils/Editor/Tests/SpatialDeploymentManagerTests.cs
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/Editor/Tests/SpatialDeploymentManagerTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Linq;
 using System.Net;
+using Improbable.Gdk.Tools;
 using NUnit.Framework;
 
 namespace Improbable.Gdk.TestUtils.Editor.Tests
@@ -9,10 +10,12 @@ namespace Improbable.Gdk.TestUtils.Editor.Tests
     [TestFixture]
     public class SpatialDeploymentManagerTests
     {
+        private static string RuntimeVersion = GdkToolsConfiguration.GetOrCreateInstance().RuntimeVersion;
+
         [Test]
         public void Start_throws_an_exception_if_deployment_config_does_not_exist()
         {
-            var task = SpatialDeploymentManager.Start("does_not_exist.json", "snapshots/default.snapshot");
+            var task = SpatialDeploymentManager.Start("does_not_exist.json", "snapshots/default.snapshot", RuntimeVersion);
             Assert.IsTrue(task.IsFaulted);
             Assert.IsInstanceOf<ArgumentException>(task.Exception.InnerExceptions.First());
         }
@@ -20,7 +23,7 @@ namespace Improbable.Gdk.TestUtils.Editor.Tests
         [Test]
         public void Start_throws_an_exception_if_snapshot_does_not_exist()
         {
-            var task = SpatialDeploymentManager.Start("default_launch.json", "does_not_exist.snapshot");
+            var task = SpatialDeploymentManager.Start("default_launch.json", "does_not_exist.snapshot", RuntimeVersion);
             Assert.IsTrue(task.IsFaulted);
             Assert.IsInstanceOf<ArgumentException>(task.Exception.InnerExceptions.First());
         }
@@ -28,7 +31,7 @@ namespace Improbable.Gdk.TestUtils.Editor.Tests
         [Test]
         public void Start_correctly_starts_a_spatial_deployment()
         {
-            using (SpatialDeploymentManager.Start("default_launch.json", "snapshots/default.snapshot").Result)
+            using (SpatialDeploymentManager.Start("default_launch.json", "snapshots/default.snapshot", RuntimeVersion).Result)
             {
                 var request = WebRequest.Create("http://localhost:21000/inspector");
                 Assert.DoesNotThrow(() => request.GetResponse());
@@ -38,7 +41,7 @@ namespace Improbable.Gdk.TestUtils.Editor.Tests
         [Test]
         public void Deployment_is_dead_after_Dispose()
         {
-            using (SpatialDeploymentManager.Start("default_launch.json", "snapshots/default.snapshot").Result)
+            using (SpatialDeploymentManager.Start("default_launch.json", "snapshots/default.snapshot", RuntimeVersion).Result)
             {
             }
 
@@ -49,9 +52,9 @@ namespace Improbable.Gdk.TestUtils.Editor.Tests
         [Test]
         public void Start_throws_if_deployment_fails_to_start()
         {
-            using (SpatialDeploymentManager.Start("default_launch.json", "snapshots/default.snapshot").Result)
+            using (SpatialDeploymentManager.Start("default_launch.json", "snapshots/default.snapshot", RuntimeVersion).Result)
             {
-                var task = SpatialDeploymentManager.Start("default_launch.json", "snapshots/default.snapshot");
+                var task = SpatialDeploymentManager.Start("default_launch.json", "snapshots/default.snapshot", RuntimeVersion);
                 Assert.Throws<AggregateException>(() => task.Wait());
             }
         }


### PR DESCRIPTION
This was missed way back when the runtime version was a required parameter.

Split from #1491 
