### PR TITLE
Update minimum Unity version in packages to 2020.1

### DIFF
--- a/workers/unity/Packages/io.improbable.gdk.buildsystem/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.buildsystem/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.buildsystem",
   "displayName": "SpatialOS GDK Build System",
   "version": "0.4.0",
-  "unity": "2019.3",
+  "unity": "2020.1",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Build System Module.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.gdk.core/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.core/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.core",
   "displayName": "SpatialOS GDK Core",
   "version": "0.4.0",
-  "unity": "2019.3",
+  "unity": "2020.1",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Core Module.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.gdk.debug/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.debug/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.debug",
   "displayName": "SpatialOS GDK Debug Extensions",
   "version": "0.4.0",
-  "unity": "2019.3",
+  "unity": "2020.1",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Debug Module.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.deploymentlauncher/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.deploymentlauncher",
   "displayName": "SpatialOS GDK Deployment Launcher",
   "version": "0.4.0",
-  "unity": "2019.3",
+  "unity": "2020.1",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Deployment Launcher.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.gameobjectcreation/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.gameobjectcreation",
   "displayName": "SpatialOS GDK GameObject Creation",
   "version": "0.4.0",
-  "unity": "2019.3",
+  "unity": "2020.1",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK GameObject Creation Module.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.gdk.loadbalancing/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.loadbalancing/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.loadbalancing",
   "displayName": "SpatialOS GDK Load Balancing",
   "version": "0.4.0",
-  "unity": "2019.3",
+  "unity": "2020.1",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Load Balancing Module.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.gdk.mobile/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.mobile/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.mobile",
   "displayName": "SpatialOS GDK Mobile Support",
   "version": "0.4.0",
-  "unity": "2019.3",
+  "unity": "2020.1",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Mobile Support Module.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.gdk.playerlifecycle/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.playerlifecycle/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.playerlifecycle",
   "displayName": "SpatialOS GDK Player Lifecycle",
   "version": "0.4.0",
-  "unity": "2019.3",
+  "unity": "2020.1",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Player Lifecycle Module.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.gdk.querybasedinteresthelper/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.querybasedinteresthelper/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.querybasedinteresthelper",
   "displayName": "SpatialOS GDK Query-based Interest Helper",
   "version": "0.4.0",
-  "unity": "2019.3",
+  "unity": "2020.1",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Query-based Interest Helper Module.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.gdk.testutils/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.testutils/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.testutils",
   "displayName": "SpatialOS GDK Test Utils",
   "version": "0.4.0",
-  "unity": "2019.3",
+  "unity": "2020.1",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Test Utils.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.gdk.tools/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.tools/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.tools",
   "displayName": "SpatialOS GDK Tools",
   "version": "0.4.0",
-  "unity": "2019.3",
+  "unity": "2020.1",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Support Tools.",
   "dependencies": {}

--- a/workers/unity/Packages/io.improbable.gdk.transformsynchronization/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.transformsynchronization/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.transformsynchronization",
   "displayName": "SpatialOS GDK Transform Synchronization",
   "version": "0.4.0",
-  "unity": "2019.3",
+  "unity": "2020.1",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Transform Synchronization Module.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.gdk.transformsynchronization2d/package.json
+++ b/workers/unity/Packages/io.improbable.gdk.transformsynchronization2d/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.gdk.transformsynchronization2d",
   "displayName": "SpatialOS GDK Transform Synchronization 2D",
   "version": "0.4.0",
-  "unity": "2019.3",
+  "unity": "2020.1",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS GDK Transform Synchronization Module 2D.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.worker.sdk.mobile/package.json
+++ b/workers/unity/Packages/io.improbable.worker.sdk.mobile/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.worker.sdk.mobile",
   "displayName": "SpatialOS Worker Mobile SDK",
   "version": "0.4.0",
-  "unity": "2019.3",
+  "unity": "2020.1",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS Worker Mobile SDK.",
   "dependencies": {

--- a/workers/unity/Packages/io.improbable.worker.sdk/package.json
+++ b/workers/unity/Packages/io.improbable.worker.sdk/package.json
@@ -2,7 +2,7 @@
   "name": "io.improbable.worker.sdk",
   "displayName": "SpatialOS Worker SDK",
   "version": "0.4.0",
-  "unity": "2019.3",
+  "unity": "2020.1",
   "author": "Improbable Worlds Ltd",
   "description": "SpatialOS Worker SDK.",
   "dependencies": {}


### PR DESCRIPTION
Update minimum Unity version in packages to 2020.1

https://docs.unity3d.com/2020.1/Documentation/Manual/upm-manifestPkg.html

#### Tests

- opened unity

#### Documentation

- not required as we already document that 2020.1 is the minimum version required

