### PR TITLE
Remove entity query loop from `SendCreatePlayerRequestSystem`. 

### DIFF
--- a/workers/unity/Assets/Playground/Editor/SnapshotGenerator/SnapshotGenerator.cs
+++ b/workers/unity/Assets/Playground/Editor/SnapshotGenerator/SnapshotGenerator.cs
@@ -31,11 +31,7 @@ namespace Playground.Editor.SnapshotGenerator
             var snapshot = new Snapshot();
 
             snapshot.AddEntity(new EntityId(1), EntityTemplates.CreateLoadBalancingPartition());
-
-            AddPlayerSpawner(snapshot, new Coordinates(200, 0, 200));
-            AddPlayerSpawner(snapshot, new Coordinates(200, 0, -200));
-            AddPlayerSpawner(snapshot, new Coordinates(-200, 0, -200));
-            AddPlayerSpawner(snapshot, new Coordinates(-200, 0, 200));
+            snapshot.AddEntity(new EntityId(2), EntityTemplates.CreatePlayerSpawnerEntityTemplate(new Coordinates()));
 
             AddCubeGrid(snapshot, cubeCount);
 
@@ -43,12 +39,6 @@ namespace Playground.Editor.SnapshotGenerator
             CreateSpinner(snapshot, new Coordinates { X = -5.5, Y = 0.5f, Z = 0.0 });
 
             return snapshot;
-        }
-
-        private static void AddPlayerSpawner(Snapshot snapshot, Coordinates playerSpawnerLocation)
-        {
-            var template = EntityTemplates.CreatePlayerSpawnerEntityTemplate(playerSpawnerLocation);
-            snapshot.AddEntity(template);
         }
 
         private static void CreateSpinner(Snapshot snapshot, Coordinates coords)

--- a/workers/unity/Assets/Playground/Scripts/OneTimeInitialisation.cs
+++ b/workers/unity/Assets/Playground/Scripts/OneTimeInitialisation.cs
@@ -1,3 +1,4 @@
+using Improbable.Gdk.Core;
 using Improbable.Gdk.PlayerLifecycle;
 using UnityEngine;
 
@@ -19,6 +20,7 @@ namespace Playground
 
             // Setup template to use for player on connecting client
             PlayerLifecycleConfig.CreatePlayerEntityTemplate = EntityTemplates.CreatePlayerEntityTemplate;
+            PlayerLifecycleConfig.PlayerCreatorEntityId = new EntityId(2);
         }
     }
 }

--- a/workers/unity/Packages/io.improbable.gdk.playerlifecycle/Config/PlayerLifecycleConfig.cs
+++ b/workers/unity/Packages/io.improbable.gdk.playerlifecycle/Config/PlayerLifecycleConfig.cs
@@ -54,16 +54,6 @@ namespace Improbable.Gdk.PlayerLifecycle
         public static int MaxPlayerCreationRetries = 5;
 
         /// <summary>
-        ///     The maximum number of retries for finding player creator entities, before any player creation occurs.
-        /// </summary>
-        /// <remarks>
-        ///     All player creation requests must be sent to a player creator entity, which are initially queried for when
-        ///     the <see cref="SendCreatePlayerRequestSystem"/> starts. This field indicates the maximum number of retries for the
-        //      initial entity query to find the player creator entities.
-        /// </remarks>
-        public static int MaxPlayerCreatorQueryRetries = 5;
-
-        /// <summary>
         ///     This indicates whether a player should be created automatically upon a worker connecting to SpatialOS.
         /// </summary>
         /// <remarks>
@@ -81,5 +71,10 @@ namespace Improbable.Gdk.PlayerLifecycle
         ///     The system uses this delegate to request a new player entity based on the returned <see cref="EntityTemplate"/>.
         /// </remarks>
         public static GetPlayerEntityTemplateDelegate CreatePlayerEntityTemplate;
+
+        /// <summary>
+        ///     The <see cref="EntityId"/> of the player creator that clients send player creation requests to.
+        /// </summary>
+        public static EntityId PlayerCreatorEntityId;
     }
 }


### PR DESCRIPTION
Entity queries cannot have component level permissions in v15, so this system should not use them otherwise we require clients to have full query permissions over the deployment.

I additionally refactored the system to move all the stateful parts into a separate class, this makes it easier to reason about (imo). 